### PR TITLE
feat: show Linear issues in issue board

### DIFF
--- a/doc/plans/2026-05-02-linear-source-issue-board.md
+++ b/doc/plans/2026-05-02-linear-source-issue-board.md
@@ -1,0 +1,134 @@
+---
+title: Linear source issue board
+date: 2026-05-02
+kind: implementation
+status: implemented
+area: ui
+entities:
+  - plugin_linear
+  - issue_board
+  - external_issue_source
+issue:
+related_plans:
+  - 2026-04-25-linear-import-plugin-completion.md
+  - 2026-04-30-linear-issue-sidebar-projects.md
+  - 2026-04-24-issue-board-display-properties.md
+supersedes: []
+related_code:
+  - ui/src/pages/Issues.tsx
+  - ui/src/components/IssuesList.tsx
+  - ui/src/components/KanbanBoard.tsx
+  - ui/src/components/LinearIssueSourceBoard.tsx
+  - ui/src/components/BreadcrumbBar.tsx
+  - ui/src/components/ThreeColumnContextSidebar.tsx
+  - packages/plugins/examples/plugin-linear/src/worker.ts
+  - packages/plugins/examples/plugin-linear/src/ui/index.tsx
+commit_refs: []
+updated_at: 2026-05-02
+---
+
+# Linear Source Issue Board
+
+## Summary
+
+Move the primary Linear browsing flow into the native Issue Tracker instead of
+forcing operators through a separate Linear intake page. When an operator picks a
+Linear team or Linear project from the Issues sidebar, the main Issue board
+should switch into a read-only external-source mode that reuses the existing
+board/list controls to inspect Linear issues and import selected work into
+Rudder.
+
+## Problem
+
+The current Linear plugin is import-first, but its main workflow lives in a
+plugin page. That makes Linear feel like a side utility rather than a first-class
+source of incoming work. Operators should be able to stay in the Issue Tracker,
+inspect all Linear projects under a connected team, and import only the issues
+that should become executable Rudder work.
+
+## Scope
+
+- Add a `source=linear` mode to the Issues route.
+- Render Linear issues in the existing Issue Tracker board/list surface.
+- Keep Linear issue cards visually distinct as external, read-only rows before
+  import.
+- Allow selecting one or more Linear issues and importing them into a chosen
+  Rudder project.
+- Show imported Linear issues as linked to their Rudder issue.
+- Expand the Issues sidebar Linear group to support team/project navigation.
+- Keep the existing `/linear` plugin page available as an advanced/bulk intake
+  surface.
+- Do not add background sync, bidirectional status sync, webhooks, comment sync,
+  or agent execution against non-imported Linear issues.
+
+## Implementation Plan
+
+1. Inspect the current Issue Tracker, Kanban board, Linear plugin worker, and
+   sidebar contracts on latest `origin/main`.
+2. Add a `source=linear` branch in `Issues.tsx` that stays on the Issue route
+   while delegating external-source rendering to a dedicated host board
+   component.
+3. Introduce an external issue source presentation shape in the UI layer rather
+   than extending the shared `Issue` type.
+4. Add `LinearIssueSourceBoard` to resolve the Linear contribution and query
+   `linear-catalog`, `page-bootstrap`, `linear-issues`, and
+   `import-linear-issues`.
+5. Add board/list views, selection, and import controls for external Linear
+   rows, including target Rudder project selection and row-level imported state.
+6. Update the Issues header so Linear source mode reads as `Linear Issues` and
+   does not show the native issue create/search controls.
+7. Update `ThreeColumnContextSidebar` so Linear navigation points at
+   `/issues?source=linear&linearTeamId=...` and
+   `/issues?source=linear&linearTeamId=...&linearProjectId=...` instead of
+   making the plugin page the primary path.
+8. Add focused unit tests for sidebar routing, Linear source board rendering,
+   selection/import behavior, and plugin URL filter compatibility.
+9. Extend or add E2E coverage for the Linear source Issue board path where the
+   local browser environment allows it.
+
+## Design Notes
+
+- The Issue Tracker remains the primary work surface; `/linear` remains a
+  plugin-owned advanced page.
+- External Linear rows must not be draggable or status-mutating. A Linear issue
+  becomes executable only after import creates a native Rudder issue.
+- Status lanes for Linear rows use the plugin's configured Linear-to-Rudder
+  status mapping.
+- The UI should expose source state in compact operator language: `External`,
+  `Imported`, and `Open Rudder issue`.
+- The new `external_issue_source` entity is introduced for this class of
+  host-board external source views.
+
+## Success Criteria
+
+- Selecting a Linear team/project in the Issues sidebar keeps the operator on
+  `/issues` with `source=linear`.
+- The main Issue Tracker renders Linear issues in board/list mode with an
+  external-source heading.
+- Linear rows are read-only before import and cannot be dragged to mutate
+  status.
+- Operators can select Linear rows, choose a target Rudder project, and import
+  them.
+- Imported rows show an `Imported` state and link to the created Rudder issue.
+- Existing native Rudder Issue Tracker behavior and tests keep passing.
+
+## Validation
+
+- Passed: `pnpm --filter @rudderhq/ui exec vitest run src/components/LinearIssueSourceBoard.test.tsx src/components/ThreeColumnContextSidebar.test.tsx src/pages/Issues.test.tsx src/components/BreadcrumbBar.test.tsx`
+- Passed: `pnpm --filter @rudderhq/plugin-linear test -- --run`
+- Passed: `pnpm -r typecheck`
+- Passed: `pnpm build`
+- Passed: `RUDDER_E2E_USE_EXISTING_SERVER=1 RUDDER_E2E_BASE_URL=http://127.0.0.1:3101 RUDDER_E2E_CHROMIUM_EXECUTABLE=/Applications/Browser/Google Chrome.app/Contents/MacOS/Google Chrome npx playwright test --config tests/e2e/playwright.config.ts tests/e2e/linear-plugin-import.spec.ts --project=chromium --workers=1 --timeout=90000`
+- Verified rendered desktop and mobile Linear source board screenshots:
+  `/tmp/rudder-linear-source-board-desktop.png` and
+  `/tmp/rudder-linear-source-board-mobile.png`.
+- Failed, unrelated to this feature: `pnpm test:run` still fails in embedded
+  PostgreSQL-backed suites with `Postgres init script exited with code 1`.
+
+## Open Issues
+
+- Import target choice may start as an explicit selector and later remember the
+  last target per Linear source.
+- Team-level source views should work even when a Linear team has no projects.
+- The first pass may keep some advanced Linear filters on `/linear` if they do
+  not map cleanly to the Issue Tracker toolbar.

--- a/packages/plugins/examples/plugin-linear/src/linear-api.ts
+++ b/packages/plugins/examples/plugin-linear/src/linear-api.ts
@@ -24,8 +24,8 @@ const FIXTURE_TEAMS: LinearTeamSummary[] = [
 ];
 
 const FIXTURE_PROJECTS: LinearProjectSummary[] = [
-  { id: "proj-roadmap", name: "Roadmap" },
-  { id: "proj-growth", name: "Growth" },
+  { id: "proj-roadmap", name: "Roadmap", teamIds: ["team-eng"], teams: [FIXTURE_TEAMS[0]!] },
+  { id: "proj-growth", name: "Growth", teamIds: ["team-eng"], teams: [FIXTURE_TEAMS[0]!] },
 ];
 
 const FIXTURE_USERS: LinearUserSummary[] = [
@@ -155,6 +155,18 @@ function normalizeIssue(issue: Record<string, any>): LinearIssueSummary {
       ? {
         id: String(issue.project.id),
         name: String(issue.project.name),
+        teamIds: Array.isArray(issue.project.teams?.nodes)
+          ? issue.project.teams.nodes.map((team: Record<string, any>) => String(team.id))
+          : Array.isArray(issue.project.teamIds)
+            ? issue.project.teamIds.map((teamId: unknown) => String(teamId))
+            : [],
+        teams: Array.isArray(issue.project.teams?.nodes)
+          ? issue.project.teams.nodes.map((team: Record<string, any>) => ({
+            id: String(team.id),
+            key: String(team.key ?? team.name ?? team.id),
+            name: String(team.name),
+          }))
+          : undefined,
       }
       : null,
     assignee: issue.assignee
@@ -302,6 +314,13 @@ export function createLinearApiClient(
             nodes {
               id
               name
+              teams(first: 20) {
+                nodes {
+                  id
+                  key
+                  name
+                }
+              }
             }
           }
           users(first: 100) {
@@ -329,10 +348,26 @@ export function createLinearApiClient(
             }))
             : [],
         })),
