### PR TITLE
Propagate explicit issue status from chat proposals and enqueue issue-assignment wakeup

### DIFF
--- a/packages/shared/src/validators/chat.ts
+++ b/packages/shared/src/validators/chat.ts
@@ -6,6 +6,7 @@ import {
   CHAT_MESSAGE_KINDS,
   CHAT_MESSAGE_ROLES,
   CHAT_MESSAGE_STATUSES,
+  ISSUE_STATUSES,
 } from "../constants.js";
 
 export const chatConversationStatusSchema = z.enum(CHAT_CONVERSATION_STATUSES);
@@ -56,6 +57,7 @@ const chatIssueProposalSchema = z.object({
   title: z.string().trim().min(1).max(200),
   description: z.string().trim().min(1).max(20000),
   priority: z.enum(["critical", "high", "medium", "low"]).optional().default("medium"),
+  status: z.enum(ISSUE_STATUSES).optional(),
   projectId: z.string().uuid().optional().nullable(),
   goalId: z.string().uuid().optional().nullable(),
   parentId: z.string().uuid().optional().nullable(),

--- a/server/src/services/chats.ts
+++ b/server/src/services/chats.ts
@@ -20,9 +20,11 @@ import { agentService } from "./agents.js";
 import { logActivity } from "./activity-log.js";
 import { approvalService } from "./approvals.js";
 import { documentService } from "./documents.js";
+import { queueIssueAssignmentWakeup } from "./issue-assignment-wakeup.js";
 import { organizationService } from "./orgs.js";
 import { issueApprovalService } from "./issue-approvals.js";
 import { issueService } from "./issues.js";
+import { heartbeatService } from "./runtime-kernel/heartbeat.js";
 
 type ConversationRow = typeof chatConversations.$inferSelect;
 type ConversationUserStateRow = typeof chatConversationUserStates.$inferSelect;
@@ -96,6 +98,14 @@ function issueProposalFromPayload(payload: Record<string, unknown> | null | unde
   const description = safeTrim(typeof proposal.description === "string" ? proposal.description : null);
   if (!title || !description) return null;
 
+  const assigneeAgentId = safeTrim(typeof proposal.assigneeAgentId === "string" ? proposal.assigneeAgentId : null);
+  const assigneeUserId = safeTrim(typeof proposal.assigneeUserId === "string" ? proposal.assigneeUserId : null);
+  const explicitStatus =
+    typeof proposal.status === "string" &&
+    ["backlog", "todo", "in_progress", "in_review", "blocked", "done", "cancelled"].includes(proposal.status)
+      ? proposal.status
+      : null;
+
   return {
     title,
     description,
@@ -104,11 +114,12 @@ function issueProposalFromPayload(payload: Record<string, unknown> | null | unde
       ["critical", "high", "medium", "low"].includes(proposal.priority)
         ? proposal.priority
         : "medium",
+    status: explicitStatus ?? (assigneeAgentId || assigneeUserId ? "todo" : undefined),
     projectId: safeTrim(typeof proposal.projectId === "string" ? proposal.projectId : null),
     goalId: safeTrim(typeof proposal.goalId === "string" ? proposal.goalId : null),
     parentId: safeTrim(typeof proposal.parentId === "string" ? proposal.parentId : null),
-    assigneeAgentId: safeTrim(typeof proposal.assigneeAgentId === "string" ? proposal.assigneeAgentId : null),
-    assigneeUserId: safeTrim(typeof proposal.assigneeUserId === "string" ? proposal.assigneeUserId : null),
+    assigneeAgentId,
+    assigneeUserId,
   };
 }
 
@@ -208,6 +219,7 @@ export function chatService(db: Db) {
   const organizationsSvc = organizationService(db);
   const agentsSvc = agentService(db);
   const documentsSvc = documentService(db);
+  const heartbeat = heartbeatService(db);
 
   async function resolveContextEntities(rows: ContextLinkRow[]) {
     const issueIds = rows.filter((row) => row.entityType === "issue").map((row) => row.entityId);
@@ -1124,6 +1136,15 @@ export function chatService(db: Db) {
       const issue = await issuesSvc.create(conversation.orgId, {
         ...issueProposal,
         createdByUserId: input.actorUserId,
+      });
+      void queueIssueAssignmentWakeup({
+        heartbeat,
+        issue,
+        reason: "issue_assigned",
+        mutation: "create",
+        contextSource: "chat.convert_to_issue",
+        requestedByActorType: input.actorUserId ? "user" : "system",
+        requestedByActorId: input.actorUserId ?? "chat-assistant",
       });
       const planDocument = planDocumentFromPayload(
         sourceMessage?.structuredPayload ?? input.proposal ?? null,


### PR DESCRIPTION
### Motivation
- Allow chat-originated issue proposals to include an explicit issue `status` and ensure downstream assignment logic runs after converting a chat proposal to an issue.

### Description
- Import `ISSUE_STATUSES` and add an optional `status` field to the chat issue proposal validator (`chatIssueProposalSchema`).
- Update `issueProposalFromPayload` to capture `assigneeAgentId` and `assigneeUserId`, accept an explicit `status` when provided, and default status to `"todo"` when an assignee is present and no explicit status is given.
- Wire up `heartbeatService` and call `queueIssueAssignmentWakeup` right after creating an issue in `chatService.convert -> create` flow to trigger assignment processing with contextual metadata.

### Testing
- Ran the TypeScript build/typecheck via `pnpm -w build` which completed successfully.
- Executed the repository unit tests via `pnpm -w test` which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef987fa8348326b3f5575e64a33b12)