### PR TITLE
feat: add following issues scope to issue board

### DIFF
--- a/ui/src/components/ThreeColumnContextSidebar.test.tsx
+++ b/ui/src/components/ThreeColumnContextSidebar.test.tsx
@@ -187,6 +187,13 @@ function renderSidebar() {
 }
 
 describe("ThreeColumnContextSidebar issue draft recovery", () => {
+  it("shows the following issues scope in the issues sidebar", () => {
+    renderSidebar();
+
+    const followingLink = document.querySelector('a[href="/issues?scope=following"]');
+    expect(followingLink?.textContent).toContain("Following");
+  });
+
   const savedDraft = {
     id: "draft-1",
     orgId: "org-1",

--- a/ui/src/components/ThreeColumnContextSidebar.tsx
+++ b/ui/src/components/ThreeColumnContextSidebar.tsx
@@ -40,6 +40,7 @@ import { formatSidebarAgentLabel } from "@/lib/agent-labels";
 import { queryKeys } from "@/lib/queryKeys";
 import { relativeTime } from "@/lib/utils";
 import { readRecentIssueIds, resolveRecentIssues } from "@/lib/recent-issues";
+import { isFollowingIssue } from "@/lib/issue-scope-filters";
 import {
   deleteIssueDraft,
   ISSUE_DRAFT_CHANGED_EVENT,
@@ -348,6 +349,10 @@ export function ThreeColumnContextSidebar() {
     () => resolveRecentIssues(recentIssueIds, allIssues ?? []),
     [allIssues, recentIssueIds],
   );
+  const followingIssueCount = useMemo(() => {
+    if (!currentUserId) return 0;
+    return (allIssues ?? []).filter((issue) => isFollowingIssue(issue, currentUserId)).length;
+  }, [allIssues, currentUserId]);
   const issueContextItems = [
     {
       key: "all",
@@ -357,11 +362,11 @@ export function ThreeColumnContextSidebar() {
       active: scope === "" && !selectedProjectId,
     },
     {
-      key: "assigned",
-      to: `/issues${currentUserId ? "?scope=assigned" : ""}`,
+      key: "following",
+      to: `/issues${currentUserId ? "?scope=following" : ""}`,
       icon: UserRound,
-      label: "Assigned to Me",
-      active: scope === "assigned",
+      label: `Following${followingIssueCount > 0 ? ` (${followingIssueCount})` : ""}`,
+      active: scope === "following",
     },
     {
       key: "starred",

--- a/ui/src/lib/issue-scope-filters.test.ts
+++ b/ui/src/lib/issue-scope-filters.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { getIssueScopeFilters } from "./issue-scope-filters";
+import { getIssueScopeFilters, isFollowingIssue } from "./issue-scope-filters";
 
 describe("getIssueScopeFilters", () => {
   it("maps assigned scope to the current user's assignee filter", () => {
@@ -15,5 +15,21 @@ describe("getIssueScopeFilters", () => {
   it("leaves other scopes unchanged", () => {
     expect(getIssueScopeFilters("recent", "user-123")).toEqual({});
     expect(getIssueScopeFilters("", "user-123")).toEqual({});
+  });
+});
+
+
+describe("isFollowingIssue", () => {
+  it("returns true when the current user created the issue", () => {
+    expect(isFollowingIssue({ createdByUserId: "user-123", assigneeUserId: null }, "user-123")).toBe(true);
+  });
+
+  it("returns true when the current user is assigned the issue", () => {
+    expect(isFollowingIssue({ createdByUserId: null, assigneeUserId: "user-123" }, "user-123")).toBe(true);
+  });
+
+  it("returns false for unrelated issues or missing user context", () => {
+    expect(isFollowingIssue({ createdByUserId: "user-456", assigneeUserId: "user-789" }, "user-123")).toBe(false);
+    expect(isFollowingIssue({ createdByUserId: "user-123", assigneeUserId: null }, null)).toBe(false);
   });
 });

--- a/ui/src/lib/issue-scope-filters.ts
+++ b/ui/src/lib/issue-scope-filters.ts
@@ -1,3 +1,5 @@
+import type { Issue } from "@rudderhq/shared";
+
 type IssueScope = string;
 
 type IssueScopeFilters = {
@@ -10,4 +12,9 @@ export function getIssueScopeFilters(issueScope: IssueScope, currentUserId: stri
   }
 
   return {};
+}
+
+export function isFollowingIssue(issue: Pick<Issue, "createdByUserId" | "assigneeUserId">, currentUserId: string | null): boolean {
+  if (!currentUserId) return false;
+  return issue.createdByUserId === currentUserId || issue.assigneeUserId === currentUserId;
 }

--- a/ui/src/pages/Issues.tsx
+++ b/ui/src/pages/Issues.tsx
@@ -11,7 +11,7 @@ import { useBreadcrumbs } from "../context/BreadcrumbContext";
 import { queryKeys } from "../lib/queryKeys";
 import { createIssueDetailLocationState } from "../lib/issueDetailBreadcrumb";
 import { rememberIssueNavigation } from "../lib/issue-navigation";
-import { getIssueScopeFilters } from "../lib/issue-scope-filters";
+import { getIssueScopeFilters, isFollowingIssue } from "../lib/issue-scope-filters";
 import { readRecentIssueIds, recordRecentIssue, resolveRecentIssues } from "../lib/recent-issues";
 import { EmptyState } from "../components/EmptyState";
 import { IssuesList } from "../components/IssuesList";
@@ -151,8 +151,11 @@ export function Issues() {
     if (issueScope === "recent") {
       return resolveRecentIssues(recentIssueIds, allIssues);
     }
+    if (issueScope === "following" && currentUserId) {
+      return allIssues.filter((issue) => isFollowingIssue(issue, currentUserId));
+    }
     return allIssues;
-  }, [followedIssueIds, issues, issueScope, recentIssueIds]);
+  }, [currentUserId, followedIssueIds, issues, issueScope, recentIssueIds]);
 
   const updateIssue = useMutation({
     mutationFn: ({ id, data }: { id: string; data: Record<string, unknown> }) =>


### PR DESCRIPTION
### Motivation

- Provide a focused "Following" view that surfaces issues the current user cares about (those they created or are assigned to).

### Description

- Add `isFollowingIssue` helper in `ui/src/lib/issue-scope-filters.ts` and reuse it for page filtering and sidebar counts.
- Wire a new `following` scope into the Issues page filtering logic in `ui/src/pages/Issues.tsx` so `?scope=following` returns issues where the user is creator or assignee.
- Replace the sidebar "Assigned to Me" item with a "Following" item and show a dynamic matching count in `ui/src/components/ThreeColumnContextSidebar.tsx`.
- Add/extend tests in `ui/src/lib/issue-scope-filters.test.ts` and `ui/src/components/ThreeColumnContextSidebar.test.tsx` to cover the helper and the new sidebar link.

### Testing

- Ran unit tests with `pnpm --filter @rudderhq/ui exec vitest run src/lib/issue-scope-filters.test.ts src/components/ThreeColumnContextSidebar.test.tsx`, and all selected tests passed. 
- Ran type checking with `pnpm --filter @rudderhq/ui typecheck`, and the UI package typecheck completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef3de2e618832687e06580ee4a8c4d)