### PR TITLE
chore: prepare 0.4.4 release

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rudderhq/cli",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Rudder CLI — orchestrate AI agent teams to run a business",
   "type": "module",
   "bin": {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rudderhq/desktop",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "private": true,
   "description": "Rudder Desktop local-first Electron shell",
   "author": "Rudder",

--- a/docs/releases.mdx
+++ b/docs/releases.mdx
@@ -18,6 +18,30 @@ npx @rudderhq/cli@latest start
 
 This changelog tracks stable releases only. Canary builds are published more frequently for validation and Desktop asset testing; use [GitHub Releases](https://github.com/Undertone0809/rudder/releases) when you need prerelease history.
 
+## v0.4.4
+
+Released: 2026-07-09
+
+[GitHub Release](https://github.com/Undertone0809/rudder/releases/tag/v0.4.4)
+
+### New Features
+
+- Added a global side panel workbench that can open chat references, Library entries, local pages, and issue context without forcing operators out of the active conversation.
+- Added first-party Rudder Agent MCP tools and managed runtime injection so local agent runtimes can use scoped Rudder control-plane actions from their normal work sessions.
+- Added organization workspace and Library improvements, including friendly workspace folders, backup zip support, Library copy actions, hidden-section reveal controls, and a default app file opener.
+
+### Improvements
+
+- Improved Messenger and issue-detail workflows with editable expanded issue panels, steadier pinned groups, better composer reference tokens, more reliable scrolling, and the global new-chat shortcut.
+- Improved Codex, Claude, OpenCode, and Pi runtime behavior around startup memory filenames, cleanup-warning filtering, runtime availability reporting, boot-failure classification, and active update handoff.
+- Improved dashboard, navigation, and release polish with token cache ratio metrics, website favicon alignment, safer legacy-route rails, and expanded release/product contract documentation.
+
+### Bug Fixes
+
+- Fixed side panel browser readiness, local URL loading, chat branch switching during streams, stopped-reply leakage, and several side panel layout regressions.
+- Fixed website metadata icons, markdown card previews, issue mention status icons, Library tabs, and pinned Messenger row alignment.
+- Fixed CI health checks, heartbeat fallback preflight stability, Feishu markdown card handling, Feishu stop-reply wait coverage, and workspace map write serialization.
+
 ## v0.4.2
 
 Released: 2026-06-30

--- a/docs/zh/releases.mdx
+++ b/docs/zh/releases.mdx
@@ -18,6 +18,30 @@ npx @rudderhq/cli@latest start
 
 这个页面只记录稳定版本。Canary 会更频繁地用于验证和 Desktop 资产测试；如果需要查看预发布历史，可以看 [GitHub Releases](https://github.com/Undertone0809/rudder/releases)。
 
+## v0.4.4
+
+发布时间：2026-07-09
+
+[GitHub Release](https://github.com/Undertone0809/rudder/releases/tag/v0.4.4)
+
+### New Features
+
+- 增加全局 side panel workbench，可以在不离开当前 conversation 的情况下打开 chat references、Library entries、local pages 和 issue context。
+- 增加 first-party Rudder Agent MCP tools 和 managed runtime injection，让 local agent runtimes 可以在正常 work session 中使用 scoped Rudder control-plane actions。
+- 增加 organization workspace 和 Library 改进，包括 friendly workspace folders、backup zip support、Library copy actions、hidden-section reveal controls 和 default app file opener。
+
+### Improvements
+
+- 改善 Messenger 和 issue-detail workflows，包括可编辑的 expanded issue panels、更稳定的 pinned groups、更好的 composer reference tokens、更可靠的 scrolling，以及 global new-chat shortcut。
+- 改善 Codex、Claude、OpenCode 和 Pi runtime behavior，覆盖 startup memory filenames、cleanup-warning filtering、runtime availability reporting、boot-failure classification 和 active update handoff。
+- 改善 dashboard、navigation 和 release polish，包括 token cache ratio metrics、website favicon alignment、更安全的 legacy-route rails，以及扩展后的 release/product contract documentation。
+
+### Bug Fixes
+
+- 修复 side panel browser readiness、local URL loading、stream 期间的 chat branch switching、stopped-reply leakage，以及多个 side panel layout regressions。
+- 修复 website metadata icons、markdown card previews、issue mention status icons、Library tabs 和 pinned Messenger row alignment。
+- 修复 CI health checks、heartbeat fallback preflight stability、Feishu markdown card handling、Feishu stop-reply wait coverage 和 workspace map write serialization。
+
 ## v0.4.2
 
 发布时间：2026-06-30

--- a/packages/agent-runtime-utils/package.json
+++ b/packages/agent-runtime-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rudderhq/agent-runtime-utils",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "license": "SEE LICENSE IN LICENSE",
   "homepage": "https://github.com/Undertone0809/rudder",
   "bugs": {

--- a/packages/agent-runtimes/claude-local/package.json
+++ b/packages/agent-runtimes/claude-local/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rudderhq/agent-runtime-claude-local",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "license": "SEE LICENSE IN LICENSE",
   "homepage": "https://github.com/Undertone0809/rudder",
   "bugs": {

--- a/packages/agent-runtimes/codex-local/package.json
+++ b/packages/agent-runtimes/codex-local/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rudderhq/agent-runtime-codex-local",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "license": "SEE LICENSE IN LICENSE",
   "homepage": "https://github.com/Undertone0809/rudder",
   "bugs": {

--- a/packages/agent-runtimes/cursor-local/package.json
+++ b/packages/agent-runtimes/cursor-local/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rudderhq/agent-runtime-cursor-local",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "license": "SEE LICENSE IN LICENSE",
   "homepage": "https://github.com/Undertone0809/rudder",
   "bugs": {

--- a/packages/agent-runtimes/gemini-local/package.json
+++ b/packages/agent-runtimes/gemini-local/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rudderhq/agent-runtime-gemini-local",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "license": "SEE LICENSE IN LICENSE",
   "homepage": "https://github.com/Undertone0809/rudder",
   "bugs": {

--- a/packages/agent-runtimes/openclaw-gateway/package.json
+++ b/packages/agent-runtimes/openclaw-gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rudderhq/agent-runtime-openclaw-gateway",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "license": "SEE LICENSE IN LICENSE",
   "homepage": "https://github.com/Undertone0809/rudder",
   "bugs": {

--- a/packages/agent-runtimes/opencode-local/package.json
+++ b/packages/agent-runtimes/opencode-local/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rudderhq/agent-runtime-opencode-local",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "license": "SEE LICENSE IN LICENSE",
   "homepage": "https://github.com/Undertone0809/rudder",
   "bugs": {

--- a/packages/agent-runtimes/pi-local/package.json
+++ b/packages/agent-runtimes/pi-local/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rudderhq/agent-runtime-pi-local",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "license": "SEE LICENSE IN LICENSE",
   "homepage": "https://github.com/Undertone0809/rudder",
   "bugs": {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rudderhq/db",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "license": "SEE LICENSE IN LICENSE",
   "homepage": "https://github.com/Undertone0809/rudder",
   "bugs": {

--- a/packages/plugins/create-rudder-plugin/package.json
+++ b/packages/plugins/create-rudder-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rudderhq/create-rudder-plugin",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "license": "SEE LICENSE IN LICENSE",
   "homepage": "https://github.com/Undertone0809/rudder",
   "bugs": {

--- a/packages/plugins/sdk/package.json
+++ b/packages/plugins/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rudderhq/plugin-sdk",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Stable public API for Rudder plugins — worker-side context and UI bridge hooks",
   "license": "SEE LICENSE IN LICENSE",
   "homepage": "https://github.com/Undertone0809/rudder",

--- a/packages/run-intelligence-core/package.json
+++ b/packages/run-intelligence-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rudderhq/run-intelligence-core",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "license": "SEE LICENSE IN LICENSE",
   "homepage": "https://github.com/Undertone0809/rudder",
   "bugs": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rudderhq/shared",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "license": "SEE LICENSE IN LICENSE",
   "homepage": "https://github.com/Undertone0809/rudder",
   "bugs": {

--- a/releases/v0.4.4.md
+++ b/releases/v0.4.4.md
@@ -1,0 +1,17 @@
+## New Features
+
+- Added a global side panel workbench that can open chat references, Library entries, local pages, and issue context without forcing operators out of the active conversation.
+- Added first-party Rudder Agent MCP tools and managed runtime injection so local agent runtimes can use scoped Rudder control-plane actions from their normal work sessions.
+- Added organization workspace and Library improvements, including friendly workspace folders, backup zip support, Library copy actions, hidden-section reveal controls, and a default app file opener.
+
+## Improvements
+
+- Improved Messenger and issue-detail workflows with editable expanded issue panels, steadier pinned groups, better composer reference tokens, more reliable scrolling, and the global new-chat shortcut.
+- Improved Codex, Claude, OpenCode, and Pi runtime behavior around startup memory filenames, cleanup-warning filtering, runtime availability reporting, boot-failure classification, and active update handoff.
+- Improved dashboard, navigation, and release polish with token cache ratio metrics, website favicon alignment, safer legacy-route rails, and expanded release/product contract documentation.
+
+## Bug Fixes
+
+- Fixed side panel browser readiness, local URL loading, chat branch switching during streams, stopped-reply leakage, and several side panel layout regressions.
+- Fixed website metadata icons, markdown card previews, issue mention status icons, Library tabs, and pinned Messenger row alignment.
+- Fixed CI health checks, heartbeat fallback preflight stability, Feishu markdown card handling, Feishu stop-reply wait coverage, and workspace map write serialization.

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rudderhq/server",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "license": "SEE LICENSE IN LICENSE",
   "homepage": "https://github.com/Undertone0809/rudder",
   "bugs": {


### PR DESCRIPTION
Prepare the v0.4.4 stable release.\n\n- bump public Rudder packages and Desktop metadata to 0.4.4\n- add releases/v0.4.4.md\n- add English and Chinese docs changelog entries\n\nLocal checks:\n- pnpm -r typecheck\n- targeted release script tests\n- pnpm test:run attempted; local DB/resource tests hit environment timeouts unrelated to release-prep files\n- pnpm build attempted; local Desktop staging npm downloads stalled with ECONNRESET, so release dry-run will be the clean runner gate