### PR TITLE
fix: open agent chats from composer

### DIFF
--- a/doc/plans/2026-04-26-agent-row-actions.md
+++ b/doc/plans/2026-04-26-agent-row-actions.md
@@ -49,6 +49,8 @@ should stay quiet until row hover/focus or menu-open state.
   is open.
 - Menu actions cover task creation, preferred-agent chat, heartbeat invoke,
   pause/resume, and copy name.
+- Chat entry opens the new chat composer with the agent preselected instead of
+  creating an empty conversation record.
 - Mutating actions invalidate agent and heartbeat data and report errors through
   toast feedback.
 - The same action affordance works in list, org-tree, and agent detail sidebar
@@ -61,8 +63,9 @@ should stay quiet until row hover/focus or menu-open state.
 1. Add a shared `AgentActionsMenu` component used by agent rows across
    surfaces.
 2. Reuse existing APIs: `openNewIssue({ assigneeAgentId })`,
-   `chatsApi.create({ preferredAgentId, contextLinks })`, `agentsApi.invoke`,
-   `agentsApi.pause`, `agentsApi.resume`, and clipboard copy.
+   `navigate({ pathname: "/messenger/chat", search: "?agentId=..." })`,
+   `agentsApi.invoke`, `agentsApi.pause`, `agentsApi.resume`, and clipboard
+   copy.
 3. Stop row navigation from firing when the action trigger or menu items are
    used.
 4. Add the shared menu to the detail-page Agents sidebar row used by the desktop
@@ -76,6 +79,7 @@ should stay quiet until row hover/focus or menu-open state.
 - `pnpm -r typecheck`
 - `pnpm build`
 - `pnpm --filter @rudderhq/ui exec vitest run src/components/ThreeColumnContextSidebar.test.tsx`
+- `pnpm --filter @rudderhq/ui exec vitest run src/components/ThreeColumnContextSidebar.test.tsx src/lib/chat-route-state.test.ts`
 - `pnpm test:e2e tests/e2e/agents-row-actions.spec.ts` was attempted, but
   Playwright timed out launching `chrome-headless-shell` before the test body
   executed.

--- a/tests/e2e/agents-row-actions.spec.ts
+++ b/tests/e2e/agents-row-actions.spec.ts
@@ -72,13 +72,11 @@ test.describe("Agents row actions", () => {
     await row.hover();
     await actions.click();
     await page.getByRole("menuitem", { name: "Chat with agent" }).click();
-    await expect(page).toHaveURL(new RegExp(`/${organization.issuePrefix}/messenger/chat/[^/]+$`));
-    const chatId = new URL(page.url()).pathname.split("/").pop();
-    expect(chatId).toBeTruthy();
-    const chatRes = await page.request.get(`${E2E_BASE_URL}/api/chats/${chatId}`);
-    expect(chatRes.ok()).toBe(true);
-    const chat = (await chatRes.json()) as { preferredAgentId: string | null };
-    expect(chat.preferredAgentId).toBe(agent.id);
+    await expect(page).toHaveURL(new RegExp(`/${organization.issuePrefix}/messenger/chat(?:\\?.*)?$`));
+    await expect
+      .poll(() => page.url())
+      .not.toContain("agentId=");
+    await expect(page.getByRole("button", { name: "Row Action Agent (Founding Engineer)" })).toBeVisible();
 
     await page.goto(`${E2E_BASE_URL}/${organization.issuePrefix}/agents/all`);
     await row.hover();

--- a/ui/src/components/AgentActionsMenu.tsx
+++ b/ui/src/components/AgentActionsMenu.tsx
@@ -3,7 +3,6 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Copy, HeartPulse, Loader2, MessageSquare, MoreHorizontal, Pause, Play, Plus } from "lucide-react";
 import type { Agent } from "@rudderhq/shared";
 import { agentsApi } from "@/api/agents";
-import { chatsApi } from "@/api/chats";
 import { useDialog } from "@/context/DialogContext";
 import { useToast } from "@/context/ToastContext";
 import { useNavigate } from "@/lib/router";
@@ -48,30 +47,6 @@ export function AgentActionsMenu({
       queryClient.invalidateQueries({ queryKey: queryKeys.liveRuns(orgId) }),
     ]);
   };
-
-  const chatMutation = useMutation({
-    mutationFn: () =>
-      chatsApi.create(orgId, {
-        title: `Chat with ${agent.name}`,
-        preferredAgentId: agent.id,
-        contextLinks: [{ entityType: "agent", entityId: agent.id }],
-      }),
-    onSuccess: async (conversation) => {
-      await Promise.all([
-        queryClient.invalidateQueries({ queryKey: queryKeys.chats.list(orgId) }),
-        queryClient.invalidateQueries({ queryKey: queryKeys.messenger.threads(orgId) }),
-      ]);
-      onActionComplete?.();
-      navigate(`/messenger/chat/${conversation.id}`);
-    },
-    onError: (error) => {
-      pushToast({
-        title: "Failed to open chat",
-        body: error instanceof Error ? error.message : undefined,
-        tone: "error",
-      });
-    },
-  });
 
   const heartbeatMutation = useMutation({
     mutationFn: () => agentsApi.invoke(agent.id, orgId),
@@ -120,6 +95,14 @@ export function AgentActionsMenu({
     onActionComplete?.();
   };
 
+  const handleChatWithAgent = () => {
+    onActionComplete?.();
+    navigate({
+      pathname: "/messenger/chat",
+      search: `?agentId=${encodeURIComponent(agent.id)}`,
+    });
+  };
+
   const handleCopyName = async () => {
     try {
       await navigator.clipboard.writeText(agent.name);
@@ -134,7 +117,7 @@ export function AgentActionsMenu({
     }
   };
 
-  const isBusy = chatMutation.isPending || heartbeatMutation.isPending || pauseResumeMutation.isPending;
+  const isBusy = heartbeatMutation.isPending || pauseResumeMutation.isPending;
 
   return (
     <DropdownMenu open={open} onOpenChange={setOpen}>
@@ -163,7 +146,7 @@ export function AgentActionsMenu({
           <Plus className="h-4 w-4" />
           Create task
         </DropdownMenuItem>
-        <DropdownMenuItem onSelect={() => chatMutation.mutate()} disabled={chatMutation.isPending || isTerminated}>
+        <DropdownMenuItem onSelect={handleChatWithAgent} disabled={isTerminated}>
           <MessageSquare className="h-4 w-4" />
           Chat with agent
         </DropdownMenuItem>


### PR DESCRIPTION
## Summary
- Route Agents menu "Chat with agent" to `/messenger/chat?agentId=...` so the new chat composer preselects the agent.
- Stop creating an empty chat thread from the row action.
- Update the row-actions E2E expectation and plan notes for the composer-prefill behavior.

## Validation
- `pnpm --filter @rudderhq/ui typecheck`
- `pnpm --filter @rudderhq/ui exec vitest run src/components/ThreeColumnContextSidebar.test.tsx src/lib/chat-route-state.test.ts`
- `pnpm build`
- `pnpm -r typecheck` attempted; fails in existing `cli/src/__tests__/start.test.ts` `.dmg` type mismatch, outside this change.
- `pnpm test:e2e tests/e2e/agent-detail-chat-entry.spec.ts tests/e2e/agents-row-actions.spec.ts` attempted; Playwright Chromium launch timed out before test bodies ran.