### PR TITLE
[codex] Polish Linear issue board UX

### DIFF
--- a/packages/plugins/examples/plugin-linear/src/ui/index.tsx
+++ b/packages/plugins/examples/plugin-linear/src/ui/index.tsx
@@ -1245,7 +1245,11 @@ export function LinearPluginSettingsPage(_props: PluginSettingsPageProps) {
           <div>
             <h3 style={{ margin: 0 }}>Connect Linear</h3>
             <p style={layoutStyles.subtitle}>
-              Pick a Rudder organization, paste a token, and Rudder will prepare the import setup from Linear.
+              Pick a Rudder organization, paste a token, and Rudder will prepare the import setup from Linear.{" "}
+              <a href="https://linear.app/settings/account/security" target="_blank" rel="noreferrer" style={layoutStyles.monoLink}>
+                Create a Linear token
+              </a>
+              .
             </p>
           </div>
         </div>

--- a/tests/e2e/linear-plugin-import.spec.ts
+++ b/tests/e2e/linear-plugin-import.spec.ts
@@ -281,7 +281,7 @@ test.describe("Linear plugin import workflow", () => {
     await page.goto(`/${organization.issuePrefix}/issues`);
     const linearSection = page.getByTestId("issue-linear-section");
     await expect(linearSection).toContainText("Linear");
-    await expect(linearSection).toContainText("External");
+    await expect(linearSection).not.toContainText("External");
 
     const roadmapLink = page.getByTestId("issue-linear-project-proj-roadmap");
     await expect(roadmapLink).toContainText("Roadmap");

--- a/ui/src/components/BreadcrumbBar.test.tsx
+++ b/ui/src/components/BreadcrumbBar.test.tsx
@@ -103,7 +103,7 @@ describe("BreadcrumbBar", () => {
 
     expect(html).toContain("Linear Issues");
     expect(html).not.toContain("Issue Tracker");
-    expect(html).not.toContain("Search issues...");
+    expect(html).toContain("Search Linear issues...");
     expect(html).not.toContain("Create Issue");
   });
 });

--- a/ui/src/components/BreadcrumbBar.tsx
+++ b/ui/src/components/BreadcrumbBar.tsx
@@ -222,21 +222,23 @@ export function BreadcrumbBar({
           <h1 className="truncate text-[15px] font-semibold tracking-tight text-foreground">{threeColumnTitle}</h1>
         </div>
         {desktopChrome ? <div className="desktop-window-drag hidden min-h-full flex-1 md:block" /> : null}
-        {isIssuesRoute && !isLinearIssueSource ? (
+        {isIssuesRoute ? (
           <div className={cn("hidden items-center gap-3 md:flex", desktopChrome && "desktop-window-no-drag")}>
             <div className="relative w-80">
               <Search className="pointer-events-none absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
               <Input
                 value={issueSearch}
                 onChange={(event) => setIssueSearch(event.target.value)}
-                placeholder="Search issues..."
+                placeholder={isLinearIssueSource ? "Search Linear issues..." : "Search issues..."}
                 className="h-9 border-[color:var(--border-soft)] bg-[color:var(--surface-inset)] pl-8 text-sm"
               />
             </div>
-            <Button size="sm" className="px-4" onClick={() => openNewIssue()}>
-              <Plus className="mr-1.5 h-3.5 w-3.5" />
-              Create Issue
-            </Button>
+            {!isLinearIssueSource ? (
+              <Button size="sm" className="px-4" onClick={() => openNewIssue()}>
+                <Plus className="mr-1.5 h-3.5 w-3.5" />
+                Create Issue
+              </Button>
+            ) : null}
           </div>
         ) : null}
         {isProjectsRoute && (!isProjectsIndex || (visibleProjects?.length ?? 0) > 0) ? (

--- a/ui/src/components/LinearIssueSourceBoard.test.tsx
+++ b/ui/src/components/LinearIssueSourceBoard.test.tsx
@@ -196,6 +196,7 @@ describe("LinearIssueSourceBoard", () => {
 
     expect(document.querySelector("[data-testid='linear-source-board']")?.textContent).toContain("Roadmap");
     expect(document.querySelector("[data-testid='linear-source-kanban-column-in_progress']")?.textContent).toContain("ENG-102");
+    expect(document.querySelector("[data-testid='linear-source-hidden-columns']")?.textContent).toContain("Done");
     expect(document.querySelector("[data-testid='linear-source-board-card-lin-2']")?.textContent).not.toContain("Import");
   });
 

--- a/ui/src/components/LinearIssueSourceBoard.test.tsx
+++ b/ui/src/components/LinearIssueSourceBoard.test.tsx
@@ -115,6 +115,7 @@ async function renderBoard() {
       <QueryClientProvider client={client}>
         <LinearIssueSourceBoard
           orgId="org-1"
+          orgName="Rudder QA"
           projects={[{ id: "rudder-project", name: "Rudder Project", archivedAt: null }]}
           linearTeamId="team-eng"
           linearProjectId="linear-roadmap"
@@ -193,24 +194,17 @@ describe("LinearIssueSourceBoard", () => {
   it("groups Linear issues into mapped Rudder status lanes without native drag controls", async () => {
     await renderBoard();
 
-    expect(document.querySelector("[data-testid='linear-source-board']")?.textContent).toContain("Linear Issues");
+    expect(document.querySelector("[data-testid='linear-source-board']")?.textContent).toContain("Roadmap");
     expect(document.querySelector("[data-testid='linear-source-kanban-column-in_progress']")?.textContent).toContain("ENG-102");
-    expect(document.querySelector("[data-testid='linear-source-board-card-lin-2']")?.textContent).toContain("External");
+    expect(document.querySelector("[data-testid='linear-source-board-card-lin-2']")?.textContent).not.toContain("Import");
   });
 
-  it("imports selected Linear issues into a chosen Rudder project", async () => {
+  it("imports selected Linear issues after choosing a project in the import dialog", async () => {
     await renderBoard();
 
     const listToggle = document.querySelector<HTMLButtonElement>("[data-testid='linear-source-view-list']");
     act(() => {
       listToggle?.click();
-    });
-
-    const target = document.querySelector<HTMLSelectElement>("[data-testid='linear-source-target-project']");
-    act(() => {
-      if (!target) return;
-      target.value = "rudder-project";
-      target.dispatchEvent(new Event("change", { bubbles: true }));
     });
 
     const checkbox = document.querySelector<HTMLInputElement>("[data-testid='linear-source-row-checkbox-lin-2']");
@@ -221,6 +215,20 @@ describe("LinearIssueSourceBoard", () => {
     const importButton = document.querySelector<HTMLButtonElement>("[data-testid='linear-source-import-selected']");
     await act(async () => {
       importButton?.click();
+    });
+    await flushAsyncWork();
+
+    expect(document.body.textContent).toContain("Project in Rudder QA");
+    const target = document.querySelector<HTMLSelectElement>("[data-testid='linear-source-import-project']");
+    act(() => {
+      if (!target) return;
+      target.value = "rudder-project";
+      target.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+
+    const confirmButton = document.querySelector<HTMLButtonElement>("[data-testid='linear-source-confirm-import']");
+    await act(async () => {
+      confirmButton?.click();
     });
     await flushAsyncWork();
 

--- a/ui/src/components/LinearIssueSourceBoard.tsx
+++ b/ui/src/components/LinearIssueSourceBoard.tsx
@@ -16,6 +16,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { EmptyState } from "@/components/EmptyState";
 import { PageSkeleton } from "@/components/PageSkeleton";
 import { StatusIcon } from "@/components/StatusIcon";
@@ -324,6 +325,32 @@ function LinearListView({
   );
 }
 
+function LinearHiddenBoardStatus({
+  status,
+  issueCount,
+}: {
+  status: IssueStatus;
+  issueCount: number;
+}) {
+  return (
+    <div
+      data-testid={`linear-source-hidden-column-${status}`}
+      className={cn(
+        "flex items-center gap-2 rounded-[calc(var(--radius-sm)-1px)] border px-2 py-2",
+        laneSurfaceClasses[status],
+      )}
+    >
+      <StatusIcon status={status} />
+      <span className="min-w-0 flex-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+        {statusLabel(status)}
+      </span>
+      <span className="text-xs text-muted-foreground/60 tabular-nums">
+        {issueCount}
+      </span>
+    </div>
+  );
+}
+
 function LinearBoardView({
   rows,
   teamMappings,
@@ -350,10 +377,11 @@ function LinearBoardView({
   }, [rows, teamMappings]);
 
   const visibleStatuses = boardStatuses.filter((status) => (grouped.get(status)?.length ?? 0) > 0);
+  const hiddenStatuses = boardStatuses.filter((status) => (grouped.get(status)?.length ?? 0) === 0);
 
   return (
     <div className="scrollbar-auto-hide min-h-0 flex-1 overflow-x-auto overflow-y-hidden pb-3">
-      <div className="flex h-full min-h-[440px] min-w-max items-stretch gap-3 pr-2">
+      <div className="flex h-full min-h-full min-w-max items-stretch gap-3 pr-2">
         {visibleStatuses.map((status) => {
           const laneRows = grouped.get(status) ?? [];
           return (
@@ -426,6 +454,30 @@ function LinearBoardView({
             </section>
           );
         })}
+        {hiddenStatuses.length > 0 ? (
+          <div
+            data-testid="linear-source-hidden-columns"
+            className="flex h-full min-h-0 w-[228px] min-w-[228px] shrink-0 flex-col rounded-[calc(var(--radius-sm)+1px)] border border-[color:var(--border-base)] bg-[color:color-mix(in_oklab,var(--surface-inset)_78%,transparent)] p-2"
+          >
+            <div className="mb-2 flex items-center gap-2 px-1">
+              <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                Hidden columns
+              </span>
+              <span className="ml-auto text-xs text-muted-foreground/60 tabular-nums">
+                {hiddenStatuses.length}
+              </span>
+            </div>
+            <div className="space-y-2">
+              {hiddenStatuses.map((status) => (
+                <LinearHiddenBoardStatus
+                  key={status}
+                  status={status}
+                  issueCount={grouped.get(status)?.length ?? 0}
+                />
+              ))}
+            </div>
+          </div>
+        ) : null}
       </div>
     </div>
   );
@@ -651,6 +703,9 @@ export function LinearIssueSourceBoard({
   const selectedImportCount = selectedIssueIds.length;
   const selectedTargetProject = targetProjects.find((project) => project.id === importTargetProjectId) ?? null;
   const totalLoaded = rows.length;
+  const activeFilterCount = Number(Boolean(stateId)) + Number(Boolean(assigneeId));
+  const selectedStateLabel = stateOptions.find((state) => state.id === stateId)?.name ?? "All states";
+  const selectedAssigneeLabel = catalog?.users.find((user) => user.id === assigneeId)?.name ?? "Anyone";
 
   const toggleSelected = useCallback((issueId: string) => {
     setSelectedIssueIds((current) =>
@@ -702,17 +757,22 @@ export function LinearIssueSourceBoard({
 
   return (
     <div data-testid="linear-source-board" className="flex h-full min-h-0 flex-col gap-4">
-      <div className="surface-panel flex flex-col gap-3 rounded-[calc(var(--radius-sm)+1px)] px-3 py-3">
-        <div className="flex min-w-0 flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
-          <div className="min-w-0">
-            <h2 className="truncate text-sm font-semibold text-foreground">{sourceLabel}</h2>
-            <div className="mt-1 flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
-              <span>{totalLoaded} loaded</span>
-              {importedCount > 0 ? <span>{importedCount} imported</span> : null}
-              {hasNextPage ? <span>More loads as you scroll</span> : null}
-            </div>
+      <div
+        data-testid="linear-source-toolbar"
+        className="surface-panel flex items-center justify-between gap-2 rounded-[calc(var(--radius-sm)+1px)] px-3 py-3 sm:gap-3"
+      >
+        <div className="flex min-w-0 items-baseline gap-3">
+          <div className="truncate text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
+            {sourceLabel}
           </div>
+          <div className="hidden min-w-0 items-center gap-2 text-xs text-muted-foreground md:flex">
+            <span>{totalLoaded} loaded</span>
+            {importedCount > 0 ? <span>{importedCount} imported</span> : null}
+            {hasNextPage ? <span>Loads as you scroll</span> : null}
+          </div>
+        </div>
 
+        <div className="flex shrink-0 items-center gap-0.5 sm:gap-1">
           <div className="flex items-center overflow-hidden rounded-[var(--radius-sm)] border border-[color:var(--border-base)] bg-[color:color-mix(in_oklab,var(--surface-inset)_82%,transparent)]">
             <button
               className={cn(
@@ -737,64 +797,103 @@ export function LinearIssueSourceBoard({
               <Columns3 className="h-3.5 w-3.5" />
             </button>
           </div>
-        </div>
 
-        <div className="grid min-w-0 grid-cols-1 gap-2 sm:grid-cols-2 xl:grid-cols-[minmax(9rem,11rem)_minmax(9rem,11rem)_minmax(8rem,10rem)_auto]">
-          <ToolbarField label="State">
-          <select
-            className={selectClassName("h-8 w-full")}
-            value={stateId}
-            aria-label="Filter by Linear state"
-            onChange={(event) => setStateId(event.target.value)}
-          >
-            <option value="">All states</option>
-            {stateOptions.map((state) => (
-              <option key={state.id} value={state.id}>{state.name}</option>
-            ))}
-          </select>
-          </ToolbarField>
-          <ToolbarField label="Assignee">
-          <select
-            className={selectClassName("h-8 w-full")}
-            value={assigneeId}
-            aria-label="Filter by Linear assignee"
-            onChange={(event) => setAssigneeId(event.target.value)}
-          >
-            <option value="">Anyone</option>
-            {(catalog?.users ?? []).map((user) => (
-              <option key={user.id} value={user.id}>{user.name}</option>
-            ))}
-          </select>
-          </ToolbarField>
-          <ToolbarField label="Sort">
-          <select
-            className={selectClassName("h-8 w-full")}
-            value={sortField}
-            aria-label="Sort Linear issues"
-            onChange={(event) => setSortField(event.target.value as LinearSortField)}
-          >
-            <option value="updated">Updated</option>
-            <option value="created">Created</option>
-            <option value="identifier">Identifier</option>
-          </select>
-          </ToolbarField>
-          <ToolbarField label="Order" className="sm:max-w-44">
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            className="h-8 justify-start"
-            title={`Sort ${sortDir === "asc" ? "ascending" : "descending"}`}
-            onClick={() => setSortDir((current) => (current === "asc" ? "desc" : "asc"))}
-          >
-            <ArrowUpDown className="h-3.5 w-3.5" />
-            <span>{sortDir === "asc" ? "Ascending" : "Descending"}</span>
-          </Button>
-          </ToolbarField>
+          <Popover>
+            <PopoverTrigger asChild>
+              <Button variant="ghost" size="sm" className={cn("text-xs", activeFilterCount > 0 && "text-[color:var(--accent-strong)]")}>
+                <Filter className="h-3.5 w-3.5 sm:h-3 sm:w-3 sm:mr-1" />
+                <span className="hidden sm:inline">{activeFilterCount > 0 ? `Filters: ${activeFilterCount}` : "Filter"}</span>
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent align="end" className="w-72 p-3">
+              <div className="space-y-3">
+                <div className="flex items-center justify-between">
+                  <span className="text-sm font-medium">Filters</span>
+                  {activeFilterCount > 0 ? (
+                    <button
+                      type="button"
+                      className="text-xs text-muted-foreground hover:text-foreground"
+                      onClick={() => {
+                        setStateId("");
+                        setAssigneeId("");
+                      }}
+                    >
+                      Clear
+                    </button>
+                  ) : null}
+                </div>
+                <ToolbarField label="State">
+                  <select
+                    className={selectClassName("h-8 w-full")}
+                    value={stateId}
+                    aria-label="Filter by Linear state"
+                    onChange={(event) => setStateId(event.target.value)}
+                  >
+                    <option value="">All states</option>
+                    {stateOptions.map((state) => (
+                      <option key={state.id} value={state.id}>{state.name}</option>
+                    ))}
+                  </select>
+                </ToolbarField>
+                <ToolbarField label="Assignee">
+                  <select
+                    className={selectClassName("h-8 w-full")}
+                    value={assigneeId}
+                    aria-label="Filter by Linear assignee"
+                    onChange={(event) => setAssigneeId(event.target.value)}
+                  >
+                    <option value="">Anyone</option>
+                    {(catalog?.users ?? []).map((user) => (
+                      <option key={user.id} value={user.id}>{user.name}</option>
+                    ))}
+                  </select>
+                </ToolbarField>
+                <div className="rounded-[calc(var(--radius-sm)-1px)] border border-[color:var(--border-soft)] bg-[color:var(--surface-inset)] px-2.5 py-2 text-xs text-muted-foreground">
+                  {selectedStateLabel} / {selectedAssigneeLabel}
+                </div>
+              </div>
+            </PopoverContent>
+          </Popover>
+
+          <Popover>
+            <PopoverTrigger asChild>
+              <Button variant="ghost" size="sm" className="text-xs">
+                <ArrowUpDown className="h-3.5 w-3.5 sm:h-3 sm:w-3 sm:mr-1" />
+                <span className="hidden sm:inline">Sort</span>
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent align="end" className="w-56 p-3">
+              <div className="space-y-3">
+                <ToolbarField label="Sort by">
+                  <select
+                    className={selectClassName("h-8 w-full")}
+                    value={sortField}
+                    aria-label="Sort Linear issues"
+                    onChange={(event) => setSortField(event.target.value as LinearSortField)}
+                  >
+                    <option value="updated">Updated</option>
+                    <option value="created">Created</option>
+                    <option value="identifier">Identifier</option>
+                  </select>
+                </ToolbarField>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="h-8 w-full justify-start"
+                  title={`Sort ${sortDir === "asc" ? "ascending" : "descending"}`}
+                  onClick={() => setSortDir((current) => (current === "asc" ? "desc" : "asc"))}
+                >
+                  <ArrowUpDown className="h-3.5 w-3.5" />
+                  <span>{sortDir === "asc" ? "Ascending" : "Descending"}</span>
+                </Button>
+              </div>
+            </PopoverContent>
+          </Popover>
         </div>
       </div>
 
-      <div className="surface-panel flex flex-col gap-3 rounded-[calc(var(--radius-sm)+1px)] px-3 py-3 md:flex-row md:items-center md:justify-between">
+      <div className="surface-panel flex flex-col gap-3 rounded-[calc(var(--radius-sm)+1px)] px-3 py-2.5 md:flex-row md:items-center md:justify-between">
         <div className="flex min-w-0 flex-wrap items-center gap-2">
           <Button
             type="button"

--- a/ui/src/components/LinearIssueSourceBoard.tsx
+++ b/ui/src/components/LinearIssueSourceBoard.tsx
@@ -1,14 +1,21 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { Link } from "@/lib/router";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { ExternalLink, Import, List, Search, Columns3, Check, ArrowUpDown, Filter, FolderKanban, UserRound } from "lucide-react";
+import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { ExternalLink, Import, List, Columns3, Check, ArrowUpDown, Filter, FolderKanban, UserRound } from "lucide-react";
 import { pluginsApi, type PluginUiContribution } from "@/api/plugins";
 import { queryKeys } from "@/lib/queryKeys";
 import { useToast } from "@/context/ToastContext";
 import { cn } from "@/lib/utils";
 import { timeAgo } from "@/lib/timeAgo";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { EmptyState } from "@/components/EmptyState";
 import { PageSkeleton } from "@/components/PageSkeleton";
 import { StatusIcon } from "@/components/StatusIcon";
@@ -127,11 +134,11 @@ type ImportLinearIssuesActionResult = {
 
 type LinearIssueSourceBoardProps = {
   orgId: string;
+  orgName?: string;
   projects?: Array<Pick<Project, "id" | "name" | "archivedAt">>;
   linearTeamId?: string;
   linearProjectId?: string;
   initialSearch?: string;
-  onSearchChange?: (search: string) => void;
 };
 
 type LinearViewMode = "list" | "board";
@@ -183,12 +190,20 @@ function issueRudderHref(row: LinearIssueRow): string | null {
   return ref ? `/issues/${ref}` : null;
 }
 
-function SourceBadge({ children }: { children: string }) {
+function ToolbarField({
+  label,
+  children,
+  className,
+}: {
+  label: string;
+  children: ReactNode;
+  className?: string;
+}) {
   return (
-    <span className="inline-flex items-center gap-1 rounded-[calc(var(--radius-sm)-2px)] border border-[color:var(--border-soft)] bg-[color:var(--surface-inset)] px-1.5 py-0.5 text-[11px] font-medium text-muted-foreground">
-      <ExternalLink className="h-3 w-3" />
+    <label className={cn("flex min-w-0 flex-col gap-1", className)}>
+      <span className="text-[11px] font-medium text-muted-foreground">{label}</span>
       {children}
-    </span>
+    </label>
   );
 }
 
@@ -229,62 +244,40 @@ function resolveLinearTypeStatus(type: string | null | undefined): IssueStatus {
   return "todo";
 }
 
-function LinearRowAction({
+function LinearImportedAction({
   row,
   orgId,
-  targetProjectId,
-  importing,
-  onImport,
 }: {
   row: LinearIssueRow;
   orgId: string;
-  targetProjectId: string;
-  importing: boolean;
-  onImport: (row: LinearIssueRow) => void;
 }) {
-  if (row.imported) {
-    const href = issueRudderHref(row);
-    const sameOrgLink = !row.importedOrgId || row.importedOrgId === orgId;
-    if (href && sameOrgLink) {
-      return (
-        <Button asChild variant="ghost" size="sm">
-          <Link to={href}>Open Rudder issue</Link>
-        </Button>
-      );
-    }
-    return <span className="text-xs text-muted-foreground">Imported elsewhere</span>;
+  if (!row.imported) return null;
+
+  const href = issueRudderHref(row);
+  const sameOrgLink = !row.importedOrgId || row.importedOrgId === orgId;
+  if (href && sameOrgLink) {
+    return (
+      <Button asChild variant="ghost" size="sm">
+        <Link to={href}>Open issue</Link>
+      </Button>
+    );
   }
 
-  return (
-    <Button
-      type="button"
-      variant="outline"
-      size="sm"
-      disabled={!targetProjectId || importing}
-      onClick={() => onImport(row)}
-    >
-      <Import className="h-3.5 w-3.5" />
-      Import
-    </Button>
-  );
+  return <span className="text-xs text-muted-foreground">Imported elsewhere</span>;
 }
 
 function LinearListView({
   rows,
   selectedIssueIds,
   orgId,
-  targetProjectId,
   importing,
   onToggleSelected,
-  onImport,
 }: {
   rows: LinearIssueRow[];
   selectedIssueIds: string[];
   orgId: string;
-  targetProjectId: string;
   importing: boolean;
   onToggleSelected: (issueId: string) => void;
-  onImport: (row: LinearIssueRow) => void;
 }) {
   return (
     <div className="min-h-0 overflow-hidden rounded-[calc(var(--radius-sm)+1px)] border border-[color:var(--border-base)] bg-[color:var(--surface-elevated)]">
@@ -317,19 +310,12 @@ function LinearListView({
                   {" "}
                   {row.title}
                 </a>
-                <SourceBadge>External</SourceBadge>
                 {row.imported ? <ImportedBadge /> : null}
               </div>
               <LinearIssueMeta row={row} />
             </div>
             <div className="flex shrink-0 items-center">
-              <LinearRowAction
-                row={row}
-                orgId={orgId}
-                targetProjectId={targetProjectId}
-                importing={importing}
-                onImport={onImport}
-              />
+              <LinearImportedAction row={row} orgId={orgId} />
             </div>
           </article>
         );
@@ -343,19 +329,15 @@ function LinearBoardView({
   teamMappings,
   selectedIssueIds,
   orgId,
-  targetProjectId,
   importing,
   onToggleSelected,
-  onImport,
 }: {
   rows: LinearIssueRow[];
   teamMappings: LinearTeamMapping[] | undefined;
   selectedIssueIds: string[];
   orgId: string;
-  targetProjectId: string;
   importing: boolean;
   onToggleSelected: (issueId: string) => void;
-  onImport: (row: LinearIssueRow) => void;
 }) {
   const grouped = useMemo(() => {
     const next = new Map<IssueStatus, LinearIssueRow[]>();
@@ -415,7 +397,7 @@ function LinearBoardView({
                       >
                         {row.identifier}
                       </a>
-                      {row.imported ? <ImportedBadge /> : <SourceBadge>External</SourceBadge>}
+                      {row.imported ? <ImportedBadge /> : null}
                     </div>
                     <p className="mb-2 line-clamp-2 text-sm leading-snug">{row.title}</p>
                     <div className="space-y-1.5 text-xs text-muted-foreground">
@@ -433,15 +415,11 @@ function LinearBoardView({
                       </span>
                       <span>Updated {timeAgo(row.updatedAt)}</span>
                     </div>
-                    <div className="mt-3 flex justify-end">
-                      <LinearRowAction
-                        row={row}
-                        orgId={orgId}
-                        targetProjectId={targetProjectId}
-                        importing={importing}
-                        onImport={onImport}
-                      />
-                    </div>
+                    {row.imported ? (
+                      <div className="mt-3 flex justify-end">
+                        <LinearImportedAction row={row} orgId={orgId} />
+                      </div>
+                    ) : null}
                   </article>
                 ))}
               </div>
@@ -455,25 +433,27 @@ function LinearBoardView({
 
 export function LinearIssueSourceBoard({
   orgId,
+  orgName,
   projects,
   linearTeamId = "",
   linearProjectId = "",
   initialSearch = "",
-  onSearchChange,
 }: LinearIssueSourceBoardProps) {
   const queryClient = useQueryClient();
   const { pushToast } = useToast();
   const [viewMode, setViewMode] = useState<LinearViewMode>(() => getStoredViewMode());
-  const [targetProjectId, setTargetProjectId] = useState("");
+  const [importDialogOpen, setImportDialogOpen] = useState(false);
+  const [pendingImportMode, setPendingImportMode] = useState<"selected" | "allMatching">("selected");
+  const [importTargetProjectId, setImportTargetProjectId] = useState("");
   const [stateId, setStateId] = useState("");
   const [assigneeId, setAssigneeId] = useState("");
   const [sortField, setSortField] = useState<LinearSortField>("updated");
   const [sortDir, setSortDir] = useState<LinearSortDir>("desc");
   const [search, setSearch] = useState(initialSearch);
   const [debouncedSearch, setDebouncedSearch] = useState(initialSearch);
-  const [afterCursor, setAfterCursor] = useState<string | null>(null);
-  const [cursorHistory, setCursorHistory] = useState<string[]>([]);
   const [selectedIssueIds, setSelectedIssueIds] = useState<string[]>([]);
+  const loadMoreRef = useRef<HTMLDivElement | null>(null);
+  const orgDisplayName = orgName?.trim() || "this organization";
 
   useEffect(() => {
     setSearch(initialSearch);
@@ -486,8 +466,6 @@ export function LinearIssueSourceBoard({
   }, [search]);
 
   useEffect(() => {
-    setAfterCursor(null);
-    setCursorHistory([]);
     setSelectedIssueIds([]);
   }, [linearTeamId, linearProjectId, stateId, assigneeId, debouncedSearch]);
 
@@ -533,19 +511,27 @@ export function LinearIssueSourceBoard({
     stateId || "__all__",
     assigneeId || "__all__",
     debouncedSearch || "__none__",
-    afterCursor ?? "__first__",
   ] as const;
 
-  const { data: issueData, isLoading: issuesLoading, error: issuesError } = useQuery({
+  const {
+    data: issuePages,
+    isLoading: issuesLoading,
+    error: issuesError,
+    hasNextPage,
+    fetchNextPage,
+    isFetchingNextPage,
+  } = useInfiniteQuery({
     queryKey: issuesQueryKey,
-    queryFn: async () => {
+    initialPageParam: null as string | null,
+    queryFn: async ({ pageParam }) => {
+      const after = typeof pageParam === "string" && pageParam ? pageParam : undefined;
       const response = await pluginsApi.bridgeGetData(
         pluginId,
         DATA_KEY_ISSUES,
         {
           orgId,
           limit: LINEAR_PAGE_SIZE,
-          after: afterCursor ?? undefined,
+          after,
           teamId: linearTeamId || undefined,
           projectId: linearProjectId || undefined,
           stateId: stateId || undefined,
@@ -556,18 +542,19 @@ export function LinearIssueSourceBoard({
       );
       return response.data as LinearIssuesData;
     },
+    getNextPageParam: (lastPage) => lastPage.hasNextPage && lastPage.endCursor ? lastPage.endCursor : undefined,
     enabled: !!orgId && !!pluginId && bootstrap?.configured === true,
   });
 
   const importMutation = useMutation({
-    mutationFn: async ({ mode, issueIds }: { mode: "single" | "selected" | "allMatching"; issueIds?: string[] }) => {
-      if (!targetProjectId) throw new Error("Choose a target Rudder project before importing.");
+    mutationFn: async ({ mode, issueIds }: { mode: "selected" | "allMatching"; issueIds?: string[] }) => {
+      if (!importTargetProjectId) throw new Error(`Choose a project in ${orgDisplayName} before importing.`);
       const response = await pluginsApi.bridgePerformAction(
         pluginId,
         ACTION_KEY_IMPORT_ISSUES,
         {
           orgId,
-          targetProjectId,
+          targetProjectId: importTargetProjectId,
           mode,
           issueIds,
           filters: {
@@ -589,6 +576,7 @@ export function LinearIssueSourceBoard({
         tone: "success",
       });
       setSelectedIssueIds([]);
+      setImportDialogOpen(false);
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: ["plugins", LINEAR_PLUGIN_KEY, DATA_KEY_ISSUES, orgId] }),
         queryClient.invalidateQueries({ queryKey: queryKeys.issues.list(orgId) }),
@@ -604,7 +592,7 @@ export function LinearIssueSourceBoard({
   });
 
   const rows = useMemo(() => {
-    const sourceRows = [...(issueData?.rows ?? [])];
+    const sourceRows = [...(issuePages?.pages.flatMap((page) => page.rows) ?? [])];
     sourceRows.sort((left, right) => {
       let delta = 0;
       if (sortField === "updated") delta = compareNullableIso(left.updatedAt, right.updatedAt);
@@ -613,7 +601,7 @@ export function LinearIssueSourceBoard({
       return sortDir === "asc" ? delta : -delta;
     });
     return sourceRows;
-  }, [issueData?.rows, sortDir, sortField]);
+  }, [issuePages?.pages, sortDir, sortField]);
 
   useEffect(() => {
     const visibleIds = new Set(rows.map((row) => row.id));
@@ -635,6 +623,14 @@ export function LinearIssueSourceBoard({
     const source = bootstrap?.projects?.length ? bootstrap.projects : (projects ?? []);
     return source.filter((project) => !("archivedAt" in project) || !project.archivedAt);
   }, [bootstrap?.projects, projects]);
+  useEffect(() => {
+    if (targetProjects.length === 0) {
+      if (importTargetProjectId) setImportTargetProjectId("");
+      return;
+    }
+    if (targetProjects.some((project) => project.id === importTargetProjectId)) return;
+    setImportTargetProjectId(targetProjects.length === 1 ? targetProjects[0]!.id : "");
+  }, [importTargetProjectId, targetProjects]);
   const stateOptions = useMemo(() => {
     const sourceTeams = linearTeamId
       ? (catalog?.teams ?? []).filter((candidate) => candidate.id === linearTeamId)
@@ -652,6 +648,9 @@ export function LinearIssueSourceBoard({
   const importing = importMutation.isPending;
   const loading = contributionsLoading || bootstrapLoading || catalogLoading || issuesLoading;
   const error = bootstrapError ?? issuesError;
+  const selectedImportCount = selectedIssueIds.length;
+  const selectedTargetProject = targetProjects.find((project) => project.id === importTargetProjectId) ?? null;
+  const totalLoaded = rows.length;
 
   const toggleSelected = useCallback((issueId: string) => {
     setSelectedIssueIds((current) =>
@@ -659,9 +658,25 @@ export function LinearIssueSourceBoard({
     );
   }, []);
 
-  const importRow = useCallback((row: LinearIssueRow) => {
-    importMutation.mutate({ mode: "single", issueIds: [row.id] });
-  }, [importMutation]);
+  const openImportDialog = useCallback((mode: "selected" | "allMatching") => {
+    setPendingImportMode(mode);
+    setImportDialogOpen(true);
+  }, []);
+
+  useEffect(() => {
+    const node = loadMoreRef.current;
+    if (!node || !hasNextPage || loading || importing || isFetchingNextPage) return;
+    if (typeof IntersectionObserver === "undefined") return;
+
+    const observer = new IntersectionObserver((entries) => {
+      const visible = entries.some((entry) => entry.isIntersecting);
+      if (!visible || !hasNextPage || isFetchingNextPage || importing) return;
+      void fetchNextPage();
+    }, { root: null, rootMargin: "280px 0px" });
+
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [fetchNextPage, hasNextPage, importing, isFetchingNextPage, loading, totalLoaded]);
 
   if (!contributionsLoading && !contribution) {
     return (
@@ -687,75 +702,17 @@ export function LinearIssueSourceBoard({
 
   return (
     <div data-testid="linear-source-board" className="flex h-full min-h-0 flex-col gap-4">
-      <div className="surface-panel flex flex-col gap-3 rounded-[calc(var(--radius-sm)+1px)] px-3 py-3 lg:flex-row lg:items-center lg:justify-between">
-        <div className="min-w-0">
-          <div className="flex min-w-0 items-center gap-2">
-            <h1 className="shrink-0 text-base font-semibold text-foreground">Linear Issues</h1>
-            <SourceBadge>External</SourceBadge>
+      <div className="surface-panel flex flex-col gap-3 rounded-[calc(var(--radius-sm)+1px)] px-3 py-3">
+        <div className="flex min-w-0 flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+          <div className="min-w-0">
+            <h2 className="truncate text-sm font-semibold text-foreground">{sourceLabel}</h2>
+            <div className="mt-1 flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
+              <span>{totalLoaded} loaded</span>
+              {importedCount > 0 ? <span>{importedCount} imported</span> : null}
+              {hasNextPage ? <span>More loads as you scroll</span> : null}
+            </div>
           </div>
-          <div className="mt-1 flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
-            <span className="truncate">{sourceLabel}</span>
-            <span>{rows.length} shown</span>
-            {importedCount > 0 ? <span>{importedCount} imported</span> : null}
-          </div>
-        </div>
 
-        <div className="flex min-w-0 flex-wrap items-center gap-2">
-          <div className="relative w-full min-w-44 sm:w-64">
-            <Search className="pointer-events-none absolute left-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
-            <Input
-              value={search}
-              onChange={(event) => {
-                setSearch(event.target.value);
-                onSearchChange?.(event.target.value);
-              }}
-              placeholder="Search Linear issues..."
-              className="pl-7 text-xs sm:text-sm"
-              aria-label="Search Linear issues"
-            />
-          </div>
-          <select
-            className={selectClassName("w-40")}
-            value={stateId}
-            aria-label="Filter by Linear state"
-            onChange={(event) => setStateId(event.target.value)}
-          >
-            <option value="">All states</option>
-            {stateOptions.map((state) => (
-              <option key={state.id} value={state.id}>{state.name}</option>
-            ))}
-          </select>
-          <select
-            className={selectClassName("w-40")}
-            value={assigneeId}
-            aria-label="Filter by Linear assignee"
-            onChange={(event) => setAssigneeId(event.target.value)}
-          >
-            <option value="">Anyone</option>
-            {(catalog?.users ?? []).map((user) => (
-              <option key={user.id} value={user.id}>{user.name}</option>
-            ))}
-          </select>
-          <select
-            className={selectClassName("w-36")}
-            value={sortField}
-            aria-label="Sort Linear issues"
-            onChange={(event) => setSortField(event.target.value as LinearSortField)}
-          >
-            <option value="updated">Updated</option>
-            <option value="created">Created</option>
-            <option value="identifier">Identifier</option>
-          </select>
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            title={`Sort ${sortDir === "asc" ? "ascending" : "descending"}`}
-            onClick={() => setSortDir((current) => (current === "asc" ? "desc" : "asc"))}
-          >
-            <ArrowUpDown className="h-3.5 w-3.5" />
-            <span className="hidden sm:inline">{sortDir === "asc" ? "Asc" : "Desc"}</span>
-          </Button>
           <div className="flex items-center overflow-hidden rounded-[var(--radius-sm)] border border-[color:var(--border-base)] bg-[color:color-mix(in_oklab,var(--surface-inset)_82%,transparent)]">
             <button
               className={cn(
@@ -781,22 +738,64 @@ export function LinearIssueSourceBoard({
             </button>
           </div>
         </div>
+
+        <div className="grid min-w-0 grid-cols-1 gap-2 sm:grid-cols-2 xl:grid-cols-[minmax(9rem,11rem)_minmax(9rem,11rem)_minmax(8rem,10rem)_auto]">
+          <ToolbarField label="State">
+          <select
+            className={selectClassName("h-8 w-full")}
+            value={stateId}
+            aria-label="Filter by Linear state"
+            onChange={(event) => setStateId(event.target.value)}
+          >
+            <option value="">All states</option>
+            {stateOptions.map((state) => (
+              <option key={state.id} value={state.id}>{state.name}</option>
+            ))}
+          </select>
+          </ToolbarField>
+          <ToolbarField label="Assignee">
+          <select
+            className={selectClassName("h-8 w-full")}
+            value={assigneeId}
+            aria-label="Filter by Linear assignee"
+            onChange={(event) => setAssigneeId(event.target.value)}
+          >
+            <option value="">Anyone</option>
+            {(catalog?.users ?? []).map((user) => (
+              <option key={user.id} value={user.id}>{user.name}</option>
+            ))}
+          </select>
+          </ToolbarField>
+          <ToolbarField label="Sort">
+          <select
+            className={selectClassName("h-8 w-full")}
+            value={sortField}
+            aria-label="Sort Linear issues"
+            onChange={(event) => setSortField(event.target.value as LinearSortField)}
+          >
+            <option value="updated">Updated</option>
+            <option value="created">Created</option>
+            <option value="identifier">Identifier</option>
+          </select>
+          </ToolbarField>
+          <ToolbarField label="Order" className="sm:max-w-44">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-8 justify-start"
+            title={`Sort ${sortDir === "asc" ? "ascending" : "descending"}`}
+            onClick={() => setSortDir((current) => (current === "asc" ? "desc" : "asc"))}
+          >
+            <ArrowUpDown className="h-3.5 w-3.5" />
+            <span>{sortDir === "asc" ? "Ascending" : "Descending"}</span>
+          </Button>
+          </ToolbarField>
+        </div>
       </div>
 
       <div className="surface-panel flex flex-col gap-3 rounded-[calc(var(--radius-sm)+1px)] px-3 py-3 md:flex-row md:items-center md:justify-between">
         <div className="flex min-w-0 flex-wrap items-center gap-2">
-          <select
-            data-testid="linear-source-target-project"
-            className={selectClassName("w-60 max-w-full")}
-            value={targetProjectId}
-            aria-label="Target Rudder project"
-            onChange={(event) => setTargetProjectId(event.target.value)}
-          >
-            <option value="">Choose target Rudder project</option>
-            {targetProjects.map((project) => (
-              <option key={project.id} value={project.id}>{project.name}</option>
-            ))}
-          </select>
           <Button
             type="button"
             variant="ghost"
@@ -805,7 +804,7 @@ export function LinearIssueSourceBoard({
             onClick={() => setSelectedIssueIds(selectableRows.map((row) => row.id))}
           >
             <Filter className="h-3.5 w-3.5" />
-            Select page
+            Select loaded
           </Button>
           <Button
             type="button"
@@ -818,14 +817,14 @@ export function LinearIssueSourceBoard({
           </Button>
         </div>
         <div className="flex min-w-0 flex-wrap items-center justify-end gap-2">
-          <span className="text-xs text-muted-foreground">{selectedIssueIds.length} selected</span>
+          <span className="text-xs text-muted-foreground">{selectedImportCount} selected</span>
           <Button
             type="button"
             variant="outline"
             size="sm"
             data-testid="linear-source-import-selected"
-            disabled={!targetProjectId || selectedIssueIds.length === 0 || importing}
-            onClick={() => importMutation.mutate({ mode: "selected", issueIds: selectedIssueIds })}
+            disabled={selectedImportCount === 0 || importing}
+            onClick={() => openImportDialog("selected")}
           >
             <Import className="h-3.5 w-3.5" />
             Import selected
@@ -833,8 +832,8 @@ export function LinearIssueSourceBoard({
           <Button
             type="button"
             size="sm"
-            disabled={!targetProjectId || importing}
-            onClick={() => importMutation.mutate({ mode: "allMatching" })}
+            disabled={totalLoaded === 0 || importing}
+            onClick={() => openImportDialog("allMatching")}
           >
             Import matching
           </Button>
@@ -855,10 +854,8 @@ export function LinearIssueSourceBoard({
           rows={rows}
           selectedIssueIds={selectedIssueIds}
           orgId={orgId}
-          targetProjectId={targetProjectId}
           importing={importing}
           onToggleSelected={toggleSelected}
-          onImport={importRow}
         />
       ) : null}
 
@@ -868,49 +865,78 @@ export function LinearIssueSourceBoard({
           teamMappings={bootstrap?.teamMappings}
           selectedIssueIds={selectedIssueIds}
           orgId={orgId}
-          targetProjectId={targetProjectId}
           importing={importing}
           onToggleSelected={toggleSelected}
-          onImport={importRow}
         />
       ) : null}
 
       {!loading && !error && rows.length > 0 ? (
-        <div className="flex items-center justify-between gap-3 text-xs text-muted-foreground">
-          <span>Showing {issueData?.totalShown ?? rows.length} issue(s).</span>
-          <div className="flex items-center gap-2">
+        <div
+          ref={loadMoreRef}
+          data-testid="linear-source-load-more-sentinel"
+          className="flex min-h-8 items-center justify-between gap-3 text-xs text-muted-foreground"
+        >
+          <span>
+            Loaded {totalLoaded} issue{totalLoaded === 1 ? "" : "s"}
+            {isFetchingNextPage ? " - loading more" : hasNextPage ? " - more load as you scroll" : " - all matching issues loaded"}
+          </span>
+        </div>
+      ) : null}
+
+      <Dialog open={importDialogOpen} onOpenChange={setImportDialogOpen}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>
+              {pendingImportMode === "selected" ? "Import selected Linear issues" : "Import matching Linear issues"}
+            </DialogTitle>
+            <DialogDescription>
+              Choose the project in {orgDisplayName} where these issues should land.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-3">
+            <label className="flex flex-col gap-1.5">
+              <span className="text-xs font-medium text-muted-foreground">Project in {orgDisplayName}</span>
+              <select
+                data-testid="linear-source-import-project"
+                className={selectClassName("w-full")}
+                value={importTargetProjectId}
+                aria-label={`Project in ${orgDisplayName}`}
+                onChange={(event) => setImportTargetProjectId(event.target.value)}
+              >
+                <option value="">Choose a project in {orgDisplayName}</option>
+                {targetProjects.map((project) => (
+                  <option key={project.id} value={project.id}>{project.name}</option>
+                ))}
+              </select>
+            </label>
+            <div className="rounded-[calc(var(--radius-sm)-1px)] border border-[color:var(--border-soft)] bg-[color:var(--surface-inset)] px-3 py-2 text-xs text-muted-foreground">
+              {pendingImportMode === "selected"
+                ? `${selectedImportCount} selected Linear issue${selectedImportCount === 1 ? "" : "s"}`
+                : `All matching Linear issues from ${sourceLabel}`}
+              {selectedTargetProject ? ` -> ${selectedTargetProject.name}` : ""}
+            </div>
+          </div>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => setImportDialogOpen(false)}>
+              Cancel
+            </Button>
             <Button
               type="button"
-              variant="ghost"
-              size="sm"
-              disabled={cursorHistory.length === 0 || importing}
+              data-testid="linear-source-confirm-import"
+              disabled={!importTargetProjectId || importing || (pendingImportMode === "selected" && selectedImportCount === 0)}
               onClick={() => {
-                setCursorHistory((current) => {
-                  const nextHistory = [...current];
-                  const previousCursor = nextHistory.pop() ?? null;
-                  setAfterCursor(previousCursor);
-                  return nextHistory;
+                importMutation.mutate({
+                  mode: pendingImportMode,
+                  issueIds: pendingImportMode === "selected" ? selectedIssueIds : undefined,
                 });
               }}
             >
-              Previous
+              <Import className="h-3.5 w-3.5" />
+              {importing ? "Importing" : "Import"}
             </Button>
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              disabled={!issueData?.hasNextPage || importing}
-              onClick={() => {
-                if (!issueData?.endCursor) return;
-                setCursorHistory((current) => [...current, afterCursor ?? ""]);
-                setAfterCursor(issueData.endCursor);
-              }}
-            >
-              Next
-            </Button>
-          </div>
-        </div>
-      ) : null}
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/ui/src/components/ThreeColumnContextSidebar.test.tsx
+++ b/ui/src/components/ThreeColumnContextSidebar.test.tsx
@@ -532,7 +532,8 @@ describe("ThreeColumnContextSidebar issue draft recovery", () => {
 
     const activeLink = document.querySelector<HTMLAnchorElement>("[data-testid='issue-linear-team-team-rudder']");
     expect(activeLink?.getAttribute("aria-current")).toBe("page");
-    expect(document.querySelector("[data-testid='issue-linear-sidebar-active-indicator']")).not.toBeNull();
+    expect(activeLink?.className).toContain("bg-[color:color-mix");
+    expect(document.querySelector("[data-testid='issue-linear-sidebar-active-indicator']")).toBeNull();
   });
 
   it("shows Linear projects under their connected team and routes them into the issue board", () => {

--- a/ui/src/components/ThreeColumnContextSidebar.test.tsx
+++ b/ui/src/components/ThreeColumnContextSidebar.test.tsx
@@ -501,7 +501,8 @@ describe("ThreeColumnContextSidebar issue draft recovery", () => {
 
     const section = document.querySelector("[data-testid='issue-linear-section']");
     expect(section?.textContent).toContain("Linear");
-    expect(section?.textContent).toContain("External");
+    expect(section?.textContent).not.toContain("External");
+    expect(document.querySelector("[data-testid='issue-linear-section-toggle']")).not.toBeNull();
 
     const teamLink = document.querySelector<HTMLAnchorElement>("[data-testid='issue-linear-team-team-rudder']");
     expect(teamLink?.textContent).toContain("Rudder");

--- a/ui/src/components/ThreeColumnContextSidebar.tsx
+++ b/ui/src/components/ThreeColumnContextSidebar.tsx
@@ -904,11 +904,6 @@ export function ThreeColumnContextSidebar() {
     const routeRef = projectRouteRef(project);
     return selectedProjectId === project.id || activeProjectRef === routeRef;
   });
-  const issueLinearActiveIndex = linearSidebarItems.findIndex((item) =>
-    item.kind === "project"
-      ? selectedLinearProjectId === item.id && (!item.teamId || selectedLinearTeamId === item.teamId)
-      : selectedIssueSource === "linear" && selectedLinearTeamId === item.id && !selectedLinearProjectId,
-  );
   const orgContextItems = [
     { key: "structure", to: "/org", icon: Network, label: "Structure", active: /^\/org(?:\/|$)/.test(relativePath) },
     { key: "resources", to: "/resources", icon: Boxes, label: "Resources", active: /^\/resources(?:\/|$)/.test(relativePath) },
@@ -1319,10 +1314,9 @@ export function ThreeColumnContextSidebar() {
               </SectionLabel>
               {isIssueSectionCollapsed("linear") ? null : (
                 <SlidingContextNav
-                  activeIndex={issueLinearActiveIndex}
+                  activeIndex={-1}
                   ariaLabel="Linear issue source slices"
                   className="mt-2"
-                  indicatorTestId="issue-linear-sidebar-active-indicator"
                 >
                   {linearSidebarItems.map((item) => {
                     const active = item.kind === "project"
@@ -1339,7 +1333,7 @@ export function ThreeColumnContextSidebar() {
                           "relative z-10 mx-1.5 flex min-h-[var(--motion-context-item-height)] items-center gap-3 rounded-[calc(var(--radius-sm)-1px)] border border-transparent px-3 py-2 text-sm transition-[background-color,border-color,color]",
                           item.kind === "project" && item.teamId ? "ml-6 min-h-8 py-1.5 text-xs" : "",
                           active
-                            ? "font-medium text-foreground"
+                            ? "border-[color:color-mix(in_oklab,var(--border-soft)_72%,transparent)] bg-[color:color-mix(in_oklab,var(--surface-elevated)_92%,var(--surface-active))] font-medium text-foreground"
                             : "text-muted-foreground hover:border-[color:color-mix(in_oklab,var(--border-soft)_52%,transparent)] hover:bg-[color:color-mix(in_oklab,var(--surface-elevated)_58%,transparent)] hover:text-foreground",
                         )}
                       >

--- a/ui/src/components/ThreeColumnContextSidebar.tsx
+++ b/ui/src/components/ThreeColumnContextSidebar.tsx
@@ -1,4 +1,4 @@
-import { type CSSProperties, type ReactNode, useEffect, useMemo, useState } from "react";
+import { type CSSProperties, type ReactNode, useCallback, useEffect, useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   Archive,
@@ -14,7 +14,6 @@ import {
   DollarSign,
   Eye,
   EyeOff,
-  ExternalLink,
   FolderTree,
   History,
   MessageSquare,
@@ -121,18 +120,44 @@ function SectionLabel({
   children,
   action,
   testId,
+  collapsed,
+  onToggle,
 }: {
   children: string;
   action?: ReactNode;
   testId?: string;
+  collapsed?: boolean;
+  onToggle?: () => void;
 }) {
+  const canToggle = typeof collapsed === "boolean" && onToggle;
   return (
     <div
       data-testid={testId}
-      className="group flex items-center justify-between px-3.5 pt-3.5 text-[10px] font-semibold tracking-[0.08em] text-muted-foreground/72"
+      className="group flex items-center justify-between px-3.5 pt-3.5 text-[11px] font-medium tracking-normal text-muted-foreground/76"
     >
       <span>{children}</span>
-      {action ? <div className="flex shrink-0 items-center">{action}</div> : null}
+      {action || canToggle ? (
+        <div className="flex shrink-0 items-center gap-1">
+          {action}
+          {canToggle ? (
+            <button
+              type="button"
+              onClick={onToggle}
+              aria-label={`${collapsed ? "Expand" : "Collapse"} ${children}`}
+              title={collapsed ? "Expand" : "Collapse"}
+              data-testid={testId ? `${testId}-toggle` : undefined}
+              className={cn(
+                "inline-flex h-5 w-5 items-center justify-center rounded-[calc(var(--radius-sm)-2px)] text-muted-foreground/72 transition-[opacity,background-color,color]",
+                "hover:bg-[color:color-mix(in_oklab,var(--surface-elevated)_82%,transparent)] hover:text-foreground",
+                "opacity-100 md:opacity-0 md:group-hover:opacity-100 md:group-focus-within:opacity-100",
+                collapsed && "md:opacity-100",
+              )}
+            >
+              {collapsed ? <ChevronRight className="h-3.5 w-3.5" /> : <ChevronDown className="h-3.5 w-3.5" />}
+            </button>
+          ) : null}
+        </div>
+      ) : null}
     </div>
   );
 }
@@ -542,11 +567,15 @@ function RecentIssueListSection({
   activeIssueRef,
   closeMobileSidebar,
   onOpenIssue,
+  collapsed,
+  onToggleCollapsed,
 }: {
   issues: Issue[];
   activeIssueRef: string | null;
   closeMobileSidebar: () => void;
   onOpenIssue: (issue: Issue) => void;
+  collapsed: boolean;
+  onToggleCollapsed: () => void;
 }) {
   const [expanded, setExpanded] = useState(false);
 
@@ -559,7 +588,15 @@ function RecentIssueListSection({
 
   return (
     <section aria-label="Recently viewed issues" className="mt-1">
-      <SectionLabel testId="issue-recent-section">Recently Viewed</SectionLabel>
+      <SectionLabel
+        testId="issue-recent-section"
+        collapsed={collapsed}
+        onToggle={onToggleCollapsed}
+      >
+        Recently Viewed
+      </SectionLabel>
+      {collapsed ? null : (
+        <>
       <div
         data-testid="issue-recent-list"
         className={cn(
@@ -615,6 +652,8 @@ function RecentIssueListSection({
           <span>{expanded ? "Show less" : `Show ${expandCount} more`}</span>
         </button>
       ) : null}
+        </>
+      )}
     </section>
   );
 }
@@ -636,6 +675,17 @@ export function ThreeColumnContextSidebar() {
   const { pushToast } = useToast();
   const { openNewAgent, openNewProject } = useDialog();
   const queryClient = useQueryClient();
+  const [collapsedIssueSections, setCollapsedIssueSections] = useState<Record<string, boolean>>({});
+  const isIssueSectionCollapsed = useCallback(
+    (key: string) => collapsedIssueSections[key] === true,
+    [collapsedIssueSections],
+  );
+  const toggleIssueSection = useCallback((key: string) => {
+    setCollapsedIssueSections((current) => ({
+      ...current,
+      [key]: !current[key],
+    }));
+  }, []);
   const calendarSidebarScrollRef = useScrollbarActivityRef("rudder:sidebar-scroll:calendar");
   const {
     cursor,
@@ -1179,25 +1229,32 @@ export function ThreeColumnContextSidebar() {
         className="workspace-context-sidebar flex min-h-0 w-full min-w-0 shrink-0 flex-col"
       >
         <ContextColumnHeader title={contextHeader.title} description={contextHeader.description} />
-        <SectionLabel>Issues</SectionLabel>
-        <SlidingContextNav
-          activeIndex={activeIssueContextIndex}
-          ariaLabel="Issue navigation"
-          className="mt-2"
-          indicatorTestId="issue-sidebar-active-indicator"
+        <SectionLabel
+          collapsed={isIssueSectionCollapsed("issues")}
+          onToggle={() => toggleIssueSection("issues")}
         >
-          {issueContextItems.map((item) => (
-            <ContextItem
-              key={item.key}
-              to={item.to}
-              icon={item.icon}
-              label={item.label}
-              active={item.active}
-              testId={item.testId}
-              slidingActiveIndicator
-            />
-          ))}
-        </SlidingContextNav>
+          Issues
+        </SectionLabel>
+        {isIssueSectionCollapsed("issues") ? null : (
+          <SlidingContextNav
+            activeIndex={activeIssueContextIndex}
+            ariaLabel="Issue navigation"
+            className="mt-2"
+            indicatorTestId="issue-sidebar-active-indicator"
+          >
+            {issueContextItems.map((item) => (
+              <ContextItem
+                key={item.key}
+                to={item.to}
+                icon={item.icon}
+                label={item.label}
+                active={item.active}
+                testId={item.testId}
+                slidingActiveIndicator
+              />
+            ))}
+          </SlidingContextNav>
+        )}
 
         <div className="min-h-0 flex-1 overflow-y-auto pb-3.5">
           <RecentIssueListSection
@@ -1205,89 +1262,94 @@ export function ThreeColumnContextSidebar() {
             activeIssueRef={activeIssueRef}
             closeMobileSidebar={closeMobileSidebar}
             onOpenIssue={recordRecentIssueOpen}
+            collapsed={isIssueSectionCollapsed("recent")}
+            onToggleCollapsed={() => toggleIssueSection("recent")}
           />
-          <SectionLabel testId="workspace-projects-section">Projects</SectionLabel>
-          <SlidingContextNav
-            activeIndex={issueProjectActiveIndex}
-            ariaLabel="Issue project slices"
-            className="mt-2"
-            indicatorTestId="issue-project-sidebar-active-indicator"
+          <SectionLabel
+            testId="workspace-projects-section"
+            collapsed={isIssueSectionCollapsed("projects")}
+            onToggle={() => toggleIssueSection("projects")}
           >
-            {visibleProjects.map((project) => {
-              const routeRef = projectRouteRef(project);
-              const active = selectedProjectId === project.id || activeProjectRef === routeRef;
-              const liveCount = liveCountByProject.get(project.id) ?? 0;
-              return (
-                <Link
-                  key={project.id}
-                  to={`/issues?projectId=${project.id}`}
-                  onClick={closeMobileSidebar}
-                  data-testid={`issue-project-row-${project.id}`}
-                  className={cn(
-                    "relative z-10 mx-1.5 flex min-h-[var(--motion-context-item-height)] items-center gap-3 rounded-[calc(var(--radius-sm)-1px)] border border-transparent px-3 py-2 text-sm transition-[background-color,border-color,color]",
-                    active
-                      ? "font-medium text-foreground"
-                      : "text-muted-foreground hover:border-[color:color-mix(in_oklab,var(--border-soft)_52%,transparent)] hover:bg-[color:color-mix(in_oklab,var(--surface-elevated)_58%,transparent)] hover:text-foreground",
-                  )}
-                >
-                  <Circle
-                    data-testid={`issue-project-color-${project.id}`}
-                    className="h-2.5 w-2.5 shrink-0 fill-current"
-                    style={{ color: projectColorAccent(project.color) }}
-                  />
-                  <span className="min-w-0 flex-1 truncate">{project.name}</span>
-                  {liveCount > 0 ? <SidebarLiveCount count={liveCount} /> : null}
-                </Link>
-              );
-            })}
-          </SlidingContextNav>
+            Projects
+          </SectionLabel>
+          {isIssueSectionCollapsed("projects") ? null : (
+            <SlidingContextNav
+              activeIndex={issueProjectActiveIndex}
+              ariaLabel="Issue project slices"
+              className="mt-2"
+              indicatorTestId="issue-project-sidebar-active-indicator"
+            >
+              {visibleProjects.map((project) => {
+                const routeRef = projectRouteRef(project);
+                const active = selectedProjectId === project.id || activeProjectRef === routeRef;
+                const liveCount = liveCountByProject.get(project.id) ?? 0;
+                return (
+                  <Link
+                    key={project.id}
+                    to={`/issues?projectId=${project.id}`}
+                    onClick={closeMobileSidebar}
+                    data-testid={`issue-project-row-${project.id}`}
+                    className={cn(
+                      "relative z-10 mx-1.5 flex min-h-[var(--motion-context-item-height)] items-center gap-3 rounded-[calc(var(--radius-sm)-1px)] border border-transparent px-3 py-2 text-sm transition-[background-color,border-color,color]",
+                      active
+                        ? "font-medium text-foreground"
+                        : "text-muted-foreground hover:border-[color:color-mix(in_oklab,var(--border-soft)_52%,transparent)] hover:bg-[color:color-mix(in_oklab,var(--surface-elevated)_58%,transparent)] hover:text-foreground",
+                    )}
+                  >
+                    <Circle
+                      data-testid={`issue-project-color-${project.id}`}
+                      className="h-2.5 w-2.5 shrink-0 fill-current"
+                      style={{ color: projectColorAccent(project.color) }}
+                    />
+                    <span className="min-w-0 flex-1 truncate">{project.name}</span>
+                    {liveCount > 0 ? <SidebarLiveCount count={liveCount} /> : null}
+                  </Link>
+                );
+              })}
+            </SlidingContextNav>
+          )}
           {linearSidebarItems.length > 0 ? (
             <>
               <SectionLabel
                 testId="issue-linear-section"
-                action={(
-                  <span
-                    title="External source"
-                    className="inline-flex items-center gap-1 rounded-[calc(var(--radius-sm)-2px)] border border-[color:color-mix(in_oklab,var(--border-soft)_70%,transparent)] px-1.5 py-0.5 text-[10px] font-medium normal-case tracking-normal text-muted-foreground/78"
-                  >
-                    <ExternalLink className="h-3 w-3" />
-                    External
-                  </span>
-                )}
+                collapsed={isIssueSectionCollapsed("linear")}
+                onToggle={() => toggleIssueSection("linear")}
               >
                 Linear
               </SectionLabel>
-              <SlidingContextNav
-                activeIndex={issueLinearActiveIndex}
-                ariaLabel="Linear issue source slices"
-                className="mt-2"
-                indicatorTestId="issue-linear-sidebar-active-indicator"
-              >
-                {linearSidebarItems.map((item) => {
-                  const active = item.kind === "project"
-                    ? selectedLinearProjectId === item.id && (!item.teamId || selectedLinearTeamId === item.teamId)
-                    : selectedIssueSource === "linear" && selectedLinearTeamId === item.id && !selectedLinearProjectId;
-                  return (
-                    <Link
-                      key={`${item.kind}-${item.id}`}
-                      to={linearIssueSourceHref(item)}
-                      onClick={closeMobileSidebar}
-                      data-testid={`issue-linear-${item.kind}-${item.id}`}
-                      aria-current={active ? "page" : undefined}
-                      className={cn(
-                        "relative z-10 mx-1.5 flex min-h-[var(--motion-context-item-height)] items-center gap-3 rounded-[calc(var(--radius-sm)-1px)] border border-transparent px-3 py-2 text-sm transition-[background-color,border-color,color]",
-                        item.kind === "project" && item.teamId ? "ml-6 min-h-8 py-1.5 text-xs" : "",
-                        active
-                          ? "font-medium text-foreground"
-                          : "text-muted-foreground hover:border-[color:color-mix(in_oklab,var(--border-soft)_52%,transparent)] hover:bg-[color:color-mix(in_oklab,var(--surface-elevated)_58%,transparent)] hover:text-foreground",
-                      )}
-                    >
-                      <span className="h-2.5 w-2.5 shrink-0 rounded-[calc(var(--radius-sm)-4px)] border border-[color:color-mix(in_oklab,var(--muted-foreground)_54%,transparent)] bg-[color:color-mix(in_oklab,var(--muted-foreground)_18%,transparent)]" />
-                      <span className="min-w-0 flex-1 truncate">{item.name}</span>
-                    </Link>
-                  );
-                })}
-              </SlidingContextNav>
+              {isIssueSectionCollapsed("linear") ? null : (
+                <SlidingContextNav
+                  activeIndex={issueLinearActiveIndex}
+                  ariaLabel="Linear issue source slices"
+                  className="mt-2"
+                  indicatorTestId="issue-linear-sidebar-active-indicator"
+                >
+                  {linearSidebarItems.map((item) => {
+                    const active = item.kind === "project"
+                      ? selectedLinearProjectId === item.id && (!item.teamId || selectedLinearTeamId === item.teamId)
+                      : selectedIssueSource === "linear" && selectedLinearTeamId === item.id && !selectedLinearProjectId;
+                    return (
+                      <Link
+                        key={`${item.kind}-${item.id}`}
+                        to={linearIssueSourceHref(item)}
+                        onClick={closeMobileSidebar}
+                        data-testid={`issue-linear-${item.kind}-${item.id}`}
+                        aria-current={active ? "page" : undefined}
+                        className={cn(
+                          "relative z-10 mx-1.5 flex min-h-[var(--motion-context-item-height)] items-center gap-3 rounded-[calc(var(--radius-sm)-1px)] border border-transparent px-3 py-2 text-sm transition-[background-color,border-color,color]",
+                          item.kind === "project" && item.teamId ? "ml-6 min-h-8 py-1.5 text-xs" : "",
+                          active
+                            ? "font-medium text-foreground"
+                            : "text-muted-foreground hover:border-[color:color-mix(in_oklab,var(--border-soft)_52%,transparent)] hover:bg-[color:color-mix(in_oklab,var(--surface-elevated)_58%,transparent)] hover:text-foreground",
+                        )}
+                      >
+                        <span className="h-2.5 w-2.5 shrink-0 rounded-[calc(var(--radius-sm)-4px)] border border-[color:color-mix(in_oklab,var(--muted-foreground)_54%,transparent)] bg-[color:color-mix(in_oklab,var(--muted-foreground)_18%,transparent)]" />
+                        <span className="min-w-0 flex-1 truncate">{item.name}</span>
+                      </Link>
+                    );
+                  })}
+                </SlidingContextNav>
+              )}
             </>
           ) : null}
         </div>

--- a/ui/src/pages/Issues.tsx
+++ b/ui/src/pages/Issues.tsx
@@ -152,7 +152,7 @@ function DraftIssuesView({
 }
 
 export function Issues() {
-  const { selectedOrganizationId } = useOrganization();
+  const { selectedOrganizationId, selectedOrganization } = useOrganization();
   const { setBreadcrumbs } = useBreadcrumbs();
   const { openNewIssue } = useDialog();
   const { pushToast } = useToast();
@@ -362,11 +362,11 @@ export function Issues() {
       <div className="flex h-full min-h-0 flex-col">
         <LinearIssueSourceBoard
           orgId={selectedOrganizationId}
+          orgName={selectedOrganization?.name}
           projects={projects}
           linearTeamId={linearTeamId}
           linearProjectId={linearProjectId}
           initialSearch={initialSearch}
-          onSearchChange={handleSearchChange}
         />
       </div>
     );


### PR DESCRIPTION
## Summary

Polishes the Linear issue source board so it behaves more like the native Rudder issue board and removes redundant external-source affordances.

## Changes

- Move Linear issue search into the main issue header and hide native issue creation on Linear source pages.
- Remove per-issue Linear import buttons and redundant `External` labels; keep batch import only.
- Move target project selection into the import modal with organization-aware copy such as `Project in sss`.
- Replace manual cursor pagination with passive loading as the user scrolls.
- Compact the Linear board toolbar and move filters/sort controls into popovers.
- Add hidden empty status columns on the Linear board, matching the native issue board pattern.
- Align Linear sidebar item selected and hover states, especially for nested project rows.

## Validation

- `pnpm --filter @rudderhq/ui exec vitest run src/components/LinearIssueSourceBoard.test.tsx src/components/ThreeColumnContextSidebar.test.tsx src/components/BreadcrumbBar.test.tsx src/pages/Issues.test.tsx`
- `pnpm --filter @rudderhq/plugin-linear test -- --run`
- `pnpm --filter @rudderhq/ui typecheck`
- `pnpm -r typecheck`
- `pnpm build`
- Browser visual verification against `http://127.0.0.1:3910/SSS/issues?source=linear&linearTeamId=team-eng`

Notes: `pnpm test:run` still fails in this worktree on the existing embedded PostgreSQL init failure; the Linear-specific UI and plugin checks pass.