-        projects: data.projects.nodes.map((project) => ({
-          id: String(project.id),
-          name: String(project.name),
-        })),
+        projects: data.projects.nodes
+          .map((project) => {
+            const teams: Array<Pick<LinearTeamSummary, "id" | "key" | "name">> = Array.isArray(project.teams?.nodes)
+              ? project.teams.nodes.map((team: Record<string, any>) => ({
+                id: String(team.id),
+                key: String(team.key ?? team.name ?? team.id),
+                name: String(team.name),
+              }))
+              : [];
+            return {
+              id: String(project.id),
+              name: String(project.name),
+              teamIds: teams.map((team) => team.id),
+              teams,
+            };
+          })
+          .filter((project) => {
+            if (!allowedTeamIds?.length || project.teamIds.length === 0) return true;
+            return project.teamIds.some((teamId) => allowedTeamIds.includes(teamId));
+          }),
         users: data.users.nodes
           .filter((user) => user.active !== false)
           .map((user) => ({
@@ -380,6 +415,13 @@ export function createLinearApiClient(
               project {
                 id
                 name
+                teams(first: 20) {
+                  nodes {
+                    id
+                    key
+                    name
+                  }
+                }
               }
               assignee {
                 id
@@ -438,6 +480,13 @@ export function createLinearApiClient(
             project {
               id
               name
+              teams(first: 20) {
+                nodes {
+                  id
+                  key
+                  name
+                }
+              }
             }
             assignee {
               id

--- a/packages/plugins/examples/plugin-linear/src/types.ts
+++ b/packages/plugins/examples/plugin-linear/src/types.ts
@@ -33,6 +33,8 @@ export type LinearUserSummary = {
 export type LinearProjectSummary = {
   id: string;
   name: string;
+  teamIds: string[];
+  teams?: Array<Pick<LinearTeamSummary, "id" | "key" | "name">>;
 };
 
 export type LinearStateSummary = {

--- a/packages/plugins/examples/plugin-linear/src/worker.ts
+++ b/packages/plugins/examples/plugin-linear/src/worker.ts
@@ -18,6 +18,7 @@ import type {
   ImportLinearIssuesActionResult,
   ImportedLinearLink,
   IssueLinkData,
+  LinearCatalog,
   LinearIssueListFilters,
   LinearIssueSummary,
   LinearLinkState,
@@ -75,6 +76,26 @@ function getOrgMapping(config: LinearPluginConfig, orgId: string): LinearOrganiz
 
 function getAllowedTeamIds(mapping: LinearOrganizationMapping): string[] {
   return mapping.teamMappings.map((team) => team.teamId);
+}
+
+function filterCatalogForMapping(catalog: LinearCatalog, mapping: LinearOrganizationMapping): LinearCatalog {
+  const allowedTeamIds = new Set(getAllowedTeamIds(mapping));
+  if (allowedTeamIds.size === 0) {
+    return {
+      teams: [],
+      projects: [],
+      users: [],
+    };
+  }
+
+  return {
+    teams: catalog.teams.filter((team) => allowedTeamIds.has(team.id)),
+    projects: catalog.projects.filter((project) => {
+      if (project.teamIds.length === 0) return true;
+      return project.teamIds.some((teamId) => allowedTeamIds.has(teamId));
+    }),
+    users: catalog.users,
+  };
 }
 
 function sanitizeFilters(
@@ -500,7 +521,7 @@ const plugin = definePlugin({
       const orgId = requireOrgId(params);
       try {
         const { client, mapping } = await resolveLinearClient(ctx, orgId);
-        const catalog = await client.getCatalog(getAllowedTeamIds(mapping));
+        const catalog = filterCatalogForMapping(await client.getCatalog(), mapping);
         return {
           orgId,
           ...catalog,

--- a/packages/plugins/examples/plugin-linear/tests/ui.spec.tsx
+++ b/packages/plugins/examples/plugin-linear/tests/ui.spec.tsx
@@ -685,7 +685,7 @@ describe("@rudderhq/plugin-linear UI", () => {
           createdAt: "2026-04-20T00:00:00.000Z",
           team: { id: "team-1", key: "ENG", name: "Engineering", states: [] },
           state: { id: "state-2", name: "In Progress" },
-          project: { id: "project-1", name: "Roadmap" },
+          project: { id: "project-1", name: "Roadmap", teamIds: ["team-1"] },
           assignee: { id: "user-1", name: "Amy Zhang" },
         },
         staleReason: null,

--- a/packages/plugins/examples/plugin-linear/tests/worker.spec.ts
+++ b/packages/plugins/examples/plugin-linear/tests/worker.spec.ts
@@ -30,6 +30,11 @@ describe("@rudderhq/plugin-linear worker", () => {
         });
       }
       if (body.query?.includes("LinearCatalog")) {
+        if (Array.isArray(body.variables?.teamIds)) {
+          return makeJsonResponse({
+            errors: [{ message: "Filtered team catalog query failed" }],
+          });
+        }
         return makeJsonResponse({
           data: {
             teams: {
@@ -45,9 +50,32 @@ describe("@rudderhq/plugin-linear worker", () => {
                     ],
                   },
                 },
+                {
+                  id: "team-ops",
+                  key: "OPS",
+                  name: "Operations",
+                  states: {
+                    nodes: [
+                      { id: "state-ops-backlog", name: "Backlog", type: "backlog" },
+                    ],
+                  },
+                },
               ],
             },
-            projects: { nodes: [{ id: "linear-project", name: "Roadmap" }] },
+            projects: {
+              nodes: [
+                {
+                  id: "linear-project",
+                  name: "Roadmap",
+                  teams: { nodes: [{ id: "team-eng", key: "ENG", name: "Engineering" }] },
+                },
+                {
+                  id: "ops-project",
+                  name: "Operations Queue",
+                  teams: { nodes: [{ id: "team-ops", key: "OPS", name: "Operations" }] },
+                },
+              ],
+            },
             users: { nodes: [{ id: "user-1", name: "Amy Zhang", email: "amy@example.com", active: true }] },
           },
         });
@@ -217,13 +245,41 @@ describe("@rudderhq/plugin-linear worker", () => {
     await plugin.definition.setup(harness.ctx);
 
     const catalog = await harness.getData<SettingsCatalogData>(DATA_KEYS.settingsCatalog, { orgId });
-    expect(catalog.teams).toEqual([
+    expect(catalog.teams).toContainEqual(
       expect.objectContaining({
         id: "team-eng",
         name: "Engineering",
       }),
-    ]);
+    );
     expect(catalog.projects).toContainEqual(expect.objectContaining({ id: "linear-project" }));
+  });
+
+  it("builds the page catalog from the full Linear catalog and filters it by mapped teams", async () => {
+    const harness = createTestHarness({
+      manifest,
+      config: normalizeConfig({
+        apiTokenSecretRef: "linear-token",
+        organizationMappings: [
+          {
+            orgId,
+            teamMappings: [
+              {
+                teamId: "team-eng",
+                teamName: "Engineering",
+                stateMappings: [],
+              },
+            ],
+          },
+        ],
+      }),
+    });
+
+    await plugin.definition.setup(harness.ctx);
+
+    const catalog = await harness.getData<SettingsCatalogData>(DATA_KEYS.catalog, { orgId });
+    expect(catalog.teams.map((team) => team.id)).toEqual(["team-eng"]);
+    expect(catalog.projects.map((project) => project.id)).toEqual(["linear-project"]);
+    expect(catalog.users.map((user) => user.id)).toEqual(["user-1"]);
   });
 
   it("imports selected issues, skips duplicates, and reports fallback statuses", async () => {

--- a/tests/e2e/linear-plugin-import.spec.ts
+++ b/tests/e2e/linear-plugin-import.spec.ts
@@ -271,11 +271,11 @@ test.describe("Linear plugin import workflow", () => {
 
     const catalog = await pluginData<{
       teams: Array<{ id: string; name: string }>;
-      projects: Array<{ id: string; name: string }>;
+      projects: Array<{ id: string; name: string; teamIds?: string[] }>;
       users: Array<{ id: string; name: string }>;
     }>(request, plugin, "linear-catalog", organization);
     expect(catalog.teams).toContainEqual(expect.objectContaining({ id: "team-eng", name: "Engineering" }));
-    expect(catalog.projects).toContainEqual(expect.objectContaining({ id: "proj-roadmap", name: "Roadmap" }));
+    expect(catalog.projects).toContainEqual(expect.objectContaining({ id: "proj-roadmap", name: "Roadmap", teamIds: ["team-eng"] }));
     expect(catalog.users).toContainEqual(expect.objectContaining({ id: "user-amy", name: "Amy Zhang" }));
 
     await page.goto(`/${organization.issuePrefix}/issues`);
@@ -287,11 +287,11 @@ test.describe("Linear plugin import workflow", () => {
     await expect(roadmapLink).toContainText("Roadmap");
     await expect(roadmapLink).toHaveAttribute(
       "href",
-      new RegExp(`/${organization.issuePrefix}/linear\\?linearProjectId=proj-roadmap$`),
+      new RegExp(`/${organization.issuePrefix}/issues\\?source=linear&linearTeamId=team-eng&linearProjectId=proj-roadmap$`),
     );
     await roadmapLink.click();
-    await expect(page).toHaveURL(new RegExp(`/${organization.issuePrefix}/linear\\?linearProjectId=proj-roadmap$`));
-    await expect(page.locator("#linear-project-filter")).toHaveValue("proj-roadmap");
+    await expect(page).toHaveURL(new RegExp(`/${organization.issuePrefix}/issues\\?source=linear&linearTeamId=team-eng&linearProjectId=proj-roadmap$`));
+    await expect(page.getByTestId("linear-source-board")).toContainText("Roadmap");
 
     const filtered = await pluginData<{
       rows: LinearIssueRow[];

--- a/ui/src/components/BreadcrumbBar.test.tsx
+++ b/ui/src/components/BreadcrumbBar.test.tsx
@@ -5,13 +5,14 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { BreadcrumbBar } from "./BreadcrumbBar";
 
 let pathname = "/RUD/messenger/issues";
+let search = "";
 let sidebarOpen = true;
 
 vi.mock("@/lib/router", () => ({
   Link: ({ to, children, ...props }: { to: string; children: import("react").ReactNode }) => (
     <a href={to} {...props}>{children}</a>
   ),
-  useLocation: () => ({ pathname, search: "" }),
+  useLocation: () => ({ pathname, search }),
   useNavigate: () => vi.fn(),
 }));
 
@@ -59,6 +60,7 @@ vi.mock("@/plugins/launchers", () => ({
 describe("BreadcrumbBar", () => {
   beforeEach(() => {
     pathname = "/RUD/messenger/issues";
+    search = "";
     sidebarOpen = true;
   });
 
@@ -91,5 +93,17 @@ describe("BreadcrumbBar", () => {
     const html = renderToStaticMarkup(<BreadcrumbBar variant="card" />);
 
     expect(html).toContain("Open workspace sidebar");
+  });
+
+  it("uses the Linear source header without native issue actions", () => {
+    pathname = "/RUD/issues";
+    search = "?source=linear&linearTeamId=team-rudder";
+
+    const html = renderToStaticMarkup(<BreadcrumbBar variant="card" />);
+
+    expect(html).toContain("Linear Issues");
+    expect(html).not.toContain("Issue Tracker");
+    expect(html).not.toContain("Search issues...");
+    expect(html).not.toContain("Create Issue");
   });
 });

--- a/ui/src/components/BreadcrumbBar.tsx
+++ b/ui/src/components/BreadcrumbBar.tsx
@@ -57,6 +57,7 @@ export function BreadcrumbBar({
   const navigate = useNavigate();
   const [issueSearch, setIssueSearch] = useState("");
   const relativePath = useMemo(() => toOrganizationRelativePath(location.pathname), [location.pathname]);
+  const activeIssueSource = useMemo(() => new URLSearchParams(location.search).get("source") ?? "", [location.search]);
   const isPrimaryRailPage = useMemo(
     () => /^\/(?:dashboard|inbox|chat|messenger|issues|agents|projects|goals|automations|calendar)(?:\/|$)/.test(relativePath),
     [relativePath],
@@ -69,7 +70,7 @@ export function BreadcrumbBar({
     if (/^\/dashboard(?:\/|$)/.test(relativePath)) return "Dashboard";
     if (/^\/messenger(?:\/|$)/.test(relativePath)) return "Messenger";
     if (/^\/inbox(?:\/|$)/.test(relativePath)) return "Inbox";
-    if (/^\/issues(?:\/|$)/.test(relativePath)) return "Issue Tracker";
+    if (/^\/issues(?:\/|$)/.test(relativePath)) return activeIssueSource === "linear" ? "Linear Issues" : "Issue Tracker";
     if (/^\/chat(?:\/|$)/.test(relativePath)) return "Chat";
     if (/^\/projects(?:\/|$)/.test(relativePath)) return "Projects";
     if (/^\/agents(?:\/|$)/.test(relativePath)) return "Agents";
@@ -77,7 +78,7 @@ export function BreadcrumbBar({
     if (/^\/automations(?:\/|$)/.test(relativePath)) return "Automations";
     if (/^\/calendar(?:\/|$)/.test(relativePath)) return "Calendar";
     return null;
-  }, [relativePath]);
+  }, [activeIssueSource, relativePath]);
   const { data: visibleProjects } = useQuery({
     queryKey: queryKeys.projects.list(selectedOrganizationId ?? "__none__"),
     queryFn: async () => {
@@ -202,6 +203,7 @@ export function BreadcrumbBar({
 
   if (threeColumnTitle) {
     const isIssuesRoute = /^\/issues(?:\/|$)/.test(relativePath);
+    const isLinearIssueSource = isIssuesRoute && activeIssueSource === "linear";
     const isProjectsRoute = /^\/projects(?:\/|$)/.test(relativePath);
     const isProjectsIndex = isProjectsRoute && !/^\/projects\/[^/]+/.test(relativePath);
     return (
@@ -220,7 +222,7 @@ export function BreadcrumbBar({
           <h1 className="truncate text-[15px] font-semibold tracking-tight text-foreground">{threeColumnTitle}</h1>
         </div>
         {desktopChrome ? <div className="desktop-window-drag hidden min-h-full flex-1 md:block" /> : null}
-        {isIssuesRoute ? (
+        {isIssuesRoute && !isLinearIssueSource ? (
           <div className={cn("hidden items-center gap-3 md:flex", desktopChrome && "desktop-window-no-drag")}>
             <div className="relative w-80">
               <Search className="pointer-events-none absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />

--- a/ui/src/components/LinearIssueSourceBoard.test.tsx
+++ b/ui/src/components/LinearIssueSourceBoard.test.tsx
@@ -1,0 +1,247 @@
+// @vitest-environment jsdom
+
+import { act, type ReactNode } from "react";
+import { createRoot } from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { LinearIssueSourceBoard } from "./LinearIssueSourceBoard";
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const mockState = vi.hoisted(() => ({
+  pushToast: vi.fn(),
+  listUiContributions: vi.fn(),
+  bridgeGetData: vi.fn(),
+  bridgePerformAction: vi.fn(),
+}));
+
+vi.mock("@/api/plugins", () => ({
+  pluginsApi: {
+    listUiContributions: mockState.listUiContributions,
+    bridgeGetData: mockState.bridgeGetData,
+    bridgePerformAction: mockState.bridgePerformAction,
+  },
+}));
+
+vi.mock("@/context/ToastContext", () => ({
+  useToast: () => ({
+    pushToast: mockState.pushToast,
+  }),
+}));
+
+vi.mock("@/lib/router", () => ({
+  Link: ({ children, to, ...props }: { children: ReactNode; to: string }) => (
+    <a href={to} {...props}>{children}</a>
+  ),
+}));
+
+let cleanupFn: (() => void) | null = null;
+
+const linearContribution = {
+  pluginId: "plugin-linear",
+  pluginKey: "rudder.linear",
+  displayName: "Linear",
+  version: "0.1.0",
+  uiEntryFile: "index.js",
+  slots: [{ type: "page", routePath: "linear" }],
+  launchers: [],
+};
+
+const catalog = {
+  orgId: "org-1",
+  teams: [{
+    id: "team-eng",
+    key: "ENG",
+    name: "Engineering",
+    states: [
+      { id: "state-backlog", name: "Backlog", type: "backlog" },
+      { id: "state-progress", name: "In Progress", type: "started" },
+    ],
+  }],
+  projects: [{ id: "linear-roadmap", name: "Roadmap", teamIds: ["team-eng"] }],
+  users: [{ id: "user-amy", name: "Amy" }],
+};
+
+const issueRow = {
+  id: "lin-2",
+  identifier: "ENG-102",
+  title: "Status mapped issue",
+  description: "External issue",
+  url: "https://linear.app/example/issue/ENG-102",
+  updatedAt: "2026-04-21T08:30:00.000Z",
+  createdAt: "2026-04-11T09:00:00.000Z",
+  team: catalog.teams[0]!,
+  state: catalog.teams[0]!.states[1]!,
+  project: catalog.projects[0]!,
+  assignee: catalog.users[0]!,
+  imported: false,
+  importedRudderIssueId: null,
+  importedRudderIssueIdentifier: null,
+  importedOrgId: null,
+};
+
+function installLocalStorageMock() {
+  const storageState: Record<string, string> = {};
+  vi.stubGlobal("localStorage", {
+    getItem: vi.fn((key: string) => storageState[key] ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      storageState[key] = String(value);
+    }),
+    removeItem: vi.fn((key: string) => {
+      delete storageState[key];
+    }),
+    clear: vi.fn(() => {
+      for (const key of Object.keys(storageState)) delete storageState[key];
+    }),
+  });
+}
+
+async function renderBoard() {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  cleanupFn = () => root.unmount();
+
+  await act(async () => {
+    root.render(
+      <QueryClientProvider client={client}>
+        <LinearIssueSourceBoard
+          orgId="org-1"
+          projects={[{ id: "rudder-project", name: "Rudder Project", archivedAt: null }]}
+          linearTeamId="team-eng"
+          linearProjectId="linear-roadmap"
+        />
+      </QueryClientProvider>,
+    );
+  });
+  await flushAsyncWork();
+}
+
+async function flushAsyncWork() {
+  for (let index = 0; index < 5; index += 1) {
+    await act(async () => {
+      await new Promise((resolve) => window.setTimeout(resolve, 0));
+    });
+  }
+}
+
+beforeEach(() => {
+  installLocalStorageMock();
+  mockState.pushToast.mockReset();
+  mockState.listUiContributions.mockReset();
+  mockState.bridgeGetData.mockReset();
+  mockState.bridgePerformAction.mockReset();
+  mockState.listUiContributions.mockResolvedValue([linearContribution]);
+  mockState.bridgeGetData.mockImplementation(async (_pluginId: string, key: string) => {
+    if (key === "page-bootstrap") {
+      return {
+        data: {
+          configured: true,
+          message: null,
+          projects: [{ id: "rudder-project", name: "Rudder Project" }],
+          teamMappings: [{
+            teamId: "team-eng",
+            teamName: "Engineering",
+            stateMappings: [{ linearStateId: "state-progress", linearStateName: "In Progress", rudderStatus: "in_progress" }],
+          }],
+        },
+      };
+    }
+    if (key === "linear-catalog") return { data: catalog };
+    if (key === "linear-issues") {
+      return {
+        data: {
+          rows: [issueRow],
+          endCursor: null,
+          hasNextPage: false,
+          totalShown: 1,
+        },
+      };
+    }
+    return { data: null };
+  });
+  mockState.bridgePerformAction.mockResolvedValue({
+    data: {
+      importedCount: 1,
+      duplicateCount: 0,
+      fallbackCount: 0,
+      adjustedCount: 0,
+    },
+  });
+});
+
+afterEach(() => {
+  if (cleanupFn) {
+    act(() => {
+      cleanupFn?.();
+    });
+  }
+  cleanupFn = null;
+  document.body.innerHTML = "";
+  vi.unstubAllGlobals();
+});
+
+describe("LinearIssueSourceBoard", () => {
+  it("groups Linear issues into mapped Rudder status lanes without native drag controls", async () => {
+    await renderBoard();
+
+    expect(document.querySelector("[data-testid='linear-source-board']")?.textContent).toContain("Linear Issues");
+    expect(document.querySelector("[data-testid='linear-source-kanban-column-in_progress']")?.textContent).toContain("ENG-102");
+    expect(document.querySelector("[data-testid='linear-source-board-card-lin-2']")?.textContent).toContain("External");
+  });
+
+  it("imports selected Linear issues into a chosen Rudder project", async () => {
+    await renderBoard();
+
+    const listToggle = document.querySelector<HTMLButtonElement>("[data-testid='linear-source-view-list']");
+    act(() => {
+      listToggle?.click();
+    });
+
+    const target = document.querySelector<HTMLSelectElement>("[data-testid='linear-source-target-project']");
+    act(() => {
+      if (!target) return;
+      target.value = "rudder-project";
+      target.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+
+    const checkbox = document.querySelector<HTMLInputElement>("[data-testid='linear-source-row-checkbox-lin-2']");
+    act(() => {
+      checkbox?.click();
+    });
+
+    const importButton = document.querySelector<HTMLButtonElement>("[data-testid='linear-source-import-selected']");
+    await act(async () => {
+      importButton?.click();
+    });
+    await flushAsyncWork();
+
+    expect(mockState.bridgePerformAction).toHaveBeenCalledWith(
+      "plugin-linear",
+      "import-linear-issues",
+      expect.objectContaining({
+        orgId: "org-1",
+        targetProjectId: "rudder-project",
+        mode: "selected",
+        issueIds: ["lin-2"],
+        filters: expect.objectContaining({
+          teamId: "team-eng",
+          projectId: "linear-roadmap",
+        }),
+      }),
+      "org-1",
+    );
+    expect(mockState.pushToast).toHaveBeenCalledWith(expect.objectContaining({
+      title: "Linear import complete",
+      tone: "success",
+    }));
+  });
+});

--- a/ui/src/components/LinearIssueSourceBoard.tsx
+++ b/ui/src/components/LinearIssueSourceBoard.tsx
@@ -1,0 +1,916 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Link } from "@/lib/router";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { ExternalLink, Import, List, Search, Columns3, Check, ArrowUpDown, Filter, FolderKanban, UserRound } from "lucide-react";
+import { pluginsApi, type PluginUiContribution } from "@/api/plugins";
+import { queryKeys } from "@/lib/queryKeys";
+import { useToast } from "@/context/ToastContext";
+import { cn } from "@/lib/utils";
+import { timeAgo } from "@/lib/timeAgo";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { EmptyState } from "@/components/EmptyState";
+import { PageSkeleton } from "@/components/PageSkeleton";
+import { StatusIcon } from "@/components/StatusIcon";
+import type { Issue, Project } from "@rudderhq/shared";
+
+const LINEAR_PLUGIN_KEY = "rudder.linear";
+const DATA_KEY_PAGE_BOOTSTRAP = "page-bootstrap";
+const DATA_KEY_CATALOG = "linear-catalog";
+const DATA_KEY_ISSUES = "linear-issues";
+const ACTION_KEY_IMPORT_ISSUES = "import-linear-issues";
+const LINEAR_PAGE_SIZE = 50;
+
+type IssueStatus = Issue["status"];
+
+const boardStatuses: IssueStatus[] = [
+  "backlog",
+  "todo",
+  "in_progress",
+  "in_review",
+  "blocked",
+  "done",
+  "cancelled",
+];
+
+const laneSurfaceClasses: Record<IssueStatus, string> = {
+  backlog: "border-[color:color-mix(in_oklab,var(--border-soft)_88%,transparent)] bg-[color:color-mix(in_oklab,var(--surface-inset)_88%,transparent)]",
+  todo: "border-blue-200/75 bg-blue-50/70 dark:border-blue-900/55 dark:bg-blue-950/24",
+  in_progress: "border-amber-200/75 bg-amber-50/70 dark:border-amber-900/55 dark:bg-amber-950/24",
+  in_review: "border-violet-200/75 bg-violet-50/70 dark:border-violet-900/55 dark:bg-violet-950/24",
+  blocked: "border-red-200/75 bg-red-50/70 dark:border-red-900/55 dark:bg-red-950/24",
+  done: "border-emerald-200/75 bg-emerald-50/70 dark:border-emerald-900/55 dark:bg-emerald-950/24",
+  cancelled: "border-neutral-200/75 bg-neutral-50/70 dark:border-neutral-800/60 dark:bg-neutral-900/26",
+};
+
+type LinearStateSummary = {
+  id: string;
+  name: string;
+  type?: string | null;
+};
+
+type LinearTeamSummary = {
+  id: string;
+  key?: string;
+  name: string;
+  states: LinearStateSummary[];
+};
+
+type LinearProjectSummary = {
+  id: string;
+  name: string;
+  teamIds?: string[];
+  teams?: Array<Pick<LinearTeamSummary, "id" | "key" | "name">>;
+};
+
+type LinearUserSummary = {
+  id: string;
+  name: string;
+  email?: string | null;
+};
+
+type LinearIssueRow = {
+  id: string;
+  identifier: string;
+  title: string;
+  description: string | null;
+  url: string;
+  updatedAt: string;
+  createdAt?: string | null;
+  team: LinearTeamSummary;
+  state: LinearStateSummary;
+  project: LinearProjectSummary | null;
+  assignee: LinearUserSummary | null;
+  imported: boolean;
+  importedRudderIssueId: string | null;
+  importedRudderIssueIdentifier: string | null;
+  importedOrgId: string | null;
+};
+
+type LinearCatalogData = {
+  orgId: string;
+  teams: LinearTeamSummary[];
+  projects: LinearProjectSummary[];
+  users: LinearUserSummary[];
+};
+
+type LinearTeamMapping = {
+  teamId: string;
+  teamName?: string;
+  stateMappings: Array<{
+    linearStateId: string;
+    linearStateName?: string;
+    rudderStatus: IssueStatus;
+  }>;
+};
+
+type PageBootstrapData = {
+  configured: boolean;
+  message: string | null;
+  projects: Array<Pick<Project, "id" | "name">>;
+  teamMappings: LinearTeamMapping[];
+};
+
+type LinearIssuesData = {
+  rows: LinearIssueRow[];
+  endCursor: string | null;
+  hasNextPage: boolean;
+  totalShown: number;
+};
+
+type ImportLinearIssuesActionResult = {
+  importedCount: number;
+  duplicateCount: number;
+  fallbackCount: number;
+  adjustedCount: number;
+};
+
+type LinearIssueSourceBoardProps = {
+  orgId: string;
+  projects?: Array<Pick<Project, "id" | "name" | "archivedAt">>;
+  linearTeamId?: string;
+  linearProjectId?: string;
+  initialSearch?: string;
+  onSearchChange?: (search: string) => void;
+};
+
+type LinearViewMode = "list" | "board";
+type LinearSortField = "updated" | "created" | "identifier";
+type LinearSortDir = "asc" | "desc";
+
+function resolveLinearContribution(contributions: PluginUiContribution[] | undefined): PluginUiContribution | null {
+  return contributions?.find((entry) => entry.pluginKey === LINEAR_PLUGIN_KEY) ?? null;
+}
+
+function statusLabel(status: string): string {
+  return status.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function summarizeImportResult(result: ImportLinearIssuesActionResult): string {
+  const parts = [`Imported ${result.importedCount}`];
+  if (result.duplicateCount > 0) parts.push(`${result.duplicateCount} duplicate`);
+  if (result.fallbackCount > 0) parts.push(`${result.fallbackCount} fallback`);
+  if (result.adjustedCount > 0) parts.push(`${result.adjustedCount} adjusted`);
+  return parts.join(" / ");
+}
+
+function selectClassName(className?: string): string {
+  return cn(
+    "h-9 min-w-0 rounded-[calc(var(--radius-sm)-1px)] border border-[color:var(--border-base)] bg-[color:var(--surface-elevated)] px-2.5 text-sm text-foreground outline-none transition-[border-color,box-shadow] focus:border-ring focus:ring-[3px] focus:ring-ring/40 disabled:cursor-not-allowed disabled:opacity-50",
+    className,
+  );
+}
+
+function getStoredViewMode(): LinearViewMode {
+  if (typeof window === "undefined") return "board";
+  const value = window.localStorage.getItem("rudder:linear-source-view-mode");
+  return value === "list" || value === "board" ? value : "board";
+}
+
+function resolveMappedStatus(row: LinearIssueRow, teamMappings: LinearTeamMapping[] | undefined): IssueStatus {
+  const teamMapping = teamMappings?.find((mapping) => mapping.teamId === row.team.id);
+  return teamMapping?.stateMappings.find((mapping) => mapping.linearStateId === row.state.id)?.rudderStatus ?? "backlog";
+}
+
+function compareNullableIso(left: string | null | undefined, right: string | null | undefined): number {
+  const leftValue = left ? Date.parse(left) : 0;
+  const rightValue = right ? Date.parse(right) : 0;
+  return leftValue - rightValue;
+}
+
+function issueRudderHref(row: LinearIssueRow): string | null {
+  const ref = row.importedRudderIssueIdentifier ?? row.importedRudderIssueId;
+  return ref ? `/issues/${ref}` : null;
+}
+
+function SourceBadge({ children }: { children: string }) {
+  return (
+    <span className="inline-flex items-center gap-1 rounded-[calc(var(--radius-sm)-2px)] border border-[color:var(--border-soft)] bg-[color:var(--surface-inset)] px-1.5 py-0.5 text-[11px] font-medium text-muted-foreground">
+      <ExternalLink className="h-3 w-3" />
+      {children}
+    </span>
+  );
+}
+
+function ImportedBadge() {
+  return (
+    <span className="inline-flex items-center gap-1 rounded-[calc(var(--radius-sm)-2px)] border border-emerald-300/60 bg-emerald-50 px-1.5 py-0.5 text-[11px] font-medium text-emerald-700 dark:border-emerald-900/60 dark:bg-emerald-950/28 dark:text-emerald-300">
+      <Check className="h-3 w-3" />
+      Imported
+    </span>
+  );
+}
+
+function LinearIssueMeta({ row }: { row: LinearIssueRow }) {
+  return (
+    <div className="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
+      <span className="inline-flex min-w-0 items-center gap-1">
+        <StatusIcon status={resolveLinearTypeStatus(row.state.type)} />
+        <span className="truncate">{row.state.name}</span>
+      </span>
+      <span className="inline-flex min-w-0 items-center gap-1">
+        <FolderKanban className="h-3 w-3 shrink-0" />
+        <span className="truncate">{row.project?.name ?? "No Linear project"}</span>
+      </span>
+      <span className="inline-flex min-w-0 items-center gap-1">
+        <UserRound className="h-3 w-3 shrink-0" />
+        <span className="truncate">{row.assignee?.name ?? "Unassigned"}</span>
+      </span>
+      <span>Updated {timeAgo(row.updatedAt)}</span>
+    </div>
+  );
+}
+
+function resolveLinearTypeStatus(type: string | null | undefined): IssueStatus {
+  if (type === "started") return "in_progress";
+  if (type === "completed") return "done";
+  if (type === "canceled") return "cancelled";
+  if (type === "backlog") return "backlog";
+  return "todo";
+}
+
+function LinearRowAction({
+  row,
+  orgId,
+  targetProjectId,
+  importing,
+  onImport,
+}: {
+  row: LinearIssueRow;
+  orgId: string;
+  targetProjectId: string;
+  importing: boolean;
+  onImport: (row: LinearIssueRow) => void;
+}) {
+  if (row.imported) {
+    const href = issueRudderHref(row);
+    const sameOrgLink = !row.importedOrgId || row.importedOrgId === orgId;
+    if (href && sameOrgLink) {
+      return (
+        <Button asChild variant="ghost" size="sm">
+          <Link to={href}>Open Rudder issue</Link>
+        </Button>
+      );
+    }
+    return <span className="text-xs text-muted-foreground">Imported elsewhere</span>;
+  }
+
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      size="sm"
+      disabled={!targetProjectId || importing}
+      onClick={() => onImport(row)}
+    >
+      <Import className="h-3.5 w-3.5" />
+      Import
+    </Button>
+  );
+}
+
+function LinearListView({
+  rows,
+  selectedIssueIds,
+  orgId,
+  targetProjectId,
+  importing,
+  onToggleSelected,
+  onImport,
+}: {
+  rows: LinearIssueRow[];
+  selectedIssueIds: string[];
+  orgId: string;
+  targetProjectId: string;
+  importing: boolean;
+  onToggleSelected: (issueId: string) => void;
+  onImport: (row: LinearIssueRow) => void;
+}) {
+  return (
+    <div className="min-h-0 overflow-hidden rounded-[calc(var(--radius-sm)+1px)] border border-[color:var(--border-base)] bg-[color:var(--surface-elevated)]">
+      {rows.map((row) => {
+        const checked = selectedIssueIds.includes(row.id);
+        return (
+          <article
+            key={row.id}
+            data-testid={`linear-source-row-${row.id}`}
+            className="grid min-h-16 grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-3 border-b border-[color:var(--border-soft)] px-3 py-3 last:border-b-0"
+          >
+            <input
+              type="checkbox"
+              data-testid={`linear-source-row-checkbox-${row.id}`}
+              className="h-4 w-4 rounded border-[color:var(--border-base)]"
+              checked={checked}
+              disabled={row.imported || importing}
+              aria-label={`Select ${row.identifier}`}
+              onChange={() => onToggleSelected(row.id)}
+            />
+            <div className="min-w-0">
+              <div className="flex min-w-0 items-center gap-2">
+                <a
+                  href={row.url}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="min-w-0 truncate text-sm font-medium text-foreground no-underline hover:underline"
+                >
+                  <span className="font-mono text-xs text-muted-foreground">{row.identifier}</span>
+                  {" "}
+                  {row.title}
+                </a>
+                <SourceBadge>External</SourceBadge>
+                {row.imported ? <ImportedBadge /> : null}
+              </div>
+              <LinearIssueMeta row={row} />
+            </div>
+            <div className="flex shrink-0 items-center">
+              <LinearRowAction
+                row={row}
+                orgId={orgId}
+                targetProjectId={targetProjectId}
+                importing={importing}
+                onImport={onImport}
+              />
+            </div>
+          </article>
+        );
+      })}
+    </div>
+  );
+}
+
+function LinearBoardView({
+  rows,
+  teamMappings,
+  selectedIssueIds,
+  orgId,
+  targetProjectId,
+  importing,
+  onToggleSelected,
+  onImport,
+}: {
+  rows: LinearIssueRow[];
+  teamMappings: LinearTeamMapping[] | undefined;
+  selectedIssueIds: string[];
+  orgId: string;
+  targetProjectId: string;
+  importing: boolean;
+  onToggleSelected: (issueId: string) => void;
+  onImport: (row: LinearIssueRow) => void;
+}) {
+  const grouped = useMemo(() => {
+    const next = new Map<IssueStatus, LinearIssueRow[]>();
+    for (const status of boardStatuses) next.set(status, []);
+    for (const row of rows) {
+      const status = resolveMappedStatus(row, teamMappings);
+      next.get(status)?.push(row);
+    }
+    return next;
+  }, [rows, teamMappings]);
+
+  const visibleStatuses = boardStatuses.filter((status) => (grouped.get(status)?.length ?? 0) > 0);
+
+  return (
+    <div className="scrollbar-auto-hide min-h-0 flex-1 overflow-x-auto overflow-y-hidden pb-3">
+      <div className="flex h-full min-h-[440px] min-w-max items-stretch gap-3 pr-2">
+        {visibleStatuses.map((status) => {
+          const laneRows = grouped.get(status) ?? [];
+          return (
+            <section key={status} className="flex h-full min-h-0 w-[272px] min-w-[272px] shrink-0 flex-col">
+              <div className="mb-1 flex items-center gap-2 px-2 py-2">
+                <StatusIcon status={status} />
+                <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                  {statusLabel(status)}
+                </span>
+                <span className="ml-auto text-xs text-muted-foreground/60 tabular-nums">
+                  {laneRows.length}
+                </span>
+              </div>
+              <div
+                data-testid={`linear-source-kanban-column-${status}`}
+                className={cn(
+                  "scrollbar-auto-hide flex-1 space-y-1.5 overflow-y-auto rounded-[calc(var(--radius-sm)-1px)] border p-1.5",
+                  laneSurfaceClasses[status],
+                )}
+              >
+                {laneRows.map((row) => (
+                  <article
+                    key={row.id}
+                    data-testid={`linear-source-board-card-${row.id}`}
+                    className="overflow-hidden rounded-[calc(var(--radius-sm)-1px)] border bg-card p-2.5"
+                  >
+                    <div className="mb-1.5 flex min-w-0 items-start gap-2">
+                      <input
+                        type="checkbox"
+                        className="mt-0.5 h-4 w-4 rounded border-[color:var(--border-base)]"
+                        checked={selectedIssueIds.includes(row.id)}
+                        disabled={row.imported || importing}
+                        aria-label={`Select ${row.identifier}`}
+                        onChange={() => onToggleSelected(row.id)}
+                      />
+                      <a
+                        href={row.url}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="min-w-0 flex-1 truncate font-mono text-xs text-muted-foreground no-underline hover:underline"
+                      >
+                        {row.identifier}
+                      </a>
+                      {row.imported ? <ImportedBadge /> : <SourceBadge>External</SourceBadge>}
+                    </div>
+                    <p className="mb-2 line-clamp-2 text-sm leading-snug">{row.title}</p>
+                    <div className="space-y-1.5 text-xs text-muted-foreground">
+                      <span className="flex min-w-0 items-center gap-1.5">
+                        <StatusIcon status={resolveLinearTypeStatus(row.state.type)} />
+                        <span className="truncate">{row.state.name}</span>
+                      </span>
+                      <span className="flex min-w-0 items-center gap-1.5">
+                        <FolderKanban className="h-3 w-3 shrink-0" />
+                        <span className="truncate">{row.project?.name ?? "No Linear project"}</span>
+                      </span>
+                      <span className="flex min-w-0 items-center gap-1.5">
+                        <UserRound className="h-3 w-3 shrink-0" />
+                        <span className="truncate">{row.assignee?.name ?? "Unassigned"}</span>
+                      </span>
+                      <span>Updated {timeAgo(row.updatedAt)}</span>
+                    </div>
+                    <div className="mt-3 flex justify-end">
+                      <LinearRowAction
+                        row={row}
+                        orgId={orgId}
+                        targetProjectId={targetProjectId}
+                        importing={importing}
+                        onImport={onImport}
+                      />
+                    </div>
+                  </article>
+                ))}
+              </div>
+            </section>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+export function LinearIssueSourceBoard({
+  orgId,
+  projects,
+  linearTeamId = "",
+  linearProjectId = "",
+  initialSearch = "",
+  onSearchChange,
+}: LinearIssueSourceBoardProps) {
+  const queryClient = useQueryClient();
+  const { pushToast } = useToast();
+  const [viewMode, setViewMode] = useState<LinearViewMode>(() => getStoredViewMode());
+  const [targetProjectId, setTargetProjectId] = useState("");
+  const [stateId, setStateId] = useState("");
+  const [assigneeId, setAssigneeId] = useState("");
+  const [sortField, setSortField] = useState<LinearSortField>("updated");
+  const [sortDir, setSortDir] = useState<LinearSortDir>("desc");
+  const [search, setSearch] = useState(initialSearch);
+  const [debouncedSearch, setDebouncedSearch] = useState(initialSearch);
+  const [afterCursor, setAfterCursor] = useState<string | null>(null);
+  const [cursorHistory, setCursorHistory] = useState<string[]>([]);
+  const [selectedIssueIds, setSelectedIssueIds] = useState<string[]>([]);
+
+  useEffect(() => {
+    setSearch(initialSearch);
+    setDebouncedSearch(initialSearch);
+  }, [initialSearch]);
+
+  useEffect(() => {
+    const timeout = window.setTimeout(() => setDebouncedSearch(search.trim()), 300);
+    return () => window.clearTimeout(timeout);
+  }, [search]);
+
+  useEffect(() => {
+    setAfterCursor(null);
+    setCursorHistory([]);
+    setSelectedIssueIds([]);
+  }, [linearTeamId, linearProjectId, stateId, assigneeId, debouncedSearch]);
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem("rudder:linear-source-view-mode", viewMode);
+    }
+  }, [viewMode]);
+
+  const { data: contributions, isLoading: contributionsLoading } = useQuery({
+    queryKey: queryKeys.plugins.uiContributions,
+    queryFn: () => pluginsApi.listUiContributions(),
+  });
+  const contribution = useMemo(() => resolveLinearContribution(contributions), [contributions]);
+  const pluginId = contribution?.pluginId ?? "";
+
+  const { data: bootstrap, isLoading: bootstrapLoading, error: bootstrapError } = useQuery({
+    queryKey: ["plugins", LINEAR_PLUGIN_KEY, DATA_KEY_PAGE_BOOTSTRAP, orgId, pluginId] as const,
+    queryFn: async () => {
+      const response = await pluginsApi.bridgeGetData(pluginId, DATA_KEY_PAGE_BOOTSTRAP, { orgId }, orgId);
+      return response.data as PageBootstrapData;
+    },
+    enabled: !!orgId && !!pluginId,
+  });
+
+  const { data: catalog, isLoading: catalogLoading } = useQuery({
+    queryKey: ["plugins", LINEAR_PLUGIN_KEY, DATA_KEY_CATALOG, orgId, pluginId] as const,
+    queryFn: async () => {
+      const response = await pluginsApi.bridgeGetData(pluginId, DATA_KEY_CATALOG, { orgId }, orgId);
+      return response.data as LinearCatalogData;
+    },
+    enabled: !!orgId && !!pluginId && bootstrap?.configured !== false,
+  });
+
+  const issuesQueryKey = [
+    "plugins",
+    LINEAR_PLUGIN_KEY,
+    DATA_KEY_ISSUES,
+    orgId,
+    pluginId,
+    linearTeamId || "__all__",
+    linearProjectId || "__all__",
+    stateId || "__all__",
+    assigneeId || "__all__",
+    debouncedSearch || "__none__",
+    afterCursor ?? "__first__",
+  ] as const;
+
+  const { data: issueData, isLoading: issuesLoading, error: issuesError } = useQuery({
+    queryKey: issuesQueryKey,
+    queryFn: async () => {
+      const response = await pluginsApi.bridgeGetData(
+        pluginId,
+        DATA_KEY_ISSUES,
+        {
+          orgId,
+          limit: LINEAR_PAGE_SIZE,
+          after: afterCursor ?? undefined,
+          teamId: linearTeamId || undefined,
+          projectId: linearProjectId || undefined,
+          stateId: stateId || undefined,
+          assigneeId: assigneeId || undefined,
+          query: debouncedSearch || undefined,
+        },
+        orgId,
+      );
+      return response.data as LinearIssuesData;
+    },
+    enabled: !!orgId && !!pluginId && bootstrap?.configured === true,
+  });
+
+  const importMutation = useMutation({
+    mutationFn: async ({ mode, issueIds }: { mode: "single" | "selected" | "allMatching"; issueIds?: string[] }) => {
+      if (!targetProjectId) throw new Error("Choose a target Rudder project before importing.");
+      const response = await pluginsApi.bridgePerformAction(
+        pluginId,
+        ACTION_KEY_IMPORT_ISSUES,
+        {
+          orgId,
+          targetProjectId,
+          mode,
+          issueIds,
+          filters: {
+            teamId: linearTeamId || undefined,
+            stateId: stateId || undefined,
+            projectId: linearProjectId || undefined,
+            assigneeId: assigneeId || undefined,
+            query: debouncedSearch || undefined,
+          },
+        },
+        orgId,
+      );
+      return response.data as ImportLinearIssuesActionResult;
+    },
+    onSuccess: async (result) => {
+      pushToast({
+        title: "Linear import complete",
+        body: summarizeImportResult(result),
+        tone: "success",
+      });
+      setSelectedIssueIds([]);
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ["plugins", LINEAR_PLUGIN_KEY, DATA_KEY_ISSUES, orgId] }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.issues.list(orgId) }),
+      ]);
+    },
+    onError: (error) => {
+      pushToast({
+        title: "Linear import failed",
+        body: error instanceof Error ? error.message : String(error),
+        tone: "error",
+      });
+    },
+  });
+
+  const rows = useMemo(() => {
+    const sourceRows = [...(issueData?.rows ?? [])];
+    sourceRows.sort((left, right) => {
+      let delta = 0;
+      if (sortField === "updated") delta = compareNullableIso(left.updatedAt, right.updatedAt);
+      else if (sortField === "created") delta = compareNullableIso(left.createdAt, right.createdAt);
+      else delta = left.identifier.localeCompare(right.identifier);
+      return sortDir === "asc" ? delta : -delta;
+    });
+    return sourceRows;
+  }, [issueData?.rows, sortDir, sortField]);
+
+  useEffect(() => {
+    const visibleIds = new Set(rows.map((row) => row.id));
+    setSelectedIssueIds((current) => current.filter((id) => visibleIds.has(id)));
+  }, [rows]);
+
+  const team = useMemo(
+    () => catalog?.teams.find((candidate) => candidate.id === linearTeamId) ?? null,
+    [catalog?.teams, linearTeamId],
+  );
+  const linearProject = useMemo(
+    () => catalog?.projects.find((candidate) => candidate.id === linearProjectId) ?? null,
+    [catalog?.projects, linearProjectId],
+  );
+  const sourceLabel = linearProject
+    ? `${linearProject.name}${team ? ` / ${team.name}` : ""}`
+    : team?.name ?? "All Linear teams";
+  const targetProjects = useMemo(() => {
+    const source = bootstrap?.projects?.length ? bootstrap.projects : (projects ?? []);
+    return source.filter((project) => !("archivedAt" in project) || !project.archivedAt);
+  }, [bootstrap?.projects, projects]);
+  const stateOptions = useMemo(() => {
+    const sourceTeams = linearTeamId
+      ? (catalog?.teams ?? []).filter((candidate) => candidate.id === linearTeamId)
+      : catalog?.teams ?? [];
+    const deduped = new Map<string, string>();
+    for (const sourceTeam of sourceTeams) {
+      for (const state of sourceTeam.states ?? []) {
+        deduped.set(state.id, state.name);
+      }
+    }
+    return [...deduped.entries()].map(([id, name]) => ({ id, name }));
+  }, [catalog?.teams, linearTeamId]);
+  const importedCount = rows.filter((row) => row.imported).length;
+  const selectableRows = rows.filter((row) => !row.imported);
+  const importing = importMutation.isPending;
+  const loading = contributionsLoading || bootstrapLoading || catalogLoading || issuesLoading;
+  const error = bootstrapError ?? issuesError;
+
+  const toggleSelected = useCallback((issueId: string) => {
+    setSelectedIssueIds((current) =>
+      current.includes(issueId) ? current.filter((id) => id !== issueId) : [...current, issueId],
+    );
+  }, []);
+
+  const importRow = useCallback((row: LinearIssueRow) => {
+    importMutation.mutate({ mode: "single", issueIds: [row.id] });
+  }, [importMutation]);
+
+  if (!contributionsLoading && !contribution) {
+    return (
+      <div className="flex min-h-[58vh] items-center justify-center" data-testid="linear-source-board">
+        <EmptyState icon={ExternalLink} message="Linear is not installed or ready." />
+      </div>
+    );
+  }
+
+  if (!bootstrapLoading && bootstrap?.configured === false) {
+    return (
+      <div className="flex h-full min-h-0 flex-col px-1" data-testid="linear-source-board">
+        <div className="rounded-[calc(var(--radius-sm)+1px)] border border-dashed border-[color:var(--border-base)] bg-[color:color-mix(in_oklab,var(--surface-inset)_82%,transparent)] px-4 py-4 text-sm text-muted-foreground">
+          <div className="font-medium text-foreground">Linear is not configured for this organization.</div>
+          <div className="mt-1">{bootstrap.message ?? "Connect Linear and choose teams in plugin settings."}</div>
+          <Button asChild variant="outline" size="sm" className="mt-3">
+            <Link to="/instance/settings/plugins">Open plugin settings</Link>
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div data-testid="linear-source-board" className="flex h-full min-h-0 flex-col gap-4">
+      <div className="surface-panel flex flex-col gap-3 rounded-[calc(var(--radius-sm)+1px)] px-3 py-3 lg:flex-row lg:items-center lg:justify-between">
+        <div className="min-w-0">
+          <div className="flex min-w-0 items-center gap-2">
+            <h1 className="shrink-0 text-base font-semibold text-foreground">Linear Issues</h1>
+            <SourceBadge>External</SourceBadge>
+          </div>
+          <div className="mt-1 flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
+            <span className="truncate">{sourceLabel}</span>
+            <span>{rows.length} shown</span>
+            {importedCount > 0 ? <span>{importedCount} imported</span> : null}
+          </div>
+        </div>
+
+        <div className="flex min-w-0 flex-wrap items-center gap-2">
+          <div className="relative w-full min-w-44 sm:w-64">
+            <Search className="pointer-events-none absolute left-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              value={search}
+              onChange={(event) => {
+                setSearch(event.target.value);
+                onSearchChange?.(event.target.value);
+              }}
+              placeholder="Search Linear issues..."
+              className="pl-7 text-xs sm:text-sm"
+              aria-label="Search Linear issues"
+            />
+          </div>
+          <select
+            className={selectClassName("w-40")}
+            value={stateId}
+            aria-label="Filter by Linear state"
+            onChange={(event) => setStateId(event.target.value)}
+          >
+            <option value="">All states</option>
+            {stateOptions.map((state) => (
+              <option key={state.id} value={state.id}>{state.name}</option>
+            ))}
+          </select>
+          <select
+            className={selectClassName("w-40")}
+            value={assigneeId}
+            aria-label="Filter by Linear assignee"
+            onChange={(event) => setAssigneeId(event.target.value)}
+          >
+            <option value="">Anyone</option>
+            {(catalog?.users ?? []).map((user) => (
+              <option key={user.id} value={user.id}>{user.name}</option>
+            ))}
+          </select>
+          <select
+            className={selectClassName("w-36")}
+            value={sortField}
+            aria-label="Sort Linear issues"
+            onChange={(event) => setSortField(event.target.value as LinearSortField)}
+          >
+            <option value="updated">Updated</option>
+            <option value="created">Created</option>
+            <option value="identifier">Identifier</option>
+          </select>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            title={`Sort ${sortDir === "asc" ? "ascending" : "descending"}`}
+            onClick={() => setSortDir((current) => (current === "asc" ? "desc" : "asc"))}
+          >
+            <ArrowUpDown className="h-3.5 w-3.5" />
+            <span className="hidden sm:inline">{sortDir === "asc" ? "Asc" : "Desc"}</span>
+          </Button>
+          <div className="flex items-center overflow-hidden rounded-[var(--radius-sm)] border border-[color:var(--border-base)] bg-[color:color-mix(in_oklab,var(--surface-inset)_82%,transparent)]">
+            <button
+              className={cn(
+                "p-1.5 transition-colors",
+                viewMode === "list" ? "bg-[color:var(--surface-active)] text-foreground" : "text-muted-foreground hover:text-foreground",
+              )}
+              onClick={() => setViewMode("list")}
+              title="List view"
+              data-testid="linear-source-view-list"
+            >
+              <List className="h-3.5 w-3.5" />
+            </button>
+            <button
+              className={cn(
+                "p-1.5 transition-colors",
+                viewMode === "board" ? "bg-[color:var(--surface-active)] text-foreground" : "text-muted-foreground hover:text-foreground",
+              )}
+              onClick={() => setViewMode("board")}
+              title="Board view"
+              data-testid="linear-source-view-board"
+            >
+              <Columns3 className="h-3.5 w-3.5" />
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <div className="surface-panel flex flex-col gap-3 rounded-[calc(var(--radius-sm)+1px)] px-3 py-3 md:flex-row md:items-center md:justify-between">
+        <div className="flex min-w-0 flex-wrap items-center gap-2">
+          <select
+            data-testid="linear-source-target-project"
+            className={selectClassName("w-60 max-w-full")}
+            value={targetProjectId}
+            aria-label="Target Rudder project"
+            onChange={(event) => setTargetProjectId(event.target.value)}
+          >
+            <option value="">Choose target Rudder project</option>
+            {targetProjects.map((project) => (
+              <option key={project.id} value={project.id}>{project.name}</option>
+            ))}
+          </select>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            disabled={selectableRows.length === 0 || importing}
+            onClick={() => setSelectedIssueIds(selectableRows.map((row) => row.id))}
+          >
+            <Filter className="h-3.5 w-3.5" />
+            Select page
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            disabled={selectedIssueIds.length === 0 || importing}
+            onClick={() => setSelectedIssueIds([])}
+          >
+            Clear
+          </Button>
+        </div>
+        <div className="flex min-w-0 flex-wrap items-center justify-end gap-2">
+          <span className="text-xs text-muted-foreground">{selectedIssueIds.length} selected</span>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            data-testid="linear-source-import-selected"
+            disabled={!targetProjectId || selectedIssueIds.length === 0 || importing}
+            onClick={() => importMutation.mutate({ mode: "selected", issueIds: selectedIssueIds })}
+          >
+            <Import className="h-3.5 w-3.5" />
+            Import selected
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            disabled={!targetProjectId || importing}
+            onClick={() => importMutation.mutate({ mode: "allMatching" })}
+          >
+            Import matching
+          </Button>
+        </div>
+      </div>
+
+      {loading ? <PageSkeleton variant="issues-list" /> : null}
+      {error ? <p className="text-sm text-destructive">{error instanceof Error ? error.message : String(error)}</p> : null}
+
+      {!loading && !error && rows.length === 0 ? (
+        <div className="flex min-h-[48vh] items-center justify-center">
+          <EmptyState icon={ExternalLink} message="No Linear issues match this source." />
+        </div>
+      ) : null}
+
+      {!loading && !error && rows.length > 0 && viewMode === "list" ? (
+        <LinearListView
+          rows={rows}
+          selectedIssueIds={selectedIssueIds}
+          orgId={orgId}
+          targetProjectId={targetProjectId}
+          importing={importing}
+          onToggleSelected={toggleSelected}
+          onImport={importRow}
+        />
+      ) : null}
+
+      {!loading && !error && rows.length > 0 && viewMode === "board" ? (
+        <LinearBoardView
+          rows={rows}
+          teamMappings={bootstrap?.teamMappings}
+          selectedIssueIds={selectedIssueIds}
+          orgId={orgId}
+          targetProjectId={targetProjectId}
+          importing={importing}
+          onToggleSelected={toggleSelected}
+          onImport={importRow}
+        />
+      ) : null}
+
+      {!loading && !error && rows.length > 0 ? (
+        <div className="flex items-center justify-between gap-3 text-xs text-muted-foreground">
+          <span>Showing {issueData?.totalShown ?? rows.length} issue(s).</span>
+          <div className="flex items-center gap-2">
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              disabled={cursorHistory.length === 0 || importing}
+              onClick={() => {
+                setCursorHistory((current) => {
+                  const nextHistory = [...current];
+                  const previousCursor = nextHistory.pop() ?? null;
+                  setAfterCursor(previousCursor);
+                  return nextHistory;
+                });
+              }}
+            >
+              Previous
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              disabled={!issueData?.hasNextPage || importing}
+              onClick={() => {
+                if (!issueData?.endCursor) return;
+                setCursorHistory((current) => [...current, afterCursor ?? ""]);
+                setAfterCursor(issueData.endCursor);
+              }}
+            >
+              Next
+            </Button>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/ui/src/components/ThreeColumnContextSidebar.test.tsx
+++ b/ui/src/components/ThreeColumnContextSidebar.test.tsx
@@ -34,7 +34,7 @@ const mockState = vi.hoisted(() => ({
   }>,
   linearCatalog: null as null | {
     orgId: string;
-    projects: Array<{ id: string; name: string }>;
+    projects: Array<{ id: string; name: string; teamIds?: string[] }>;
     teams: Array<{ id: string; name: string }>;
   },
   liveRuns: [] as Array<{
@@ -507,13 +507,13 @@ describe("ThreeColumnContextSidebar issue draft recovery", () => {
 
     const teamLink = document.querySelector<HTMLAnchorElement>("[data-testid='issue-linear-team-team-rudder']");
     expect(teamLink?.textContent).toContain("Rudder");
-    expect(teamLink?.getAttribute("href")).toBe("/linear?linearTeamId=team-rudder");
+    expect(teamLink?.getAttribute("href")).toBe("/issues?source=linear&linearTeamId=team-rudder");
   });
 
-  it("marks a Linear team slice active on the Linear plugin page", () => {
-    mockState.pathname = "/RUD/linear";
-    mockState.relativePath = "/linear";
-    mockState.search = "?linearTeamId=team-rudder";
+  it("marks a Linear team slice active on the issue source board", () => {
+    mockState.pathname = "/RUD/issues";
+    mockState.relativePath = "/issues";
+    mockState.search = "?source=linear&linearTeamId=team-rudder";
     mockState.linearContributions = [{
       pluginId: "plugin-linear",
       pluginKey: "rudder.linear",
@@ -534,6 +534,29 @@ describe("ThreeColumnContextSidebar issue draft recovery", () => {
     const activeLink = document.querySelector<HTMLAnchorElement>("[data-testid='issue-linear-team-team-rudder']");
     expect(activeLink?.getAttribute("aria-current")).toBe("page");
     expect(document.querySelector("[data-testid='issue-linear-sidebar-active-indicator']")).not.toBeNull();
+  });
+
+  it("shows Linear projects under their connected team and routes them into the issue board", () => {
+    mockState.linearContributions = [{
+      pluginId: "plugin-linear",
+      pluginKey: "rudder.linear",
+      displayName: "Linear",
+      version: "0.1.0",
+      uiEntryFile: "index.js",
+      slots: [{ type: "page", routePath: "linear" }],
+      launchers: [],
+    }];
+    mockState.linearCatalog = {
+      orgId: "org-1",
+      projects: [{ id: "project-roadmap", name: "Roadmap", teamIds: ["team-rudder"] }],
+      teams: [{ id: "team-rudder", name: "Rudder" }],
+    };
+
+    renderSidebar();
+
+    const projectLink = document.querySelector<HTMLAnchorElement>("[data-testid='issue-linear-project-project-roadmap']");
+    expect(projectLink?.textContent).toContain("Roadmap");
+    expect(projectLink?.getAttribute("href")).toBe("/issues?source=linear&linearTeamId=team-rudder&linearProjectId=project-roadmap");
   });
 
   it("shows live run counts on issue project rows", () => {

--- a/ui/src/components/ThreeColumnContextSidebar.tsx
+++ b/ui/src/components/ThreeColumnContextSidebar.tsx
@@ -93,11 +93,12 @@ type LinearSidebarItem = {
   id: string;
   name: string;
   kind: "project" | "team";
+  teamId?: string;
 };
 
 type LinearSidebarCatalog = {
   orgId: string;
-  projects: Array<{ id: string; name: string }>;
+  projects: Array<{ id: string; name: string; teamIds?: string[] }>;
   teams: Array<{ id: string; name: string }>;
 };
 
@@ -110,6 +111,18 @@ function resolveLinearPageContribution(contributions: PluginUiContribution[] | u
     pluginId: contribution.pluginId,
     routePath: pageSlot.routePath || LINEAR_PLUGIN_ROUTE_PATH,
   };
+}
+
+function linearIssueSourceHref(item: LinearSidebarItem): string {
+  const params = new URLSearchParams();
+  params.set("source", "linear");
+  if (item.kind === "team") {
+    params.set("linearTeamId", item.id);
+  } else {
+    if (item.teamId) params.set("linearTeamId", item.teamId);
+    params.set("linearProjectId", item.id);
+  }
+  return `/issues?${params.toString()}`;
 }
 
 function SectionLabel({
@@ -781,6 +794,7 @@ export function ThreeColumnContextSidebar() {
   const currentUserId = session?.user?.id ?? session?.session?.userId ?? null;
   const rawScope = new URLSearchParams(location.search).get("scope") ?? "";
   const scope = rawScope === "recent" ? "" : rawScope;
+  const selectedIssueSource = new URLSearchParams(location.search).get("source") ?? "";
   const activeCustomViewId = new URLSearchParams(location.search).get("view") ?? "";
   const selectedProjectId = new URLSearchParams(location.search).get("projectId") ?? "";
   const selectedLinearProjectId = new URLSearchParams(location.search).get("linearProjectId") ?? "";
@@ -818,12 +832,35 @@ export function ThreeColumnContextSidebar() {
     enabled: !!selectedOrganizationId && !!linearPageContribution?.pluginId && isIssuesRoute,
   });
   const linearSidebarItems = useMemo<LinearSidebarItem[]>(() => {
-    const projects = linearCatalog?.projects ?? [];
-    const teams = linearCatalog?.teams ?? [];
-    const source = projects.length > 0
-      ? projects.map((project) => ({ ...project, kind: "project" as const }))
-      : teams.map((team) => ({ ...team, kind: "team" as const }));
-    return [...source].sort((a, b) => a.name.localeCompare(b.name));
+    const projects = [...(linearCatalog?.projects ?? [])].sort((a, b) => a.name.localeCompare(b.name));
+    const teams = [...(linearCatalog?.teams ?? [])].sort((a, b) => a.name.localeCompare(b.name));
+    if (teams.length === 0) {
+      return projects.map((project) => ({ ...project, kind: "project" as const }));
+    }
+
+    const items: LinearSidebarItem[] = [];
+    const groupedProjectIds = new Set<string>();
+    for (const team of teams) {
+      items.push({ ...team, kind: "team" });
+      for (const project of projects) {
+        const teamIds = project.teamIds ?? [];
+        if (!teamIds.includes(team.id)) continue;
+        groupedProjectIds.add(project.id);
+        items.push({
+          id: project.id,
+          name: project.name,
+          kind: "project",
+          teamId: team.id,
+        });
+      }
+    }
+
+    for (const project of projects) {
+      if (groupedProjectIds.has(project.id)) continue;
+      items.push({ ...project, kind: "project" });
+    }
+
+    return items;
   }, [linearCatalog?.projects, linearCatalog?.teams]);
   const visibleAgents = useMemo(
     () => (agents ?? []).filter((agent) => agent.status !== "terminated").sort((a, b) => a.name.localeCompare(b.name)),
@@ -871,7 +908,7 @@ export function ThreeColumnContextSidebar() {
       to: "/issues",
       icon: Circle,
       label: "All Issues",
-      active: scope === "" && !selectedProjectId && !activeCustomViewId,
+      active: selectedIssueSource !== "linear" && scope === "" && !selectedProjectId && !activeCustomViewId,
     },
     ...(issueDraftSummaries.length > 0
       ? [{
@@ -897,7 +934,9 @@ export function ThreeColumnContextSidebar() {
     return selectedProjectId === project.id || activeProjectRef === routeRef;
   });
   const issueLinearActiveIndex = linearSidebarItems.findIndex((item) =>
-    item.kind === "project" ? selectedLinearProjectId === item.id : selectedLinearTeamId === item.id,
+    item.kind === "project"
+      ? selectedLinearProjectId === item.id && (!item.teamId || selectedLinearTeamId === item.teamId)
+      : selectedIssueSource === "linear" && selectedLinearTeamId === item.id && !selectedLinearProjectId,
   );
   const orgContextItems = [
     { key: "structure", to: "/org", icon: Network, label: "Structure", active: /^\/org(?:\/|$)/.test(relativePath) },
@@ -1337,18 +1376,18 @@ export function ThreeColumnContextSidebar() {
               >
                 {linearSidebarItems.map((item) => {
                   const active = item.kind === "project"
-                    ? selectedLinearProjectId === item.id
-                    : selectedLinearTeamId === item.id;
-                  const paramName = item.kind === "project" ? "linearProjectId" : "linearTeamId";
+                    ? selectedLinearProjectId === item.id && (!item.teamId || selectedLinearTeamId === item.teamId)
+                    : selectedIssueSource === "linear" && selectedLinearTeamId === item.id && !selectedLinearProjectId;
                   return (
                     <Link
                       key={`${item.kind}-${item.id}`}
-                      to={`/${linearPageContribution?.routePath ?? LINEAR_PLUGIN_ROUTE_PATH}?${paramName}=${encodeURIComponent(item.id)}`}
+                      to={linearIssueSourceHref(item)}
                       onClick={closeMobileSidebar}
                       data-testid={`issue-linear-${item.kind}-${item.id}`}
                       aria-current={active ? "page" : undefined}
                       className={cn(
                         "relative z-10 mx-1.5 flex min-h-[var(--motion-context-item-height)] items-center gap-3 rounded-[calc(var(--radius-sm)-1px)] border border-transparent px-3 py-2 text-sm transition-[background-color,border-color,color]",
+                        item.kind === "project" && item.teamId ? "ml-6 min-h-8 py-1.5 text-xs" : "",
                         active
                           ? "font-medium text-foreground"
                           : "text-muted-foreground hover:border-[color:color-mix(in_oklab,var(--border-soft)_52%,transparent)] hover:bg-[color:color-mix(in_oklab,var(--surface-elevated)_58%,transparent)] hover:text-foreground",

--- a/ui/src/pages/Issues.tsx
+++ b/ui/src/pages/Issues.tsx
@@ -26,6 +26,7 @@ import {
 import { relativeTime } from "../lib/utils";
 import { EmptyState } from "../components/EmptyState";
 import { IssuesList, type IssueViewState } from "../components/IssuesList";
+import { LinearIssueSourceBoard } from "../components/LinearIssueSourceBoard";
 import {
   createIssueCustomView,
   deleteIssueCustomView,
@@ -170,9 +171,13 @@ export function Issues() {
   const queryClient = useQueryClient();
 
   const initialSearch = searchParams.get("q") ?? "";
+  const issueSource = searchParams.get("source") ?? "";
   const issueScope = searchParams.get("scope") ?? "";
   const effectiveIssueScope = issueScope === "recent" ? "" : issueScope;
   const isDraftScope = effectiveIssueScope === "drafts";
+  const isLinearSource = issueSource === "linear" && !isDraftScope;
+  const linearTeamId = searchParams.get("linearTeamId") ?? undefined;
+  const linearProjectId = searchParams.get("linearProjectId") ?? undefined;
   const customViewId = searchParams.get("view") ?? "";
   const projectId = searchParams.get("projectId") ?? undefined;
   const participantAgentId = searchParams.get("participantAgentId") ?? undefined;
@@ -272,8 +277,8 @@ export function Issues() {
   );
 
   useEffect(() => {
-    setBreadcrumbs([{ label: isDraftScope ? "Draft Issues" : "Issue Tracker" }]);
-  }, [isDraftScope, setBreadcrumbs]);
+    setBreadcrumbs([{ label: isDraftScope ? "Draft Issues" : isLinearSource ? "Linear Issues" : "Issue Tracker" }]);
+  }, [isDraftScope, isLinearSource, setBreadcrumbs]);
 
   useEffect(() => {
     const refreshIssueDraftSummaries = () => {
@@ -304,12 +309,12 @@ export function Issues() {
   }, [selectedOrganizationId]);
 
   useEffect(() => {
-    if (!selectedOrganizationId || participantAgentId || isDraftScope || customViewId) return;
+    if (!selectedOrganizationId || participantAgentId || isDraftScope || isLinearSource || customViewId) return;
     rememberIssueNavigation(selectedOrganizationId, {
       scope: effectiveIssueScope || undefined,
       projectId,
     });
-  }, [customViewId, effectiveIssueScope, isDraftScope, participantAgentId, projectId, selectedOrganizationId]);
+  }, [customViewId, effectiveIssueScope, isDraftScope, isLinearSource, participantAgentId, projectId, selectedOrganizationId]);
 
   const issueFilters = useMemo(
     () => getIssueScopeFilters(effectiveIssueScope, currentUserId),
@@ -329,7 +334,7 @@ export function Issues() {
       projectId ?? "__all__",
     ],
     queryFn: () => issuesApi.list(selectedOrganizationId!, { participantAgentId, projectId, ...issueFilters }),
-    enabled: !!selectedOrganizationId && !isDraftScope,
+    enabled: !!selectedOrganizationId && !isDraftScope && !isLinearSource,
   });
   const visibleIssues = useMemo(() => {
     const allIssues = issues ?? [];
@@ -394,6 +399,21 @@ export function Issues() {
           pushToast({ title: "Draft issue deleted", tone: "success" });
         }}
       />
+    );
+  }
+
+  if (isLinearSource) {
+    return (
+      <div className="flex h-full min-h-0 flex-col">
+        <LinearIssueSourceBoard
+          orgId={selectedOrganizationId}
+          projects={projects}
+          linearTeamId={linearTeamId}
+          linearProjectId={linearProjectId}
+          initialSearch={initialSearch}
+          onSearchChange={handleSearchChange}
+        />
+      </div>
     );
   }
 


### PR DESCRIPTION
## Summary
- route Linear team/project navigation into the native Issues page with source=linear
- add a read-only Linear issue source board with board/list modes and import controls
- include Linear project team membership in the plugin catalog so sidebar project links keep team context

## Validation
- pnpm --filter @rudderhq/ui exec vitest run src/components/LinearIssueSourceBoard.test.tsx src/components/ThreeColumnContextSidebar.test.tsx src/pages/Issues.test.tsx src/components/BreadcrumbBar.test.tsx
- pnpm --filter @rudderhq/plugin-linear test -- --run
- pnpm -r typecheck
- pnpm build
- RUDDER_E2E_USE_EXISTING_SERVER=1 RUDDER_E2E_BASE_URL=http://127.0.0.1:3101 RUDDER_E2E_CHROMIUM_EXECUTABLE=/Applications/Browser/Google Chrome.app/Contents/MacOS/Google Chrome npx playwright test --config tests/e2e/playwright.config.ts tests/e2e/linear-plugin-import.spec.ts --project=chromium --workers=1 --timeout=90000

## Known local failure
- pnpm test:run still fails in embedded PostgreSQL-backed suites with "Postgres init script exited with code 1"; focused tests and E2E for this feature pass.