### PR TITLE
Fix workspace launcher app icons

### DIFF
--- a/desktop/src/workspace-launch-icons.test.ts
+++ b/desktop/src/workspace-launch-icons.test.ts
@@ -35,7 +35,7 @@ describe("resolveDarwinAppBundleIconPath", () => {
 });
 
 describe("readWorkspaceLaunchTargetIconDataUrl", () => {
-  it("uses bundle resources for macOS app icons without calling the native file icon API", async () => {
+  it("uses the native file icon API first for macOS app icons", async () => {
     const getFileIcon = vi.fn(async () => image("data:image/png;base64,file"));
     const createImageFromPath = vi.fn(() => image("data:image/png;base64,bundle"));
 
@@ -49,12 +49,10 @@ describe("readWorkspaceLaunchTargetIconDataUrl", () => {
       getFileIcon,
       createImageFromPath,
       resolveBundleIconPath: async () => "/Applications/Visual Studio Code.app/Contents/Resources/Code.icns",
-    })).resolves.toBe("data:image/png;base64,bundle");
+    })).resolves.toBe("data:image/png;base64,file");
 
-    expect(getFileIcon).not.toHaveBeenCalled();
-    expect(createImageFromPath).toHaveBeenCalledWith(
-      "/Applications/Visual Studio Code.app/Contents/Resources/Code.icns",
-    );
+    expect(getFileIcon).toHaveBeenCalledWith("/Applications/Visual Studio Code.app", { size: "large" });
+    expect(createImageFromPath).not.toHaveBeenCalled();
   });
 
   it("falls back to the native file icon API for non-app targets", async () => {
@@ -76,7 +74,7 @@ describe("readWorkspaceLaunchTargetIconDataUrl", () => {
     expect(createImageFromPath).not.toHaveBeenCalled();
   });
 
-  it("falls back to bundle icons when the native file icon is unavailable", async () => {
+  it("falls back to bundle icons when the native macOS app file icon is unavailable", async () => {
     const getFileIcon = vi.fn(async () => image("", true));
     const createImageFromPath = vi.fn(() => image("data:image/png;base64,bundle"));
 
@@ -92,6 +90,9 @@ describe("readWorkspaceLaunchTargetIconDataUrl", () => {
       resolveBundleIconPath: async () => "/System/Applications/Utilities/Terminal.app/Contents/Resources/Terminal.icns",
     })).resolves.toBe("data:image/png;base64,bundle");
 
-    expect(getFileIcon).not.toHaveBeenCalled();
+    expect(getFileIcon).toHaveBeenCalledWith("/System/Applications/Utilities/Terminal.app", { size: "large" });
+    expect(createImageFromPath).toHaveBeenCalledWith(
+      "/System/Applications/Utilities/Terminal.app/Contents/Resources/Terminal.icns",
+    );
   });
 });

--- a/desktop/src/workspace-launch-icons.ts
+++ b/desktop/src/workspace-launch-icons.ts
@@ -54,6 +54,18 @@ function iconDataUrl(image: WorkspaceLaunchNativeImage): string | undefined {
   return image.resize({ width: WORKSPACE_LAUNCH_ICON_SIZE, height: WORKSPACE_LAUNCH_ICON_SIZE }).toDataURL();
 }
 
+async function readNativeFileIconDataUrl(
+  targetPath: string,
+  deps: Pick<WorkspaceLaunchIconDependencies, "getFileIcon">,
+): Promise<string | undefined> {
+  try {
+    const fileIcon = await deps.getFileIcon(targetPath, { size: "large" });
+    return iconDataUrl(fileIcon);
+  } catch {
+    return undefined;
+  }
+}
+
 export async function resolveDarwinAppBundleIconPath(
   appPath: string,
   options: DarwinBundleIconOptions = {},
@@ -86,27 +98,12 @@ export async function readWorkspaceLaunchTargetIconDataUrl(
   if (!target.iconPath) return undefined;
   const platform = deps.platform ?? process.platform;
 
-  if (platform === "darwin" && target.iconPath.endsWith(".app")) {
-    const bundleIconPath = deps.resolveBundleIconPath
-      ? await deps.resolveBundleIconPath(target.iconPath)
-      : await resolveDarwinAppBundleIconPath(target.iconPath, { platform });
-    if (!bundleIconPath) return undefined;
-
-    const bundleIcon = deps.createImageFromPath(bundleIconPath);
-    return iconDataUrl(bundleIcon);
-  }
-
-  try {
-    const fileIcon = await deps.getFileIcon(target.iconPath, { size: "large" });
-    const dataUrl = iconDataUrl(fileIcon);
-    if (dataUrl) return dataUrl;
-  } catch {
-    // Fall back to the app bundle icon path below.
-  }
+  const nativeIconDataUrl = await readNativeFileIconDataUrl(target.iconPath, deps);
+  if (nativeIconDataUrl) return nativeIconDataUrl;
 
   const bundleIconPath = deps.resolveBundleIconPath
     ? await deps.resolveBundleIconPath(target.iconPath)
-    : await resolveDarwinAppBundleIconPath(target.iconPath, { platform: deps.platform });
+    : await resolveDarwinAppBundleIconPath(target.iconPath, { platform });
   if (!bundleIconPath) return undefined;
 
   const bundleIcon = deps.createImageFromPath(bundleIconPath);

--- a/ui/src/pages/OrganizationWorkspaces.launcher-icon.test.tsx
+++ b/ui/src/pages/OrganizationWorkspaces.launcher-icon.test.tsx
@@ -73,4 +73,38 @@ describe("WorkspaceLaunchTargetIcon", () => {
 
     unmount();
   });
+
+  it("uses app-specific fallbacks instead of the shared generic code glyph for VS Code and Xcode", () => {
+    const vscode = renderIcon(
+      <WorkspaceLaunchTargetIcon
+        target={{
+          id: "vscode",
+          label: "VS Code",
+          kind: "ide",
+        }}
+      />,
+    );
+    const xcode = renderIcon(
+      <WorkspaceLaunchTargetIcon
+        target={{
+          id: "xcode",
+          label: "Xcode",
+          kind: "ide",
+        }}
+      />,
+    );
+
+    const vscodeFallback = vscode.container.querySelector("[data-workspace-launch-target-icon='vscode']");
+    const xcodeFallback = xcode.container.querySelector("[data-workspace-launch-target-icon='xcode']");
+    expect(vscodeFallback?.getAttribute("data-app-specific-fallback")).toBe("true");
+    expect(xcodeFallback?.getAttribute("data-app-specific-fallback")).toBe("true");
+    expect(vscodeFallback?.textContent).toBe("VS");
+    expect(xcodeFallback?.textContent).toBe("XC");
+    expect(vscodeFallback?.className).not.toBe(xcodeFallback?.className);
+    expect(vscode.container.querySelector("svg")).toBeNull();
+    expect(xcode.container.querySelector("svg")).toBeNull();
+
+    vscode.unmount();
+    xcode.unmount();
+  });
 });

--- a/ui/src/pages/OrganizationWorkspaces.tsx
+++ b/ui/src/pages/OrganizationWorkspaces.tsx
@@ -52,6 +52,18 @@ const WORKSPACE_LAUNCH_TARGET_IDS = [
   "finder",
 ] as const satisfies readonly DesktopWorkspaceLaunchTarget["id"][];
 const WORKSPACE_IMAGE_FILE_EXTENSIONS = new Set([".avif", ".bmp", ".gif", ".ico", ".jpeg", ".jpg", ".png", ".svg", ".webp"]);
+const WORKSPACE_LAUNCH_TARGET_FALLBACKS: Partial<Record<DesktopWorkspaceLaunchTarget["id"], {
+  label: string;
+  className: string;
+}>> = {
+  cursor: { label: "C", className: "bg-[#111827] text-white" },
+  vscode: { label: "VS", className: "bg-[#0078d4] text-white" },
+  windsurf: { label: "W", className: "bg-[#14b8a6] text-white" },
+  zed: { label: "Z", className: "bg-[#171717] text-white" },
+  webstorm: { label: "WS", className: "bg-[#ec4899] text-white" },
+  intellij: { label: "IJ", className: "bg-[#f97316] text-white" },
+  xcode: { label: "XC", className: "bg-[#147efb] text-white" },
+};
 
 function isWorkspaceLaunchTargetId(value: string | null): value is DesktopWorkspaceLaunchTarget["id"] {
   return WORKSPACE_LAUNCH_TARGET_IDS.includes(value as DesktopWorkspaceLaunchTarget["id"]);
@@ -94,6 +106,25 @@ export function WorkspaceLaunchTargetIcon({
           className="h-full w-full object-contain drop-shadow-[0_0_1px_rgba(0,0,0,0.35)]"
           onError={() => setImageFailed(true)}
         />
+      </span>
+    );
+  }
+
+  const appSpecificFallback = WORKSPACE_LAUNCH_TARGET_FALLBACKS[target.id];
+  if (appSpecificFallback) {
+    return (
+      <span
+        aria-hidden="true"
+        className={cn(
+          "inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-[4px] border border-[color:var(--border-base)] text-[8px] font-semibold leading-none",
+          appSpecificFallback.className,
+          className,
+        )}
+        data-workspace-launch-target-icon={target.id}
+        data-fallback-icon="true"
+        data-app-specific-fallback="true"
+      >
+        {appSpecificFallback.label}
       </span>
     );
   }


### PR DESCRIPTION
## Summary
- Prefer Electron native file icons for macOS app launch targets before bundle icon fallback.
- Add app-specific visible fallbacks so VS Code and Xcode no longer share the generic Code2 glyph.
- Cover desktop icon resolution and launcher UI fallback behavior with focused regression tests.

## Validation
- `pnpm exec vitest run desktop/src/workspace-launch-icons.test.ts --config desktop/vitest.config.ts`
- `pnpm exec vitest run ui/src/pages/OrganizationWorkspaces.launcher-icon.test.tsx --config ui/vitest.config.ts`
- `pnpm --filter @rudderhq/desktop typecheck`
- `pnpm --filter @rudderhq/ui typecheck`

## Known local validation boundary
- `pnpm --filter @rudderhq/desktop smoke` still fails before app startup because local `node_modules/.pnpm/electron@37.10.3/node_modules/electron/index.js` reports `Electron failed to install correctly, please delete node_modules/electron and try installing again`.