### PR TITLE
fix: harden Windows desktop install

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -31,7 +31,7 @@
   },
   "scripts": {
     "dev": "tsx src/index.ts",
-    "build": "node --input-type=module -e \"import esbuild from 'esbuild'; import config from './esbuild.config.mjs'; await esbuild.build(config);\" && chmod +x dist/index.js",
+    "build": "node --input-type=module -e \"import { chmod } from 'node:fs/promises'; import esbuild from 'esbuild'; import config from './esbuild.config.mjs'; await esbuild.build(config); if (process.platform !== 'win32') await chmod('dist/index.js', 0o755);\"",
     "clean": "rm -rf dist",
     "typecheck": "tsc --noEmit"
   },

--- a/cli/src/__tests__/start.test.ts
+++ b/cli/src/__tests__/start.test.ts
@@ -20,6 +20,8 @@ import {
   buildGithubReleaseAssetDownloadUrl,
   buildForceQuitCommand,
   buildLinuxDesktopEntry,
+  buildWindowsRobocopyMirrorCommand,
+  buildWindowsZipExtractCommand,
   compareStableSemver,
   copyPortableAppBundle,
   downloadAsset,
@@ -27,6 +29,7 @@ import {
   getCliUpdateNotice,
   isInstalledDesktopCurrent,
   isPersistentCliVersionCurrent,
+  isSuccessfulRobocopyExitCode,
   parseChecksumFile,
   resolveAssetChecksum,
   resolveCliInstallSpec,
@@ -352,6 +355,33 @@ describe("desktop start command helpers", () => {
     } finally {
       await rm(root, { recursive: true, force: true });
     }
+  });
+
+  it("uses Windows-native archive and mirror commands for portable app installs", () => {
+    expect(buildWindowsZipExtractCommand("C:\\Temp\\Rudder.zip", "C:\\Temp\\rudder-extract")).toEqual({
+      command: "tar.exe",
+      args: ["-xf", "C:\\Temp\\Rudder.zip", "-C", "C:\\Temp\\rudder-extract"],
+    });
+    expect(buildWindowsRobocopyMirrorCommand("C:\\Temp\\win-unpacked", "C:\\Users\\test\\AppData\\Local\\Programs\\Rudder")).toEqual({
+      command: "robocopy.exe",
+      args: [
+        "C:\\Temp\\win-unpacked",
+        "C:\\Users\\test\\AppData\\Local\\Programs\\Rudder",
+        "/MIR",
+        "/R:2",
+        "/W:1",
+        "/NFL",
+        "/NDL",
+        "/NJH",
+        "/NJS",
+        "/NP",
+      ],
+    });
+    expect(isSuccessfulRobocopyExitCode(0)).toBe(true);
+    expect(isSuccessfulRobocopyExitCode(1)).toBe(true);
+    expect(isSuccessfulRobocopyExitCode(7)).toBe(true);
+    expect(isSuccessfulRobocopyExitCode(8)).toBe(false);
+    expect(isSuccessfulRobocopyExitCode(null)).toBe(false);
   });
 
   it("resolves the current CLI version from npm execution metadata", () => {

--- a/cli/src/commands/start.ts
+++ b/cli/src/commands/start.ts
@@ -432,8 +432,31 @@ function runChecked(command: string, args: string[], options: { cwd?: string; sh
   throw new Error(`${command} ${args.join(" ")} failed${output ? `: ${output}` : ""}`);
 }
 
+function formatCommandFailure(command: string, args: string[], stdout: unknown, stderr: unknown): string {
+  const output = [stdout, stderr]
+    .filter((value): value is string => typeof value === "string" && value.trim().length > 0)
+    .join("\n")
+    .trim();
+  return `${command} ${args.join(" ")} failed${output ? `: ${output}` : ""}`;
+}
+
 function powershellQuote(value: string): string {
   return `'${value.replaceAll("'", "''")}'`;
+}
+
+export function buildWindowsZipExtractCommand(zipPath: string, outputDir: string): { command: string; args: string[] } {
+  return { command: "tar.exe", args: ["-xf", zipPath, "-C", outputDir] };
+}
+
+export function buildWindowsRobocopyMirrorCommand(sourcePath: string, destinationPath: string): { command: string; args: string[] } {
+  return {
+    command: "robocopy.exe",
+    args: [sourcePath, destinationPath, "/MIR", "/R:2", "/W:1", "/NFL", "/NDL", "/NJH", "/NJS", "/NP"],
+  };
+}
+
+export function isSuccessfulRobocopyExitCode(status: number | null): boolean {
+  return typeof status === "number" && status >= 0 && status <= 7;
 }
 
 async function extractZip(zipPath: string, outputDir: string, target: DesktopAssetTarget): Promise<void> {
@@ -446,13 +469,8 @@ async function extractZip(zipPath: string, outputDir: string, target: DesktopAss
   }
 
   if (target.platform === "windows") {
-    runChecked("powershell.exe", [
-      "-NoProfile",
-      "-ExecutionPolicy",
-      "Bypass",
-      "-Command",
-      `Expand-Archive -LiteralPath ${powershellQuote(zipPath)} -DestinationPath ${powershellQuote(outputDir)} -Force`,
-    ]);
+    const command = buildWindowsZipExtractCommand(zipPath, outputDir);
+    runChecked(command.command, command.args);
     return;
   }
 
@@ -644,6 +662,17 @@ async function installPortableDesktop(
 }
 
 export async function copyPortableAppBundle(sourcePath: string, destinationPath: string): Promise<void> {
+  if (process.platform === "win32") {
+    await mkdir(destinationPath, { recursive: true });
+    const command = buildWindowsRobocopyMirrorCommand(sourcePath, destinationPath);
+    const result = spawnSync(command.command, command.args, {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    if (isSuccessfulRobocopyExitCode(result.status)) return;
+    throw new Error(formatCommandFailure(command.command, command.args, result.stdout, result.stderr));
+  }
+
   await cp(sourcePath, destinationPath, { recursive: true, verbatimSymlinks: true });
 }
 

--- a/scripts/prepare-server-ui-dist.mjs
+++ b/scripts/prepare-server-ui-dist.mjs
@@ -7,13 +7,26 @@ import { spawnSync } from "node:child_process";
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const uiDist = path.join(repoRoot, "ui", "dist");
 const serverUiDist = path.join(repoRoot, "server", "ui-dist");
-const pnpmBin = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
 
-function run(command, args) {
+function resolvePackageManagerCommand() {
+  if (process.env.npm_execpath) {
+    return {
+      command: process.execPath,
+      argsPrefix: [process.env.npm_execpath],
+    };
+  }
+
+  return {
+    command: process.platform === "win32" ? "pnpm.cmd" : "pnpm",
+    argsPrefix: [],
+  };
+}
+
+function run(command, args, options = {}) {
   const result = spawnSync(command, args, {
     cwd: repoRoot,
     stdio: "inherit",
-    shell: process.platform === "win32",
+    ...options,
   });
   if (result.status === 0) return;
   throw new Error(`${command} ${args.join(" ")} exited with code ${result.status ?? "unknown"}`);
@@ -29,7 +42,8 @@ async function pathExists(filePath) {
 }
 
 console.log("  -> Building @rudderhq/ui...");
-run(pnpmBin, ["--filter", "@rudderhq/ui", "build"]);
+const packageManager = resolvePackageManagerCommand();
+run(packageManager.command, [...packageManager.argsPrefix, "--filter", "@rudderhq/ui", "build"]);
 
 if (!(await pathExists(path.join(uiDist, "index.html")))) {
   throw new Error(`UI build output missing at ${path.join(uiDist, "index.html")}`);

--- a/scripts/prepare-server-ui-dist.mjs
+++ b/scripts/prepare-server-ui-dist.mjs
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+import { cp, rm, stat } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const uiDist = path.join(repoRoot, "ui", "dist");
+const serverUiDist = path.join(repoRoot, "server", "ui-dist");
+const pnpmBin = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
+
+function run(command, args) {
+  const result = spawnSync(command, args, {
+    cwd: repoRoot,
+    stdio: "inherit",
+    shell: process.platform === "win32",
+  });
+  if (result.status === 0) return;
+  throw new Error(`${command} ${args.join(" ")} exited with code ${result.status ?? "unknown"}`);
+}
+
+async function pathExists(filePath) {
+  try {
+    await stat(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+console.log("  -> Building @rudderhq/ui...");
+run(pnpmBin, ["--filter", "@rudderhq/ui", "build"]);
+
+if (!(await pathExists(path.join(uiDist, "index.html")))) {
+  throw new Error(`UI build output missing at ${path.join(uiDist, "index.html")}`);
+}
+
+await rm(serverUiDist, { recursive: true, force: true });
+await cp(uiDist, serverUiDist, { recursive: true });
+console.log("  -> Copied ui/dist to server/ui-dist");

--- a/server/package.json
+++ b/server/package.json
@@ -35,7 +35,7 @@
   "scripts": {
     "dev": "tsx src/index.ts",
     "dev:watch": "cross-env RUDDER_MIGRATION_PROMPT=never RUDDER_MIGRATION_AUTO_APPLY=true tsx watch --ignore ../ui/node_modules --ignore ../ui/.vite --ignore ../ui/dist src/index.ts",
-    "prepare:ui-dist": "bash ../scripts/prepare-server-ui-dist.sh",
+    "prepare:ui-dist": "node ../scripts/prepare-server-ui-dist.mjs",
     "build": "pnpm --filter @rudderhq/plugin-sdk build && pnpm --filter @rudderhq/plugin-linear build && node ../scripts/build-tsc-copy-assets.mjs --copy src/onboarding-assets dist/onboarding-assets && node ../scripts/stage-bundled-plugins.mjs",
     "prepack": "pnpm run prepare:ui-dist",
     "postpack": "rm -rf ui-dist",


### PR DESCRIPTION
## Summary
- Switch Windows Desktop portable zip extraction from PowerShell `Expand-Archive` to `tar.exe`.
- Switch Windows portable app bundle copy to `robocopy.exe /MIR` and treat robocopy exit codes `0..7` as success.
- Make CLI build and server UI dist preparation work on Windows without Unix-only `chmod`/`bash`.

## Validation
- `pnpm vitest run cli/src/__tests__/start.test.ts`
- `pnpm --filter @rudderhq/cli typecheck`
- `pnpm --filter @rudderhq/cli build`
- `pnpm --filter @rudderhq/server prepare:ui-dist`
- `pnpm -r typecheck`
- `pnpm build`

## Notes
- `pnpm test:run` was attempted and still fails on existing Windows test-environment issues unrelated to this change, including `spawn pnpm ENOENT`, macOS-specific Desktop tests running on Windows, and temporary directory `EPERM` cleanup failures.