### PR TITLE
fix: use pnpm publish to apply publishConfig.exports overrides

### DIFF
--- a/desktop/scripts/after-pack.mjs
+++ b/desktop/scripts/after-pack.mjs
@@ -24,7 +24,8 @@ async function rewriteInternalPackageManifest(packageDir) {
   };
 
   if (manifest.publishConfig.exports) {
-    nextManifest.exports = manifest.publishConfig.exports;
+    nextManifest.exports = JSON.parse(JSON.stringify(manifest.publishConfig.exports));
+    addDefaultExportCondition(nextManifest.exports);
   }
   if (manifest.publishConfig.main) {
     nextManifest.main = manifest.publishConfig.main;
@@ -34,6 +35,21 @@ async function rewriteInternalPackageManifest(packageDir) {
   }
 
   await fs.writeFile(`${manifestPath}`, `${JSON.stringify(nextManifest, null, 2)}\n`, "utf8");
+}
+
+function addDefaultExportCondition(exportsObj) {
+  if (typeof exportsObj !== "object" || exportsObj === null || Array.isArray(exportsObj)) {
+    return;
+  }
+  for (const key of Object.keys(exportsObj)) {
+    const entry = exportsObj[key];
+    if (entry && typeof entry === "object" && !Array.isArray(entry)) {
+      if (entry.import && !entry.default) {
+        entry.default = entry.import;
+      }
+      addDefaultExportCondition(entry);
+    }
+  }
 }
 
 async function listTopLevelPackages(nodeModulesDir) {
@@ -126,6 +142,15 @@ async function copyTreePreservingSymlinks(sourcePath, destinationPath) {
   if (stats.isSymbolicLink()) {
     const target = await fs.readlink(sourcePath);
     await fs.mkdir(path.dirname(destinationPath), { recursive: true });
+
+    // Windows symlink creation requires developer mode or admin privileges.
+    // Dereference symlinks on Windows to avoid permission-related packaging failures.
+    if (process.platform === "win32") {
+      const resolvedTarget = path.resolve(path.dirname(sourcePath), target);
+      await copyTreePreservingSymlinks(resolvedTarget, destinationPath);
+      return;
+    }
+
     await fs.symlink(target, destinationPath);
     return;
   }

--- a/desktop/scripts/stage-server.mjs
+++ b/desktop/scripts/stage-server.mjs
@@ -38,7 +38,8 @@ async function rewritePublishedManifest(packageDir) {
 
   const nextManifest = { ...manifest };
   if (manifest.publishConfig.exports) {
-    nextManifest.exports = manifest.publishConfig.exports;
+    nextManifest.exports = JSON.parse(JSON.stringify(manifest.publishConfig.exports));
+    addDefaultExportCondition(nextManifest.exports);
   }
   if (manifest.publishConfig.main) {
     nextManifest.main = manifest.publishConfig.main;
@@ -48,6 +49,21 @@ async function rewritePublishedManifest(packageDir) {
   }
 
   await fs.writeFile(manifestPath, `${JSON.stringify(nextManifest, null, 2)}\n`, "utf8");
+}
+
+function addDefaultExportCondition(exportsObj) {
+  if (typeof exportsObj !== "object" || exportsObj === null || Array.isArray(exportsObj)) {
+    return;
+  }
+  for (const key of Object.keys(exportsObj)) {
+    const entry = exportsObj[key];
+    if (entry && typeof entry === "object" && !Array.isArray(entry)) {
+      if (entry.import && !entry.default) {
+        entry.default = entry.import;
+      }
+      addDefaultExportCondition(entry);
+    }
+  }
 }
 
 async function normalizeSelfReference(packageDir) {

--- a/doc/PUBLISHING.md
+++ b/doc/PUBLISHING.md
@@ -136,8 +136,9 @@ That means:
 - no long-lived `NPM_TOKEN` in repository secrets
 - GitHub Actions obtains short-lived publish credentials
 - trusted publisher rules are configured per workflow file
-- publish jobs use npm CLI for the final `npm publish` step while pnpm remains
-  the workspace build and install tool
+- publish jobs use `pnpm publish` so that `publishConfig` overrides (including
+  `exports`) are applied correctly; pnpm remains the workspace build and install
+  tool
 
 See [doc/RELEASE-AUTOMATION-SETUP.md](RELEASE-AUTOMATION-SETUP.md) for the GitHub/npm setup steps.
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -269,7 +269,7 @@ if [ "$dry_run" = true ]; then
     [ -z "$pkg_dir" ] && continue
     release_info "  --- $pkg_dir ---"
     cd "$REPO_ROOT/$pkg_dir"
-    npm publish --dry-run --tag "$DIST_TAG" --access public 2>&1 | tail -3
+    pnpm publish --dry-run --tag "$DIST_TAG" --access public 2>&1 | tail -3
   done <<< "$VERSIONED_PACKAGE_INFO"
   release_info "  [dry-run] Would create git tag $tag_name on $CURRENT_SHA"
 else
@@ -282,7 +282,7 @@ else
     if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
       npm_publish_args+=(--provenance)
     fi
-    npm "${npm_publish_args[@]}"
+    pnpm "${npm_publish_args[@]}"
   done <<< "$VERSIONED_PACKAGE_INFO"
   release_info "  ✓ Published all packages under dist-tag $DIST_TAG"
 fi


### PR DESCRIPTION
## Problem

npm publish does not rewrite package.json fields from publishConfig. All published @rudderhq/* packages retained dev exports pointing to src/index.ts instead of dist/index.js, causing Cannot find module errors for npm-installed users.

Additionally, Windows Desktop builds were missing dependencies because pnpm deploy produces symlink-based node_modules, and electron-builder's after-pack copy tried to recreate symlinks which fail without developer mode or admin privileges.

## Fix

1. **Release script**: Switch from npm publish to pnpm publish in scripts/release.sh. pnpm correctly applies publishConfig overrides (including exports) before packing.

2. **Desktop packaging (after-pack.mjs)**: On Windows, dereference symlinks instead of recreating them. This avoids permission-related packaging failures that caused dependencies to go missing in the installed app.

3. **Desktop staging (stage-server.mjs)**: Also rewrite @rudderhq/* sub-package exports when staging the server package, ensuring the default export fallback is present for createRequire resolution.

4. **Build verification (verify-server-package.mjs)**: New script that validates the packaged server-package after build:
   - All symlinks in node_modules are valid
   - Critical dependencies (drizzle-orm, express, etc.) are present
   - All @rudderhq/* packages have default export fallback
   - createRequire can resolve @rudderhq/server entrypoint

## Changes

- scripts/release.sh:273 — npm publish --dry-run → pnpm publish --dry-run
- scripts/release.sh:285 — npm publish → pnpm publish
- doc/PUBLISHING.md:139 — updated docs to reflect the tool change
- desktop/scripts/after-pack.mjs — dereference symlinks on Windows; add default export condition
- desktop/scripts/stage-server.mjs — rewrite @rudderhq/* sub-package exports
- desktop/scripts/verify-server-package.mjs — new build verification script
- desktop/package.json — integrate verification into pnpm desktop:dist

## Verification

- pnpm 9.15.4 supports --dry-run, --tag, --access, and --provenance flags
- Auth via .npmrc (set up by actions/setup-node) works for both npm and pnpm
- Local test: node desktop/scripts/verify-server-package.mjs passes against .packaged/server-package