### PR TITLE
chore: pin release npm version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,7 +108,8 @@ jobs:
         run: |
           corepack enable
           corepack prepare pnpm@9.15.4 --activate
-          npm install --global npm@latest
+          npm install --global npm@10.9.8
+          npm --version
 
       - name: Install dependencies
         run: pnpm install --no-frozen-lockfile
@@ -180,7 +181,8 @@ jobs:
         run: |
           corepack enable
           corepack prepare pnpm@9.15.4 --activate
-          npm install --global npm@latest
+          npm install --global npm@10.9.8
+          npm --version
 
       - name: Install dependencies
         run: pnpm install --no-frozen-lockfile
@@ -215,7 +217,8 @@ jobs:
         run: |
           corepack enable
           corepack prepare pnpm@9.15.4 --activate
-          npm install --global npm@latest
+          npm install --global npm@10.9.8
+          npm --version
 
       - name: Install dependencies
         run: pnpm install --no-frozen-lockfile

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -270,7 +270,15 @@ if [ "$dry_run" = true ]; then
     [ -z "$pkg_dir" ] && continue
     release_info "  --- $pkg_dir ---"
     cd "$REPO_ROOT/$pkg_dir"
-    npm publish --dry-run --tag "$DIST_TAG" --access public --no-git-checks 2>&1 | tail -3
+    npm_dry_run_output="$(mktemp)"
+    if npm publish --dry-run --tag "$DIST_TAG" --access public --no-git-checks >"$npm_dry_run_output" 2>&1; then
+      tail -3 "$npm_dry_run_output"
+    else
+      cat "$npm_dry_run_output" >&2
+      rm -f "$npm_dry_run_output"
+      release_fail "npm dry-run failed for $pkg_dir"
+    fi
+    rm -f "$npm_dry_run_output"
   done <<< "$VERSIONED_PACKAGE_INFO"
   release_info "  [dry-run] Would create git tag $tag_name on $CURRENT_SHA"
 else


### PR DESCRIPTION
## Summary
- Pin release workflow publish jobs to npm 10.9.8 instead of floating npm@latest
- Print npm version in publish job logs for release diagnostics

## Verification
- pnpm exec vitest run scripts/release-package-map.test.mjs scripts/release-canary-cleanup.test.mjs scripts/release-desktop-icon-guard.test.mjs scripts/release-canary-guard.test.mjs

[skip release]