### PR TITLE
feat: add passive issue closeout follow-up

### DIFF
--- a/doc/SPEC-implementation.md
+++ b/doc/SPEC-implementation.md
@@ -39,6 +39,7 @@ These decisions close open questions from `SPEC.md` for V1.
 | Communication | Issues remain the execution surface; Messenger is the board communication shell that unifies chat conversations and inbox-style attention streams |
 | Task ownership | Single assignee; atomic checkout required for `in_progress` transition |
 | Recovery | No automatic reassignment; work recovery stays explicit/auditable; visible same-agent recovery retry is allowed |
+| Issue close-out | Successful issue-backed runs must leave a close-out signal or Rudder may queue bounded same-agent passive follow-up |
 | Agent adapters | Built-in `process` and `http` adapters |
 | Auth | Mode-dependent human auth (`local_trusted` implicit board in current code; authenticated mode uses sessions), API keys for agents |
 | Budget period | Monthly UTC calendar window |
@@ -438,6 +439,13 @@ Side effects:
 - entering `done` sets `completed_at`
 - entering `cancelled` sets `cancelled_at`
 
+Issue-backed run close-out:
+
+- a successful run on a `todo` or `in_progress` issue is expected to leave one closure signal before exit
+- closure signals are a run-attributed issue comment, moving the issue out of `todo` / `in_progress`, reassignment, or an existing deferred issue wake
+- if no closure signal exists and near-term timer heartbeat continuity is not credible, Rudder queues a same-agent `issue_passive_followup` wake after a short cooldown
+- passive follow-up is bounded to two attempts; after that Rudder emits `issue.closure_needs_operator_review` without mutating the issue workflow status
+
 ## 8.3 Approval Status
 
 - `pending -> approved | rejected | cancelled`
@@ -511,6 +519,7 @@ All endpoints are under `/api` and return JSON.
 - `POST /agents/:agentId/terminate`
 - `POST /agents/:agentId/keys` (create API key)
 - `POST /agents/:agentId/heartbeat/invoke`
+- `issue_passive_followup` is an internal same-agent wake reason created by issue close-out governance, not a public reassignment surface
 
 ## 10.4 Tasks (Issues)
 

--- a/doc/developing/RUN-RECOVERY.md
+++ b/doc/developing/RUN-RECOVERY.md
@@ -20,6 +20,8 @@ Recovery must not silently:
 - hide the failure
 - create a brand-new task interpretation when prior work already exists
 
+Passive issue close-out follow-up is separate from recovery. It is created after a successful issue-backed run that left no comment, status transition, handoff, or deferred continuation signal. Those runs use `contextSnapshot.passiveFollowup` and `agent_wakeup_requests.reason = "issue_passive_followup"`, not `contextSnapshot.recovery`.
+
 ## 2. Recovery Contract
 
 Manual retry and automatic `process_lost` retry share the same contract.
@@ -96,6 +98,8 @@ V1 still does not do:
 - automatic reassignment
 - automatic issue release
 - automatic issue status rollback
+
+Missing issue close-out is not treated as a failed-run recovery case. Rudder may queue a bounded same-agent passive follow-up for `missing_closure`, but that prompt asks the agent to close, comment, block, or hand off the issue rather than resume a failed runtime.
 
 ## 6. Case Library
 
@@ -175,6 +179,20 @@ Expected behavior:
 Coverage:
 
 - automated: `packages/agent-runtime-utils/src/server-utils.test.ts`
+
+### Case: successful issue run exits without close-out
+
+Expected behavior:
+
+- no recovery metadata is attached because the run succeeded
+- if timer continuity is not credible, Rudder queues `issue_passive_followup`
+- after max passive attempts, Rudder emits `issue.closure_needs_operator_review`
+
+Coverage:
+
+- automated: `server/src/__tests__/heartbeat-passive-issue-closeout.test.ts`
+- automated: `packages/agent-runtime-utils/src/server-utils.test.ts`
+- e2e: `tests/e2e/issue-passive-followup.spec.ts`
 
 ## 7. Debugging Checklist
 

--- a/doc/spec/agent-runs.md
+++ b/doc/spec/agent-runs.md
@@ -110,7 +110,9 @@ Control flow (happy path):
 4. Adapter executes, emits status/log/usage events.
 5. Full logs stream to `RunLogStore`; metadata/events are persisted to DB and pushed to websocket subscribers.
 6. Process exits, output parser updates run result + runtime state.
-7. Agent returns to `idle` or `error`; UI updates in real time.
+7. For issue-backed successful runs, close-out governance checks whether the run left a comment, status transition, handoff, or deferred continuation signal.
+8. If close-out is missing and normal timer continuity is not expected soon, Rudder queues a bounded same-agent `issue_passive_followup` run and keeps the issue execution lock on that queued run.
+9. Agent returns to `idle` or `error`; UI updates in real time.
 
 ## 6. Agent Run Protocol (Version `agent-run/v1`)
 
@@ -673,6 +675,16 @@ Recovery retry is explicit run derivation, not a lossy wakeup shortcut.
 3. Issue-backed recovery keeps the prior issue/comment/task context when available.
 4. Recovery prompts must say this is a recovery and must instruct the agent to inspect prior progress and side effects before continuing.
 5. Automatic recovery remains narrow: V1 only auto-retries `process_lost`, and it must stay visible in the run timeline.
+
+## 12.6 Passive issue close-out follow-up
+
+Passive follow-up is issue closure governance, not runtime failure recovery.
+
+1. It only applies after a successful issue-backed run on a `todo` or `in_progress` issue.
+2. Rudder suppresses it when the run added an issue comment, the issue moved out of the trigger statuses, the issue was reassigned, a deferred issue wake exists, or timer heartbeat continuity is expected within `min(2x interval, 15 minutes)`.
+3. When triggered, Rudder queues a same-agent automation run with `agent_wakeup_requests.reason = "issue_passive_followup"` and `heartbeat_runs.contextSnapshot.passiveFollowup`.
+4. The queued run starts after cooldown, carries `originRunId`, `previousRunId`, `attempt`, `maxAttempts`, and `reason: "missing_closure"`, and uses the passive follow-up prompt template.
+5. After two passive follow-up attempts, Rudder stops auto-follow-up and emits `issue.closure_needs_operator_review` activity instead of changing the issue status.
 
 ## 13. API Surface Changes
 

--- a/packages/agent-runtime-utils/src/server-utils.test.ts
+++ b/packages/agent-runtime-utils/src/server-utils.test.ts
@@ -73,6 +73,39 @@ describe("selectPromptTemplate", () => {
     expect(rendered).not.toContain("Current Issue Context");
   });
 
