### PR TITLE
fix: fallback to latest server version when exact version is missing on npm

### DIFF
--- a/cli/src/__tests__/start.test.ts
+++ b/cli/src/__tests__/start.test.ts
@@ -1063,6 +1063,77 @@ describe("runtime install helpers", () => {
     }
   });
 
+  it("falls back to latest when the exact version is not found on npm", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "rudder-runtime-fallback-test."));
+    try {
+      const spawnSyncImpl = vi
+        .fn()
+        .mockReturnValueOnce({
+          status: 1,
+          stdout: "",
+          stderr: "npm error code ETARGET\nnpm error notarget No matching version found for @rudderhq/server@1.2.3.",
+        })
+        .mockReturnValueOnce({
+          status: 0,
+          stdout: "added 1 package",
+          stderr: "",
+        });
+
+      const result = await ensureRuntimeInstalled({
+        version: "1.2.3",
+        homeDir: root,
+        spawnSyncImpl: spawnSyncImpl as never,
+      });
+
+      expect(result.status).toBe("installed");
+      expect(result.packageSpec).toBe("@rudderhq/server@latest");
+      expect(result.cacheDir).toBe(resolveRuntimeCacheDir("latest", root));
+      expect(result.output).toBe("added 1 package");
+      expect(spawnSyncImpl).toHaveBeenCalledTimes(2);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("falls back to latest cache hit when the exact version is not found on npm", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "rudder-runtime-fallback-hit-test."));
+    try {
+      const fallbackCacheDir = resolveRuntimeCacheDir("latest", root);
+      const packageDir = path.join(fallbackCacheDir, "node_modules", "@rudderhq", "server");
+      await mkdir(packageDir, { recursive: true });
+      await writeFile(path.join(fallbackCacheDir, "package.json"), JSON.stringify({ private: true }), "utf8");
+      await writeFile(
+        path.join(fallbackCacheDir, RUNTIME_METADATA_FILE),
+        JSON.stringify({ version: 1, packageName: "@rudderhq/server", packageVersion: "latest", installedAt: "now" }),
+        "utf8",
+      );
+      await writeFile(
+        path.join(packageDir, "package.json"),
+        JSON.stringify({ name: "@rudderhq/server", version: "1.0.0" }),
+        "utf8",
+      );
+
+      const spawnSyncImpl = vi.fn(() => ({
+        status: 1,
+        stdout: "",
+        stderr: "npm error code ETARGET\nnpm error notarget No matching version found for @rudderhq/server@1.2.3.",
+      }));
+
+      const result = await ensureRuntimeInstalled({
+        version: "1.2.3",
+        homeDir: root,
+        spawnSyncImpl: spawnSyncImpl as never,
+      });
+
+      expect(result.status).toBe("hit");
+      expect(result.packageSpec).toBe("@rudderhq/server@latest");
+      expect(result.cacheDir).toBe(fallbackCacheDir);
+      expect(spawnSyncImpl).toHaveBeenCalledTimes(1);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("prunes older canary runtime caches while retaining current, latest stable, and previous entries", async () => {
     const root = await mkdtemp(path.join(tmpdir(), "rudder-runtime-prune-test."));
     try {

--- a/cli/src/runtime/install.ts
+++ b/cli/src/runtime/install.ts
@@ -181,6 +181,47 @@ export async function ensureRuntimeInstalled(
   const spawnSyncImpl = options.spawnSyncImpl ?? spawnSync;
   const result = runNpmRuntimeInstall(spawnSyncImpl, cacheDir, packageSpec);
   const output = collectSpawnOutput(result);
+
+  if (result.status !== 0 && packageVersion !== "latest" && isVersionNotFoundError(output)) {
+    const fallbackVersion = "latest";
+    const fallbackCacheDir = resolveRuntimeCacheDir(fallbackVersion, options.homeDir);
+    const fallbackSpec = resolveRuntimePackageSpec(fallbackVersion, packageName);
+
+    if (await isRuntimeCacheHit({ cacheDir: fallbackCacheDir, version: fallbackVersion, packageName })) {
+      await touchRuntimeInstallMetadata(fallbackCacheDir);
+      return {
+        status: "hit",
+        cacheDir: fallbackCacheDir,
+        packageSpec: fallbackSpec,
+        command: `npm install --prefix ${fallbackCacheDir} --omit=dev --no-audit --no-fund ${fallbackSpec}`,
+        output: "",
+      };
+    }
+
+    await mkdir(fallbackCacheDir, { recursive: true });
+    await writeFile(path.join(fallbackCacheDir, "package.json"), `${JSON.stringify({ private: true, type: "module" }, null, 2)}\n`, "utf8");
+
+    const fallbackResult = runNpmRuntimeInstall(spawnSyncImpl, fallbackCacheDir, fallbackSpec);
+    const fallbackOutput = collectSpawnOutput(fallbackResult);
+    if (fallbackResult.status === 0) {
+      const fallbackMetadata: RuntimeInstallMetadata = {
+        version: 1,
+        packageName,
+        packageVersion: fallbackVersion,
+        installedAt: new Date().toISOString(),
+        lastUsedAt: new Date().toISOString(),
+      };
+      await writeRuntimeInstallMetadata(fallbackCacheDir, fallbackMetadata);
+      return {
+        status: "installed",
+        cacheDir: fallbackCacheDir,
+        packageSpec: fallbackSpec,
+        command: `npm install --prefix ${fallbackCacheDir} --omit=dev --no-audit --no-fund ${fallbackSpec}`,
+        output: fallbackOutput,
+      };
+    }
+  }
+
   if (result.status !== 0) {
     throw new RuntimeInstallError(
       `Rudder runtime installation failed. Re-run manually: ${command}`,
@@ -236,6 +277,15 @@ function collectSpawnOutput(result: SpawnSyncResultLike): string {
     .filter((value): value is string => typeof value === "string" && value.trim().length > 0)
     .join("\n")
     .trim();
+}
+
+function isVersionNotFoundError(output: string): boolean {
+  const normalized = output.toLowerCase();
+  return (
+    normalized.includes("enoent") ||
+    normalized.includes("etarget") ||
+    normalized.includes("no matching version found")
+  );
 }
 
 interface RuntimeCacheEntry {


### PR DESCRIPTION
When @rudderhq/cli@X.Y.Z is published but the matching @rudderhq/server@X.Y.Z is not yet available, `rudder start` fails with ETARGET / "No matching version found". This adds a fallback in ensureRuntimeInstalled that retries with `latest` when the exact version is not found, so the CLI remains usable even when server publish lags behind.

## Thinking Path

<!--
  Required. Trace your reasoning from the top of the project down to this
  specific change. Start with what Rudder is, then narrow through the
  subsystem, the problem, and why this PR exists. Use blockquote style.
  Aim for 5–8 steps. See CONTRIBUTING.md for full examples.
-->

> - Rudder orchestrates AI agents for zero-human companies
> - [Which subsystem or capability is involved]
> - [What problem or gap exists]
> - [Why it needs to be addressed]
> - This pull request ...
> - The benefit is ...

## What Changed

<!-- Bullet list of concrete changes. One bullet per logical unit. -->

-

## Verification

<!--
  How can a reviewer confirm this works? Include test commands, manual
  steps, or both. For UI changes, include before/after screenshots.
-->

-

## Risks

<!--
  What could go wrong? Mention migration safety, breaking changes,
  behavioral shifts, or "Low risk" if genuinely minor.
-->

-

## Checklist

- [ ] I have included a thinking path that traces from project context to this change
- [ ] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] I have considered and documented any risks above
- [ ] I will address all Greptile and reviewer comments before requesting merge
