### PR TITLE
test: align rudder skill docs expectation

### DIFF
--- a/server/src/__tests__/bundled-rudder-skill-docs.test.ts
+++ b/server/src/__tests__/bundled-rudder-skill-docs.test.ts
@@ -29,8 +29,8 @@ describe("bundled rudder skill docs", () => {
     const contents = await readSkillDoc();
 
     expect(contents).toContain("This is the control-plane practice skill for agents working under Rudder");
-    expect(contents).toContain("Goal -> Issue -> Agent run -> Review -> Feedback -> Learning -> Better future runs");
     expect(contents).toContain("Runtime-owned heartbeat prompts provide the fixed heartbeat execution flow");
+    expect(contents).toContain("ownership, checkout, approvals, comments, reviews, Library handoffs, and");
     expect(contents).toContain("## Control-Plane Rails");
     expect(contents).toContain("## Essential Commands");
     expect(contents).toContain("Use `references/cli-reference.md` for the stable command catalog");


### PR DESCRIPTION
## Summary
- Update the bundled Rudder skill docs fixture test to match the current control-plane skill text.
- Fixes the latest main CI/Release unit-test failure in `server/src/__tests__/bundled-rudder-skill-docs.test.ts`.

## Evidence
- Latest failing CI run: https://github.com/Undertone0809/rudder/actions/runs/27780919618
- Latest failing Release run: https://github.com/Undertone0809/rudder/actions/runs/27780920626
- Local validation on the fix branch previously passed: targeted vitest, server typecheck, lint:changed, and git diff --check.

Rudder issues: ZST-436, ZST-440