### PR TITLE
fix: add agent sidebar row actions

### DIFF
--- a/doc/plans/2026-04-26-agent-row-actions.md
+++ b/doc/plans/2026-04-26-agent-row-actions.md
@@ -12,6 +12,8 @@ related_plans:
   - 2026-04-22-agent-dashboard-skills-analytics.md
 supersedes: []
 related_code:
+  - ui/src/components/AgentActionsMenu.tsx
+  - ui/src/components/ThreeColumnContextSidebar.tsx
   - ui/src/pages/Agents.tsx
   - ui/src/api/chats.ts
   - tests/e2e/agents-row-actions.spec.ts
@@ -49,31 +51,37 @@ should stay quiet until row hover/focus or menu-open state.
   pause/resume, and copy name.
 - Mutating actions invalidate agent and heartbeat data and report errors through
   toast feedback.
-- The same action affordance works in list and org-tree views.
-- E2E coverage proves the main menu workflows from the Agents page.
+- The same action affordance works in list, org-tree, and agent detail sidebar
+  views.
+- E2E coverage proves the main menu workflows from the Agents page and the
+  agent detail sidebar entrypoint.
 
 ## Implementation
 
-1. Add an `AgentRowActionsMenu` inside `ui/src/pages/Agents.tsx`.
+1. Add a shared `AgentActionsMenu` component used by agent rows across
+   surfaces.
 2. Reuse existing APIs: `openNewIssue({ assigneeAgentId })`,
    `chatsApi.create({ preferredAgentId, contextLinks })`, `agentsApi.invoke`,
    `agentsApi.pause`, `agentsApi.resume`, and clipboard copy.
 3. Stop row navigation from firing when the action trigger or menu items are
    used.
-4. Add focused E2E coverage for menu visibility and key actions.
-5. Verify with targeted E2E, typecheck, and build where feasible.
+4. Add the shared menu to the detail-page Agents sidebar row used by the desktop
+   three-column shell.
+5. Add focused E2E coverage for menu visibility and key actions.
+6. Verify with targeted E2E, typecheck, and build where feasible.
 
 ## Verification
 
 - `pnpm --filter @rudderhq/ui typecheck`
 - `pnpm -r typecheck`
 - `pnpm build`
+- `pnpm --filter @rudderhq/ui exec vitest run src/components/ThreeColumnContextSidebar.test.tsx`
 - `pnpm test:e2e tests/e2e/agents-row-actions.spec.ts` was attempted, but
   Playwright timed out launching `chrome-headless-shell` before the test body
   executed.
 - Direct browser verification through the available browser MCP tools was also
-  attempted against `http://127.0.0.1:3100`, but both Playwright MCP and Chrome
-  MCP navigation timed out before page interaction.
+  attempted against `http://127.0.0.1:3100`, but Chrome MCP navigation timed out
+  before page interaction.
 - `pnpm test:run` was attempted and failed in unrelated pre-existing areas:
   PrimaryRail active-index expectation, company import/export skill duplication,
   agent avatar upload status expectation, issue reopen mock expectation, and

