### PR TITLE
fix: stabilize CI workflow installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,10 +35,11 @@ jobs:
             test: cli-start
     env:
       CI: true
+      ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
 

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -46,12 +46,12 @@ jobs:
             arch: x64
             runner: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ inputs.source_ref || inputs.release_tag || github.ref_name }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
 
@@ -91,7 +91,7 @@ jobs:
             --arch "${{ matrix.arch }}" \
             --out dist/desktop-assets
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: desktop-${{ matrix.platform }}-${{ matrix.arch }}
           path: dist/desktop-assets/*
@@ -102,12 +102,12 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ inputs.source_ref || inputs.release_tag || github.ref_name }}
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           path: dist/desktop-assets
           merge-multiple: true

--- a/.github/workflows/npm-dist-tag.yml
+++ b/.github/workflows/npm-dist-tag.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     environment: npm-canary
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/public-install-smoke.yml
+++ b/.github/workflows/public-install-smoke.yml
@@ -40,9 +40,9 @@ jobs:
           - label: macOS arm64
             runner: macos-14
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,16 +43,17 @@ jobs:
             test: cli-start
     env:
       CI: true
+      ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
     defaults:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.source_ref || github.sha }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
 
@@ -84,14 +85,16 @@ jobs:
     if: github.event_name == 'push' && github.repository == 'Undertone0809/rudder' && !contains(github.event.head_commit.message, '[skip release]')
     runs-on: ubuntu-latest
     environment: npm-canary
+    env:
+      ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
     outputs:
       version: ${{ steps.publish.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           registry-url: "https://registry.npmjs.org"
@@ -152,13 +155,15 @@ jobs:
     needs: verify
     if: github.event_name == 'workflow_dispatch' && inputs.dry_run
     runs-on: ubuntu-latest
+    env:
+      ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ inputs.source_ref }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           registry-url: "https://registry.npmjs.org"
@@ -181,15 +186,17 @@ jobs:
     if: github.event_name == 'workflow_dispatch' && !inputs.dry_run && github.repository == 'Undertone0809/rudder'
     runs-on: ubuntu-latest
     environment: npm-stable
+    env:
+      ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
     outputs:
       version: ${{ steps.publish.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ inputs.source_ref }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           registry-url: "https://registry.npmjs.org"


### PR DESCRIPTION
## Summary
- skip Electron binary download for non-Desktop CI/release install jobs
- update official GitHub Actions to Node 24 major versions
- leave Desktop packaging installs downloading Electron normally

## Validation
- `git diff --check -- .github/workflows`
- `ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].sort.each { |f| YAML.load_file(f); puts "ok #{f}" }'`
- `pnpm dlx @tktco/node-actionlint <changed workflow>` for each changed workflow; only existing `macos-15-intel` label warning remains in `desktop-release.yml`
- `ELECTRON_SKIP_BINARY_DOWNLOAD=1 pnpm --store-dir /Users/zeeland/Library/pnpm/store/v3 --filter @rudderhq/desktop rebuild electron`

Refs ZST-60.