+  it("renders a passive issue follow-up prompt when close-out governance wakes the agent", () => {
+    const context = {
+      wakeReason: "issue_passive_followup",
+      issue: {
+        id: "issue-2",
+        title: "Publish onboarding notes",
+        status: "in_progress",
+        priority: "medium",
+        description: "Write the notes and close out the issue.",
+      },
+      passiveFollowup: {
+        originRunId: "run-origin",
+        previousRunId: "run-prev",
+        attempt: 1,
+        maxAttempts: 2,
+        reason: "missing_closure",
+      },
+    };
+
+    const template = selectPromptTemplate(undefined, context);
+    const rendered = renderTemplate(template, {
+      agent: { id: "agent-3", name: "Builder" },
+      context,
+      issue: context.issue,
+    });
+
+    expect(rendered).toContain("This is a passive issue follow-up");
+    expect(rendered).toContain("The previous run ended without sufficient issue close-out.");
+    expect(rendered).toContain("**Origin Run ID:** run-origin");
+    expect(rendered).toContain("Publish onboarding notes");
+    expect(rendered).toContain("add a progress comment, mark the issue done, block it with a reason, or hand it off");
+  });
+
   it("injects the shared org resources section into default prompts when present", () => {
     const context = {
       rudderWorkspace: {

--- a/packages/agent-runtime-utils/src/server-utils.ts
+++ b/packages/agent-runtime-utils/src/server-utils.ts
@@ -351,6 +351,31 @@ export const RECOVERY_PROMPT_TEMPLATE = `You are agent {{agent.id}} ({{agent.nam
 
 Before doing anything else, inspect what the previous run already completed and any side effects it may have caused. Continue the remaining work from the current state. Avoid blindly re-running the whole task.`;
 
+export const ISSUE_PASSIVE_FOLLOWUP_PROMPT_TEMPLATE = `You are agent {{agent.id}} ({{agent.name}}). This is a passive issue follow-up, not a fresh assignment and not a failure recovery.
+
+{{context.rudderWorkspace.orgResourcesPrompt}}
+
+## Why You Were Woken
+
+The previous run ended without sufficient issue close-out.
+
+**Origin Run ID:** {{context.passiveFollowup.originRunId}}
+**Previous Run ID:** {{context.passiveFollowup.previousRunId}}
+**Attempt:** {{context.passiveFollowup.attempt}} / {{context.passiveFollowup.maxAttempts}}
+**Reason:** {{context.passiveFollowup.reason}}
+
+## Current Issue Context
+
+**Issue:** {{issue.title}}
+**ID:** {{issue.id}}
+**Status:** {{issue.status}}
+**Priority:** {{issue.priority}}
+
+**Description:**
+{{issue.description}}
+
+Before changing the issue, inspect the current issue state and any side effects from the previous run. Then do exactly one close-out action: add a progress comment, mark the issue done, block it with a reason, or hand it off explicitly with explanation.`;
+
 /**
  * Selects the base heartbeat prompt template used by runtimes before final prompt assembly.
  *
@@ -368,6 +393,9 @@ Before doing anything else, inspect what the previous run already completed and 
  *   "This is a recovery run, not a fresh task ..."
  *   Includes original run id, failure metadata, and a continue-preferred instruction to
  *   inspect prior progress/side effects before resuming.
+ * - passive issue follow-up:
+ *   "This is a passive issue follow-up, not a fresh assignment ..."
+ *   Includes close-out lineage and tells the agent to comment, finish, block, or hand off.
  * - fallback:
  *   Generic "Continue your Rudder work."
  *
@@ -408,6 +436,9 @@ export function selectPromptTemplate(
     return typeof context.issue === "object" && context.issue !== null && !Array.isArray(context.issue)
       ? ISSUE_RECOVERY_PROMPT_TEMPLATE
       : RECOVERY_PROMPT_TEMPLATE;
+  }
+  if (wakeReason === "issue_passive_followup") {
+    return ISSUE_PASSIVE_FOLLOWUP_PROMPT_TEMPLATE;
   }
   if (wakeSource === "assignment" || wakeReason === "issue_assigned") {
     return ISSUE_ASSIGN_PROMPT_TEMPLATE;

--- a/packages/agent-runtime-utils/vitest.config.ts
+++ b/packages/agent-runtime-utils/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+});

--- a/packages/shared/src/types/heartbeat.ts
+++ b/packages/shared/src/types/heartbeat.ts
@@ -18,8 +18,18 @@ export interface HeartbeatRunRecoveryContext {
   recoveryMode: HeartbeatRecoveryMode;
 }
 
+export interface HeartbeatRunPassiveFollowupContext {
+  originRunId: string;
+  previousRunId: string;
+  attempt: number;
+  maxAttempts: number;
+  reason: "missing_closure";
+  queuedAt: string;
+}
+
 export interface HeartbeatRunContextSnapshot extends Record<string, unknown> {
   recovery?: HeartbeatRunRecoveryContext;
+  passiveFollowup?: HeartbeatRunPassiveFollowupContext;
 }
 
 export interface HeartbeatRun {

--- a/server/resources/bundled-skills/rudder/SKILL.md
+++ b/server/resources/bundled-skills/rudder/SKILL.md
@@ -131,6 +131,8 @@ rudder issue comments list "<issue-id-or-identifier>" --after "<last-comment-id>
 
 **Step 8 — Communicate outcome.**
 
+Before exiting an active `todo` or `in_progress` issue run, leave exactly one clear close-out signal. Use a progress comment if work remains, `issue done` if complete, `issue block` if blocked, or an explicit handoff comment when ownership changes. Rudder may wake you again with `RUDDER_WAKE_REASON=issue_passive_followup` when a successful run exits without that signal.
+
 - progress-only update:
 
 ```bash
@@ -208,6 +210,7 @@ Planning rules:
 - Never look for unassigned work.
 - Self-assign only on explicit @-mention handoff.
 - Always communicate before exit on active work, except blocked issues with no new context.
+- Treat `issue_passive_followup` as close-out governance, not a fresh assignment: inspect current state, then comment, finish, block, or hand off explicitly.
 - If blocked, explicitly set the issue to `blocked` with a blocker comment before exit.
 - Never cancel cross-team tasks. Reassign upward with explanation.
 - Use `chainOfCommand` for escalation.

--- a/server/resources/bundled-skills/rudder/references/cli-reference.md
+++ b/server/resources/bundled-skills/rudder/references/cli-reference.md
@@ -41,6 +41,17 @@ Stable CLI contract for agents using the bundled `rudder` skill. Prefer these co
 | `rudder skill scan-local --org-id <id> [--roots <csv>]` | Scan local roots for skill packages and import new ones. | yes | required | no | attached when available |
 | `rudder skill scan-projects --org-id <id> [--project-ids <csv>] [--workspace-ids <csv>]` | Scan the org workspace and any legacy project workspace records for skill packages and import new ones. | yes | required | no | attached when available |
 
+## Issue Close-Out Signals
+
+Before a successful `todo` or `in_progress` issue run exits, leave one close-out signal with the command that matches the outcome:
+
+- progress remains: `rudder issue comment <issue> --body <text>`
+- work is complete: `rudder issue done <issue> --comment <text>`
+- work is blocked: `rudder issue block <issue> --comment <text>`
+- ownership changes: add an explicit handoff comment before or with the assignee update
+
+If `RUDDER_WAKE_REASON=issue_passive_followup`, the run is close-out governance for the same issue. Inspect current issue state first, then leave a progress comment, completion, blocker, or explicit handoff.
+
 ## Compatibility Commands
 
 - `rudder agent list --org-id <id>` — List agents for an organization.

--- a/server/src/__tests__/heartbeat-passive-issue-closeout.test.ts
+++ b/server/src/__tests__/heartbeat-passive-issue-closeout.test.ts
@@ -1,0 +1,466 @@
+import { randomUUID } from "node:crypto";
+import fs from "node:fs";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import { eq } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  activityLog,
+  agentRuntimeState,
+  agentTaskSessions,
+  agentWakeupRequests,
+  agents,
+  applyPendingMigrations,
+  createDb,
+  ensurePostgresDatabase,
+  heartbeatRunEvents,
+  heartbeatRuns,
+  issueComments,
+  issues,
+  organizationSkills,
+  organizations,
+} from "@rudder/db";
+import { deriveOrganizationUrlKey } from "@rudder/shared";
+import { heartbeatService } from "../services/heartbeat.ts";
+
+const mockBudgetService = vi.hoisted(() => ({
+  getInvocationBlock: vi.fn(),
+}));
+
+vi.mock("../services/budgets.ts", async () => {
+  const actual = await vi.importActual("../services/budgets.ts");
+  return {
+    ...actual,
+    budgetService: () => mockBudgetService,
+  };
+});
+
+type EmbeddedPostgresInstance = {
+  initialise(): Promise<void>;
+  start(): Promise<void>;
+  stop(): Promise<void>;
+};
+
+type EmbeddedPostgresCtor = new (opts: {
+  databaseDir: string;
+  user: string;
+  password: string;
+  port: number;
+  persistent: boolean;
+  initdbFlags?: string[];
+  onLog?: (message: unknown) => void;
+  onError?: (message: unknown) => void;
+}) => EmbeddedPostgresInstance;
+
+async function getEmbeddedPostgresCtor(): Promise<EmbeddedPostgresCtor> {
+  const mod = await import("embedded-postgres");
+  return mod.default as EmbeddedPostgresCtor;
+}
+
+async function getAvailablePort(): Promise<number> {
+  return await new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.unref();
+    server.on("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        server.close(() => reject(new Error("Failed to allocate test port")));
+        return;
+      }
+      const { port } = address;
+      server.close((error) => {
+        if (error) reject(error);
+        else resolve(port);
+      });
+    });
+  });
+}
+
+async function startTempDatabase() {
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "rudder-passive-closeout-"));
+  const port = await getAvailablePort();
+  const EmbeddedPostgres = await getEmbeddedPostgresCtor();
+  const instance = new EmbeddedPostgres({
+    databaseDir: dataDir,
+    user: "rudder",
+    password: "rudder",
+    port,
+    persistent: true,
+    initdbFlags: ["--encoding=UTF8", "--locale=C"],
+    onLog: () => {},
+    onError: () => {},
+  });
+  await instance.initialise();
+  await instance.start();
+
+  const adminConnectionString = `postgres://rudder:rudder@127.0.0.1:${port}/postgres`;
+  await ensurePostgresDatabase(adminConnectionString, "rudder");
+  const connectionString = `postgres://rudder:rudder@127.0.0.1:${port}/rudder`;
+  await applyPendingMigrations(connectionString);
+  return { connectionString, instance, dataDir };
+}
+
+async function waitFor<T>(
+  fn: () => Promise<T | null | false | undefined>,
+  timeoutMs = 5_000,
+): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  let lastValue: T | null | false | undefined;
+  while (Date.now() < deadline) {
+    lastValue = await fn();
+    if (lastValue) return lastValue;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error(`Timed out waiting for condition; last value: ${JSON.stringify(lastValue)}`);
+}
+
+describe("heartbeat passive issue closeout", () => {
+  let db!: ReturnType<typeof createDb>;
+  let instance: EmbeddedPostgresInstance | null = null;
+  let dataDir = "";
+
+  beforeAll(async () => {
+    const started = await startTempDatabase();
+    db = createDb(started.connectionString);
+    instance = started.instance;
+    dataDir = started.dataDir;
+  }, 20_000);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockBudgetService.getInvocationBlock.mockResolvedValue(null);
+  });
+
+  afterEach(async () => {
+    for (let attempt = 0; attempt < 6; attempt += 1) {
+      try {
+        await db.delete(activityLog);
+        await db.delete(issueComments);
+        await db.delete(issues);
+        await db.delete(heartbeatRunEvents);
+        await db.delete(heartbeatRuns);
+        await db.delete(agentTaskSessions);
+        await db.delete(agentRuntimeState);
+        await db.delete(agentWakeupRequests);
+        await db.delete(organizationSkills);
+        await db.delete(agents);
+        await db.delete(organizations);
+        return;
+      } catch (error) {
+        if (attempt === 5) throw error;
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
+    }
+  });
+
+  afterAll(async () => {
+    await instance?.stop();
+    if (dataDir) {
+      fs.rmSync(dataDir, { recursive: true, force: true });
+    }
+  });
+
+  async function seedFixture(input?: {
+    agentRuntimeConfig?: Record<string, unknown>;
+    runtimeConfig?: Record<string, unknown>;
+    issueStatus?: "todo" | "in_progress";
+  }) {
+    const orgId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const issuePrefix = `P${orgId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+    const orgName = `Passive Closeout ${orgId.slice(0, 6)}`;
+
+    await db.insert(organizations).values({
+      id: orgId,
+      name: orgName,
+      urlKey: deriveOrganizationUrlKey(orgName),
+      issuePrefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      orgId,
+      name: "Builder",
+      role: "engineer",
+      status: "idle",
+      agentRuntimeType: "process",
+      agentRuntimeConfig: input?.agentRuntimeConfig ?? {
+        command: process.execPath,
+        args: ["-e", "process.exit(0)"],
+        timeoutSec: 5,
+      },
+      runtimeConfig: input?.runtimeConfig ?? {},
+      permissions: {},
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      orgId,
+      title: "Close out the issue",
+      description: "The run must leave an issue close-out signal.",
+      status: input?.issueStatus ?? "in_progress",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      issueNumber: 1,
+      identifier: `${issuePrefix}-1`,
+    });
+
+    return { orgId, agentId, issueId };
+  }
+
+  async function wakeIssueRun(input: {
+    agentId: string;
+    issueId: string;
+    reason?: string;
+    passiveFollowup?: Record<string, unknown>;
+  }) {
+    const heartbeat = heartbeatService(db);
+    const run = await heartbeat.wakeup(input.agentId, {
+      source: "assignment",
+      triggerDetail: "system",
+      reason: input.reason ?? "issue_assigned",
+      payload: { issueId: input.issueId },
+      requestedByActorType: "system",
+      requestedByActorId: "test",
+      contextSnapshot: {
+        issueId: input.issueId,
+        taskId: input.issueId,
+        taskKey: input.issueId,
+        wakeReason: input.reason ?? "issue_assigned",
+        wakeSource: input.reason === "issue_passive_followup" ? "passive_issue_followup" : "assignment",
+        issue: {
+          id: input.issueId,
+          title: "Close out the issue",
+          status: "in_progress",
+          priority: "medium",
+          description: "The run must leave an issue close-out signal.",
+        },
+        ...(input.passiveFollowup ? { passiveFollowup: input.passiveFollowup } : {}),
+      },
+    });
+    if (!run) throw new Error("Expected wakeup to create a run");
+    return run;
+  }
+
+  async function getRun(runId: string) {
+    return db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runId))
+      .then((rows) => rows[0] ?? null);
+  }
+
+  async function getIssue(issueId: string) {
+    return db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+  }
+
+  it("queues a same-agent passive follow-up when a successful issue run exits without close-out", async () => {
+    const { agentId, issueId } = await seedFixture();
+    const run = await wakeIssueRun({ agentId, issueId });
+
+    const followup = await waitFor(async () => {
+      const runs = await db
+        .select()
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.agentId, agentId));
+      return runs.find((row) => row.id !== run.id) ?? null;
+    });
+
+    const runs = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.agentId, agentId));
+    expect(runs).toHaveLength(2);
+
+    expect(followup).toMatchObject({
+      agentId,
+      status: "queued",
+      invocationSource: "automation",
+      triggerDetail: "system",
+    });
+    expect(followup?.contextSnapshot).toMatchObject({
+      issueId,
+      wakeReason: "issue_passive_followup",
+      passiveFollowup: {
+        originRunId: run.id,
+        previousRunId: run.id,
+        attempt: 1,
+        maxAttempts: 2,
+        reason: "missing_closure",
+      },
+    });
+
+    const wakeup = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.id, followup?.wakeupRequestId ?? ""))
+      .then((rows) => rows[0] ?? null);
+    expect(wakeup?.reason).toBe("issue_passive_followup");
+    expect(new Date(wakeup?.requestedAt ?? 0).getTime()).toBeGreaterThan(Date.now());
+
+    const issue = await getIssue(issueId);
+    expect(issue?.executionRunId).toBe(followup?.id);
+    expect(issue?.status).toBe("in_progress");
+  });
+
+  it("does not queue passive follow-up when the run leaves a run-attributed progress comment", async () => {
+    const { agentId, issueId, orgId } = await seedFixture({
+      agentRuntimeConfig: {
+        command: process.execPath,
+        args: ["-e", "setTimeout(() => process.exit(0), 750)"],
+        timeoutSec: 5,
+      },
+    });
+    const run = await wakeIssueRun({ agentId, issueId });
+
+    await waitFor(async () => {
+      const current = await getRun(run.id);
+      return current?.status === "running" ? current : null;
+    });
+
+    const commentId = randomUUID();
+    await db.insert(issueComments).values({
+      id: commentId,
+      orgId,
+      issueId,
+      authorAgentId: agentId,
+      body: "Progress: finished the first chunk and will continue next run.",
+    });
+    await db.insert(activityLog).values({
+      orgId,
+      actorType: "agent",
+      actorId: agentId,
+      action: "issue.comment_added",
+      entityType: "issue",
+      entityId: issueId,
+      agentId,
+      runId: run.id,
+      details: { commentId },
+    });
+
+    await waitFor(async () => {
+      const issue = await getIssue(issueId);
+      return issue?.executionRunId === null ? issue : null;
+    });
+
+    const runs = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.agentId, agentId));
+    expect(runs).toHaveLength(1);
+  });
+
+  it("does not queue passive follow-up when the run moves the issue out of trigger statuses", async () => {
+    const { agentId, issueId } = await seedFixture({
+      agentRuntimeConfig: {
+        command: process.execPath,
+        args: ["-e", "setTimeout(() => process.exit(0), 750)"],
+        timeoutSec: 5,
+      },
+    });
+    const run = await wakeIssueRun({ agentId, issueId });
+
+    await waitFor(async () => {
+      const current = await getRun(run.id);
+      return current?.status === "running" ? current : null;
+    });
+
+    await db
+      .update(issues)
+      .set({
+        status: "done",
+        completedAt: new Date(),
+        updatedAt: new Date(),
+      })
+      .where(eq(issues.id, issueId));
+
+    await waitFor(async () => {
+      const issue = await getIssue(issueId);
+      return issue?.executionRunId === null ? issue : null;
+    });
+
+    const runs = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.agentId, agentId));
+    expect(runs).toHaveLength(1);
+  });
+
+  it("does not queue passive follow-up when timer heartbeat continuity is near-term", async () => {
+    const { agentId, issueId } = await seedFixture({
+      runtimeConfig: {
+        heartbeat: {
+          enabled: true,
+          intervalSec: 300,
+        },
+      },
+    });
+    const run = await wakeIssueRun({ agentId, issueId });
+
+    await waitFor(async () => {
+      const issue = await getIssue(issueId);
+      return issue?.executionRunId === null ? issue : null;
+    });
+
+    const runs = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.agentId, agentId));
+    expect(runs).toHaveLength(1);
+  });
+
+  it("stops after max passive follow-up attempts and emits operator review activity", async () => {
+    const { agentId, issueId } = await seedFixture();
+    const originRunId = randomUUID();
+    const run = await wakeIssueRun({
+      agentId,
+      issueId,
+      reason: "issue_passive_followup",
+      passiveFollowup: {
+        originRunId,
+        previousRunId: randomUUID(),
+        attempt: 2,
+        maxAttempts: 2,
+        reason: "missing_closure",
+        queuedAt: new Date().toISOString(),
+      },
+    });
+
+    const reviewEvent = await waitFor(async () => {
+      return db
+        .select()
+        .from(activityLog)
+        .where(eq(activityLog.action, "issue.closure_needs_operator_review"))
+        .then((rows) => rows[0] ?? null);
+    });
+
+    const runs = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.agentId, agentId));
+    expect(runs).toHaveLength(1);
+
+    expect(reviewEvent).toMatchObject({
+      actorType: "system",
+      actorId: "issue_closure_governance",
+      entityType: "issue",
+      entityId: issueId,
+      runId: run.id,
+    });
+    expect(reviewEvent?.details).toMatchObject({
+      originRunId,
+      previousRunId: run.id,
+      attempts: 2,
+      maxAttempts: 2,
+      reason: "missing_closure",
+    });
+  });
+});

--- a/server/src/onboarding-assets/ceo/HEARTBEAT.md
+++ b/server/src/onboarding-assets/ceo/HEARTBEAT.md
@@ -36,6 +36,7 @@ If `RUDDER_APPROVAL_ID` is set:
 - Never retry a 409 -- that task belongs to someone else.
 - Use `rudder issue context "<issue-id-or-identifier>" --json` to load compact context.
 - Do the work. Use `rudder issue comment`, `rudder issue done`, or `rudder issue block` to communicate outcome.
+- If `RUDDER_WAKE_REASON=issue_passive_followup`, treat the wake as close-out governance, not a fresh assignment: inspect state and leave a progress comment, completion, blocker, or explicit handoff.
 
 ## 6. Delegation
 
@@ -54,6 +55,7 @@ If `RUDDER_APPROVAL_ID` is set:
 ## 8. Exit
 
 - Comment on any in_progress work before exiting.
+- A successful `todo` or `in_progress` issue run without a close-out signal can trigger a same-agent passive follow-up.
 - If no assignments and no valid mention-handoff, exit cleanly.
 
 ---

--- a/server/src/onboarding-assets/default/HEARTBEAT.md
+++ b/server/src/onboarding-assets/default/HEARTBEAT.md
@@ -27,8 +27,10 @@ If approval context is set, review linked issues and close/comment.
 
 - Always checkout before working.
 - Do the work. Update status and comment when done.
+- If `RUDDER_WAKE_REASON=issue_passive_followup`, inspect current issue state first, then leave a close-out signal: progress comment, done, blocked with reason, or explicit handoff.
 
 ## 6. Exit
 
 - Comment on in_progress work before exiting.
+- A successful `todo` or `in_progress` issue run without a close-out signal can trigger a same-agent passive follow-up.
 - Exit cleanly if no assignments.

--- a/server/src/services/activity.ts
+++ b/server/src/services/activity.ts
@@ -131,6 +131,8 @@ export function activityService(db: Db) {
           finishedAt: heartbeatRuns.finishedAt,
           createdAt: heartbeatRuns.createdAt,
           invocationSource: heartbeatRuns.invocationSource,
+          triggerDetail: heartbeatRuns.triggerDetail,
+          contextSnapshot: heartbeatRuns.contextSnapshot,
           usageJson: heartbeatRuns.usageJson,
           resultJson: heartbeatRuns.resultJson,
         })

--- a/server/src/services/runtime-kernel/heartbeat.ts
+++ b/server/src/services/runtime-kernel/heartbeat.ts
@@ -16,6 +16,7 @@ import {
   agentRuntimeState,
   agentTaskSessions,
   agentWakeupRequests,
+  activityLog,
   heartbeatRunEvents,
   heartbeatRuns,
   issueComments,
@@ -77,6 +78,7 @@ import {
   resolveExecutionWorkspaceMode,
 } from "../execution-workspace-policy.js";
 import { instanceSettingsService } from "../instance-settings.js";
+import { logActivity } from "../activity-log.js";
 import { redactCurrentUserText, redactCurrentUserValue } from "../../log-redaction.js";
 import {
   hasSessionCompactionThresholds,
@@ -101,6 +103,15 @@ const ORPHANED_PROCESS_KILL_WAIT_MS = 500;
 const ORPHANED_PROCESS_POLL_INTERVAL_MS = 100;
 const startLocksByAgent = new Map<string, Promise<void>>();
 const MAX_RECOVERY_CHAIN_DEPTH = 8;
+const ISSUE_PASSIVE_FOLLOWUP_REASON = "issue_passive_followup";
+const ISSUE_PASSIVE_FOLLOWUP_WAKE_SOURCE = "passive_issue_followup";
+const ISSUE_PASSIVE_FOLLOWUP_FAILURE_REASON = "missing_closure";
+const ISSUE_PASSIVE_FOLLOWUP_MAX_ATTEMPTS = 2;
+const ISSUE_PASSIVE_FOLLOWUP_COOLDOWN_MS_BY_ATTEMPT = new Map<number, number>([
+  [1, 2 * 60 * 1000],
+  [2, 5 * 60 * 1000],
+]);
+const ISSUE_PASSIVE_FOLLOWUP_TIMER_CONTINUITY_MAX_WINDOW_MS = 15 * 60 * 1000;
 const SESSIONED_LOCAL_ADAPTERS = new Set([
   "claude_local",
   "codex_local",
@@ -920,6 +931,132 @@ function buildRecoveryContextSnapshot(input: {
     retryOfRunId: run.id,
     retryReason: failureKind,
     recovery,
+  };
+}
+
+type PassiveFollowupIssueRow = Pick<
+  typeof issues.$inferSelect,
+  "id" | "orgId" | "title" | "description" | "status" | "priority" | "projectId" | "assigneeAgentId"
+>;
+
+type PassiveFollowupContext = {
+  originRunId: string;
+  previousRunId: string | null;
+  attempt: number;
+  maxAttempts: number;
+  reason: typeof ISSUE_PASSIVE_FOLLOWUP_FAILURE_REASON;
+  queuedAt: string | null;
+};
+
+type PassiveIssueClosureOutcome =
+  | { kind: "none"; reason: string }
+  | {
+      kind: "queued";
+      run: typeof heartbeatRuns.$inferSelect;
+      issue: PassiveFollowupIssueRow;
+      originRunId: string;
+      previousRunId: string;
+      attempt: number;
+      requestedAt: Date;
+    }
+  | {
+      kind: "operator_review";
+      issue: PassiveFollowupIssueRow;
+      originRunId: string;
+      previousRunId: string;
+      attempts: number;
+      reason: typeof ISSUE_PASSIVE_FOLLOWUP_FAILURE_REASON;
+    };
+
+function normalizePassiveFollowupContext(raw: unknown): PassiveFollowupContext | null {
+  const parsed = parseObject(raw);
+  const originRunId = readNonEmptyString(parsed.originRunId);
+  if (!originRunId) return null;
+  const attempt = Math.max(0, Math.floor(asNumber(parsed.attempt, 0)));
+  return {
+    originRunId,
+    previousRunId: readNonEmptyString(parsed.previousRunId),
+    attempt,
+    maxAttempts: Math.max(1, Math.floor(asNumber(parsed.maxAttempts, ISSUE_PASSIVE_FOLLOWUP_MAX_ATTEMPTS))),
+    reason: ISSUE_PASSIVE_FOLLOWUP_FAILURE_REASON,
+    queuedAt: readNonEmptyString(parsed.queuedAt),
+  };
+}
+
+function passiveFollowupCooldownMs(attempt: number) {
+  return ISSUE_PASSIVE_FOLLOWUP_COOLDOWN_MS_BY_ATTEMPT.get(attempt) ?? 5 * 60 * 1000;
+}
+
+function isAgentEligibleForTimerContinuation(agent: typeof agents.$inferSelect) {
+  return (
+    agent.status !== "paused" &&
+    agent.status !== "terminated" &&
+    agent.status !== "pending_approval"
+  );
+}
+
+function hasCredibleTimerContinuation(input: {
+  agent: typeof agents.$inferSelect;
+  policy: { enabled: boolean; intervalSec: number };
+  run: typeof heartbeatRuns.$inferSelect;
+  now: Date;
+}) {
+  if (!input.policy.enabled || input.policy.intervalSec <= 0) return false;
+  if (!isAgentEligibleForTimerContinuation(input.agent)) return false;
+
+  const intervalMs = input.policy.intervalSec * 1000;
+  const nearTermWindowMs = Math.min(
+    intervalMs * 2,
+    ISSUE_PASSIVE_FOLLOWUP_TIMER_CONTINUITY_MAX_WINDOW_MS,
+  );
+  const lastHeartbeatMs = input.agent.lastHeartbeatAt
+    ? new Date(input.agent.lastHeartbeatAt).getTime()
+    : new Date(input.agent.createdAt).getTime();
+  const runFinishedMs = input.run.finishedAt
+    ? new Date(input.run.finishedAt).getTime()
+    : input.now.getTime();
+  const baselineMs = Math.max(lastHeartbeatMs, runFinishedMs);
+  const nextTimerMs = baselineMs + intervalMs;
+  return Math.max(0, nextTimerMs - input.now.getTime()) <= nearTermWindowMs;
+}
+
+function buildPassiveFollowupContextSnapshot(input: {
+  run: typeof heartbeatRuns.$inferSelect;
+  issue: PassiveFollowupIssueRow;
+  originRunId: string;
+  attempt: number;
+  now: Date;
+}) {
+  const baseContext = { ...parseObject(input.run.contextSnapshot) };
+  delete baseContext.recovery;
+  delete baseContext.retryOfRunId;
+  delete baseContext.retryReason;
+
+  const taskKey = deriveTaskKey(baseContext, { issueId: input.issue.id }) ?? input.issue.id;
+  return {
+    ...baseContext,
+    issueId: input.issue.id,
+    taskId: input.issue.id,
+    taskKey,
+    projectId: readNonEmptyString(baseContext.projectId) ?? input.issue.projectId ?? undefined,
+    wakeReason: ISSUE_PASSIVE_FOLLOWUP_REASON,
+    wakeSource: ISSUE_PASSIVE_FOLLOWUP_WAKE_SOURCE,
+    wakeTriggerDetail: "system",
+    issue: {
+      id: input.issue.id,
+      title: input.issue.title,
+      description: input.issue.description,
+      status: input.issue.status,
+      priority: input.issue.priority,
+    },
+    passiveFollowup: {
+      originRunId: input.originRunId,
+      previousRunId: input.run.id,
+      attempt: input.attempt,
+      maxAttempts: ISSUE_PASSIVE_FOLLOWUP_MAX_ATTEMPTS,
+      reason: ISSUE_PASSIVE_FOLLOWUP_FAILURE_REASON,
+      queuedAt: input.now.toISOString(),
+    },
   };
 }
 
@@ -2072,6 +2209,203 @@ export function heartbeatService(db: Db) {
     };
   }
 
+  async function runHasIssueClosureComment(tx: any, run: typeof heartbeatRuns.$inferSelect, issueId: string) {
+    const commentActivity = await tx
+      .select({ id: activityLog.id })
+      .from(activityLog)
+      .where(
+        and(
+          eq(activityLog.orgId, run.orgId),
+          eq(activityLog.action, "issue.comment_added"),
+          eq(activityLog.entityType, "issue"),
+          eq(activityLog.entityId, issueId),
+          eq(activityLog.runId, run.id),
+        ),
+      )
+      .limit(1)
+      .then((rows: Array<{ id: string }>) => rows[0] ?? null);
+    return Boolean(commentActivity);
+  }
+
+  async function issueHasDeferredWake(tx: any, orgId: string, issueId: string) {
+    const deferred = await tx
+      .select({ id: agentWakeupRequests.id })
+      .from(agentWakeupRequests)
+      .where(
+        and(
+          eq(agentWakeupRequests.orgId, orgId),
+          eq(agentWakeupRequests.status, "deferred_issue_execution"),
+          sql`${agentWakeupRequests.payload} ->> 'issueId' = ${issueId}`,
+        ),
+      )
+      .limit(1)
+      .then((rows: Array<{ id: string }>) => rows[0] ?? null);
+    return Boolean(deferred);
+  }
+
+  async function passiveFollowupAlreadyRecorded(tx: any, runId: string) {
+    const idempotencyKey = `${ISSUE_PASSIVE_FOLLOWUP_REASON}:${runId}`;
+    const existingWake = await tx
+      .select({ id: agentWakeupRequests.id })
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.idempotencyKey, idempotencyKey))
+      .limit(1)
+      .then((rows: Array<{ id: string }>) => rows[0] ?? null);
+    if (existingWake) return true;
+
+    const existingReview = await tx
+      .select({ id: activityLog.id })
+      .from(activityLog)
+      .where(
+        and(
+          eq(activityLog.runId, runId),
+          eq(activityLog.action, "issue.closure_needs_operator_review"),
+        ),
+      )
+      .limit(1)
+      .then((rows: Array<{ id: string }>) => rows[0] ?? null);
+    return Boolean(existingReview);
+  }
+
+  async function evaluatePassiveIssueClosureForLockedIssue(input: {
+    tx: any;
+    run: typeof heartbeatRuns.$inferSelect;
+    issue: PassiveFollowupIssueRow;
+    now: Date;
+  }): Promise<PassiveIssueClosureOutcome> {
+    const { tx, run, issue, now } = input;
+    const context = parseObject(run.contextSnapshot);
+    const runIssueId = readNonEmptyString(context.issueId);
+    if (!runIssueId || runIssueId !== issue.id) return { kind: "none", reason: "run_not_issue_backed" };
+    if (run.status !== "succeeded") return { kind: "none", reason: "run_not_successful" };
+    if (issue.status !== "todo" && issue.status !== "in_progress") {
+      return { kind: "none", reason: "issue_has_closure_status" };
+    }
+    if (issue.assigneeAgentId !== run.agentId) {
+      return { kind: "none", reason: "issue_no_longer_assigned_to_run_agent" };
+    }
+
+    if (await runHasIssueClosureComment(tx, run, issue.id)) {
+      return { kind: "none", reason: "run_authored_issue_comment" };
+    }
+    if (await issueHasDeferredWake(tx, issue.orgId, issue.id)) {
+      return { kind: "none", reason: "deferred_issue_wake_exists" };
+    }
+    if (await passiveFollowupAlreadyRecorded(tx, run.id)) {
+      return { kind: "none", reason: "passive_followup_already_recorded" };
+    }
+
+    const agent = await tx
+      .select()
+      .from(agents)
+      .where(eq(agents.id, run.agentId))
+      .then((rows: Array<typeof agents.$inferSelect>) => rows[0] ?? null);
+    if (!agent || agent.orgId !== run.orgId) {
+      return { kind: "none", reason: "agent_not_found" };
+    }
+
+    const policy = parseHeartbeatPolicy(agent);
+    if (hasCredibleTimerContinuation({ agent, policy, run, now })) {
+      return { kind: "none", reason: "timer_continuity_expected" };
+    }
+
+    const passiveContext = normalizePassiveFollowupContext(context.passiveFollowup);
+    const currentAttempt = passiveContext?.attempt ?? 0;
+    const originRunId = passiveContext?.originRunId ?? run.id;
+    if (currentAttempt >= ISSUE_PASSIVE_FOLLOWUP_MAX_ATTEMPTS) {
+      return {
+        kind: "operator_review",
+        issue,
+        originRunId,
+        previousRunId: run.id,
+        attempts: currentAttempt,
+        reason: ISSUE_PASSIVE_FOLLOWUP_FAILURE_REASON,
+      };
+    }
+
+    const nextAttempt = currentAttempt + 1;
+    const requestedAt = new Date(now.getTime() + passiveFollowupCooldownMs(nextAttempt));
+    const contextSnapshot = buildPassiveFollowupContextSnapshot({
+      run,
+      issue,
+      originRunId,
+      attempt: nextAttempt,
+      now,
+    });
+    const taskKey = deriveTaskKey(contextSnapshot, { issueId: issue.id });
+    const sessionBefore = await resolveSessionBeforeForWakeup(agent, taskKey);
+    const requestPayload = {
+      issueId: issue.id,
+      originRunId,
+      previousRunId: run.id,
+      attempt: nextAttempt,
+      reason: ISSUE_PASSIVE_FOLLOWUP_FAILURE_REASON,
+    };
+
+    const wakeupRequest = await tx
+      .insert(agentWakeupRequests)
+      .values({
+        orgId: run.orgId,
+        agentId: run.agentId,
+        source: "automation",
+        triggerDetail: "system",
+        reason: ISSUE_PASSIVE_FOLLOWUP_REASON,
+        payload: requestPayload,
+        status: "queued",
+        requestedByActorType: "system",
+        requestedByActorId: "issue_closure_governance",
+        idempotencyKey: `${ISSUE_PASSIVE_FOLLOWUP_REASON}:${run.id}`,
+        requestedAt,
+        updatedAt: now,
+      })
+      .returning()
+      .then((rows: Array<typeof agentWakeupRequests.$inferSelect>) => rows[0]);
+
+    const followupRun = await tx
+      .insert(heartbeatRuns)
+      .values({
+        orgId: run.orgId,
+        agentId: run.agentId,
+        invocationSource: "automation",
+        triggerDetail: "system",
+        status: "queued",
+        wakeupRequestId: wakeupRequest.id,
+        contextSnapshot,
+        sessionIdBefore: sessionBefore,
+        updatedAt: now,
+      })
+      .returning()
+      .then((rows: Array<typeof heartbeatRuns.$inferSelect>) => rows[0]);
+
+    await tx
+      .update(agentWakeupRequests)
+      .set({
+        runId: followupRun.id,
+        updatedAt: now,
+      })
+      .where(eq(agentWakeupRequests.id, wakeupRequest.id));
+
+    await tx
+      .update(issues)
+      .set({
+        executionRunId: followupRun.id,
+        executionAgentNameKey: normalizeAgentNameKey(agent.name),
+        executionLockedAt: now,
+        updatedAt: now,
+      })
+      .where(eq(issues.id, issue.id));
+
+    return {
+      kind: "queued",
+      run: followupRun,
+      issue,
+      originRunId,
+      previousRunId: run.id,
+      attempt: nextAttempt,
+      requestedAt,
+    };
+  }
+
   async function countRunningRunsForAgent(agentId: string) {
     const [{ count }] = await db
       .select({ count: sql<number>`count(*)` })
@@ -2082,6 +2416,16 @@ export function heartbeatService(db: Db) {
 
   async function claimQueuedRun(run: typeof heartbeatRuns.$inferSelect) {
     if (run.status !== "queued") return run;
+    if (run.wakeupRequestId) {
+      const wakeup = await db
+        .select({ requestedAt: agentWakeupRequests.requestedAt })
+        .from(agentWakeupRequests)
+        .where(eq(agentWakeupRequests.id, run.wakeupRequestId))
+        .then((rows) => rows[0] ?? null);
+      if (wakeup && new Date(wakeup.requestedAt).getTime() > Date.now()) {
+        return null;
+      }
+    }
     const agent = await getAgent(run.agentId);
     if (!agent) {
       await cancelRunInternal(run.id, "Cancelled because the agent no longer exists");
@@ -2382,7 +2726,21 @@ export function heartbeatService(db: Db) {
       const queuedRuns = await db
         .select()
         .from(heartbeatRuns)
-        .where(and(eq(heartbeatRuns.agentId, agentId), eq(heartbeatRuns.status, "queued")))
+        .where(
+          and(
+            eq(heartbeatRuns.agentId, agentId),
+            eq(heartbeatRuns.status, "queued"),
+            sql`(
+              ${heartbeatRuns.wakeupRequestId} is null
+              or exists (
+                select 1
+                from ${agentWakeupRequests}
+                where ${agentWakeupRequests.id} = ${heartbeatRuns.wakeupRequestId}
+                  and ${agentWakeupRequests.requestedAt} <= now()
+              )
+            )`,
+          ),
+        )
         .orderBy(asc(heartbeatRuns.createdAt))
         .limit(availableSlots);
       if (queuedRuns.length === 0) return [];
@@ -3458,7 +3816,7 @@ export function heartbeatService(db: Db) {
   }
 
   async function releaseIssueExecutionAndPromote(run: typeof heartbeatRuns.$inferSelect) {
-    const promotedRun = await db.transaction(async (tx) => {
+    const outcome = await db.transaction(async (tx) => {
       await tx.execute(
         sql`select id from issues where org_id = ${run.orgId} and execution_run_id = ${run.id} for update`,
       );
@@ -3467,12 +3825,29 @@ export function heartbeatService(db: Db) {
         .select({
           id: issues.id,
           orgId: issues.orgId,
+          title: issues.title,
+          description: issues.description,
+          status: issues.status,
+          priority: issues.priority,
+          projectId: issues.projectId,
+          assigneeAgentId: issues.assigneeAgentId,
         })
         .from(issues)
         .where(and(eq(issues.orgId, run.orgId), eq(issues.executionRunId, run.id)))
         .then((rows) => rows[0] ?? null);
 
-      if (!issue) return;
+      if (!issue) return { promotedRun: null, passiveClosure: null };
+
+      const passiveClosure = await evaluatePassiveIssueClosureForLockedIssue({
+        tx,
+        run,
+        issue,
+        now: new Date(),
+      });
+
+      if (passiveClosure.kind === "queued") {
+        return { promotedRun: passiveClosure.run, passiveClosure };
+      }
 
       await tx
         .update(issues)
@@ -3499,7 +3874,7 @@ export function heartbeatService(db: Db) {
           .limit(1)
           .then((rows) => rows[0] ?? null);
 
-        if (!deferred) return null;
+        if (!deferred) return { promotedRun: null, passiveClosure };
 
         const deferredAgent = await tx
           .select()
@@ -3590,10 +3965,101 @@ export function heartbeatService(db: Db) {
           })
           .where(eq(issues.id, issue.id));
 
-        return newRun;
+        return { promotedRun: newRun, passiveClosure };
       }
     });
 
+    const passiveClosure = outcome.passiveClosure;
+    if (passiveClosure?.kind === "queued") {
+      await appendRunEvent(run, await nextRunEventSeq(run.id), {
+        eventType: "issue.passive_followup_queued",
+        stream: "system",
+        level: "warn",
+        message: `Queued passive issue follow-up ${passiveClosure.run.id}`,
+        payload: {
+          issueId: passiveClosure.issue.id,
+          followupRunId: passiveClosure.run.id,
+          originRunId: passiveClosure.originRunId,
+          previousRunId: passiveClosure.previousRunId,
+          attempt: passiveClosure.attempt,
+          maxAttempts: ISSUE_PASSIVE_FOLLOWUP_MAX_ATTEMPTS,
+          reason: ISSUE_PASSIVE_FOLLOWUP_FAILURE_REASON,
+          requestedAt: passiveClosure.requestedAt.toISOString(),
+        },
+      });
+      await appendRunEvent(passiveClosure.run, await nextRunEventSeq(passiveClosure.run.id), {
+        eventType: "issue.passive_followup_queued",
+        stream: "system",
+        level: "warn",
+        message: `Passive follow-up queued because run ${run.id} ended without issue close-out`,
+        payload: {
+          issueId: passiveClosure.issue.id,
+          originRunId: passiveClosure.originRunId,
+          previousRunId: passiveClosure.previousRunId,
+          attempt: passiveClosure.attempt,
+          maxAttempts: ISSUE_PASSIVE_FOLLOWUP_MAX_ATTEMPTS,
+          reason: ISSUE_PASSIVE_FOLLOWUP_FAILURE_REASON,
+          requestedAt: passiveClosure.requestedAt.toISOString(),
+        },
+      });
+      await logActivity(db, {
+        orgId: passiveClosure.issue.orgId,
+        actorType: "system",
+        actorId: "issue_closure_governance",
+        action: "issue.passive_followup_queued",
+        entityType: "issue",
+        entityId: passiveClosure.issue.id,
+        agentId: run.agentId,
+        runId: run.id,
+        details: {
+          issueId: passiveClosure.issue.id,
+          issueTitle: passiveClosure.issue.title,
+          followupRunId: passiveClosure.run.id,
+          originRunId: passiveClosure.originRunId,
+          previousRunId: passiveClosure.previousRunId,
+          attempt: passiveClosure.attempt,
+          maxAttempts: ISSUE_PASSIVE_FOLLOWUP_MAX_ATTEMPTS,
+          reason: ISSUE_PASSIVE_FOLLOWUP_FAILURE_REASON,
+          requestedAt: passiveClosure.requestedAt.toISOString(),
+        },
+      });
+    } else if (passiveClosure?.kind === "operator_review") {
+      await appendRunEvent(run, await nextRunEventSeq(run.id), {
+        eventType: "issue.closure_needs_operator_review",
+        stream: "system",
+        level: "warn",
+        message: "Passive issue follow-up stopped and needs operator review",
+        payload: {
+          issueId: passiveClosure.issue.id,
+          originRunId: passiveClosure.originRunId,
+          previousRunId: passiveClosure.previousRunId,
+          attempts: passiveClosure.attempts,
+          maxAttempts: ISSUE_PASSIVE_FOLLOWUP_MAX_ATTEMPTS,
+          reason: passiveClosure.reason,
+        },
+      });
+      await logActivity(db, {
+        orgId: passiveClosure.issue.orgId,
+        actorType: "system",
+        actorId: "issue_closure_governance",
+        action: "issue.closure_needs_operator_review",
+        entityType: "issue",
+        entityId: passiveClosure.issue.id,
+        agentId: run.agentId,
+        runId: run.id,
+        details: {
+          issueId: passiveClosure.issue.id,
+          issueTitle: passiveClosure.issue.title,
+          originRunId: passiveClosure.originRunId,
+          previousRunId: passiveClosure.previousRunId,
+          attempts: passiveClosure.attempts,
+          maxAttempts: ISSUE_PASSIVE_FOLLOWUP_MAX_ATTEMPTS,
+          reason: passiveClosure.reason,
+        },
+      });
+    }
+
+    const promotedRun = outcome.promotedRun;
     if (!promotedRun) return;
 
     publishLiveEvent({

--- a/tests/e2e/issue-passive-followup.spec.ts
+++ b/tests/e2e/issue-passive-followup.spec.ts
@@ -1,0 +1,130 @@
+import { expect, test, type Page } from "@playwright/test";
+import { randomUUID } from "node:crypto";
+import { activityLog, createDb, heartbeatRuns } from "../../packages/db/src/index.ts";
+import { E2E_DATABASE_URL } from "./support/e2e-env";
+
+const e2eDb = createDb(E2E_DATABASE_URL);
+
+async function createOrganization(page: Page) {
+  const orgRes = await page.request.post("/api/orgs", {
+    data: { name: `Passive-Followup-${Date.now()}` },
+  });
+  expect(orgRes.ok()).toBe(true);
+  return orgRes.json();
+}
+
+test("surfaces passive issue follow-up lineage on issue and run detail", async ({ page }) => {
+  await page.goto("/");
+
+  const organization = await createOrganization(page);
+  const agentRes = await page.request.post(`/api/orgs/${organization.id}/agents`, {
+    data: {
+      name: "Closeout Runner",
+      role: "engineer",
+      agentRuntimeType: "process",
+      agentRuntimeConfig: {
+        command: process.execPath,
+        args: ["-e", "process.exit(0)"],
+      },
+    },
+  });
+  expect(agentRes.ok()).toBe(true);
+  const agent = await agentRes.json();
+
+  const issueRes = await page.request.post(`/api/orgs/${organization.id}/issues`, {
+    data: {
+      title: "Needs passive closeout",
+      description: "The run finished without a close-out signal.",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId: agent.id,
+    },
+  });
+  expect(issueRes.ok()).toBe(true);
+  const issue = await issueRes.json();
+
+  const originRunId = randomUUID();
+  const followupRunId = randomUUID();
+  const startedAt = new Date("2026-04-24T08:00:00.000Z");
+  const finishedAt = new Date("2026-04-24T08:01:00.000Z");
+  const queuedAt = new Date("2026-04-24T08:02:00.000Z");
+
+  await e2eDb.insert(heartbeatRuns).values([
+    {
+      id: originRunId,
+      orgId: organization.id,
+      agentId: agent.id,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "succeeded",
+      startedAt,
+      finishedAt,
+      contextSnapshot: {
+        issueId: issue.id,
+        issue: { id: issue.id, title: issue.title, status: issue.status, priority: issue.priority },
+      },
+      createdAt: startedAt,
+      updatedAt: finishedAt,
+    },
+    {
+      id: followupRunId,
+      orgId: organization.id,
+      agentId: agent.id,
+      invocationSource: "automation",
+      triggerDetail: "system",
+      status: "queued",
+      contextSnapshot: {
+        issueId: issue.id,
+        taskId: issue.id,
+        taskKey: issue.id,
+        wakeReason: "issue_passive_followup",
+        wakeSource: "passive_issue_followup",
+        issue: { id: issue.id, title: issue.title, status: issue.status, priority: issue.priority },
+        passiveFollowup: {
+          originRunId,
+          previousRunId: originRunId,
+          attempt: 1,
+          maxAttempts: 2,
+          reason: "missing_closure",
+          queuedAt: queuedAt.toISOString(),
+        },
+      },
+      createdAt: queuedAt,
+      updatedAt: queuedAt,
+    },
+  ]);
+
+  await e2eDb.insert(activityLog).values({
+    orgId: organization.id,
+    actorType: "system",
+    actorId: "issue_closure_governance",
+    action: "issue.passive_followup_queued",
+    entityType: "issue",
+    entityId: issue.id,
+    agentId: agent.id,
+    runId: originRunId,
+    details: {
+      issueId: issue.id,
+      issueTitle: issue.title,
+      followupRunId,
+      originRunId,
+      previousRunId: originRunId,
+      attempt: 1,
+      maxAttempts: 2,
+      reason: "missing_closure",
+      requestedAt: queuedAt.toISOString(),
+    },
+    createdAt: queuedAt,
+  });
+
+  await page.goto(`/issues/${issue.identifier ?? issue.id}`);
+  await expect(page.getByText("Passive follow-up 1/2")).toBeVisible();
+
+  await page.getByRole("tab", { name: "Activity" }).click();
+  await expect(page.getByText(`queued passive follow-up (1/2) as run ${followupRunId.slice(0, 8)}`)).toBeVisible();
+
+  await page.goto(`/agents/${agent.id}/runs/${followupRunId}`);
+  await expect(page.getByText("Passive follow-up", { exact: true })).toBeVisible();
+  await expect(page.getByText("attempt 1/2")).toBeVisible();
+  await expect(page.getByRole("link", { name: originRunId }).first()).toBeVisible();
+});

--- a/ui/src/api/activity.ts
+++ b/ui/src/api/activity.ts
@@ -9,6 +9,8 @@ export interface RunForIssue {
   finishedAt: string | null;
   createdAt: string;
   invocationSource: string;
+  triggerDetail: string | null;
+  contextSnapshot: Record<string, unknown> | null;
   usageJson: Record<string, unknown> | null;
   resultJson: Record<string, unknown> | null;
 }

--- a/ui/src/components/CommentThread.tsx
+++ b/ui/src/components/CommentThread.tsx
@@ -28,6 +28,9 @@ interface LinkedRunItem {
   agentId: string;
   createdAt: Date | string;
   startedAt: Date | string | null;
+  invocationSource?: string;
+  triggerDetail?: string | null;
+  contextSnapshot?: Record<string, unknown> | null;
 }
 
 interface CommentReassignment {
@@ -87,6 +90,20 @@ function clearDraft(draftKey: string) {
   } catch {
     // Ignore localStorage failures.
   }
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function passiveFollowupLabel(contextSnapshot: Record<string, unknown> | null | undefined) {
+  const passive = asRecord(asRecord(contextSnapshot)?.passiveFollowup);
+  const attempt = typeof passive?.attempt === "number" ? passive.attempt : null;
+  const maxAttempts = typeof passive?.maxAttempts === "number" ? passive.maxAttempts : null;
+  if (!passive) return null;
+  return attempt && maxAttempts ? `Passive follow-up ${attempt}/${maxAttempts}` : "Passive follow-up";
 }
 
 function parseReassignment(target: string): CommentReassignment | null {
@@ -156,6 +173,7 @@ const TimelineList = memo(function TimelineList({
           const isActive = run.status === "queued" || run.status === "running";
           const transcript = runTranscriptById.get(run.runId) ?? [];
           const hasOutput = runHasOutput(run.runId);
+          const passiveLabel = passiveFollowupLabel(run.contextSnapshot);
           return (
             <div key={`run:${run.runId}`} className="overflow-hidden rounded-sm border border-border bg-accent/20 p-3">
               <div className="mb-3 flex items-start justify-between gap-3">
@@ -180,6 +198,11 @@ const TimelineList = memo(function TimelineList({
                   {run.runId.slice(0, 8)}
                 </Link>
                 <StatusBadge status={run.status} />
+                {passiveLabel && (
+                  <span className="rounded-md border border-amber-500/30 bg-amber-500/10 px-2 py-1 text-[11px] font-medium text-amber-700 dark:text-amber-300">
+                    {passiveLabel}
+                  </span>
+                )}
               </div>
               <div className="max-h-56 overflow-y-auto pr-1">
                 <RunTranscriptView

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -4003,6 +4003,13 @@ function RunDetail({ run: initialRun, agentRouteId, agentRuntimeType }: { run: H
   const recoveryFailureSummary = asNonEmptyString(recoveryContext?.failureSummary);
   const recoveryTrigger = asNonEmptyString(recoveryContext?.recoveryTrigger);
   const recoveryMode = asNonEmptyString(recoveryContext?.recoveryMode);
+  const passiveFollowupContext = asRecord(asRecord(run.contextSnapshot)?.passiveFollowup);
+  const passiveFollowupOriginRunId = asNonEmptyString(passiveFollowupContext?.originRunId);
+  const passiveFollowupPreviousRunId = asNonEmptyString(passiveFollowupContext?.previousRunId);
+  const passiveFollowupReason = asNonEmptyString(passiveFollowupContext?.reason);
+  const passiveFollowupAttempt = typeof passiveFollowupContext?.attempt === "number" ? passiveFollowupContext.attempt : null;
+  const passiveFollowupMaxAttempts =
+    typeof passiveFollowupContext?.maxAttempts === "number" ? passiveFollowupContext.maxAttempts : null;
 
   return (
     <div className="space-y-4 min-w-0">
@@ -4148,6 +4155,35 @@ function RunDetail({ run: initialRun, agentRouteId, agentRuntimeType }: { run: H
                 {(recoveryFailureKind || recoveryFailureSummary) && (
                   <div className="text-muted-foreground">
                     {[recoveryFailureKind, recoveryFailureSummary].filter(Boolean).join(": ")}
+                  </div>
+                )}
+              </div>
+            )}
+            {passiveFollowupOriginRunId && (
+              <div className="rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs space-y-1">
+                <div className="font-medium text-foreground">Passive follow-up</div>
+                <div className="text-muted-foreground">
+                  Origin run{" "}
+                  <Link className="underline underline-offset-2" to={`/agents/${run.agentId}/runs/${passiveFollowupOriginRunId}`}>
+                    {passiveFollowupOriginRunId}
+                  </Link>
+                </div>
+                {passiveFollowupPreviousRunId && (
+                  <div className="text-muted-foreground">
+                    Previous run{" "}
+                    <Link className="underline underline-offset-2" to={`/agents/${run.agentId}/runs/${passiveFollowupPreviousRunId}`}>
+                      {passiveFollowupPreviousRunId}
+                    </Link>
+                  </div>
+                )}
+                {(passiveFollowupAttempt || passiveFollowupReason) && (
+                  <div className="text-muted-foreground">
+                    {[
+                      passiveFollowupAttempt && passiveFollowupMaxAttempts
+                        ? `attempt ${passiveFollowupAttempt}/${passiveFollowupMaxAttempts}`
+                        : null,
+                      passiveFollowupReason,
+                    ].filter(Boolean).join(" · ")}
                   </div>
                 )}
               </div>

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -73,6 +73,8 @@ const ACTION_LABELS: Record<string, string> = {
   "issue.checked_out": "checked out the issue",
   "issue.released": "released the issue",
   "issue.comment_added": "added a comment",
+  "issue.passive_followup_queued": "queued passive follow-up",
+  "issue.closure_needs_operator_review": "needs operator review for close-out",
   "issue.attachment_added": "added an attachment",
   "issue.attachment_removed": "removed an attachment",
   "issue.document_created": "created a document",
@@ -199,6 +201,19 @@ function formatAction(action: string, details?: Record<string, unknown> | null):
     const key = typeof details.key === "string" ? details.key : "document";
     const title = typeof details.title === "string" && details.title ? ` (${details.title})` : "";
     return `${ACTION_LABELS[action] ?? action} ${key}${title}`;
+  }
+  if (action === "issue.passive_followup_queued" && details) {
+    const attempt = typeof details.attempt === "number" ? details.attempt : null;
+    const maxAttempts = typeof details.maxAttempts === "number" ? details.maxAttempts : null;
+    const followupRunId = typeof details.followupRunId === "string" ? details.followupRunId : null;
+    const attemptLabel = attempt && maxAttempts ? ` (${attempt}/${maxAttempts})` : "";
+    return `queued passive follow-up${attemptLabel}${followupRunId ? ` as run ${followupRunId.slice(0, 8)}` : ""}`;
+  }
+  if (action === "issue.closure_needs_operator_review" && details) {
+    const attempts = typeof details.attempts === "number" ? details.attempts : null;
+    return attempts
+      ? `stopped passive follow-up after ${attempts} attempts; operator review needed`
+      : "stopped passive follow-up; operator review needed";
   }
   return ACTION_LABELS[action] ?? action.replace(/[._]/g, " ");
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,15 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    projects: ["packages/db", "packages/shared", "packages/agent-runtimes/opencode-local", "server", "ui", "cli", "desktop"],
+    projects: [
+      "packages/db",
+      "packages/shared",
+      "packages/agent-runtime-utils",
+      "packages/agent-runtimes/opencode-local",
+      "server",
+      "ui",
+      "cli",
+      "desktop",
+    ],
   },
 });


### PR DESCRIPTION
## Summary

- Add passive close-out governance for successful issue-backed heartbeat runs that exit without a close-out signal.
- Queue bounded same-agent `issue_passive_followup` runs with cooldowns and operator-review escalation after max attempts.
- Surface passive follow-up lineage in prompts, shared run context, issue timeline, run detail, activity text, docs, and bundled Rudder skill guidance.

## Validation

- `git diff --check`
- `pnpm exec vitest run packages/agent-runtime-utils/src/server-utils.test.ts server/src/__tests__/heartbeat-passive-issue-closeout.test.ts --maxWorkers=1 --minWorkers=1`
- `pnpm -r typecheck`
- `pnpm build`
- `pnpm exec playwright test --config tests/e2e/playwright.config.ts tests/e2e/issue-passive-followup.spec.ts --list`

Note: the actual Playwright E2E run was previously blocked locally by Chromium launch timeout before the test body executed; the new E2E spec was added and verified with `--list`.