--- a/tests/e2e/agents-row-actions.spec.ts
+++ b/tests/e2e/agents-row-actions.spec.ts
@@ -47,6 +47,22 @@ test.describe("Agents row actions", () => {
     await expect(page.getByRole("menuitem", { name: "Pause agent" })).toBeVisible();
     await expect(page.getByRole("menuitem", { name: "Copy agent name" })).toBeVisible();
 
+    await page.goto(`${E2E_BASE_URL}/${organization.issuePrefix}/agents/${agent.id}/dashboard`);
+    const sidebarRow = page.getByTestId(`agent-sidebar-row-${agent.id}`);
+    const sidebarActions = page.getByTestId(`agent-sidebar-actions-${agent.id}`);
+    await expect(sidebarRow).toContainText("Row Action Agent");
+    await sidebarRow.hover();
+    await sidebarActions.click();
+    await expect(page.getByRole("menuitem", { name: "Create task" })).toBeVisible();
+    await expect(page.getByRole("menuitem", { name: "Chat with agent" })).toBeVisible();
+    await expect(page.getByRole("menuitem", { name: "Run heartbeat" })).toBeVisible();
+    await expect(page.getByRole("menuitem", { name: "Pause agent" })).toBeVisible();
+    await expect(page.getByRole("menuitem", { name: "Copy agent name" })).toBeVisible();
+    await page.keyboard.press("Escape");
+
+    await page.goto(`${E2E_BASE_URL}/${organization.issuePrefix}/agents/all`);
+    await row.hover();
+    await actions.click();
     await page.getByRole("menuitem", { name: "Create task" }).click();
     await expect(page.getByText("New issue", { exact: true })).toBeVisible();
     await expect(page.getByRole("button", { name: "Row Action Agent (Founding Engineer)" })).toBeVisible();

--- a/ui/src/components/AgentActionsMenu.tsx
+++ b/ui/src/components/AgentActionsMenu.tsx
@@ -1,0 +1,190 @@
+import { useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { Copy, HeartPulse, Loader2, MessageSquare, MoreHorizontal, Pause, Play, Plus } from "lucide-react";
+import type { Agent } from "@rudderhq/shared";
+import { agentsApi } from "@/api/agents";
+import { chatsApi } from "@/api/chats";
+import { useDialog } from "@/context/DialogContext";
+import { useToast } from "@/context/ToastContext";
+import { useNavigate } from "@/lib/router";
+import { queryKeys } from "@/lib/queryKeys";
+import { agentRouteRef, cn } from "@/lib/utils";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+export function AgentActionsMenu({
+  agent,
+  orgId,
+  triggerTestId,
+  triggerClassName,
+  visibilityClassName,
+  onActionComplete,
+}: {
+  agent: Agent;
+  orgId: string;
+  triggerTestId?: string;
+  triggerClassName?: string;
+  visibilityClassName?: string;
+  onActionComplete?: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const queryClient = useQueryClient();
+  const navigate = useNavigate();
+  const { openNewIssue } = useDialog();
+  const { pushToast } = useToast();
+  const isTerminated = agent.status === "terminated";
+  const isPaused = agent.status === "paused";
+
+  const invalidateAgentData = async () => {
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: queryKeys.agents.list(orgId) }),
+      queryClient.invalidateQueries({ queryKey: queryKeys.org(orgId) }),
+      queryClient.invalidateQueries({ queryKey: queryKeys.heartbeats(orgId) }),
+      queryClient.invalidateQueries({ queryKey: queryKeys.liveRuns(orgId) }),
+    ]);
+  };
+
+  const chatMutation = useMutation({
+    mutationFn: () =>
+      chatsApi.create(orgId, {
+        title: `Chat with ${agent.name}`,
+        preferredAgentId: agent.id,
+        contextLinks: [{ entityType: "agent", entityId: agent.id }],
+      }),
+    onSuccess: async (conversation) => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: queryKeys.chats.list(orgId) }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.messenger.threads(orgId) }),
+      ]);
+      onActionComplete?.();
+      navigate(`/messenger/chat/${conversation.id}`);
+    },
+    onError: (error) => {
+      pushToast({
+        title: "Failed to open chat",
+        body: error instanceof Error ? error.message : undefined,
+        tone: "error",
+      });
+    },
+  });
+
+  const heartbeatMutation = useMutation({
+    mutationFn: () => agentsApi.invoke(agent.id, orgId),
+    onSuccess: async (run) => {
+      await invalidateAgentData();
+      onActionComplete?.();
+      pushToast({
+        title: "Heartbeat started",
+        tone: "success",
+        action: {
+          label: "Open run",
+          href: `/agents/${agentRouteRef(agent)}/runs/${run.id}`,
+        },
+      });
+    },
+    onError: (error) => {
+      pushToast({
+        title: "Failed to run heartbeat",
+        body: error instanceof Error ? error.message : undefined,
+        tone: "error",
+      });
+    },
+  });
+
+  const pauseResumeMutation = useMutation({
+    mutationFn: () => isPaused ? agentsApi.resume(agent.id, orgId) : agentsApi.pause(agent.id, orgId),
+    onSuccess: async () => {
+      await invalidateAgentData();
+      onActionComplete?.();
+      pushToast({
+        title: isPaused ? "Agent resumed" : "Agent paused",
+        tone: "success",
+      });
+    },
+    onError: (error) => {
+      pushToast({
+        title: isPaused ? "Failed to resume agent" : "Failed to pause agent",
+        body: error instanceof Error ? error.message : undefined,
+        tone: "error",
+      });
+    },
+  });
+
+  const handleCreateTask = () => {
+    openNewIssue({ assigneeAgentId: agent.id });
+    onActionComplete?.();
+  };
+
+  const handleCopyName = async () => {
+    try {
+      await navigator.clipboard.writeText(agent.name);
+      onActionComplete?.();
+      pushToast({ title: "Copied agent name", tone: "success" });
+    } catch (error) {
+      pushToast({
+        title: "Failed to copy agent name",
+        body: error instanceof Error ? error.message : undefined,
+        tone: "error",
+      });
+    }
+  };
+
+  const isBusy = chatMutation.isPending || heartbeatMutation.isPending || pauseResumeMutation.isPending;
+
+  return (
+    <DropdownMenu open={open} onOpenChange={setOpen}>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          aria-label={`More actions for ${agent.name}`}
+          data-testid={triggerTestId ?? `agent-row-actions-${agent.id}`}
+          className={cn(
+            "flex h-7 w-7 shrink-0 items-center justify-center rounded-[calc(var(--radius-sm)-1px)] text-muted-foreground transition-[background-color,color,opacity] hover:bg-accent hover:text-foreground focus-visible:bg-accent focus-visible:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+            open || isBusy
+              ? "opacity-100"
+              : visibilityClassName ?? "opacity-100 md:opacity-0 md:group-hover/agent-row:opacity-100 md:group-focus-within/agent-row:opacity-100",
+            triggerClassName,
+          )}
+          onClick={(event) => {
+            event.preventDefault();
+            event.stopPropagation();
+          }}
+        >
+          {isBusy ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <MoreHorizontal className="h-3.5 w-3.5" />}
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="surface-overlay w-48 text-foreground">
+        <DropdownMenuItem onSelect={handleCreateTask}>
+          <Plus className="h-4 w-4" />
+          Create task
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={() => chatMutation.mutate()} disabled={chatMutation.isPending || isTerminated}>
+          <MessageSquare className="h-4 w-4" />
+          Chat with agent
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onSelect={() => heartbeatMutation.mutate()} disabled={heartbeatMutation.isPending || isTerminated}>
+          <HeartPulse className="h-4 w-4" />
+          Run heartbeat
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          onSelect={() => pauseResumeMutation.mutate()}
+          disabled={pauseResumeMutation.isPending || isTerminated}
+        >
+          {isPaused ? <Play className="h-4 w-4" /> : <Pause className="h-4 w-4" />}
+          {isPaused ? "Resume agent" : "Pause agent"}
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onSelect={() => void handleCopyName()}>
+          <Copy className="h-4 w-4" />
+          Copy agent name
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/ui/src/components/ThreeColumnContextSidebar.test.tsx
+++ b/ui/src/components/ThreeColumnContextSidebar.test.tsx
@@ -18,12 +18,41 @@ const mockState = vi.hoisted(() => ({
   setSidebarOpen: vi.fn(),
   pathname: "/RUD/issues",
   search: "",
+  relativePath: "/issues",
 }));
+
+const sidebarAgent = {
+  id: "agent-1",
+  orgId: "org-1",
+  name: "Penelope",
+  urlKey: "penelope",
+  role: "ceo",
+  title: "CEO",
+  icon: null,
+  status: "idle",
+  reportsTo: null,
+  capabilities: null,
+  agentRuntimeType: "codex_local",
+  agentRuntimeConfig: {},
+  runtimeConfig: {},
+  budgetMonthlyCents: 0,
+  spentMonthlyCents: 0,
+  pauseReason: null,
+  pausedAt: null,
+  permissions: { canCreateAgents: true, canAssignTasks: true },
+  lastHeartbeatAt: null,
+  metadata: null,
+  createdAt: new Date("2026-04-26T10:00:00.000Z"),
+  updatedAt: new Date("2026-04-26T10:00:00.000Z"),
+};
 
 vi.mock("@tanstack/react-query", () => ({
   useQuery: ({ queryKey }: { queryKey: readonly unknown[] }) => {
     if (queryKey[0] === "auth") {
       return { data: { user: { id: "user-1" } }, isLoading: false, error: null };
+    }
+    if (queryKey[0] === "agents" && queryKey[1] === "org-1") {
+      return { data: [sidebarAgent], isLoading: false, error: null };
     }
     return { data: [], isLoading: false, error: null };
   },
@@ -52,7 +81,7 @@ vi.mock("@/lib/router", () => ({
 }));
 
 vi.mock("@/lib/organization-routes", () => ({
-  toOrganizationRelativePath: () => "/issues",
+  toOrganizationRelativePath: () => mockState.relativePath,
 }));
 
 vi.mock("@/context/OrganizationContext", () => ({
@@ -115,6 +144,7 @@ vi.mock("@/components/ui/dropdown-menu", () => ({
       {children}
     </div>
   ),
+  DropdownMenuSeparator: () => <hr />,
   DropdownMenuTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
 }));
 
@@ -127,6 +157,9 @@ beforeEach(() => {
   mockState.openNewIssue.mockReset();
   mockState.pushToast.mockReset();
   mockState.setSidebarOpen.mockReset();
+  mockState.pathname = "/RUD/issues";
+  mockState.search = "";
+  mockState.relativePath = "/issues";
   vi.stubGlobal("confirm", mockState.confirm);
 });
 
@@ -141,6 +174,17 @@ afterEach(() => {
   document.body.innerHTML = "";
   vi.unstubAllGlobals();
 });
+
+function renderSidebar() {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  cleanupFn = () => root.unmount();
+
+  act(() => {
+    root.render(<ThreeColumnContextSidebar />);
+  });
+}
 
 describe("ThreeColumnContextSidebar issue draft recovery", () => {
   const savedDraft = {
@@ -192,17 +236,6 @@ describe("ThreeColumnContextSidebar issue draft recovery", () => {
 
     expect(document.querySelector("[data-testid='issue-draft-sidebar-entry']")).toBeNull();
   });
-
-  function renderSidebar() {
-    const container = document.createElement("div");
-    document.body.appendChild(container);
-    const root = createRoot(container);
-    cleanupFn = () => root.unmount();
-
-    act(() => {
-      root.render(<ThreeColumnContextSidebar />);
-    });
-  }
 
   it("opens a single saved draft issue directly from the issues sidebar", () => {
     window.localStorage.setItem(ISSUE_DRAFTS_STORAGE_KEY, JSON.stringify([savedDraft]));
@@ -303,5 +336,25 @@ describe("ThreeColumnContextSidebar issue draft recovery", () => {
     expect(storedDrafts.map((draft) => draft.id)).toEqual(["draft-1"]);
     expect(document.querySelector("[data-testid='issue-draft-sidebar-entry']")).not.toBeNull();
     expect(mockState.pushToast).not.toHaveBeenCalled();
+  });
+});
+
+describe("ThreeColumnContextSidebar agent actions", () => {
+  it("shows the agent row action menu in the agent detail sidebar", () => {
+    mockState.pathname = "/RUD/agents/penelope/dashboard";
+    mockState.relativePath = "/agents/penelope/dashboard";
+
+    renderSidebar();
+
+    const row = document.querySelector("[data-testid='agent-sidebar-row-agent-1']") as HTMLElement | null;
+    expect(row?.textContent).toContain("Penelope (CEO)");
+
+    const actions = document.querySelector("[data-testid='agent-sidebar-actions-agent-1']") as HTMLButtonElement | null;
+    expect(actions?.getAttribute("aria-label")).toBe("More actions for Penelope");
+    expect(document.body.textContent).toContain("Create task");
+    expect(document.body.textContent).toContain("Chat with agent");
+    expect(document.body.textContent).toContain("Run heartbeat");
+    expect(document.body.textContent).toContain("Pause agent");
+    expect(document.body.textContent).toContain("Copy agent name");
   });
 });

--- a/ui/src/components/ThreeColumnContextSidebar.tsx
+++ b/ui/src/components/ThreeColumnContextSidebar.tsx
@@ -46,6 +46,7 @@ import {
   summarizeIssueDrafts,
 } from "@/lib/new-issue-dialog";
 import { AgentIcon } from "@/components/AgentIconPicker";
+import { AgentActionsMenu } from "@/components/AgentActionsMenu";
 import { MessengerContextSidebar } from "@/components/MessengerContextSidebar";
 import {
   DropdownMenu,
@@ -998,23 +999,36 @@ export function ThreeColumnContextSidebar() {
           const liveCount = liveCountByAgent.get(agent.id) ?? 0;
           const active = activeAgentRef === agent.urlKey || activeAgentRef === agent.id;
           return (
-            <Link
+            <div
               key={agent.id}
-              to={agentUrl(agent)}
-              onClick={closeMobileSidebar}
+              data-testid={`agent-sidebar-row-${agent.id}`}
               className={cn(
-                "relative z-10 mx-1.5 flex min-h-[var(--motion-context-item-height)] items-center gap-3 rounded-[calc(var(--radius-sm)-1px)] px-3.5 py-2.5 text-sm transition-colors",
+                "group/agent-sidebar-row relative z-10 mx-1.5 flex min-h-[var(--motion-context-item-height)] items-center rounded-[calc(var(--radius-sm)-1px)] text-sm transition-colors",
                 active
                   ? "font-medium text-foreground"
                   : "text-foreground/80 hover:bg-[color:color-mix(in_oklab,var(--surface-active)_54%,transparent)]",
               )}
             >
-              <AgentIcon icon={agent.icon} className="h-4 w-4 shrink-0 text-muted-foreground" />
-              <span className="flex-1 truncate" title={formatSidebarAgentLabel(agent)}>
-                {formatSidebarAgentLabel(agent)}
-              </span>
-              {liveCount > 0 ? <SidebarLiveCount count={liveCount} /> : null}
-            </Link>
+              <Link
+                to={agentUrl(agent)}
+                onClick={closeMobileSidebar}
+                className="flex min-w-0 flex-1 items-center gap-3 self-stretch py-2.5 pl-3.5 pr-1 no-underline text-inherit"
+              >
+                <AgentIcon icon={agent.icon} className="h-4 w-4 shrink-0 text-muted-foreground" />
+                <span className="flex-1 truncate" title={formatSidebarAgentLabel(agent)}>
+                  {formatSidebarAgentLabel(agent)}
+                </span>
+                {liveCount > 0 ? <SidebarLiveCount count={liveCount} /> : null}
+              </Link>
+              <AgentActionsMenu
+                agent={agent}
+                orgId={selectedOrganizationId ?? agent.orgId}
+                triggerTestId={`agent-sidebar-actions-${agent.id}`}
+                triggerClassName="mr-2 h-6 w-6"
+                visibilityClassName="opacity-100 md:opacity-0 md:group-hover/agent-sidebar-row:opacity-100 md:group-focus-within/agent-sidebar-row:opacity-100"
+                onActionComplete={closeMobileSidebar}
+              />
+            </div>
           );
         })}
       </SlidingContextNav>

--- a/ui/src/pages/Agents.tsx
+++ b/ui/src/pages/Agents.tsx
@@ -1,14 +1,12 @@
 import { useState, useEffect, useMemo } from "react";
 import { Link, useNavigate, useLocation } from "@/lib/router";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { agentsApi, type OrgNode } from "../api/agents";
-import { chatsApi } from "../api/chats";
 import { heartbeatsApi } from "../api/heartbeats";
 import { useOrganization } from "../context/OrganizationContext";
 import { useDialog } from "../context/DialogContext";
 import { useBreadcrumbs } from "../context/BreadcrumbContext";
 import { useSidebar } from "../context/SidebarContext";
-import { useToast } from "../context/ToastContext";
 import { queryKeys } from "../lib/queryKeys";
 import { StatusBadge } from "../components/StatusBadge";
 import { agentStatusDot, agentStatusDotDefault } from "../lib/status-colors";
@@ -17,27 +15,8 @@ import { PageSkeleton } from "../components/PageSkeleton";
 import { relativeTime, cn, agentRouteRef, agentUrl } from "../lib/utils";
 import { PageTabBar } from "../components/PageTabBar";
 import { Tabs } from "@/components/ui/tabs";
-import {
-  Bot,
-  Copy,
-  GitBranch,
-  HeartPulse,
-  List,
-  Loader2,
-  MessageSquare,
-  MoreHorizontal,
-  Pause,
-  Play,
-  Plus,
-  SlidersHorizontal,
-} from "lucide-react";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
+import { Bot, GitBranch, List, SlidersHorizontal } from "lucide-react";
+import { AgentActionsMenu } from "@/components/AgentActionsMenu";
 import { AGENT_ROLE_LABELS, type Agent } from "@rudderhq/shared";
 
 const adapterLabels: Record<string, string> = {
@@ -84,13 +63,11 @@ function filterOrgTree(nodes: OrgNode[], tab: FilterTab, showTerminated: boolean
 
 export function Agents() {
   const { selectedOrganizationId } = useOrganization();
-  const { openNewAgent, openNewIssue } = useDialog();
+  const { openNewAgent } = useDialog();
   const { setBreadcrumbs } = useBreadcrumbs();
   const navigate = useNavigate();
   const location = useLocation();
   const { isMobile } = useSidebar();
-  const queryClient = useQueryClient();
-  const { pushToast } = useToast();
   const pathSegment = location.pathname.split("/").pop() ?? "all";
   const tab: FilterTab = (pathSegment === "all" || pathSegment === "active" || pathSegment === "paused" || pathSegment === "error") ? pathSegment : "all";
   const [view, setView] = useState<"list" | "org">("org");
@@ -251,10 +228,6 @@ export function Agents() {
                 agent={agent}
                 liveRun={liveRunByAgent.get(agent.id) ?? null}
                 orgId={selectedOrganizationId}
-                onCreateTask={() => openNewIssue({ assigneeAgentId: agent.id })}
-                queryClient={queryClient}
-                navigate={navigate}
-                pushToast={pushToast}
               />
             );
           })}
@@ -278,10 +251,6 @@ export function Agents() {
               agentMap={agentMap}
               liveRunByAgent={liveRunByAgent}
               orgId={selectedOrganizationId}
-              onCreateTask={(agentId) => openNewIssue({ assigneeAgentId: agentId })}
-              queryClient={queryClient}
-              navigate={navigate}
-              pushToast={pushToast}
             />
           ))}
         </div>
@@ -306,18 +275,10 @@ function AgentListRow({
   agent,
   liveRun,
   orgId,
-  onCreateTask,
-  queryClient,
-  navigate,
-  pushToast,
 }: {
   agent: Agent;
   liveRun: { runId: string; liveCount: number } | null;
   orgId: string;
-  onCreateTask: () => void;
-  queryClient: ReturnType<typeof useQueryClient>;
-  navigate: ReturnType<typeof useNavigate>;
-  pushToast: ReturnType<typeof useToast>["pushToast"];
 }) {
   return (
     <div
@@ -344,13 +305,9 @@ function AgentListRow({
         </div>
       </Link>
       <AgentRowMetadata agent={agent} liveRun={liveRun} />
-      <AgentRowActionsMenu
+      <AgentActionsMenu
         agent={agent}
         orgId={orgId}
-        onCreateTask={onCreateTask}
-        queryClient={queryClient}
-        navigate={navigate}
-        pushToast={pushToast}
       />
     </div>
   );
@@ -398,182 +355,18 @@ function AgentRowMetadata({
   );
 }
 
-function AgentRowActionsMenu({
-  agent,
-  orgId,
-  onCreateTask,
-  queryClient,
-  navigate,
-  pushToast,
-}: {
-  agent: Agent;
-  orgId: string;
-  onCreateTask: () => void;
-  queryClient: ReturnType<typeof useQueryClient>;
-  navigate: ReturnType<typeof useNavigate>;
-  pushToast: ReturnType<typeof useToast>["pushToast"];
-}) {
-  const [open, setOpen] = useState(false);
-  const isTerminated = agent.status === "terminated";
-  const isPaused = agent.status === "paused";
-
-  const invalidateAgentData = async () => {
-    await Promise.all([
-      queryClient.invalidateQueries({ queryKey: queryKeys.agents.list(orgId) }),
-      queryClient.invalidateQueries({ queryKey: queryKeys.org(orgId) }),
-      queryClient.invalidateQueries({ queryKey: queryKeys.heartbeats(orgId) }),
-    ]);
-  };
-
-  const chatMutation = useMutation({
-    mutationFn: () =>
-      chatsApi.create(orgId, {
-        title: `Chat with ${agent.name}`,
-        preferredAgentId: agent.id,
-        contextLinks: [{ entityType: "agent", entityId: agent.id }],
-      }),
-    onSuccess: async (conversation) => {
-      await Promise.all([
-        queryClient.invalidateQueries({ queryKey: queryKeys.chats.list(orgId) }),
-        queryClient.invalidateQueries({ queryKey: queryKeys.messenger.threads(orgId) }),
-      ]);
-      navigate(`/messenger/chat/${conversation.id}`);
-    },
-    onError: (error) => {
-      pushToast({
-        title: "Failed to open chat",
-        body: error instanceof Error ? error.message : undefined,
-        tone: "error",
-      });
-    },
-  });
-
-  const heartbeatMutation = useMutation({
-    mutationFn: () => agentsApi.invoke(agent.id, orgId),
-    onSuccess: async (run) => {
-      await invalidateAgentData();
-      pushToast({
-        title: "Heartbeat started",
-        tone: "success",
-        action: {
-          label: "Open run",
-          href: `/agents/${agentRouteRef(agent)}/runs/${run.id}`,
-        },
-      });
-    },
-    onError: (error) => {
-      pushToast({
-        title: "Failed to run heartbeat",
-        body: error instanceof Error ? error.message : undefined,
-        tone: "error",
-      });
-    },
-  });
-
-  const pauseResumeMutation = useMutation({
-    mutationFn: () => isPaused ? agentsApi.resume(agent.id, orgId) : agentsApi.pause(agent.id, orgId),
-    onSuccess: async () => {
-      await invalidateAgentData();
-      pushToast({
-        title: isPaused ? "Agent resumed" : "Agent paused",
-        tone: "success",
-      });
-    },
-    onError: (error) => {
-      pushToast({
-        title: isPaused ? "Failed to resume agent" : "Failed to pause agent",
-        body: error instanceof Error ? error.message : undefined,
-        tone: "error",
-      });
-    },
-  });
-
-  const handleCopyName = async () => {
-    try {
-      await navigator.clipboard.writeText(agent.name);
-      pushToast({ title: "Copied agent name", tone: "success" });
-    } catch (error) {
-      pushToast({
-        title: "Failed to copy agent name",
-        body: error instanceof Error ? error.message : undefined,
-        tone: "error",
-      });
-    }
-  };
-
-  const isBusy = chatMutation.isPending || heartbeatMutation.isPending || pauseResumeMutation.isPending;
-
-  return (
-    <DropdownMenu open={open} onOpenChange={setOpen}>
-      <DropdownMenuTrigger asChild>
-        <button
-          type="button"
-          aria-label={`More actions for ${agent.name}`}
-          data-testid={`agent-row-actions-${agent.id}`}
-          className={cn(
-            "flex h-7 w-7 shrink-0 items-center justify-center rounded-[calc(var(--radius-sm)-1px)] text-muted-foreground transition-[background-color,color,opacity] hover:bg-accent hover:text-foreground focus-visible:bg-accent focus-visible:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-            open || isBusy
-              ? "opacity-100"
-              : "opacity-100 md:opacity-0 md:group-hover/agent-row:opacity-100 md:group-focus-within/agent-row:opacity-100",
-          )}
-          onClick={(event) => {
-            event.stopPropagation();
-          }}
-        >
-          {isBusy ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <MoreHorizontal className="h-3.5 w-3.5" />}
-        </button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="surface-overlay w-48 text-foreground">
-        <DropdownMenuItem onSelect={onCreateTask}>
-          <Plus className="h-4 w-4" />
-          Create task
-        </DropdownMenuItem>
-        <DropdownMenuItem onSelect={() => chatMutation.mutate()} disabled={chatMutation.isPending || isTerminated}>
-          <MessageSquare className="h-4 w-4" />
-          Chat with agent
-        </DropdownMenuItem>
-        <DropdownMenuSeparator />
-        <DropdownMenuItem onSelect={() => heartbeatMutation.mutate()} disabled={heartbeatMutation.isPending || isTerminated}>
-          <HeartPulse className="h-4 w-4" />
-          Run heartbeat
-        </DropdownMenuItem>
-        <DropdownMenuItem
-          onSelect={() => pauseResumeMutation.mutate()}
-          disabled={pauseResumeMutation.isPending || isTerminated}
-        >
-          {isPaused ? <Play className="h-4 w-4" /> : <Pause className="h-4 w-4" />}
-          {isPaused ? "Resume agent" : "Pause agent"}
-        </DropdownMenuItem>
-        <DropdownMenuSeparator />
-        <DropdownMenuItem onSelect={() => void handleCopyName()}>
-          <Copy className="h-4 w-4" />
-          Copy agent name
-        </DropdownMenuItem>
-      </DropdownMenuContent>
-    </DropdownMenu>
-  );
-}
-
 function OrgTreeNode({
   node,
   depth,
   agentMap,
   liveRunByAgent,
   orgId,
-  onCreateTask,
-  queryClient,
-  navigate,
-  pushToast,
 }: {
   node: OrgNode;
   depth: number;
   agentMap: Map<string, Agent>;
   liveRunByAgent: Map<string, { runId: string; liveCount: number }>;
   orgId: string;
-  onCreateTask: (agentId: string) => void;
-  queryClient: ReturnType<typeof useQueryClient>;
-  navigate: ReturnType<typeof useNavigate>;
-  pushToast: ReturnType<typeof useToast>["pushToast"];
 }) {
   const agent = agentMap.get(node.id);
 
@@ -609,13 +402,9 @@ function OrgTreeNode({
           </span>
         )}
         {agent && (
-          <AgentRowActionsMenu
+          <AgentActionsMenu
             agent={agent}
             orgId={orgId}
-            onCreateTask={() => onCreateTask(agent.id)}
-            queryClient={queryClient}
-            navigate={navigate}
-            pushToast={pushToast}
           />
         )}
       </div>
@@ -629,10 +418,6 @@ function OrgTreeNode({
               agentMap={agentMap}
               liveRunByAgent={liveRunByAgent}
               orgId={orgId}
-              onCreateTask={onCreateTask}
-              queryClient={queryClient}
-              navigate={navigate}
-              pushToast={pushToast}
             />
           ))}
         </div>


### PR DESCRIPTION
## Summary

- Moves the agent row action menu into a shared `AgentActionsMenu` component.
- Adds the same hover/focus more-menu to the agent detail sidebar row shown in the desktop Agents panel.
- Keeps the existing Agents list/org-tree row actions wired through the shared component.
- Extends coverage for the detail sidebar entrypoint and updates the RUD-179 plan notes.

## Validation

- Passed: `pnpm --filter @rudderhq/ui typecheck`
- Passed: `pnpm --filter @rudderhq/ui exec vitest run src/components/ThreeColumnContextSidebar.test.tsx`
- Passed: `pnpm -r typecheck`
- Passed: `pnpm build`
- Attempted: `pnpm test:e2e tests/e2e/agents-row-actions.spec.ts`, but Playwright timed out launching `chrome-headless-shell` before the test body executed.
- Attempted browser verification against `http://127.0.0.1:3100`, but Chrome MCP navigation timed out before interaction.

## Notes

The earlier implementation only covered `/agents/all` list/org-tree rows. The user-reported screenshot is the agent detail sidebar inside `ThreeColumnContextSidebar`, which now has the same row-local action affordance.
