### PR TITLE
fix: harden execution and tenant trust boundaries

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,12 @@
 .git
 .github
 .rudder
+.env
+.env.*
+**/.env
+**/.env.*
+!.env.example
+!**/.env.example
 .pnpm-store
 node_modules
 **/node_modules

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,8 @@ jobs:
       ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -9,16 +9,12 @@ on:
       source_ref:
         description: "Optional source ref to build from when recovering an existing release tag"
         required: false
-  push:
-    tags:
-      - "v*"
-      - "canary/v*"
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
-  group: desktop-release-${{ inputs.release_tag || github.ref_name }}
+  group: desktop-release-${{ inputs.release_tag }}
   cancel-in-progress: false
 
 defaults:
@@ -26,9 +22,53 @@ defaults:
     shell: bash
 
 jobs:
+  resolve-source:
+    name: Resolve trusted desktop source
+    if: github.repository == 'Undertone0809/rudder' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      release_tag: ${{ steps.source.outputs.release_tag }}
+      source_sha: ${{ steps.source.outputs.source_sha }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: main
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Validate release tag and source
+        id: source
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          SOURCE_REF: ${{ inputs.source_ref || inputs.release_tag }}
+        run: |
+          if [[ ! "$RELEASE_TAG" =~ ^(canary/)?v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "Invalid desktop release tag: $RELEASE_TAG" >&2
+            exit 1
+          fi
+
+          tag_sha="$(git rev-parse --verify --end-of-options "refs/tags/${RELEASE_TAG}^{commit}")"
+          source_sha="$(git rev-parse --verify --end-of-options "${SOURCE_REF}^{commit}")"
+          if [[ "$source_sha" != "$tag_sha" ]]; then
+            echo "Desktop source must resolve to the release tag commit." >&2
+            exit 1
+          fi
+          if ! git merge-base --is-ancestor "$source_sha" origin/main; then
+            echo "Desktop release tag must belong to the protected main history." >&2
+            exit 1
+          fi
+
+          echo "release_tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
+          echo "source_sha=$source_sha" >> "$GITHUB_OUTPUT"
+
   build:
     name: Build ${{ matrix.platform }} ${{ matrix.arch }}
+    needs: resolve-source
     runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -49,7 +89,8 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          ref: ${{ inputs.source_ref || inputs.release_tag || github.ref_name }}
+          ref: ${{ needs.resolve-source.outputs.source_sha }}
+          persist-credentials: false
 
       - uses: actions/setup-node@v6
         with:
@@ -61,7 +102,7 @@ jobs:
           corepack prepare pnpm@9.15.4 --activate
 
       - name: Install dependencies
-        run: pnpm install --no-frozen-lockfile
+        run: pnpm install --frozen-lockfile
 
       - name: Prepare PostgreSQL 18.4 runtime payload
         env:
@@ -90,8 +131,9 @@ jobs:
       - name: Build desktop portable asset
         env:
           RUDDER_DESKTOP_TARGET_ARCH: ${{ matrix.arch }}
+          RELEASE_TAG: ${{ needs.resolve-source.outputs.release_tag }}
         run: |
-          tag="${{ inputs.release_tag || github.ref_name }}"
+          tag="$RELEASE_TAG"
           version="${tag##*/}"
           version="${version#v}"
           node scripts/release-package-map.mjs set-version "${version}"
@@ -105,8 +147,10 @@ jobs:
 
       - name: Collect release asset
         id: collect
+        env:
+          RELEASE_TAG: ${{ needs.resolve-source.outputs.release_tag }}
         run: |
-          tag="${{ inputs.release_tag || github.ref_name }}"
+          tag="$RELEASE_TAG"
           version="${tag##*/}"
           version="${version#v}"
           node scripts/collect-desktop-release-assets.mjs \
@@ -123,13 +167,18 @@ jobs:
 
   publish:
     name: Attach desktop artifacts
-    needs: build
+    needs:
+      - resolve-source
+      - build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          ref: ${{ inputs.source_ref || inputs.release_tag || github.ref_name }}
+          ref: ${{ needs.resolve-source.outputs.source_sha }}
+          persist-credentials: false
 
       - uses: actions/download-artifact@v8
         with:
@@ -145,8 +194,9 @@ jobs:
       - name: Create or update GitHub Release assets
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ needs.resolve-source.outputs.release_tag }}
         run: |
-          tag="${{ inputs.release_tag || github.ref_name }}"
+          tag="$RELEASE_TAG"
           release_title="${tag##*/}"
           notes_file="releases/${tag}.md"
           release_args=(create "${tag}" --title "${release_title}")

--- a/.github/workflows/docs-production.yml
+++ b/.github/workflows/docs-production.yml
@@ -13,7 +13,7 @@ on:
         default: ""
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: docs-production
@@ -31,16 +31,47 @@ env:
   DOCS_PRODUCTION_ALIASES: doc.rudder.zeeland.studio,rudder-docs.vercel.app,rudder-docs-zeelands-projects.vercel.app
 
 jobs:
-  publish:
-    name: Publish production docs
+  resolve-source:
+    name: Resolve trusted docs source
+    if: github.repository == 'Undertone0809/rudder' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
-    if: github.repository == 'Undertone0809/rudder'
+    permissions:
+      contents: read
+    outputs:
+      sha: ${{ steps.source.outputs.sha }}
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.source_ref }}
+          ref: main
           fetch-depth: 0
+          persist-credentials: false
+
+      - name: Resolve source commit from main history
+        id: source
+        env:
+          SOURCE_REF: ${{ inputs.source_ref }}
+        run: |
+          source_sha="$(git rev-parse --verify --end-of-options "${SOURCE_REF}^{commit}")"
+          if ! git merge-base --is-ancestor "$source_sha" origin/main; then
+            echo "Docs source must belong to the protected main history: $SOURCE_REF" >&2
+            exit 1
+          fi
+          echo "sha=$source_sha" >> "$GITHUB_OUTPUT"
+
+  publish:
+    name: Publish production docs
+    needs: resolve-source
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write
+    environment: docs-production
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.resolve-source.outputs.sha }}
+          fetch-depth: 0
+          persist-credentials: false
 
       - uses: actions/setup-node@v6
         with:
@@ -52,15 +83,17 @@ jobs:
           corepack prepare pnpm@9.15.4 --activate
 
       - name: Install Vercel CLI
-        run: npm install --global vercel@latest
+        run: npm install --global vercel@55.0.0
 
       - name: Resolve docs tag
         id: tag
+        env:
+          TAG_NAME: ${{ inputs.tag_name }}
         run: |
           git fetch --tags --force origin
 
-          if [[ -n "${{ inputs.tag_name }}" ]]; then
-            tag="${{ inputs.tag_name }}"
+          if [[ -n "$TAG_NAME" ]]; then
+            tag="$TAG_NAME"
           else
             tag="docs/v$(TZ=Asia/Shanghai date +%Y.%m.%d)"
           fi
@@ -207,6 +240,7 @@ jobs:
         id: deploy
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          SOURCE_REF: ${{ inputs.source_ref }}
         run: |
           deployment_output="$(
             vercel deploy "$RUNNER_TEMP/rudder-docs-export" \
@@ -216,7 +250,7 @@ jobs:
               --scope "$VERCEL_SCOPE" \
               --token "$VERCEL_TOKEN" \
               --meta githubCommitSha="${{ steps.tag.outputs.sha }}" \
-              --meta githubCommitRef="${{ inputs.source_ref }}" \
+              --meta githubCommitRef="$SOURCE_REF" \
               --meta docsChannel=production
           )"
           printf '%s\n' "$deployment_output"
@@ -256,6 +290,8 @@ jobs:
           DOCS_HEALTH_HOSTS="$hosts" node scripts/check-docs-public-health.mjs
 
       - name: Create docs release tag
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           tag="${{ steps.tag.outputs.tag }}"
           current_sha="$(git rev-parse HEAD)"
@@ -273,4 +309,6 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git tag -a "$tag" -m "docs: publish $tag"
-          git push origin "refs/tags/$tag"
+          auth_header="$(printf 'x-access-token:%s' "$GH_TOKEN" | base64 | tr -d '\n')"
+          git -c http.https://github.com/.extraheader="AUTHORIZATION: basic ${auth_header}" \
+            push origin "refs/tags/$tag"

--- a/.github/workflows/docs-public-health.yml
+++ b/.github/workflows/docs-public-health.yml
@@ -27,6 +27,8 @@ jobs:
     if: github.repository == 'Undertone0809/rudder'
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/docs-staging.yml
+++ b/.github/workflows/docs-staging.yml
@@ -35,6 +35,8 @@ jobs:
     if: github.repository == 'Undertone0809/rudder'
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@v6
         with:
@@ -46,7 +48,7 @@ jobs:
           corepack prepare pnpm@9.15.4 --activate
 
       - name: Install Vercel CLI
-        run: npm install --global vercel@latest
+        run: npm install --global vercel@55.0.0
 
       - name: Validate docs
         working-directory: docs

--- a/.github/workflows/docs-vercel-firewall.yml
+++ b/.github/workflows/docs-vercel-firewall.yml
@@ -22,6 +22,8 @@ jobs:
     if: github.repository == 'Undertone0809/rudder'
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/npm-dist-tag.yml
+++ b/.github/workflows/npm-dist-tag.yml
@@ -18,7 +18,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   promote:
@@ -28,6 +27,8 @@ jobs:
     environment: npm-canary
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@v6
         with:
@@ -37,9 +38,21 @@ jobs:
       - name: Promote dist-tag
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          PUBLISH_VERSION: ${{ inputs.version }}
+          DIST_TAG: ${{ inputs.tag }}
+          DRY_RUN: ${{ inputs.dry_run }}
         run: |
-          args=(--version "${{ inputs.version }}" --tag "${{ inputs.tag }}")
-          if [ "${{ inputs.dry_run }}" = "true" ]; then
+          if [[ ! "$PUBLISH_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "Invalid npm version: $PUBLISH_VERSION" >&2
+            exit 1
+          fi
+          if [[ ! "$DIST_TAG" =~ ^[A-Za-z][A-Za-z0-9._-]*$ ]]; then
+            echo "Invalid npm dist-tag: $DIST_TAG" >&2
+            exit 1
+          fi
+
+          args=(--version "$PUBLISH_VERSION" --tag "$DIST_TAG")
+          if [ "$DRY_RUN" = "true" ]; then
             args+=(--dry-run)
           fi
           node scripts/promote-npm-dist-tag.mjs "${args[@]}"

--- a/.github/workflows/public-install-smoke.yml
+++ b/.github/workflows/public-install-smoke.yml
@@ -41,10 +41,15 @@ jobs:
             runner: macos-14
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@v6
         with:
           node-version: 24
 
       - name: Smoke public npx install
-        run: node scripts/smoke-public-install.mjs --package-spec "${{ inputs.package_spec }}" --repo "${{ inputs.repo }}"
+        env:
+          RUDDER_PUBLIC_INSTALL_PACKAGE_SPEC: ${{ inputs.package_spec }}
+          RUDDER_PUBLIC_INSTALL_RELEASE_REPO: ${{ inputs.repo }}
+        run: node scripts/smoke-public-install.mjs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,19 +17,51 @@ on:
         default: true
 
 permissions:
-  actions: write
-  contents: write
-  id-token: write
+  contents: read
 
 concurrency:
   group: release-${{ github.event_name }}-${{ github.ref }}-${{ github.event_name == 'workflow_dispatch' && inputs.source_ref || 'push' }}
   cancel-in-progress: false
 
 jobs:
+  resolve-source:
+    name: Resolve trusted release source
+    if: >-
+      github.repository == 'Undertone0809/rudder' &&
+      (github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/main')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      sha: ${{ steps.source.outputs.sha }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: main
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Resolve source commit from main history
+        id: source
+        env:
+          SOURCE_REF: ${{ github.event_name == 'workflow_dispatch' && inputs.source_ref || github.sha }}
+        run: |
+          source_sha="$(git rev-parse --verify --end-of-options "${SOURCE_REF}^{commit}")"
+          if ! git merge-base --is-ancestor "$source_sha" origin/main; then
+            echo "Release source must belong to the protected main history: $SOURCE_REF" >&2
+            exit 1
+          fi
+          echo "sha=$source_sha" >> "$GITHUB_OUTPUT"
+
   verify:
     name: Verify ${{ matrix.os }}
-    if: (github.event_name == 'push' && github.repository == 'Undertone0809/rudder' && !contains(github.event.head_commit.message, '[skip release]')) || github.event_name == 'workflow_dispatch'
+    needs: resolve-source
+    if: >-
+      (github.event_name == 'push' && !contains(github.event.head_commit.message, '[skip release]')) ||
+      github.event_name == 'workflow_dispatch'
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     timeout-minutes: 60
     strategy:
       fail-fast: false
@@ -51,7 +83,8 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.source_ref || github.sha }}
+          persist-credentials: false
+          ref: ${{ needs.resolve-source.outputs.sha }}
 
       - uses: actions/setup-node@v6
         with:
@@ -88,6 +121,10 @@ jobs:
     if: github.event_name == 'push' && github.repository == 'Undertone0809/rudder' && !contains(github.event.head_commit.message, '[skip release]')
     runs-on: ubuntu-latest
     environment: npm-canary
+    permissions:
+      actions: write
+      contents: write
+      id-token: write
     env:
       ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
       RUDDER_ALLOW_LEGACY_EMBEDDED_POSTGRES: "1"
@@ -98,6 +135,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: actions/setup-node@v6
         with:
@@ -112,7 +150,7 @@ jobs:
           npm --version
 
       - name: Install dependencies
-        run: pnpm install --no-frozen-lockfile
+        run: pnpm install --frozen-lockfile
 
       - name: Configure git identity
         run: |
@@ -123,19 +161,22 @@ jobs:
       - name: Publish canary
         id: publish
         env:
+          GH_TOKEN: ${{ github.token }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           version="$(./scripts/release.sh canary --print-version)"
           echo "version=${version}" >> "$GITHUB_OUTPUT"
           ./scripts/release.sh canary --skip-verify
-          git push origin "refs/tags/canary/v${version}"
+          auth_header="$(printf 'x-access-token:%s' "$GH_TOKEN" | base64 | tr -d '\n')"
+          git -c http.https://github.com/.extraheader="AUTHORIZATION: basic ${auth_header}" \
+            push origin "refs/tags/canary/v${version}"
 
       - name: Start desktop release build
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           tag="canary/v${{ steps.publish.outputs.version }}"
-          gh workflow run desktop-release.yml --ref "$tag" -f release_tag="$tag"
+          gh workflow run desktop-release.yml --ref main -f release_tag="$tag"
 
       - name: Wait for desktop release assets
         env:
@@ -159,9 +200,13 @@ jobs:
 
   stable-dry-run:
     name: Preview stable release
-    needs: verify
+    needs:
+      - resolve-source
+      - verify
     if: github.event_name == 'workflow_dispatch' && inputs.dry_run
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     env:
       ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
       RUDDER_ALLOW_LEGACY_EMBEDDED_POSTGRES: "1"
@@ -170,7 +215,8 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          ref: ${{ inputs.source_ref }}
+          ref: ${{ needs.resolve-source.outputs.sha }}
+          persist-credentials: false
 
       - uses: actions/setup-node@v6
         with:
@@ -185,17 +231,23 @@ jobs:
           npm --version
 
       - name: Install dependencies
-        run: pnpm install --no-frozen-lockfile
+        run: pnpm install --frozen-lockfile
 
       - name: Preview stable publish
         run: ./scripts/release.sh stable --dry-run --skip-verify
 
   stable:
     name: Publish stable release
-    needs: verify
+    needs:
+      - resolve-source
+      - verify
     if: github.event_name == 'workflow_dispatch' && !inputs.dry_run && github.repository == 'Undertone0809/rudder'
     runs-on: ubuntu-latest
     environment: npm-stable
+    permissions:
+      actions: write
+      contents: write
+      id-token: write
     env:
       ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
       RUDDER_ALLOW_LEGACY_EMBEDDED_POSTGRES: "1"
@@ -206,7 +258,8 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          ref: ${{ inputs.source_ref }}
+          ref: ${{ needs.resolve-source.outputs.sha }}
+          persist-credentials: false
 
       - uses: actions/setup-node@v6
         with:
@@ -221,7 +274,7 @@ jobs:
           npm --version
 
       - name: Install dependencies
-        run: pnpm install --no-frozen-lockfile
+        run: pnpm install --frozen-lockfile
 
       - name: Configure git identity
         run: |
@@ -237,13 +290,15 @@ jobs:
           version="$(./scripts/release.sh stable --print-version)"
           echo "version=${version}" >> "$GITHUB_OUTPUT"
           ./scripts/release.sh stable --skip-verify
-          git push origin "refs/tags/v${version}"
+          auth_header="$(printf 'x-access-token:%s' "$GH_TOKEN" | base64 | tr -d '\n')"
+          git -c http.https://github.com/.extraheader="AUTHORIZATION: basic ${auth_header}" \
+            push origin "refs/tags/v${version}"
           PUBLISH_REMOTE=origin ./scripts/create-github-release.sh "${version}"
 
       - name: Start desktop release build
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh workflow run desktop-release.yml --ref "v${{ steps.publish.outputs.version }}" -f release_tag="v${{ steps.publish.outputs.version }}"
+        run: gh workflow run desktop-release.yml --ref main -f release_tag="v${{ steps.publish.outputs.version }}"
 
       - name: Wait for desktop release assets
         env:
@@ -260,6 +315,10 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          auth_header="$(printf 'x-access-token:%s' "$GH_TOKEN" | base64 | tr -d '\n')"
+          export GIT_CONFIG_COUNT=1
+          export GIT_CONFIG_KEY_0=http.https://github.com/.extraheader
+          export GIT_CONFIG_VALUE_0="AUTHORIZATION: basic ${auth_header}"
           node scripts/cleanup-obsolete-canaries.mjs \
             --repo "$GITHUB_REPOSITORY" \
             --remote origin \

--- a/cli/package.json
+++ b/cli/package.json
@@ -57,7 +57,7 @@
     "@rudderhq/run-intelligence-core": "workspace:*",
     "@rudderhq/server": "workspace:*",
     "@types/node": "^22.19.15",
-    "drizzle-orm": "0.38.4",
+    "drizzle-orm": "0.45.2",
     "embedded-postgres": "18.1.0-beta.16",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3"

--- a/cli/src/__tests__/agent-cli-e2e.test.ts
+++ b/cli/src/__tests__/agent-cli-e2e.test.ts
@@ -1548,25 +1548,37 @@ describe("agent CLI e2e", () => {
     expect(blockAttachments[0]?.usage).toBe("comment_inline");
   });
 
-  it("runs the CLI-only organization skill path", { timeout: 60_000 }, async () => {
-    const env = {
+  it("keeps CLI organization host-skill operations behind instance-admin access", { timeout: 60_000 }, async () => {
+    const agentEnv = {
       RUDDER_API_KEY: agentKey,
       RUDDER_ORG_ID: orgId,
       RUDDER_AGENT_ID: agentId,
       RUDDER_RUN_ID: runId,
     };
+    const boardEnv = {
+      RUDDER_ORG_ID: orgId,
+    };
+
+    await expect(runCliJson<OrganizationSkillLocalScanResult>(
+      ["skill", "scan-local", "--roots", localSkillRoot],
+      {
+        apiBase,
+        configPath,
+        env: agentEnv,
+      },
+    )).rejects.toThrow("Board access required");
 
     const scan = await runCliJson<OrganizationSkillLocalScanResult>(
       ["skill", "scan-local", "--roots", localSkillRoot],
       {
         apiBase,
         configPath,
-        env,
+        env: boardEnv,
       },
     );
     expect(scan.imported).toHaveLength(1);
 
-    const privateSkill = await runCliJson<{
+    await expect(runCliJson<{
       created: AgentSkillEntry;
       enabledSnapshot: AgentSkillSnapshot | null;
     }>(
@@ -1585,7 +1597,31 @@ describe("agent CLI e2e", () => {
       {
         apiBase,
         configPath,
-        env,
+        env: agentEnv,
+      },
+    )).rejects.toThrow("Board access required");
+
+    const privateSkill = await runCliJson<{
+      created: AgentSkillEntry;
+      enabledSnapshot: AgentSkillSnapshot | null;
+    }>(
+      [
+        "agent",
+        "skills",
+        "create",
+        agentId,
+        "--name",
+        "CLI Private Skill",
+        "--slug",
+        "cli-private-skill",
+        "--description",
+        "Private skill created by the agent CLI e2e regression.",
+        "--enable",
+      ],
+      {
+        apiBase,
+        configPath,
+        env: boardEnv,
       },
     );
     expect(privateSkill.created.selectionKey).toBe("agent:cli-private-skill");
@@ -1595,7 +1631,7 @@ describe("agent CLI e2e", () => {
     const skills = await runCliJson<OrganizationSkillListItem[]>(["skill", "list"], {
       apiBase,
       configPath,
-      env,
+      env: boardEnv,
     });
     const importedSkill = skills.find((entry) => entry.slug === "cli-e2e-skill");
     expect(importedSkill).toBeTruthy();
@@ -1603,7 +1639,7 @@ describe("agent CLI e2e", () => {
     const detail = await runCliJson<OrganizationSkillDetail>(["skill", "get", importedSkill!.id], {
       apiBase,
       configPath,
-      env,
+      env: boardEnv,
     });
     expect(detail.id).toBe(importedSkill!.id);
     expect(detail.key).toBe(importedSkill!.key);
@@ -1611,16 +1647,25 @@ describe("agent CLI e2e", () => {
     const skillFile = await runCliJson<OrganizationSkillFileDetail>(["skill", "file", importedSkill!.id], {
       apiBase,
       configPath,
-      env,
+      env: boardEnv,
     });
     expect(skillFile.content).toContain("# CLI E2E Skill");
+
+    await expect(runCliJson<AgentSkillSnapshot>(
+      ["agent", "skills", "sync", agentId, "--desired-skills", importedSkill!.key],
+      {
+        apiBase,
+        configPath,
+        env: agentEnv,
+      },
+    )).rejects.toThrow("Board access required");
 
     const snapshot = await runCliJson<AgentSkillSnapshot>(
       ["agent", "skills", "sync", agentId, "--desired-skills", importedSkill!.key],
       {
         apiBase,
         configPath,
-        env,
+        env: boardEnv,
       },
     );
     expect(snapshot.desiredSkills).toHaveLength(1);
@@ -1641,7 +1686,7 @@ describe("agent CLI e2e", () => {
       {
         apiBase,
         configPath,
-        env,
+        env: boardEnv,
       },
     );
     expect(additiveSnapshot.desiredSkills).toEqual(snapshot.desiredSkills);
@@ -1679,8 +1724,9 @@ describe("agent CLI e2e", () => {
       },
     );
 
-    expect(hire.approval).toBeNull();
-    expect(hire.agent.status).toBe("idle");
+    expect(hire.approval?.type).toBe("hire_agent");
+    expect(hire.approval?.status).toBe("pending");
+    expect(hire.agent.status).toBe("pending_approval");
 
     const created = await runCliJson<AgentDetail>(["agent", "get", hire.agent.id], {
       apiBase,
@@ -1826,8 +1872,9 @@ describe("agent CLI e2e", () => {
         env,
       },
     );
-    expect(directHire.approval).toBeNull();
-    expect(directHire.agent.status).toBe("idle");
+    expect(directHire.approval?.type).toBe("hire_agent");
+    expect(directHire.approval?.status).toBe("pending");
+    expect(directHire.agent.status).toBe("pending_approval");
 
     const db = createDb(connectionString);
     await db.update(organizations).set({ requireBoardApprovalForNewAgents: true }).where(eq(organizations.id, orgId));

--- a/cli/src/__tests__/company-import-export-e2e.test.ts
+++ b/cli/src/__tests__/company-import-export-e2e.test.ts
@@ -533,7 +533,7 @@ describe("rudder org import/export e2e", () => {
     );
 
     expect(previewExisting.errors).toEqual([]);
-    expect(previewExisting.plan.organizationAction).toBe("none");
+    expect(previewExisting.plan.organizationAction).toBe("update");
     expect(previewExisting.plan.agentPlans.some((plan) => plan.action === "create")).toBe(true);
     expect(previewExisting.plan.projectPlans.some((plan) => plan.action === "create")).toBe(true);
     expect(previewExisting.plan.issuePlans.some((plan) => plan.action === "create")).toBe(true);
@@ -559,7 +559,7 @@ describe("rudder org import/export e2e", () => {
       { apiBase, configPath },
     );
 
-    expect(importedExisting.organization.action).toBe("unchanged");
+    expect(importedExisting.organization.action).toBe("updated");
     expect(importedExisting.agents.some((agent) => agent.action === "created")).toBe(true);
 
     const twiceImportedAgents = await api<Array<{ id: string; name: string }>>(

--- a/cli/src/__tests__/company.test.ts
+++ b/cli/src/__tests__/company.test.ts
@@ -10,6 +10,7 @@ import {
   renderCompanyImportResult,
   resolveCompanyImportApiPath,
   resolveCompanyImportApplyConfirmationMode,
+  resolveCompanyImportMode,
 } from "../commands/client/company.js";
 
 describe("resolveCompanyImportApiPath", () => {
@@ -31,6 +32,26 @@ describe("resolveCompanyImportApiPath", () => {
         orgId: "company-123",
       }),
     ).toBe("/api/orgs/company-123/imports/apply");
+  });
+
+  it("uses global admin routes for board-full existing-organization imports", () => {
+    expect(
+      resolveCompanyImportApiPath({
+        dryRun: true,
+        targetMode: "existing_organization",
+        orgId: "company-123",
+        importMode: "board_full",
+      }),
+    ).toBe("/api/orgs/import/preview");
+
+    expect(
+      resolveCompanyImportApiPath({
+        dryRun: false,
+        targetMode: "existing_organization",
+        orgId: "company-123",
+        importMode: "board_full",
+      }),
+    ).toBe("/api/orgs/import");
   });
 
   it("keeps global routes for new-organization imports", () => {
@@ -57,6 +78,30 @@ describe("resolveCompanyImportApiPath", () => {
         orgId: " ",
       })
     ).toThrow(/require an orgId/i);
+  });
+});
+
+describe("resolveCompanyImportMode", () => {
+  it.each([
+    ["agents", { organization: true, agents: true, projects: false, issues: false, skills: false }],
+    ["projects", { organization: true, agents: false, projects: true, issues: false, skills: false }],
+    ["issues", { organization: true, agents: false, projects: false, issues: true, skills: false }],
+  ] as const)("uses board-full mode when importing %s", (_label, include) => {
+    expect(resolveCompanyImportMode({ include, collisionStrategy: "rename" })).toBe("board_full");
+  });
+
+  it("uses board-full mode for replace imports", () => {
+    expect(resolveCompanyImportMode({
+      include: { organization: true, agents: false, projects: false, issues: false, skills: true },
+      collisionStrategy: "replace",
+    })).toBe("board_full");
+  });
+
+  it("keeps organization-and-skill-only imports on the CEO-safe route", () => {
+    expect(resolveCompanyImportMode({
+      include: { organization: true, agents: false, projects: false, issues: false, skills: true },
+      collisionStrategy: "rename",
+    })).toBe("agent_safe");
   });
 });
 

--- a/cli/src/__tests__/start.test.ts
+++ b/cli/src/__tests__/start.test.ts
@@ -65,6 +65,7 @@ import {
   pruneRuntimeCache,
   readRuntimeInstallMetadata,
   resolveRuntimeCacheDir,
+  resolveRuntimePackageSpec,
   resolveRuntimePostgresPayloadBinDir,
   RUNTIME_METADATA_FILE,
   type RuntimeInstallError,
@@ -225,6 +226,15 @@ describe("persistent CLI install helpers", () => {
     expect(resolvePersistentCliInstallSpec({})).toBe(CLI_NPM_PACKAGE_NAME);
   });
 
+  it("ignores unsafe npm package version metadata", () => {
+    expect(
+      resolvePersistentCliInstallSpec({
+        npm_package_name: CLI_NPM_PACKAGE_NAME,
+        npm_package_version: "1.2.3 & whoami",
+      }),
+    ).toBe(CLI_NPM_PACKAGE_NAME);
+  });
+
   it("reads the global install state from npm list output", () => {
     const execFileSyncImpl = vi.fn(() =>
       JSON.stringify({
@@ -322,6 +332,17 @@ describe("persistent CLI install helpers", () => {
       npmInstallSpawnOptions,
     );
   });
+
+  it.each(["@rudderhq/cli@latest & whoami", "@rudderhq/cli@1.2.3|whoami", "left-pad@1.0.0"])(
+    "rejects an unsafe persistent install spec before spawning: %s",
+    (installSpec) => {
+      const spawnSyncImpl = vi.fn();
+      expect(() => installPersistentCli({ installSpec, spawnSyncImpl: spawnSyncImpl as never })).toThrow(
+        "Refusing unsafe Rudder CLI install spec",
+      );
+      expect(spawnSyncImpl).not.toHaveBeenCalled();
+    },
+  );
 
   it("retries with --force when npm reports an existing rudder binary", () => {
     const spawnSyncImpl = vi
@@ -1632,6 +1653,14 @@ describe("desktop start command helpers", () => {
 });
 
 describe("runtime install helpers", () => {
+  it.each([
+    ["1.2.3 & whoami", "@rudderhq/server"],
+    ["1.2.3|whoami", "@rudderhq/server"],
+    ["1.2.3", "@rudderhq/server & whoami"],
+  ])("rejects unsafe runtime npm inputs before spawning", (version, packageName) => {
+    expect(() => resolveRuntimePackageSpec(version, packageName)).toThrow("Refusing unsafe runtime package");
+  });
+
   it("uses the versioned runtime cache when metadata and package version match", async () => {
     const root = await mkdtemp(path.join(tmpdir(), "rudder-runtime-cache-test."));
     try {

--- a/cli/src/commands/client/company.ts
+++ b/cli/src/commands/client/company.ts
@@ -727,18 +727,36 @@ export function resolveCompanyImportApiPath(input: {
   dryRun: boolean;
   targetMode: "new_organization" | "existing_organization";
   orgId?: string | null;
+  importMode?: "agent_safe" | "board_full";
 }): string {
   if (input.targetMode === "existing_organization") {
     const orgId = input.orgId?.trim();
     if (!orgId) {
       throw new Error("Existing-organization imports require an orgId to resolve the API route.");
     }
-    return input.dryRun
-      ? `/api/orgs/${orgId}/imports/preview`
-      : `/api/orgs/${orgId}/imports/apply`;
+    if (input.importMode !== "board_full") {
+      return input.dryRun
+        ? `/api/orgs/${orgId}/imports/preview`
+        : `/api/orgs/${orgId}/imports/apply`;
+    }
   }
 
   return input.dryRun ? "/api/orgs/import/preview" : "/api/orgs/import";
+}
+
+export function resolveCompanyImportMode(input: {
+  include: OrganizationPortabilityInclude;
+  collisionStrategy: CompanyCollisionMode;
+}): "agent_safe" | "board_full" {
+  const importsAgents = input.include.agents ?? true;
+  const importsProjects = input.include.projects ?? false;
+  const importsIssues = input.include.issues ?? false;
+  return importsAgents
+    || importsProjects
+    || importsIssues
+    || input.collisionStrategy === "replace"
+    ? "board_full"
+    : "agent_safe";
 }
 
 export function buildCompanyDashboardUrl(apiBase: string, issuePrefix: string): string {
@@ -1217,6 +1235,15 @@ export function registerCompanyCommands(program: Command): void {
             throw new Error("Target existing organization requires --org-id (or context default orgId).");
           }
 
+          // Agents, projects, and issues may carry execution configuration,
+          // while replace imports can overwrite existing trusted state. Keep
+          // those operations on the board-full route so its instance-admin
+          // checks apply; the scoped route remains the CEO-safe path.
+          const importMode = resolveCompanyImportMode({
+            include,
+            collisionStrategy: collision,
+          });
+
           let sourcePayload:
             | { type: "inline"; rootPath?: string | null; files: Record<string, OrganizationPortabilityFileEntry> }
             | { type: "github"; url: string };
@@ -1250,6 +1277,7 @@ export function registerCompanyCommands(program: Command): void {
             dryRun: true,
             targetMode: targetPayload.mode,
             orgId: targetPayload.mode === "existing_organization" ? targetPayload.orgId : null,
+            importMode,
           });
 
           let selectedFiles: string[] | undefined;
@@ -1331,6 +1359,7 @@ export function registerCompanyCommands(program: Command): void {
             dryRun: false,
             targetMode: targetPayload.mode,
             orgId: targetPayload.mode === "existing_organization" ? targetPayload.orgId : null,
+            importMode,
           });
           const imported = await ctx.api.post<OrganizationPortabilityImportResult>(importApiPath, {
             ...previewPayload,

--- a/cli/src/install.ts
+++ b/cli/src/install.ts
@@ -2,6 +2,7 @@ import { execFileSync, spawnSync } from "node:child_process";
 
 export const CLI_NPM_PACKAGE_NAME = "@rudderhq/cli";
 export const CLI_BIN_NAME = "rudder";
+const SAFE_NPM_VERSION = /^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z]+(?:[.-][0-9A-Za-z]+)*)?$/;
 
 interface PersistentCliStateOptions {
   entryPath?: string | null | undefined;
@@ -50,7 +51,7 @@ export function resolvePersistentCliInstallSpec(env: NodeJS.ProcessEnv = process
   const pkgName = env.npm_package_name?.trim();
   const pkgVersion = env.npm_package_version?.trim();
 
-  if (pkgName === CLI_NPM_PACKAGE_NAME && pkgVersion) {
+  if (pkgName === CLI_NPM_PACKAGE_NAME && pkgVersion && SAFE_NPM_VERSION.test(pkgVersion)) {
     return `${pkgName}@${pkgVersion}`;
   }
 
@@ -148,6 +149,7 @@ export function detectPersistentCliState(options: PersistentCliStateOptions = {}
 export function installPersistentCli(
   options: InstallPersistentCliOptions,
 ): PersistentCliInstallResult {
+  assertSafePersistentCliInstallSpec(options.installSpec);
   const spawnSyncImpl = options.spawnSyncImpl ?? spawnSync;
   const command = `npm install --global ${options.installSpec}`;
   const initialResult = runNpmGlobalInstall(spawnSyncImpl, ["install", "--global", options.installSpec]);
@@ -170,6 +172,13 @@ export function installPersistentCli(
     command: forcedCommand,
     output: forcedOutput || initialOutput,
   };
+}
+
+function assertSafePersistentCliInstallSpec(installSpec: string): void {
+  if (installSpec === CLI_NPM_PACKAGE_NAME) return;
+  const prefix = `${CLI_NPM_PACKAGE_NAME}@`;
+  if (installSpec.startsWith(prefix) && SAFE_NPM_VERSION.test(installSpec.slice(prefix.length))) return;
+  throw new Error(`Refusing unsafe Rudder CLI install spec: ${installSpec}`);
 }
 
 function runNpmGlobalInstall(

--- a/cli/src/runtime/install.ts
+++ b/cli/src/runtime/install.ts
@@ -29,6 +29,9 @@ const NPM_PLATFORM_REPAIR_ENV = {
   npm_config_update_notifier: "false",
   NO_UPDATE_NOTIFIER: "1",
 };
+const SAFE_NPM_PACKAGE_NAME = /^(?:@[A-Za-z0-9][A-Za-z0-9._-]*\/)?[A-Za-z0-9][A-Za-z0-9._-]*$/;
+const SAFE_NPM_VERSION = /^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z]+(?:[.-][0-9A-Za-z]+)*)?$/;
+const SAFE_NPM_DIST_TAGS = new Set(["latest", "canary"]);
 
 type PackageJsonLike = {
   name?: string;
@@ -113,7 +116,11 @@ function sanitizeRuntimeCacheSegment(value: string): string {
 
 export function resolveRuntimePackageVersion(version: string): string {
   const normalized = version.trim();
-  return normalized.length > 0 ? normalized : "latest";
+  const resolved = normalized.length > 0 ? normalized : "latest";
+  if (!SAFE_NPM_VERSION.test(resolved) && !SAFE_NPM_DIST_TAGS.has(resolved)) {
+    throw new Error(`Refusing unsafe runtime package version: ${version}`);
+  }
+  return resolved;
 }
 
 export function resolveRuntimeCacheDir(
@@ -127,6 +134,9 @@ export function resolveRuntimePackageSpec(
   version: string,
   packageName: string = RUNTIME_NPM_PACKAGE_NAME,
 ): string {
+  if (!SAFE_NPM_PACKAGE_NAME.test(packageName)) {
+    throw new Error(`Refusing unsafe runtime package name: ${packageName}`);
+  }
   const packageVersion = resolveRuntimePackageVersion(version);
   return packageVersion === "latest" ? `${packageName}@latest` : `${packageName}@${packageVersion}`;
 }
@@ -632,8 +642,8 @@ function packageNameFromSpec(packageSpec: string): string {
 function normalizeOptionalDependencyVersion(versionRange: string | undefined): string | null {
   const trimmed = versionRange?.trim();
   if (!trimmed) return null;
-  const exactVersion = /^[~^]\s*([0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?)$/.exec(trimmed);
-  return exactVersion?.[1] ?? trimmed;
+  const exactVersion = /^(?:[~^]\s*)?([0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z]+(?:[.-][0-9A-Za-z]+)*)?)$/.exec(trimmed);
+  return exactVersion?.[1] ?? null;
 }
 
 function runtimePostgresPlatformSegment(

--- a/desktop/src/ide-opener.ts
+++ b/desktop/src/ide-opener.ts
@@ -377,19 +377,18 @@ function defaultOpenDefaultApp(absolutePath: string, platform: NodeJS.Platform) 
 }
 
 function defaultRunCommand(command: string, absolutePath: string, platform: NodeJS.Platform) {
-  if (platform === "win32") {
-    return new Promise<void>((resolve, reject) => {
-      const child = spawn(command, [absolutePath], {
-        shell: true,
-        stdio: "ignore",
-        windowsHide: true,
-      });
-      child.once("error", reject);
-      child.once("spawn", () => resolve());
-      child.unref();
+  if (platform !== "win32") return execFilePromise(command, [absolutePath]);
+
+  return new Promise<void>((resolve, reject) => {
+    const child = spawn(command, [absolutePath], {
+      shell: false,
+      stdio: "ignore",
+      windowsHide: true,
     });
-  }
-  return execFilePromise(command, [absolutePath]);
+    child.once("error", reject);
+    child.once("spawn", () => resolve());
+    child.unref();
+  });
 }
 
 function defaultRunExecutable(executablePath: string, absolutePath: string, platform: NodeJS.Platform) {

--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -1,5 +1,26 @@
-import type { BrowserWindowConstructorOptions, OpenDialogOptions, WebContents } from "electron";
-import { app, BrowserWindow, clipboard, dialog, ipcMain, Menu, MenuItem, nativeImage, nativeTheme, Notification, shell, systemPreferences, Tray } from "electron";
+import type {
+  BrowserWindowConstructorOptions,
+  IpcMainInvokeEvent,
+  OpenDialogOptions,
+  Session,
+  WebContents,
+} from "electron";
+import {
+  app,
+  BrowserWindow,
+  clipboard,
+  dialog,
+  ipcMain,
+  Menu,
+  MenuItem,
+  nativeImage,
+  nativeTheme,
+  Notification,
+  session,
+  shell,
+  systemPreferences,
+  Tray,
+} from "electron";
 import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
@@ -19,9 +40,10 @@ import {
 } from "./ide-opener.js";
 import { syncProcessPathFromLoginShell } from "./login-shell-env.js";
 import {
-  canOpenBlockedNavigationExternally,
   collectDesktopNavigationOrigins,
-  isAllowedDesktopNavigation,
+  isAllowedDesktopPrivilegedDocument,
+  isAllowedDesktopWebviewNavigation,
+  normalizeExternalOpenTarget,
 } from "./navigation-guard.js";
 import {
   consumePostUpdateReloadMarker,
@@ -68,6 +90,7 @@ import {
 } from "./desktop-workspace-launch-payload.js";
 import { isSidePanelCloseShortcutInput } from "./side-panel-close-shortcut.js";
 const MODULE_DIR = path.dirname(fileURLToPath(import.meta.url));
+const DESKTOP_BROWSER_WEBVIEW_PARTITION = "persist:rudder-browser";
 type BootState = {
   stage: string;
   message: string;
@@ -710,10 +733,11 @@ function installRendererRecoveryHandlers(window: BrowserWindow, initialUrl: stri
     serverHandle?.apiUrl,
   );
   const handleBlockedNavigation = (targetUrl: string) => {
-    if (isAllowedDesktopNavigation(targetUrl, allowedOrigins(), { allowInternalProtocols: false })) return false;
+    if (isAllowedDesktopPrivilegedDocument(targetUrl, allowedOrigins())) return false;
 
-    if (canOpenBlockedNavigationExternally(targetUrl)) {
-      shell.openExternal(targetUrl).catch((error) => {
+    const externalTarget = normalizeExternalOpenTarget(targetUrl);
+    if (externalTarget) {
+      shell.openExternal(externalTarget).catch((error) => {
         console.warn("[rudder-desktop] failed to open external navigation", targetUrl, error);
       });
     }
@@ -735,8 +759,15 @@ function installRendererRecoveryHandlers(window: BrowserWindow, initialUrl: stri
     }
   });
 
+  window.webContents.on("will-redirect", (event, targetUrl, _isInPlace, isMainFrame) => {
+    if (!isMainFrame) return;
+    if (handleBlockedNavigation(targetUrl)) {
+      event.preventDefault();
+    }
+  });
+
   window.webContents.on("did-navigate", (_event, targetUrl) => {
-    if (isAllowedDesktopNavigation(targetUrl, allowedOrigins())) {
+    if (isAllowedDesktopPrivilegedDocument(targetUrl, allowedOrigins())) {
       rememberAppUrl(targetUrl);
     }
     rendererRecoveryInFlight = false;
@@ -761,6 +792,38 @@ function installRendererRecoveryHandlers(window: BrowserWindow, initialUrl: stri
 
   window.on("unresponsive", () => {
     void promptForUnresponsiveRenderer();
+  });
+}
+
+function installDesktopWebviewSecurityHandlers(window: BrowserWindow): void {
+  window.webContents.on("will-attach-webview", (event, webPreferences, params) => {
+    webPreferences.nodeIntegration = false;
+    webPreferences.nodeIntegrationInSubFrames = false;
+    webPreferences.nodeIntegrationInWorker = false;
+    webPreferences.contextIsolation = true;
+    webPreferences.sandbox = true;
+    webPreferences.webSecurity = true;
+    webPreferences.allowRunningInsecureContent = false;
+    delete webPreferences.preload;
+    delete params.preload;
+
+    if (
+      params.partition !== DESKTOP_BROWSER_WEBVIEW_PARTITION
+      || !isAllowedDesktopWebviewNavigation(params.src ?? "")
+    ) {
+      event.preventDefault();
+    }
+  });
+
+  window.webContents.on("did-attach-webview", (_event, guestContents) => {
+    guestContents.setWindowOpenHandler(() => ({ action: "deny" }));
+    guestContents.on("will-navigate", (event, targetUrl) => {
+      if (!isAllowedDesktopWebviewNavigation(targetUrl)) event.preventDefault();
+    });
+    guestContents.on("will-redirect", (event, targetUrl, _isInPlace, isMainFrame) => {
+      if (!isMainFrame) return;
+      if (!isAllowedDesktopWebviewNavigation(targetUrl)) event.preventDefault();
+    });
   });
 }
 
@@ -819,6 +882,7 @@ async function createDesktopWindow(initialUrl: string): Promise<BrowserWindow> {
   });
 
   installRendererRecoveryHandlers(window, initialUrl);
+  installDesktopWebviewSecurityHandlers(window);
   installMainWindowSidePanelCloseShortcutHandler(window);
 
   window.on("close", (event) => {
@@ -1313,6 +1377,54 @@ async function stopLocalRudder(): Promise<void> {
   await handle.stop();
 }
 
+function currentDesktopAppOrigins(): string[] {
+  return collectDesktopNavigationOrigins(
+    resolveDesktopAppBaseUrl(),
+    serverHandle?.apiUrl,
+    lastKnownAppUrl,
+  );
+}
+
+function isTrustedDesktopMainFrameEvent(event: IpcMainInvokeEvent): boolean {
+  if (!mainWindow || mainWindow.isDestroyed() || event.sender !== mainWindow.webContents) return false;
+  if (!event.senderFrame || event.senderFrame !== event.sender.mainFrame) return false;
+  return isAllowedDesktopPrivilegedDocument(event.senderFrame.url, currentDesktopAppOrigins());
+}
+
+const securedDesktopSessions = new WeakSet<Session>();
+
+function installDesktopSessionPermissionHandlers(targetSession: Session): void {
+  if (securedDesktopSessions.has(targetSession)) return;
+  securedDesktopSessions.add(targetSession);
+
+  const isAllowedPermission = (
+    webContents: WebContents | null,
+    permission: string,
+    requestingUrl: string,
+    isMainFrame: boolean,
+  ) => permission === "notifications"
+    && Boolean(webContents)
+    && Boolean(mainWindow)
+    && !mainWindow?.isDestroyed()
+    && webContents === mainWindow?.webContents
+    && isMainFrame
+    && isAllowedDesktopPrivilegedDocument(requestingUrl || webContents?.getURL() || "", currentDesktopAppOrigins());
+
+  targetSession.setPermissionCheckHandler((webContents, permission, requestingOrigin, details) => (
+    isAllowedPermission(
+      webContents,
+      permission,
+      details.requestingUrl ?? requestingOrigin,
+      details.isMainFrame,
+    )
+  ));
+  targetSession.setPermissionRequestHandler((webContents, permission, callback, details) => {
+    callback(isAllowedPermission(webContents, permission, details.requestingUrl, details.isMainFrame));
+  });
+  targetSession.setDevicePermissionHandler(() => false);
+  targetSession.setDisplayMediaRequestHandler((_request, callback) => callback({}));
+}
+
 function registerIpc(): void {
   ipcMain.handle("desktop:get-boot-state", async () => {
     refreshDesktopSystemPermissions();
@@ -1428,8 +1540,15 @@ function registerIpc(): void {
   ipcMain.handle("desktop:send-feedback", async () => {
     await shell.openExternal(createFeedbackMailtoUrl());
   });
-  ipcMain.handle("desktop:open-external", async (_event, target: string) => {
-    await shell.openExternal(target);
+  ipcMain.handle("desktop:open-external", async (event, target: unknown) => {
+    if (!isTrustedDesktopMainFrameEvent(event)) {
+      throw new Error("External URLs can only be opened by the Rudder app.");
+    }
+    const normalizedTarget = normalizeExternalOpenTarget(target);
+    if (!normalizedTarget) {
+      throw new Error("Only HTTP, HTTPS, and mailto URLs can be opened externally.");
+    }
+    await shell.openExternal(normalizedTarget);
   });
   ipcMain.handle("desktop:pick-path", async (event, options: DesktopPathPickOptions): Promise<DesktopPathPickResult> => {
     const kind = options.kind === "file" ? "file" : "directory";
@@ -1651,6 +1770,10 @@ if (desktopCliArgv) {
       refreshDesktopSystemPermissions();
     });
 
+    app.on("session-created", (createdSession) => {
+      installDesktopSessionPermissionHandlers(createdSession);
+    });
+
     app.on("web-contents-created", (_event, contents) => {
       installSidePanelCloseShortcutHandler(contents);
     });
@@ -1666,7 +1789,10 @@ if (desktopCliArgv) {
       void beginQuitFlow();
     });
 
-    void app.whenReady().then(() => bootstrap()).catch((error) => {
+    void app.whenReady().then(() => {
+      installDesktopSessionPermissionHandlers(session.defaultSession);
+      return bootstrap();
+    }).catch((error) => {
       console.error("[rudder-desktop] Failed to bootstrap desktop app", error);
       app.exit(1);
     });

--- a/desktop/src/navigation-guard.test.ts
+++ b/desktop/src/navigation-guard.test.ts
@@ -3,6 +3,9 @@ import {
   canOpenBlockedNavigationExternally,
   collectDesktopNavigationOrigins,
   isAllowedDesktopNavigation,
+  isAllowedDesktopPrivilegedDocument,
+  isAllowedDesktopWebviewNavigation,
+  normalizeExternalOpenTarget,
 } from "./navigation-guard.js";
 
 describe("desktop navigation guard", () => {
@@ -35,5 +38,37 @@ describe("desktop navigation guard", () => {
   it("does not open unsafe blocked protocols externally", () => {
     expect(canOpenBlockedNavigationExternally("javascript:alert(1)")).toBe(false);
     expect(canOpenBlockedNavigationExternally("file:///Users/zeeland/.ssh/id_rsa")).toBe(false);
+  });
+
+  it("normalizes only explicit safe external protocols", () => {
+    expect(normalizeExternalOpenTarget(" https://example.com/docs ")).toBe("https://example.com/docs");
+    expect(normalizeExternalOpenTarget("mailto:security@example.com?subject=Report")).toBe(
+      "mailto:security@example.com?subject=Report",
+    );
+    expect(normalizeExternalOpenTarget("https://user:password@example.com/private")).toBeNull();
+    expect(normalizeExternalOpenTarget("https://example.com/\nfile:///etc/passwd")).toBeNull();
+    expect(normalizeExternalOpenTarget("mailto:security@example.com?subject=Report%0ABcc:attacker@example.com")).toBeNull();
+    expect(normalizeExternalOpenTarget({ href: "https://example.com" })).toBeNull();
+  });
+
+  it("allows webviews to load only credential-free HTTP(S) pages", () => {
+    expect(isAllowedDesktopWebviewNavigation("https://example.com/docs")).toBe(true);
+    expect(isAllowedDesktopWebviewNavigation("http://example.com/")).toBe(true);
+    expect(isAllowedDesktopWebviewNavigation("data:text/html,<h1>unsafe</h1>")).toBe(false);
+    expect(isAllowedDesktopWebviewNavigation("file:///Users/zeeland/.ssh/id_rsa")).toBe(false);
+    expect(isAllowedDesktopWebviewNavigation("about:blank")).toBe(false);
+  });
+
+  it("trusts app documents but not same-origin API or plugin responses", () => {
+    const origins = ["http://127.0.0.1:3100"];
+
+    expect(isAllowedDesktopPrivilegedDocument("http://127.0.0.1:3100/messenger/chat/abc", origins)).toBe(true);
+    expect(isAllowedDesktopPrivilegedDocument("http://127.0.0.1:3100/api/assets/asset-1/content", origins)).toBe(false);
+    expect(isAllowedDesktopPrivilegedDocument("http://127.0.0.1:3100/_plugins/example/index.html", origins)).toBe(false);
+    expect(isAllowedDesktopPrivilegedDocument("http://127.0.0.1:3100/API/assets/asset-1/content", origins)).toBe(false);
+    expect(isAllowedDesktopPrivilegedDocument("http://127.0.0.1:3100/_PLUGINS/example/index.html", origins)).toBe(false);
+    expect(isAllowedDesktopPrivilegedDocument("http://127.0.0.1:3100/api%5Cassets/payload.html", origins)).toBe(false);
+    expect(isAllowedDesktopPrivilegedDocument("http://127.0.0.1:3100/%2561pi/assets/payload.html", origins)).toBe(false);
+    expect(isAllowedDesktopPrivilegedDocument("https://example.com/messenger", origins)).toBe(false);
   });
 });

--- a/desktop/src/navigation-guard.ts
+++ b/desktop/src/navigation-guard.ts
@@ -1,5 +1,22 @@
 const INTERNAL_NAVIGATION_PROTOCOLS = new Set(["about:", "data:"]);
 const EXTERNAL_OPEN_PROTOCOLS = new Set(["http:", "https:", "mailto:"]);
+const WEBVIEW_NAVIGATION_PROTOCOLS = new Set(["http:", "https:"]);
+const PRIVILEGED_DOCUMENT_PATH_PREFIXES = ["/api", "/_plugins"];
+const CONTROL_CHARACTERS = /[\u0000-\u001f\u007f]/u;
+
+function normalizeSecurityPathname(pathname: string): string {
+  let normalized = pathname;
+  for (let pass = 0; pass < 2; pass += 1) {
+    try {
+      const decoded = decodeURIComponent(normalized);
+      if (decoded === normalized) break;
+      normalized = decoded;
+    } catch {
+      break;
+    }
+  }
+  return normalized.replaceAll("\\", "/").replace(/\/{2,}/gu, "/").toLowerCase();
+}
 
 function normalizeOrigin(value: string): string | null {
   try {
@@ -41,9 +58,56 @@ export function isAllowedDesktopNavigation(
   }
 }
 
-export function canOpenBlockedNavigationExternally(targetUrl: string): boolean {
+export function normalizeExternalOpenTarget(targetUrl: unknown): string | null {
+  if (typeof targetUrl !== "string") return null;
+  const trimmed = targetUrl.trim();
+  if (!trimmed || CONTROL_CHARACTERS.test(trimmed)) return null;
+
   try {
-    return EXTERNAL_OPEN_PROTOCOLS.has(new URL(targetUrl.trim()).protocol);
+    const parsed = new URL(trimmed);
+    if (!EXTERNAL_OPEN_PROTOCOLS.has(parsed.protocol)) return null;
+    if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+      if (!parsed.hostname || parsed.username || parsed.password) return null;
+    } else {
+      if (!parsed.pathname.trim() || parsed.host) return null;
+      if (/%0[ad]/iu.test(parsed.href)) return null;
+    }
+    return parsed.href;
+  } catch {
+    return null;
+  }
+}
+
+export function canOpenBlockedNavigationExternally(targetUrl: string): boolean {
+  return normalizeExternalOpenTarget(targetUrl) !== null;
+}
+
+export function isAllowedDesktopWebviewNavigation(targetUrl: string): boolean {
+  const trimmed = targetUrl.trim();
+  if (!trimmed || CONTROL_CHARACTERS.test(trimmed)) return false;
+
+  try {
+    const parsed = new URL(trimmed);
+    return WEBVIEW_NAVIGATION_PROTOCOLS.has(parsed.protocol)
+      && Boolean(parsed.hostname)
+      && !parsed.username
+      && !parsed.password;
+  } catch {
+    return false;
+  }
+}
+
+export function isAllowedDesktopPrivilegedDocument(targetUrl: string, allowedOrigins: string[]): boolean {
+  const trimmed = targetUrl.trim();
+  if (!trimmed || CONTROL_CHARACTERS.test(trimmed)) return false;
+
+  try {
+    const parsed = new URL(trimmed);
+    if (!WEBVIEW_NAVIGATION_PROTOCOLS.has(parsed.protocol) || !allowedOrigins.includes(parsed.origin)) return false;
+    const pathname = normalizeSecurityPathname(parsed.pathname);
+    return !PRIVILEGED_DOCUMENT_PATH_PREFIXES.some((prefix) => (
+      pathname === prefix || pathname.startsWith(`${prefix}/`)
+    ));
   } catch {
     return false;
   }

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -35,8 +35,22 @@ RUN test -f server/dist/index.js || (echo "ERROR: server build output missing" &
 
 FROM base AS production
 WORKDIR /app
-COPY --chown=node:node --from=build /app /app
-RUN npm install --global --omit=dev @anthropic-ai/claude-code@latest @openai/codex@latest opencode-ai \
+ARG CLAUDE_CODE_VERSION=2.1.206
+ARG CODEX_VERSION=0.144.1
+ARG OPENCODE_VERSION=1.17.18
+# Copy the runtime closure explicitly. In particular, do not promote the whole
+# build context into the final image, where local configuration files could
+# otherwise become readable by image consumers.
+COPY --chown=node:node --from=build /app/package.json /app/package.json
+COPY --chown=node:node --from=build /app/node_modules /app/node_modules
+COPY --chown=node:node --from=build /app/server /app/server
+COPY --chown=node:node --from=build /app/packages /app/packages
+COPY --chown=node:node --from=build /app/cli /app/cli
+COPY --chown=node:node --from=build /app/ui/dist /app/ui/dist
+RUN npm install --global --omit=dev \
+      "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
+      "@openai/codex@${CODEX_VERSION}" \
+      "opencode-ai@${OPENCODE_VERSION}" \
   && mkdir -p /rudder \
   && chown node:node /rudder
 

--- a/docker/Dockerfile.dockerignore
+++ b/docker/Dockerfile.dockerignore
@@ -1,6 +1,12 @@
 .git
 .github
 .rudder
+.env
+.env.*
+**/.env
+**/.env.*
+!.env.example
+!**/.env.example
 .pnpm-store
 node_modules
 **/node_modules

--- a/docker/Dockerfile.onboard-smoke.dockerignore
+++ b/docker/Dockerfile.onboard-smoke.dockerignore
@@ -1,6 +1,12 @@
 .git
 .github
 .rudder
+.env
+.env.*
+**/.env
+**/.env.*
+!.env.example
+!**/.env.example
 .pnpm-store
 node_modules
 **/node_modules

--- a/docker/docker-compose.untrusted-review.yml
+++ b/docker/docker-compose.untrusted-review.yml
@@ -12,12 +12,13 @@ services:
       CODEX_HOME: "/home/reviewer/.codex"
       CLAUDE_HOME: "/home/reviewer/.claude"
       RUDDER_HOME: "/home/reviewer/.rudder-review"
-      OPENAI_API_KEY: "${OPENAI_API_KEY:-}"
-      ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY:-}"
-      GITHUB_TOKEN: "${GITHUB_TOKEN:-}"
+      # This container checks out contributor-controlled code. Do not pass host
+      # credentials into it: install/test hooks can read every container env var.
+      # Authenticate and perform write operations from a separate trusted context.
     ports:
-      - "${REVIEW_RUDDER_PORT:-3100}:3100"
-      - "${REVIEW_VITE_PORT:-5173}:5173"
+      # Contributor-controlled processes must only be reachable from this host.
+      - "127.0.0.1:${REVIEW_RUDDER_PORT:-3100}:3100"
+      - "127.0.0.1:${REVIEW_VITE_PORT:-5173}:5173"
     volumes:
       - review-home:/home/reviewer
       - review-work:/work

--- a/docker/untrusted-review/Dockerfile
+++ b/docker/untrusted-review/Dockerfile
@@ -1,5 +1,8 @@
 FROM node:lts-trixie-slim
 
+ARG CLAUDE_CODE_VERSION=2.1.206
+ARG CODEX_VERSION=0.144.1
+
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
     bash \
@@ -18,7 +21,9 @@ RUN apt-get update \
 RUN ln -sf /usr/bin/fdfind /usr/local/bin/fd
 
 RUN corepack enable \
-  && npm install --global --omit=dev @anthropic-ai/claude-code@latest @openai/codex@latest
+  && npm install --global --omit=dev \
+    "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
+    "@openai/codex@${CODEX_VERSION}"
 
 RUN useradd --create-home --shell /bin/bash reviewer
 

--- a/package.json
+++ b/package.json
@@ -55,10 +55,28 @@
     "cross-env": "^10.1.0",
     "esbuild": "^0.27.4",
     "typescript": "^5.9.3",
-    "vitest": "^3.2.4"
+    "vitest": "^3.2.7"
   },
   "engines": {
     "node": ">=20"
+  },
+  "pnpm": {
+    "overrides": {
+      "axios": "1.16.0",
+      "defu": "6.1.5",
+      "fast-uri": "3.1.2",
+      "fast-xml-builder": "1.1.7",
+      "fast-xml-parser": "5.7.0",
+      "form-data": "4.0.6",
+      "js-yaml": "4.2.0",
+      "lodash-es": "4.18.1",
+      "path-to-regexp": "8.4.2",
+      "protobufjs": "7.6.3",
+      "qs": "6.15.2",
+      "set-cookie-parser": "3.1.1",
+      "undici": "7.28.0",
+      "uuid": "11.1.1"
+    }
   },
   "packageManager": "pnpm@9.15.4"
 }

--- a/packages/agent-runtimes/openclaw-gateway/package.json
+++ b/packages/agent-runtimes/openclaw-gateway/package.json
@@ -52,7 +52,7 @@
   "dependencies": {
     "@rudderhq/agent-runtime-utils": "workspace:*",
     "picocolors": "^1.1.1",
-    "ws": "^8.20.0"
+    "ws": "^8.21.0"
   },
   "devDependencies": {
     "@types/node": "^24.12.0",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "@rudderhq/shared": "workspace:*",
-    "drizzle-orm": "^0.38.4",
+    "drizzle-orm": "^0.45.2",
     "embedded-postgres": "18.1.0-beta.16",
     "postgres": "^3.4.8"
   },
@@ -53,6 +53,6 @@
     "drizzle-kit": "^0.31.10",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3",
-    "vitest": "^3.2.4"
+    "vitest": "^3.2.7"
   }
 }

--- a/packages/plugins/examples/plugin-authoring-smoke-example/package.json
+++ b/packages/plugins/examples/plugin-authoring-smoke-example/package.json
@@ -37,7 +37,7 @@
     "rollup": "^4.60.0",
     "tslib": "^2.8.1",
     "typescript": "^5.9.3",
-    "vitest": "^3.2.4"
+    "vitest": "^3.2.7"
   },
   "peerDependencies": {
     "react": ">=18"

--- a/packages/plugins/examples/plugin-linear/package.json
+++ b/packages/plugins/examples/plugin-linear/package.json
@@ -34,7 +34,7 @@
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "typescript": "^5.9.3",
-    "vitest": "^3.2.4"
+    "vitest": "^3.2.7"
   },
   "peerDependencies": {
     "react": ">=18"

--- a/packages/run-intelligence-core/package.json
+++ b/packages/run-intelligence-core/package.json
@@ -54,6 +54,6 @@
   "devDependencies": {
     "@types/node": "^24.12.0",
     "typescript": "^5.9.3",
-    "vitest": "^3.2.4"
+    "vitest": "^3.2.7"
   }
 }

--- a/packages/shared/src/validators/execution-workspace.ts
+++ b/packages/shared/src/validators/execution-workspace.ts
@@ -12,7 +12,6 @@ export const updateRunWorkspaceSchema = z.object({
   status: runWorkspaceStatusSchema.optional(),
   cleanupEligibleAt: z.string().datetime().optional().nullable(),
   cleanupReason: z.string().optional().nullable(),
-  metadata: z.record(z.unknown()).optional().nullable(),
 }).strict();
 
 export type UpdateRunWorkspace = z.infer<typeof updateRunWorkspaceSchema>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,22 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  axios: 1.16.0
+  defu: 6.1.5
+  fast-uri: 3.1.2
+  fast-xml-builder: 1.1.7
+  fast-xml-parser: 5.7.0
+  form-data: 4.0.6
+  js-yaml: 4.2.0
+  lodash-es: 4.18.1
+  path-to-regexp: 8.4.2
+  protobufjs: 7.6.3
+  qs: 6.15.2
+  set-cookie-parser: 3.1.1
+  undici: 7.28.0
+  uuid: 11.1.1
+
 importers:
 
   .:
@@ -21,8 +37,8 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
       vitest:
-        specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.5.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.32.0)(tsx@4.21.0)
+        specifier: ^3.2.7
+        version: 3.2.7(@types/debug@4.1.13)(@types/node@25.5.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.32.0)(tsx@4.21.0)
 
   cli:
     dependencies:
@@ -85,8 +101,8 @@ importers:
         specifier: ^22.19.15
         version: 22.19.15
       drizzle-orm:
-        specifier: 0.38.4
-        version: 0.38.4(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@types/react@19.2.14)(kysely@0.28.14)(pg@8.20.0)(postgres@3.4.8)(react@19.2.4)
+        specifier: 0.45.2
+        version: 0.45.2(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(kysely@0.29.3)(pg@8.20.0)(postgres@3.4.8)
       embedded-postgres:
         specifier: 18.1.0-beta.16
         version: 18.1.0-beta.16
@@ -197,8 +213,8 @@ importers:
         specifier: ^1.1.1
         version: 1.1.1
       ws:
-        specifier: ^8.20.0
-        version: 8.20.0
+        specifier: ^8.21.0
+        version: 8.21.0
     devDependencies:
       '@types/node':
         specifier: ^24.12.0
@@ -251,8 +267,8 @@ importers:
         specifier: workspace:*
         version: link:../shared
       drizzle-orm:
-        specifier: ^0.38.4
-        version: 0.38.4(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@types/react@19.2.14)(kysely@0.28.14)(pg@8.20.0)(postgres@3.4.8)(react@19.2.4)
+        specifier: ^0.45.2
+        version: 0.45.2(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(kysely@0.29.3)(pg@8.20.0)(postgres@3.4.8)
       embedded-postgres:
         specifier: 18.1.0-beta.16
         version: 18.1.0-beta.16
@@ -273,8 +289,8 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
       vitest:
-        specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.32.0)(tsx@4.21.0)
+        specifier: ^3.2.7
+        version: 3.2.7(@types/debug@4.1.13)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.32.0)(tsx@4.21.0)
 
   packages/plugins/create-rudder-plugin:
     dependencies:
@@ -323,8 +339,8 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
       vitest:
-        specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.32.0)(tsx@4.21.0)
+        specifier: ^3.2.7
+        version: 3.2.7(@types/debug@4.1.13)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.32.0)(tsx@4.21.0)
 
   packages/plugins/examples/plugin-file-browser-example:
     dependencies:
@@ -443,8 +459,8 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
       vitest:
-        specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(lightningcss@1.32.0)(tsx@4.21.0)
+        specifier: ^3.2.7
+        version: 3.2.7(@types/debug@4.1.13)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(lightningcss@1.32.0)(tsx@4.21.0)
 
   packages/plugins/sdk:
     dependencies:
@@ -505,8 +521,8 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
       vitest:
-        specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.32.0)(tsx@4.21.0)
+        specifier: ^3.2.7
+        version: 3.2.7(@types/debug@4.1.13)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.32.0)(tsx@4.21.0)
 
   packages/shared:
     dependencies:
@@ -581,8 +597,8 @@ importers:
         specifier: ^3.0.1
         version: 3.0.1(ajv@8.18.0)
       better-auth:
-        specifier: 1.4.18
-        version: 1.4.18(drizzle-kit@0.31.10)(drizzle-orm@0.38.4(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@types/react@19.2.14)(kysely@0.28.14)(pg@8.20.0)(postgres@3.4.8)(react@19.2.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.32.0)(tsx@4.21.0))(vue@3.5.34(typescript@5.9.3))
+        specifier: 1.6.23
+        version: 1.6.23(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(kysely@0.29.3)(pg@8.20.0)(postgres@3.4.8))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@3.2.7(@types/debug@4.1.13)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.32.0)(tsx@4.21.0))(vue@3.5.34(typescript@5.9.3))
       chokidar:
         specifier: ^4.0.3
         version: 4.0.3
@@ -590,14 +606,14 @@ importers:
         specifier: ^2.1.0
         version: 2.1.0
       dompurify:
-        specifier: ^3.3.3
-        version: 3.3.3
+        specifier: ^3.4.11
+        version: 3.4.11
       dotenv:
         specifier: ^17.3.1
         version: 17.3.1
       drizzle-orm:
-        specifier: ^0.38.4
-        version: 0.38.4(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@types/react@19.2.14)(kysely@0.28.14)(pg@8.20.0)(postgres@3.4.8)(react@19.2.4)
+        specifier: ^0.45.2
+        version: 0.45.2(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(kysely@0.29.3)(pg@8.20.0)(postgres@3.4.8)
       embedded-postgres:
         specifier: 18.1.0-beta.16
         version: 18.1.0-beta.16
@@ -611,8 +627,8 @@ importers:
         specifier: ^28.1.0
         version: 28.1.0(@noble/hashes@2.0.1)
       multer:
-        specifier: ^2.1.1
-        version: 2.1.1
+        specifier: ^2.2.0
+        version: 2.2.0
       open:
         specifier: ^11.0.0
         version: 11.0.0
@@ -629,8 +645,8 @@ importers:
         specifier: ^0.34.5
         version: 0.34.5
       ws:
-        specifier: ^8.20.0
-        version: 8.20.0
+        specifier: ^8.21.0
+        version: 8.21.0
       zod:
         specifier: ^3.25.76
         version: 3.25.76
@@ -675,8 +691,8 @@ importers:
         specifier: ^6.4.1
         version: 6.4.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
       vitest:
-        specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.32.0)(tsx@4.21.0)
+        specifier: ^3.2.7
+        version: 3.2.7(@types/debug@4.1.13)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.32.0)(tsx@4.21.0)
 
   ui:
     dependencies:
@@ -786,8 +802,8 @@ importers:
         specifier: ^0.574.0
         version: 0.574.0(react@19.2.4)
       mermaid:
-        specifier: ^11.13.0
-        version: 11.13.0
+        specifier: ^11.15.0
+        version: 11.16.0
       radix-ui:
         specifier: ^1.4.3
         version: 1.4.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -801,8 +817,8 @@ importers:
         specifier: ^10.1.0
         version: 10.1.0(@types/react@19.2.14)(react@19.2.4)
       react-router-dom:
-        specifier: ^7.13.2
-        version: 7.13.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: 7.15.1
+        version: 7.15.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
@@ -835,8 +851,8 @@ importers:
         specifier: ^6.4.1
         version: 6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
       vitest:
-        specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.5.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.32.0)(tsx@4.21.0)
+        specifier: ^3.2.7
+        version: 3.2.7(@types/debug@4.1.13)(@types/node@25.5.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.32.0)(tsx@4.21.0)
 
 packages:
 
@@ -1116,26 +1132,84 @@ packages:
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
-  '@better-auth/core@1.4.18':
-    resolution: {integrity: sha512-q+awYgC7nkLEBdx2sW0iJjkzgSHlIxGnOpsN1r/O1+a4m7osJNHtfK2mKJSL1I+GfNyIlxJF8WvD/NLuYMpmcg==}
+  '@better-auth/core@1.6.23':
+    resolution: {integrity: sha512-beEhOs0uVeOxYOZKUfIEBd/nQV2Bd4/6wyLxZ0OFkn6CMTK2Vi+hXuZLnyPBeB6RdHpebEoJWiHqwHxBIxgPDQ==}
     peerDependencies:
-      '@better-auth/utils': 0.3.0
-      '@better-fetch/fetch': 1.1.21
-      better-call: 1.1.8
+      '@better-auth/utils': 0.4.2
+      '@better-fetch/fetch': 1.3.1
+      '@cloudflare/workers-types': '>=4'
+      '@opentelemetry/api': ^1.9.0
+      better-call: 1.3.7
       jose: ^6.1.0
-      kysely: ^0.28.5
+      kysely: ^0.28.5 || ^0.29.0
       nanostores: ^1.0.1
+    peerDependenciesMeta:
+      '@cloudflare/workers-types':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
 
-  '@better-auth/telemetry@1.4.18':
-    resolution: {integrity: sha512-e5rDF8S4j3Um/0LIVATL2in9dL4lfO2fr2v1Wio4qTMRbfxqnUDTa+6SZtwdeJrbc4O+a3c+IyIpjG9Q/6GpfQ==}
+  '@better-auth/drizzle-adapter@1.6.23':
+    resolution: {integrity: sha512-2+/PTVfIP9E7iz6af8TB3lhnowHUj9ljC66kECmHaFEdUqPgzHoWux9epotKwO7XDg2ui4ttWQ8CMeNFLvQeKQ==}
     peerDependencies:
-      '@better-auth/core': 1.4.18
+      '@better-auth/core': ^1.6.23
+      '@better-auth/utils': 0.4.2
+      drizzle-orm: ^0.45.2
+    peerDependenciesMeta:
+      drizzle-orm:
+        optional: true
 
-  '@better-auth/utils@0.3.0':
-    resolution: {integrity: sha512-W+Adw6ZA6mgvnSnhOki270rwJ42t4XzSK6YWGF//BbVXL6SwCLWfyzBc1lN2m/4RM28KubdBKQ4X5VMoLRNPQw==}
+  '@better-auth/kysely-adapter@1.6.23':
+    resolution: {integrity: sha512-zbNJsMbG09exfkGyvFqBLLqWoMPAUWjxCuUnEK5AsjbYoZeIjj/QGZgdf4CapVWryKxjA9Q6Jlr6fbiPpC3VAg==}
+    peerDependencies:
+      '@better-auth/core': ^1.6.23
+      '@better-auth/utils': 0.4.2
+      kysely: ^0.28.17 || ^0.29.0
+    peerDependenciesMeta:
+      kysely:
+        optional: true
 
-  '@better-fetch/fetch@1.1.21':
-    resolution: {integrity: sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A==}
+  '@better-auth/memory-adapter@1.6.23':
+    resolution: {integrity: sha512-krIiR0pIVkaKlAzm690n5bcMW4NGbqeMg0HQSD9fz/KcQF/eWLqcq9gG/BhHTj2i/y96qH+W5JWPmaSOS5iTgQ==}
+    peerDependencies:
+      '@better-auth/core': ^1.6.23
+      '@better-auth/utils': 0.4.2
+
+  '@better-auth/mongo-adapter@1.6.23':
+    resolution: {integrity: sha512-7+QdevitGlKBbP6JbiSk5SBnzPsKV/mDrQBGBn8hwByQLeJwqpqbuBPw7ZI8vzUlFfAAnyFiqwP3Eb8mxnp7pA==}
+    peerDependencies:
+      '@better-auth/core': ^1.6.23
+      '@better-auth/utils': 0.4.2
+      mongodb: ^6.0.0 || ^7.0.0
+    peerDependenciesMeta:
+      mongodb:
+        optional: true
+
+  '@better-auth/prisma-adapter@1.6.23':
+    resolution: {integrity: sha512-2qSdzidq4tkb1eS5TTqb4Nzg0mdZWm3Qky9SYeXeb8PpVQbC2sxqJhEM5mK7y12uU6I8hc64wO9f7AFVNL+6UQ==}
+    peerDependencies:
+      '@better-auth/core': ^1.6.23
+      '@better-auth/utils': 0.4.2
+      '@prisma/client': ^5.0.0 || ^6.0.0 || ^7.0.0
+      prisma: ^5.0.0 || ^6.0.0 || ^7.0.0
+    peerDependenciesMeta:
+      '@prisma/client':
+        optional: true
+      prisma:
+        optional: true
+
+  '@better-auth/telemetry@1.6.23':
+    resolution: {integrity: sha512-/R2Kb+z2BpDOOWwVHqOk+c0VNpuwfCv4Hp5Yr9003WIZPax/zyNraGLB9CFE8qF2gZW8Dsz419k4I8CPrGzpDA==}
+    peerDependencies:
+      '@better-auth/core': ^1.6.23
+      '@better-auth/utils': 0.4.2
+      '@better-fetch/fetch': 1.3.1
+
+  '@better-auth/utils@0.4.2':
+    resolution: {integrity: sha512-AUxrvu+HaaODsUyzDxFgwd/8RZ1yZaYo42LXKSrU2oGgR38pS1ij8nqQKNgtTWoYGpNevNXtCfgTy6loHveW9A==}
+
+  '@better-fetch/fetch@1.3.1':
+    resolution: {integrity: sha512-ABkD1WhyfPZprKRQI3bhATjeiFuNWC9PXhfGWqL+sg/gKrM977oFrYkdb4msM3hgUGonr7KlOsOFT5TU2rht9g==}
 
   '@braintree/sanitize-url@7.1.2':
     resolution: {integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==}
@@ -1144,20 +1218,8 @@ packages:
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
     hasBin: true
 
-  '@chevrotain/cst-dts-gen@11.1.2':
-    resolution: {integrity: sha512-XTsjvDVB5nDZBQB8o0o/0ozNelQtn2KrUVteIHSlPd2VAV2utEb6JzyCJaJ8tGxACR4RiBNWy5uYUHX2eji88Q==}
-
-  '@chevrotain/gast@11.1.2':
-    resolution: {integrity: sha512-Z9zfXR5jNZb1Hlsd/p+4XWeUFugrHirq36bKzPWDSIacV+GPSVXdk+ahVWZTwjhNwofAWg/sZg58fyucKSQx5g==}
-
-  '@chevrotain/regexp-to-ast@11.1.2':
-    resolution: {integrity: sha512-nMU3Uj8naWer7xpZTYJdxbAs6RIv/dxYzkYU8GSwgUtcAAlzjcPfX1w+RKRcYG8POlzMeayOQ/znfwxEGo5ulw==}
-
   '@chevrotain/types@11.1.2':
     resolution: {integrity: sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==}
-
-  '@chevrotain/utils@11.1.2':
-    resolution: {integrity: sha512-4mudFAQ6H+MqBTfqLmU7G1ZwRzCLfJEooL/fsF6rCX5eePMbGhoy5n4g+G4vlh2muDcsCTJtL+uKbOzWxs5LHA==}
 
   '@clack/core@0.4.2':
     resolution: {integrity: sha512-NYQfcEy8MWIxrT5Fj8nIVchfRFA26yYKJcvBS7WlUIlw2OmQOY9DhGGXMovyI5J5PpxrCPGkgUi207EBrjpBvg==}
@@ -2269,8 +2331,8 @@ packages:
       react: '>= 18 || >= 19'
       react-dom: '>= 18 || >= 19'
 
-  '@mermaid-js/parser@1.0.1':
-    resolution: {integrity: sha512-opmV19kN1JsK0T6HhhokHpcVkqKpF+x2pPDKKM2ThHtZAB5F4PROopk0amuVYK5qMrIA4erzpNm8gmPNJgMDxQ==}
+  '@mermaid-js/parser@1.2.0':
+    resolution: {integrity: sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA==}
 
   '@milkdown/components@7.21.1':
     resolution: {integrity: sha512-wyU/PPWfMJEbchiFnCHmgz5mMfcwp5ZbkWrbplJSak/H/zpDg46jAL7k7TZwvyb1YHF1P63BL26P8A3B6igUDQ==}
@@ -2362,6 +2424,9 @@ packages:
   '@noble/hashes@2.0.1':
     resolution: {integrity: sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==}
     engines: {node: '>= 20.19.0'}
+
+  '@nodable/entities@2.2.0':
+    resolution: {integrity: sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==}
 
   '@npmcli/agent@3.0.0':
     resolution: {integrity: sha512-S79NdEgDQd/NGCay6TCoVzXSj74skRZIKJcpJjC5lOq34SZzyI6MqtiiWoiVWoVrTcGjNeC4ipbh1VIHlpfF5Q==}
@@ -2473,20 +2538,20 @@ packages:
   '@protobufjs/base64@1.1.2':
     resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
 
-  '@protobufjs/codegen@2.0.4':
-    resolution: {integrity: sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==}
+  '@protobufjs/codegen@2.0.5':
+    resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
 
-  '@protobufjs/eventemitter@1.1.0':
-    resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
+  '@protobufjs/eventemitter@1.1.1':
+    resolution: {integrity: sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==}
 
-  '@protobufjs/fetch@1.1.0':
-    resolution: {integrity: sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==}
+  '@protobufjs/fetch@1.1.1':
+    resolution: {integrity: sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==}
 
   '@protobufjs/float@1.0.2':
     resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
 
-  '@protobufjs/inquire@1.1.0':
-    resolution: {integrity: sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==}
+  '@protobufjs/inquire@1.1.2':
+    resolution: {integrity: sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==}
 
   '@protobufjs/path@1.1.2':
     resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
@@ -2494,8 +2559,8 @@ packages:
   '@protobufjs/pool@1.1.0':
     resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
 
-  '@protobufjs/utf8@1.1.0':
-    resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
+  '@protobufjs/utf8@1.1.2':
+    resolution: {integrity: sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==}
 
   '@radix-ui/colors@3.0.0':
     resolution: {integrity: sha512-FUOsGBkHrYJwCSEtWRCIfQbZG7q1e6DgxCIOe1SUQzDe/7rXXeA47s8yCn6fuTNQAj1Zq4oTFi9Yjp3wzElcxg==}
@@ -4010,11 +4075,11 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
-  '@vitest/expect@3.2.4':
-    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+  '@vitest/expect@3.2.7':
+    resolution: {integrity: sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==}
 
-  '@vitest/mocker@3.2.4':
-    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
+  '@vitest/mocker@3.2.7':
+    resolution: {integrity: sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
@@ -4024,20 +4089,20 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@3.2.4':
-    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+  '@vitest/pretty-format@3.2.7':
+    resolution: {integrity: sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==}
 
-  '@vitest/runner@3.2.4':
-    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
+  '@vitest/runner@3.2.7':
+    resolution: {integrity: sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==}
 
-  '@vitest/snapshot@3.2.4':
-    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
+  '@vitest/snapshot@3.2.7':
+    resolution: {integrity: sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==}
 
-  '@vitest/spy@3.2.4':
-    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+  '@vitest/spy@3.2.7':
+    resolution: {integrity: sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==}
 
-  '@vitest/utils@3.2.4':
-    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
+  '@vitest/utils@3.2.7':
+    resolution: {integrity: sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==}
 
   '@vue/compiler-core@3.5.34':
     resolution: {integrity: sha512-s9cLyK5mLcvZ4Agva5QgRsQyLKvts9WbU9DB6NqiZkkGEdwmcEiylj5Jbwkp680drF/NNCV8OlAJSe+yMLxaJw==}
@@ -4141,6 +4206,9 @@ packages:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
 
+  anynum@1.0.1:
+    resolution: {integrity: sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==}
+
   app-builder-bin@5.0.0-alpha.12:
     resolution: {integrity: sha512-j87o0j6LqPL3QRr8yid6c+Tt5gC7xNfYo6uQIQkorAC6MpeayVMZrEDzKmJJ/Hlv7EnOQpaRm53k6ktDYZyB6w==}
 
@@ -4201,8 +4269,8 @@ packages:
     resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
     engines: {node: '>=8.0.0'}
 
-  axios@1.13.6:
-    resolution: {integrity: sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==}
+  axios@1.16.0:
+    resolution: {integrity: sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==}
 
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
@@ -4222,8 +4290,8 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  better-auth@1.4.18:
-    resolution: {integrity: sha512-bnyifLWBPcYVltH3RhS7CM62MoelEqC6Q+GnZwfiDWNfepXoQZBjEvn4urcERC7NTKgKq5zNBM8rvPvRBa6xcg==}
+  better-auth@1.6.23:
+    resolution: {integrity: sha512-4vOaRd9UiKGKm9R+ej0jjU1es3MiJIiNc9Qq3VCnYqOZ4/nb5272QqTxWYoDxyUXl5x6A2x2we5KZKQO9teTQQ==}
     peerDependencies:
       '@lynx-js/react': '*'
       '@prisma/client': ^5.0.0 || ^6.0.0 || ^7.0.0
@@ -4232,7 +4300,7 @@ packages:
       '@tanstack/solid-start': ^1.0.0
       better-sqlite3: ^12.0.0
       drizzle-kit: '>=0.31.4'
-      drizzle-orm: '>=0.41.0'
+      drizzle-orm: ^0.45.2
       mongodb: ^6.0.0 || ^7.0.0
       mysql2: ^3.0.0
       next: ^14.0.0 || ^15.0.0 || ^16.0.0
@@ -4284,8 +4352,8 @@ packages:
       vue:
         optional: true
 
-  better-call@1.1.8:
-    resolution: {integrity: sha512-XMQ2rs6FNXasGNfMjzbyroSwKwYbZ/T3IxruSS6U2MJRsSYh3wYtG3o6H00ZlKZ/C/UPOAD97tqgQJNsxyeTXw==}
+  better-call@1.3.7:
+    resolution: {integrity: sha512-Al51/hjp2SSp6CRTa3F2ptcx4yQVS1xWKoY6jcVXqNYOap6mHFP2jUBn5EwIL4iIed1/Sq4hlQ+Umm6EflZG+w==}
     peerDependencies:
       zod: ^4.0.0
     peerDependenciesMeta:
@@ -4408,14 +4476,6 @@ packages:
   check-error@2.1.3:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
     engines: {node: '>= 16'}
-
-  chevrotain-allstar@0.3.1:
-    resolution: {integrity: sha512-b7g+y9A0v4mxCW1qUhf3BSVPg+/NvGErk/dOkrDaHA0nQIQGAtrOjlX//9OQtRlSCy+x9rfB5N8yC71lH1nvMw==}
-    peerDependencies:
-      chevrotain: ^11.0.0
-
-  chevrotain@11.1.2:
-    resolution: {integrity: sha512-opLQzEVriiH1uUQ4Kctsd49bRoFDXGGSC4GUqj7pGyxM3RehRhvTlZJc1FL/Flew2p5uwxa1tUDWKzI4wNM8pg==}
 
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
@@ -4632,8 +4692,8 @@ packages:
     peerDependencies:
       cytoscape: ^3.2.0
 
-  cytoscape@3.33.1:
-    resolution: {integrity: sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==}
+  cytoscape@3.34.0:
+    resolution: {integrity: sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==}
     engines: {node: '>=0.10'}
 
   d3-array@2.12.1:
@@ -4850,8 +4910,8 @@ packages:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
 
-  defu@6.1.4:
-    resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
+  defu@6.1.5:
+    resolution: {integrity: sha512-pwdBJxJuJXmqrLO6s0VBmfbRz+G7FUzkjldAsdi9Yrv86mPyzq0ll1o8+8gB4Gsr6GJHbK1Lh3ngllgTInDCjA==}
 
   delaunator@5.1.0:
     resolution: {integrity: sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==}
@@ -4911,8 +4971,8 @@ packages:
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
-  dompurify@3.3.3:
-    resolution: {integrity: sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==}
+  dompurify@3.4.11:
+    resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
 
   dotenv-expand@11.0.7:
     resolution: {integrity: sha512-zIHwmZPRshsCdpMDyVsqGmgyP0yT8GAgXUnkdAoJisxvf33k7yO6OuoKmcTGuXPWSsm8Oh88nZicRLA9Y0rUeA==}
@@ -4935,8 +4995,8 @@ packages:
     resolution: {integrity: sha512-7OZcmQUrdGI+DUNNsKBn1aW8qSoKuTH7d0mYgSP8bAzdFzKoovxEFnoGQp2dVs82EOJeYycqRtciopszwUf8bw==}
     hasBin: true
 
-  drizzle-orm@0.38.4:
-    resolution: {integrity: sha512-s7/5BpLKO+WJRHspvpqTydxFob8i1vo2rEx4pY6TGY7QSMuUfWUuzaY0DIpXCkgHOo37BaFC+SJQb99dDUXT3Q==}
+  drizzle-orm@0.45.2:
+    resolution: {integrity: sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q==}
     peerDependencies:
       '@aws-sdk/client-rds-data': '>=3'
       '@cloudflare/workers-types': '>=4'
@@ -4946,25 +5006,25 @@ packages:
       '@neondatabase/serverless': '>=0.10.0'
       '@op-engineering/op-sqlite': '>=2'
       '@opentelemetry/api': ^1.4.1
-      '@planetscale/database': '>=1'
+      '@planetscale/database': '>=1.13'
       '@prisma/client': '*'
       '@tidbcloud/serverless': '*'
       '@types/better-sqlite3': '*'
       '@types/pg': '*'
-      '@types/react': '>=18'
       '@types/sql.js': '*'
+      '@upstash/redis': '>=1.34.7'
       '@vercel/postgres': '>=0.8.0'
       '@xata.io/client': '*'
       better-sqlite3: '>=7'
       bun-types: '*'
       expo-sqlite: '>=14.0.0'
+      gel: '>=2'
       knex: '*'
       kysely: '*'
       mysql2: '>=2'
       pg: '>=8'
       postgres: '>=3'
       prisma: '*'
-      react: '>=18'
       sql.js: '>=1'
       sqlite3: '>=5'
     peerDependenciesMeta:
@@ -4994,9 +5054,9 @@ packages:
         optional: true
       '@types/pg':
         optional: true
-      '@types/react':
-        optional: true
       '@types/sql.js':
+        optional: true
+      '@upstash/redis':
         optional: true
       '@vercel/postgres':
         optional: true
@@ -5007,6 +5067,8 @@ packages:
       bun-types:
         optional: true
       expo-sqlite:
+        optional: true
+      gel:
         optional: true
       knex:
         optional: true
@@ -5019,8 +5081,6 @@ packages:
       postgres:
         optional: true
       prisma:
-        optional: true
-      react:
         optional: true
       sql.js:
         optional: true
@@ -5122,6 +5182,9 @@ packages:
   es-set-tostringtag@2.1.0:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
+
+  es-toolkit@1.49.0:
+    resolution: {integrity: sha512-G5iZ6Pc/FNRY/soKZHC+TxGDD83rHUDXxzaWhGCX44vAv/tMs56WMusnm/KMNK+luUPsgA9U28cGr4RDlSzL2g==}
 
   es5-ext@0.10.64:
     resolution: {integrity: sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==}
@@ -5231,14 +5294,14 @@ packages:
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
-  fast-xml-builder@1.1.4:
-    resolution: {integrity: sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==}
+  fast-xml-builder@1.1.7:
+    resolution: {integrity: sha512-Yh7/7rQuMXICNr0oMYDR2yHP6oUvmQsTToFeOWj/kIDhAwQ+c4Ol/lbcwOmEM5OHYQmh6S6EQSQ1sljCKP36bQ==}
 
-  fast-xml-parser@5.5.8:
-    resolution: {integrity: sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==}
+  fast-xml-parser@5.7.0:
+    resolution: {integrity: sha512-MTcrUoRQ1GSQ9iG3QJzBGquYYYeA7piZaJoIWbPFGbRn6Jj6z7xgoAyi4DrZX4y2ZIQQBF59gc/zmvvejjgoFQ==}
     hasBin: true
 
   fault@2.0.1:
@@ -5276,8 +5339,8 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
-  form-data@4.0.5:
-    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
 
   format@0.2.2:
@@ -5411,6 +5474,10 @@ packages:
 
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
   hast-util-to-jsx-runtime@2.3.6:
@@ -5611,8 +5678,8 @@ packages:
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
-  js-yaml@4.1.1:
-    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+  js-yaml@4.2.0:
+    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
     hasBin: true
 
   jsdom@27.4.0:
@@ -5665,6 +5732,10 @@ packages:
     resolution: {integrity: sha512-1DJcK/L05k1Y9Gf7wMcyuqFOL6BiY3vY0CFcAM/LPRN04NALxcl6u7lOWNsp3f/bCHWxigzQl6FbR95XJ4R84Q==}
     hasBin: true
 
+  katex@0.16.47:
+    resolution: {integrity: sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==}
+    hasBin: true
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
@@ -5675,13 +5746,9 @@ packages:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
 
-  kysely@0.28.14:
-    resolution: {integrity: sha512-SU3lgh0rPvq7upc6vvdVrCsSMUG1h3ChvHVOY7wJ2fw4C9QEB7X3d5eyYEyULUX7UQtxZJtZXGuT6U2US72UYA==}
-    engines: {node: '>=20.0.0'}
-
-  langium@4.2.1:
-    resolution: {integrity: sha512-zu9QWmjpzJcomzdJQAHgDVhLGq5bLosVak1KVa40NzQHXfqr4eAHupvnPOVXEoLkg6Ocefvf/93d//SB7du4YQ==}
-    engines: {node: '>=20.10.0', npm: '>=10.2.3'}
+  kysely@0.29.3:
+    resolution: {integrity: sha512-VHtBdW6XB/pgoTSqraM3UAa2rYoYdNXqnNPpX+8XXP+cwYbVEFuAp3HyPt1vpNfU9l7Y2kpUrA9QDPsy8uUqOQ==}
+    engines: {node: '>=22.0.0'}
 
   layout-base@1.0.2:
     resolution: {integrity: sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==}
@@ -5770,8 +5837,8 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
-  lodash-es@4.17.23:
-    resolution: {integrity: sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==}
+  lodash-es@4.18.1:
+    resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
 
   lodash.identity@3.0.0:
     resolution: {integrity: sha512-AupTIzdLQxJS5wIYUQlgGyk2XRTfGXA+MCghDHqZk0pzUNYvd3EESS6dkChNauNYVIutcb0dfHw1ri9Q1yPV8Q==}
@@ -5930,8 +5997,8 @@ packages:
     resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
     engines: {node: '>=18'}
 
-  mermaid@11.13.0:
-    resolution: {integrity: sha512-fEnci+Immw6lKMFI8sqzjlATTyjLkRa6axrEgLV2yHTfv8r+h1wjFbV6xeRtd4rUV1cS4EpR9rwp3Rci7TRWDw==}
+  mermaid@11.16.0:
+    resolution: {integrity: sha512-Zvm3kbstgdpvIJPPItlL7fppIZ3kibvc1oZIGxdvk9t6UFz6flv+Jw7FtRGKwfcI8OckmH04LqG6LlS6X4B1pA==}
 
   methods@1.1.2:
     resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
@@ -6155,8 +6222,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  multer@2.1.1:
-    resolution: {integrity: sha512-mo+QTzKlx8R7E5ylSXxWzGoXoZbOsRMpyitcht8By2KHvMbf3tjwosZ/Mu/XYU6UuJ3VZnODIrak5ZrPiPyB6A==}
+  multer@2.2.0:
+    resolution: {integrity: sha512-6rdyFg2kLrMh9Jee7/BMPuV9lEAd7lLW2YUpF9/YxR7njyoUwwQ0ZPh3TaIY50Sw6vlyD2HW3wGOkTS4P79xrQ==}
     engines: {node: '>= 10.16.0'}
 
   mustache@4.2.0:
@@ -6291,8 +6358,8 @@ packages:
   path-data-parser@0.1.0:
     resolution: {integrity: sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==}
 
-  path-expression-matcher@1.2.0:
-    resolution: {integrity: sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==}
+  path-expression-matcher@1.6.2:
+    resolution: {integrity: sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==}
     engines: {node: '>=14.0.0'}
 
   path-is-absolute@1.0.1:
@@ -6310,8 +6377,8 @@ packages:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
 
-  path-to-regexp@8.3.0:
-    resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -6543,16 +6610,17 @@ packages:
       prosemirror-view:
         optional: true
 
-  protobufjs@7.5.4:
-    resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
+  protobufjs@7.6.3:
+    resolution: {integrity: sha512-+k0vdJKNdW+Vu+dYe8tZA/VvQb6XKNWexC6URwBFXxNnjLJz9nQJCemGyNgRAWD+B7+nGNc9qMPGwcD7s4nzUw==}
     engines: {node: '>=12.0.0'}
 
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
 
-  proxy-from-env@1.1.0:
-    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+  proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
 
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
@@ -6561,8 +6629,8 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
-  qs@6.15.0:
-    resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
+  qs@6.15.2:
+    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
 
   quick-format-unescaped@4.0.4:
@@ -6649,15 +6717,15 @@ packages:
       '@types/react':
         optional: true
 
-  react-router-dom@7.13.2:
-    resolution: {integrity: sha512-aR7SUORwTqAW0JDeiWF07e9SBE9qGpByR9I8kJT5h/FrBKxPMS6TiC7rmVO+gC0q52Bx7JnjWe8Z1sR9faN4YA==}
+  react-router-dom@7.15.1:
+    resolution: {integrity: sha512-AzF62gjY6U9rkMq4RfP/r2EVtQ7DMfNMjyOp/flLTCrtRylLiK4wT4pSq6O8rOXZ2eXdZYJPEYe+ifomiv+Igg==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
       react-dom: '>=18'
 
-  react-router@7.13.2:
-    resolution: {integrity: sha512-tX1Aee+ArlKQP+NIUd7SE6Li+CiGKwQtbS+FfRxPX6Pe4vHOo6nr9d++u5cwg+Z8K/x8tP+7qLmujDtfrAoUJA==}
+  react-router@7.15.1:
+    resolution: {integrity: sha512-R8rl9HhgikFYoPJymnUtPXWbnDb3oget6lQnfIoupbt61aT9aOhRkDsY2XRhZRyX1Z/8a5sL74fXmFNm3NRK5A==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
@@ -6854,6 +6922,9 @@ packages:
   set-cookie-parser@2.7.2:
     resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
+  set-cookie-parser@3.1.1:
+    resolution: {integrity: sha512-vM9SUhjsUYs6UeJUmygc5Ofm5eQGe85riob5ju6XCgFGJI5PLV4nrDAQpQjd+LkFBpAkADn5BQQpZ9EUNkyLuA==}
+
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
@@ -7003,8 +7074,8 @@ packages:
   strip-literal@3.1.0:
     resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
 
-  strnum@2.2.2:
-    resolution: {integrity: sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==}
+  strnum@2.4.1:
+    resolution: {integrity: sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==}
 
   style-mod@4.1.3:
     resolution: {integrity: sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==}
@@ -7182,8 +7253,8 @@ packages:
   undici-types@7.24.5:
     resolution: {integrity: sha512-kNh333UBSbgK35OIW7FwJTr9tTfVIG51Fm1tSVT7m8foPHfDVjsb7OIee/q/rs3bB2aV/3qOPgG5mHNWl1odiA==}
 
-  undici@7.24.5:
-    resolution: {integrity: sha512-3IWdCpjgxp15CbJnsi/Y9TCDE7HWVN19j1hmzVhoAkY/+CJx449tVxT5wZc1Gwg8J+P0LWvzlBzxYRnHJ+1i7Q==}
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
   unidiff@1.0.4:
@@ -7273,8 +7344,8 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
-  uuid@11.1.0:
-    resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
+  uuid@11.1.1:
+    resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
     hasBin: true
 
   uvu@0.5.6:
@@ -7341,8 +7412,8 @@ packages:
       yaml:
         optional: true
 
-  vite@7.3.1:
-    resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
+  vite@7.3.5:
+    resolution: {integrity: sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -7381,16 +7452,16 @@ packages:
       yaml:
         optional: true
 
-  vitest@3.2.4:
-    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
+  vitest@3.2.7:
+    resolution: {integrity: sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@types/debug': ^4.1.12
       '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
-      '@vitest/browser': 3.2.4
-      '@vitest/ui': 3.2.4
+      '@vitest/browser': 3.2.7
+      '@vitest/ui': 3.2.7
       happy-dom: '*'
       jsdom: '*'
     peerDependenciesMeta:
@@ -7408,26 +7479,6 @@ packages:
         optional: true
       jsdom:
         optional: true
-
-  vscode-jsonrpc@8.2.0:
-    resolution: {integrity: sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==}
-    engines: {node: '>=14.0.0'}
-
-  vscode-languageserver-protocol@3.17.5:
-    resolution: {integrity: sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==}
-
-  vscode-languageserver-textdocument@1.0.12:
-    resolution: {integrity: sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==}
-
-  vscode-languageserver-types@3.17.5:
-    resolution: {integrity: sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==}
-
-  vscode-languageserver@9.0.1:
-    resolution: {integrity: sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==}
-    hasBin: true
-
-  vscode-uri@3.1.0:
-    resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
 
   vue@3.5.34:
     resolution: {integrity: sha512-WdLBG9gm02OgJIG9axd5Hpx0TFLdzVgfG2evFFu8Rur5O/IoGc5cMjnjh3tPL6GnRGsYvUhBSKVPYVcxRKpMCA==}
@@ -7493,8 +7544,8 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
-  ws@8.20.0:
-    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -8044,7 +8095,7 @@ snapshots:
   '@aws-sdk/xml-builder@3.972.15':
     dependencies:
       '@smithy/types': 4.13.1
-      fast-xml-parser: 5.5.8
+      fast-xml-parser: 5.7.0
       tslib: 2.8.1
 
   '@aws/lambda-invoke-store@0.2.4': {}
@@ -8167,26 +8218,60 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
-  '@better-auth/core@1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@3.25.76))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0)':
+  '@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@3.25.76))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0)':
     dependencies:
-      '@better-auth/utils': 0.3.0
-      '@better-fetch/fetch': 1.1.21
+      '@better-auth/utils': 0.4.2
+      '@better-fetch/fetch': 1.3.1
+      '@opentelemetry/semantic-conventions': 1.40.0
       '@standard-schema/spec': 1.1.0
-      better-call: 1.1.8(zod@4.3.6)
+      better-call: 1.3.7(zod@4.3.6)
       jose: 6.2.2
-      kysely: 0.28.14
+      kysely: 0.29.3
       nanostores: 1.2.0
       zod: 4.3.6
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
 
-  '@better-auth/telemetry@1.4.18(@better-auth/core@1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@3.25.76))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))':
+  '@better-auth/drizzle-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@3.25.76))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(kysely@0.29.3)(pg@8.20.0)(postgres@3.4.8))':
     dependencies:
-      '@better-auth/core': 1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@3.25.76))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0)
-      '@better-auth/utils': 0.3.0
-      '@better-fetch/fetch': 1.1.21
+      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@3.25.76))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0)
+      '@better-auth/utils': 0.4.2
+    optionalDependencies:
+      drizzle-orm: 0.45.2(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(kysely@0.29.3)(pg@8.20.0)(postgres@3.4.8)
 
-  '@better-auth/utils@0.3.0': {}
+  '@better-auth/kysely-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@3.25.76))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0))(@better-auth/utils@0.4.2)(kysely@0.29.3)':
+    dependencies:
+      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@3.25.76))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0)
+      '@better-auth/utils': 0.4.2
+    optionalDependencies:
+      kysely: 0.29.3
 
-  '@better-fetch/fetch@1.1.21': {}
+  '@better-auth/memory-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@3.25.76))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0))(@better-auth/utils@0.4.2)':
+    dependencies:
+      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@3.25.76))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0)
+      '@better-auth/utils': 0.4.2
+
+  '@better-auth/mongo-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@3.25.76))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0))(@better-auth/utils@0.4.2)':
+    dependencies:
+      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@3.25.76))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0)
+      '@better-auth/utils': 0.4.2
+
+  '@better-auth/prisma-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@3.25.76))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0))(@better-auth/utils@0.4.2)':
+    dependencies:
+      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@3.25.76))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0)
+      '@better-auth/utils': 0.4.2
+
+  '@better-auth/telemetry@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@3.25.76))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)':
+    dependencies:
+      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@3.25.76))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0)
+      '@better-auth/utils': 0.4.2
+      '@better-fetch/fetch': 1.3.1
+
+  '@better-auth/utils@0.4.2':
+    dependencies:
+      '@noble/hashes': 2.0.1
+
+  '@better-fetch/fetch@1.3.1': {}
 
   '@braintree/sanitize-url@7.1.2': {}
 
@@ -8194,22 +8279,7 @@ snapshots:
     dependencies:
       css-tree: 3.2.1
 
-  '@chevrotain/cst-dts-gen@11.1.2':
-    dependencies:
-      '@chevrotain/gast': 11.1.2
-      '@chevrotain/types': 11.1.2
-      lodash-es: 4.17.23
-
-  '@chevrotain/gast@11.1.2':
-    dependencies:
-      '@chevrotain/types': 11.1.2
-      lodash-es: 4.17.23
-
-  '@chevrotain/regexp-to-ast@11.1.2': {}
-
   '@chevrotain/types@11.1.2': {}
-
-  '@chevrotain/utils@11.1.2': {}
 
   '@clack/core@0.4.2':
     dependencies:
@@ -9144,13 +9214,13 @@ snapshots:
 
   '@larksuiteoapi/node-sdk@1.67.0':
     dependencies:
-      axios: 1.13.6
+      axios: 1.16.0
       lodash.identity: 3.0.0
       lodash.merge: 4.6.2
       lodash.pickby: 4.6.0
-      protobufjs: 7.5.4
-      qs: 6.15.0
-      ws: 8.20.0
+      protobufjs: 7.6.3
+      qs: 6.15.2
+      ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -9442,7 +9512,7 @@ snapshots:
       cm6-theme-basic-light: 0.2.0(@codemirror/language@6.12.2)(@codemirror/state@6.6.0)(@codemirror/view@6.40.0)(@lezer/highlight@1.2.3)
       codemirror: 6.0.2
       downshift: 7.6.2(react@19.2.4)
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
       lexical: 0.35.0
       mdast-util-directive: 3.1.0
       mdast-util-from-markdown: 2.0.3
@@ -9483,9 +9553,9 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  '@mermaid-js/parser@1.0.1':
+  '@mermaid-js/parser@1.2.0':
     dependencies:
-      langium: 4.2.1
+      '@chevrotain/types': 11.1.2
 
   '@milkdown/components@7.21.1(@codemirror/language@6.12.2)(@codemirror/state@6.6.0)(@codemirror/view@6.40.0)(typescript@5.9.3)':
     dependencies:
@@ -9505,8 +9575,8 @@ snapshots:
       '@milkdown/utils': 7.21.1
       '@types/lodash-es': 4.17.12
       clsx: 2.1.1
-      dompurify: 3.3.3
-      lodash-es: 4.17.23
+      dompurify: 3.4.11
+      lodash-es: 4.18.1
       nanoid: 5.1.11
       unist-util-visit: 5.1.0
       vue: 3.5.34(typescript@5.9.3)
@@ -9538,9 +9608,9 @@ snapshots:
       '@types/lodash-es': 4.17.12
       clsx: 2.1.1
       codemirror: 6.0.2
-      dompurify: 3.3.3
+      dompurify: 3.4.11
       katex: 0.16.40
-      lodash-es: 4.17.23
+      lodash-es: 4.18.1
       prosemirror-virtual-cursor: 0.4.2(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)
       remark-math: 6.0.0
       unist-util-visit: 5.1.0
@@ -9596,7 +9666,7 @@ snapshots:
       '@milkdown/prose': 7.21.1
       '@milkdown/utils': 7.21.1
       '@types/lodash-es': 4.17.12
-      lodash-es: 4.17.23
+      lodash-es: 4.18.1
     transitivePeerDependencies:
       - supports-color
 
@@ -9651,7 +9721,7 @@ snapshots:
       '@milkdown/ctx': 7.21.1
       '@milkdown/prose': 7.21.1
       '@types/lodash-es': 4.17.12
-      lodash-es: 4.17.23
+      lodash-es: 4.18.1
     transitivePeerDependencies:
       - supports-color
 
@@ -9662,7 +9732,7 @@ snapshots:
       '@milkdown/prose': 7.21.1
       '@milkdown/utils': 7.21.1
       '@types/lodash-es': 4.17.12
-      lodash-es: 4.17.23
+      lodash-es: 4.18.1
     transitivePeerDependencies:
       - supports-color
 
@@ -9683,7 +9753,7 @@ snapshots:
       '@milkdown/prose': 7.21.1
       '@milkdown/utils': 7.21.1
       '@types/lodash-es': 4.17.12
-      lodash-es: 4.17.23
+      lodash-es: 4.18.1
     transitivePeerDependencies:
       - supports-color
 
@@ -9792,6 +9862,8 @@ snapshots:
 
   '@noble/hashes@2.0.1': {}
 
+  '@nodable/entities@2.2.0': {}
+
   '@npmcli/agent@3.0.0':
     dependencies:
       agent-base: 7.1.4
@@ -9849,7 +9921,7 @@ snapshots:
       '@opentelemetry/sdk-logs': 0.214.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-metrics': 2.6.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.6.1(@opentelemetry/api@1.9.1)
-      protobufjs: 7.5.4
+      protobufjs: 7.6.3
 
   '@opentelemetry/resources@2.6.1(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -9906,24 +9978,23 @@ snapshots:
 
   '@protobufjs/base64@1.1.2': {}
 
-  '@protobufjs/codegen@2.0.4': {}
+  '@protobufjs/codegen@2.0.5': {}
 
-  '@protobufjs/eventemitter@1.1.0': {}
+  '@protobufjs/eventemitter@1.1.1': {}
 
-  '@protobufjs/fetch@1.1.0':
+  '@protobufjs/fetch@1.1.1':
     dependencies:
       '@protobufjs/aspromise': 1.1.2
-      '@protobufjs/inquire': 1.1.0
 
   '@protobufjs/float@1.0.2': {}
 
-  '@protobufjs/inquire@1.1.0': {}
+  '@protobufjs/inquire@1.1.2': {}
 
   '@protobufjs/path@1.1.2': {}
 
   '@protobufjs/pool@1.1.0': {}
 
-  '@protobufjs/utf8@1.1.0': {}
+  '@protobufjs/utf8@1.1.2': {}
 
   '@radix-ui/colors@3.0.0': {}
 
@@ -11556,7 +11627,7 @@ snapshots:
       '@types/cookiejar': 2.1.5
       '@types/methods': 1.1.4
       '@types/node': 25.5.0
-      form-data: 4.0.5
+      form-data: 4.0.6
 
   '@types/supertest@6.0.3':
     dependencies:
@@ -11603,53 +11674,53 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/expect@3.2.4':
+  '@vitest/expect@3.2.7':
     dependencies:
       '@types/chai': 5.2.3
-      '@vitest/spy': 3.2.4
-      '@vitest/utils': 3.2.4
+      '@vitest/spy': 3.2.7
+      '@vitest/utils': 3.2.7
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))':
+  '@vitest/mocker@3.2.7(vite@7.3.5(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))':
     dependencies:
-      '@vitest/spy': 3.2.4
+      '@vitest/spy': 3.2.7
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
+      vite: 7.3.5(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
 
-  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))':
+  '@vitest/mocker@3.2.7(vite@7.3.5(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))':
     dependencies:
-      '@vitest/spy': 3.2.4
+      '@vitest/spy': 3.2.7
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
+      vite: 7.3.5(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
 
-  '@vitest/pretty-format@3.2.4':
+  '@vitest/pretty-format@3.2.7':
     dependencies:
       tinyrainbow: 2.0.0
 
-  '@vitest/runner@3.2.4':
+  '@vitest/runner@3.2.7':
     dependencies:
-      '@vitest/utils': 3.2.4
+      '@vitest/utils': 3.2.7
       pathe: 2.0.3
       strip-literal: 3.1.0
 
-  '@vitest/snapshot@3.2.4':
+  '@vitest/snapshot@3.2.7':
     dependencies:
-      '@vitest/pretty-format': 3.2.4
+      '@vitest/pretty-format': 3.2.7
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@3.2.4':
+  '@vitest/spy@3.2.7':
     dependencies:
       tinyspy: 4.0.4
 
-  '@vitest/utils@3.2.4':
+  '@vitest/utils@3.2.7':
     dependencies:
-      '@vitest/pretty-format': 3.2.4
+      '@vitest/pretty-format': 3.2.7
       loupe: 3.2.1
       tinyrainbow: 2.0.0
 
@@ -11744,7 +11815,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -11761,6 +11832,8 @@ snapshots:
   ansi-styles@5.2.0: {}
 
   ansi-styles@6.2.3: {}
+
+  anynum@1.0.1: {}
 
   app-builder-bin@5.0.0-alpha.12: {}
 
@@ -11792,7 +11865,7 @@ snapshots:
       hosted-git-info: 4.1.0
       isbinaryfile: 5.0.7
       jiti: 2.6.1
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
       json5: 2.2.3
       lazy-val: 1.0.5
       minimatch: 10.2.4
@@ -11841,11 +11914,11 @@ snapshots:
 
   atomic-sleep@1.0.0: {}
 
-  axios@1.13.6:
+  axios@1.16.0:
     dependencies:
       follow-redirects: 1.16.0
-      form-data: 4.0.5
-      proxy-from-env: 1.1.0
+      form-data: 4.0.6
+      proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
 
@@ -11859,35 +11932,43 @@ snapshots:
 
   baseline-browser-mapping@2.10.10: {}
 
-  better-auth@1.4.18(drizzle-kit@0.31.10)(drizzle-orm@0.38.4(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@types/react@19.2.14)(kysely@0.28.14)(pg@8.20.0)(postgres@3.4.8)(react@19.2.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.32.0)(tsx@4.21.0))(vue@3.5.34(typescript@5.9.3)):
+  better-auth@1.6.23(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(kysely@0.29.3)(pg@8.20.0)(postgres@3.4.8))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@3.2.7(@types/debug@4.1.13)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.32.0)(tsx@4.21.0))(vue@3.5.34(typescript@5.9.3)):
     dependencies:
-      '@better-auth/core': 1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@3.25.76))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0)
-      '@better-auth/telemetry': 1.4.18(@better-auth/core@1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@3.25.76))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))
-      '@better-auth/utils': 0.3.0
-      '@better-fetch/fetch': 1.1.21
+      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@3.25.76))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0)
+      '@better-auth/drizzle-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@3.25.76))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(kysely@0.29.3)(pg@8.20.0)(postgres@3.4.8))
+      '@better-auth/kysely-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@3.25.76))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0))(@better-auth/utils@0.4.2)(kysely@0.29.3)
+      '@better-auth/memory-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@3.25.76))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0))(@better-auth/utils@0.4.2)
+      '@better-auth/mongo-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@3.25.76))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0))(@better-auth/utils@0.4.2)
+      '@better-auth/prisma-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@3.25.76))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0))(@better-auth/utils@0.4.2)
+      '@better-auth/telemetry': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@3.25.76))(jose@6.2.2)(kysely@0.29.3)(nanostores@1.2.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)
+      '@better-auth/utils': 0.4.2
+      '@better-fetch/fetch': 1.3.1
       '@noble/ciphers': 2.1.1
       '@noble/hashes': 2.0.1
-      better-call: 1.1.8(zod@4.3.6)
-      defu: 6.1.4
+      better-call: 1.3.7(zod@4.3.6)
+      defu: 6.1.5
       jose: 6.2.2
-      kysely: 0.28.14
+      kysely: 0.29.3
       nanostores: 1.2.0
       zod: 4.3.6
     optionalDependencies:
       drizzle-kit: 0.31.10
-      drizzle-orm: 0.38.4(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@types/react@19.2.14)(kysely@0.28.14)(pg@8.20.0)(postgres@3.4.8)(react@19.2.4)
+      drizzle-orm: 0.45.2(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(kysely@0.29.3)(pg@8.20.0)(postgres@3.4.8)
       pg: 8.20.0
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      vitest: 3.2.4(@types/debug@4.1.13)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.32.0)(tsx@4.21.0)
+      vitest: 3.2.7(@types/debug@4.1.13)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.32.0)(tsx@4.21.0)
       vue: 3.5.34(typescript@5.9.3)
+    transitivePeerDependencies:
+      - '@cloudflare/workers-types'
+      - '@opentelemetry/api'
 
-  better-call@1.1.8(zod@4.3.6):
+  better-call@1.3.7(zod@4.3.6):
     dependencies:
-      '@better-auth/utils': 0.3.0
-      '@better-fetch/fetch': 1.1.21
+      '@better-auth/utils': 0.4.2
+      '@better-fetch/fetch': 1.3.1
       rou3: 0.7.12
-      set-cookie-parser: 2.7.2
+      set-cookie-parser: 3.1.1
     optionalDependencies:
       zod: 4.3.6
 
@@ -11909,7 +11990,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
-      qs: 6.15.0
+      qs: 6.15.2
       raw-body: 3.0.2
       type-is: 2.0.1
     transitivePeerDependencies:
@@ -11974,7 +12055,7 @@ snapshots:
       fs-extra: 10.1.0
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
       sanitize-filename: 1.6.4
       source-map-support: 0.5.21
       stat-mode: 1.0.0
@@ -12058,20 +12139,6 @@ snapshots:
   character-reference-invalid@2.0.1: {}
 
   check-error@2.1.3: {}
-
-  chevrotain-allstar@0.3.1(chevrotain@11.1.2):
-    dependencies:
-      chevrotain: 11.1.2
-      lodash-es: 4.17.23
-
-  chevrotain@11.1.2:
-    dependencies:
-      '@chevrotain/cst-dts-gen': 11.1.2
-      '@chevrotain/gast': 11.1.2
-      '@chevrotain/regexp-to-ast': 11.1.2
-      '@chevrotain/types': 11.1.2
-      '@chevrotain/utils': 11.1.2
-      lodash-es: 4.17.23
 
   chokidar@4.0.3:
     dependencies:
@@ -12261,17 +12328,17 @@ snapshots:
 
   csstype@3.2.3: {}
 
-  cytoscape-cose-bilkent@4.1.0(cytoscape@3.33.1):
+  cytoscape-cose-bilkent@4.1.0(cytoscape@3.34.0):
     dependencies:
       cose-base: 1.0.3
-      cytoscape: 3.33.1
+      cytoscape: 3.34.0
 
-  cytoscape-fcose@2.2.0(cytoscape@3.33.1):
+  cytoscape-fcose@2.2.0(cytoscape@3.34.0):
     dependencies:
       cose-base: 2.2.0
-      cytoscape: 3.33.1
+      cytoscape: 3.34.0
 
-  cytoscape@3.33.1: {}
+  cytoscape@3.34.0: {}
 
   d3-array@2.12.1:
     dependencies:
@@ -12448,7 +12515,7 @@ snapshots:
   dagre-d3-es@7.0.14:
     dependencies:
       d3: 7.9.0
-      lodash-es: 4.17.23
+      lodash-es: 4.18.1
 
   data-urls@6.0.1:
     dependencies:
@@ -12513,7 +12580,7 @@ snapshots:
       object-keys: 1.1.1
     optional: true
 
-  defu@6.1.4: {}
+  defu@6.1.5: {}
 
   delaunator@5.1.0:
     dependencies:
@@ -12558,7 +12625,7 @@ snapshots:
       builder-util: 26.8.1
       fs-extra: 10.1.0
       iconv-lite: 0.6.3
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
     optionalDependencies:
       dmg-license: 1.0.11
     transitivePeerDependencies:
@@ -12581,7 +12648,7 @@ snapshots:
 
   dom-accessibility-api@0.6.3: {}
 
-  dompurify@3.3.3:
+  dompurify@3.4.11:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -12609,15 +12676,13 @@ snapshots:
       esbuild: 0.25.12
       tsx: 4.21.0
 
-  drizzle-orm@0.38.4(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@types/react@19.2.14)(kysely@0.28.14)(pg@8.20.0)(postgres@3.4.8)(react@19.2.4):
+  drizzle-orm@0.45.2(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(kysely@0.29.3)(pg@8.20.0)(postgres@3.4.8):
     optionalDependencies:
       '@electric-sql/pglite': 0.3.15
       '@opentelemetry/api': 1.9.1
-      '@types/react': 19.2.14
-      kysely: 0.28.14
+      kysely: 0.29.3
       pg: 8.20.0
       postgres: 3.4.8
-      react: 19.2.4
 
   dunder-proto@1.0.1:
     dependencies:
@@ -12664,7 +12729,7 @@ snapshots:
       builder-util: 26.8.1
       builder-util-runtime: 9.5.1
       chalk: 4.1.2
-      form-data: 4.0.5
+      form-data: 4.0.6
       fs-extra: 10.1.0
       lazy-val: 1.0.5
       mime: 2.6.0
@@ -12752,7 +12817,9 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
-      hasown: 2.0.2
+      hasown: 2.0.4
+
+  es-toolkit@1.49.0: {}
 
   es5-ext@0.10.64:
     dependencies:
@@ -12922,7 +12989,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.15.0
+      qs: 6.15.2
       range-parser: 1.2.1
       router: 2.2.0
       send: 1.2.1
@@ -12960,17 +13027,18 @@ snapshots:
 
   fast-safe-stringify@2.1.1: {}
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.2: {}
 
-  fast-xml-builder@1.1.4:
+  fast-xml-builder@1.1.7:
     dependencies:
-      path-expression-matcher: 1.2.0
+      path-expression-matcher: 1.6.2
 
-  fast-xml-parser@5.5.8:
+  fast-xml-parser@5.7.0:
     dependencies:
-      fast-xml-builder: 1.1.4
-      path-expression-matcher: 1.2.0
-      strnum: 2.2.2
+      '@nodable/entities': 2.2.0
+      fast-xml-builder: 1.1.7
+      path-expression-matcher: 1.6.2
+      strnum: 2.4.1
 
   fault@2.0.1:
     dependencies:
@@ -13006,12 +13074,12 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  form-data@4.0.5:
+  form-data@4.0.6:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
-      hasown: 2.0.2
+      hasown: 2.0.4
       mime-types: 2.1.35
 
   format@0.2.2: {}
@@ -13085,7 +13153,7 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       has-symbols: 1.1.0
-      hasown: 2.0.2
+      hasown: 2.0.4
       math-intrinsics: 1.1.0
 
   get-nonce@1.0.1: {}
@@ -13171,6 +13239,10 @@ snapshots:
       has-symbols: 1.1.0
 
   hasown@2.0.2:
+    dependencies:
+      function-bind: 1.1.2
+
+  hasown@2.0.4:
     dependencies:
       function-bind: 1.1.2
 
@@ -13358,7 +13430,7 @@ snapshots:
 
   js-tokens@9.0.1: {}
 
-  js-yaml@4.1.1:
+  js-yaml@4.2.0:
     dependencies:
       argparse: 2.0.1
 
@@ -13382,7 +13454,7 @@ snapshots:
       webidl-conversions: 8.0.1
       whatwg-mimetype: 4.0.0
       whatwg-url: 15.1.0
-      ws: 8.20.0
+      ws: 8.21.0
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - '@noble/hashes'
@@ -13407,7 +13479,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 7.24.5
+      undici: 7.28.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -13444,6 +13516,10 @@ snapshots:
     dependencies:
       commander: 8.3.0
 
+  katex@0.16.47:
+    dependencies:
+      commander: 8.3.0
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
@@ -13452,15 +13528,7 @@ snapshots:
 
   kleur@4.1.5: {}
 
-  kysely@0.28.14: {}
-
-  langium@4.2.1:
-    dependencies:
-      chevrotain: 11.1.2
-      chevrotain-allstar: 0.3.1(chevrotain@11.1.2)
-      vscode-languageserver: 9.0.1
-      vscode-languageserver-textdocument: 1.0.12
-      vscode-uri: 3.1.0
+  kysely@0.29.3: {}
 
   layout-base@1.0.2: {}
 
@@ -13523,7 +13591,7 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
-  lodash-es@4.17.23: {}
+  lodash-es@4.18.1: {}
 
   lodash.identity@3.0.0: {}
 
@@ -13817,29 +13885,29 @@ snapshots:
 
   merge-descriptors@2.0.0: {}
 
-  mermaid@11.13.0:
+  mermaid@11.16.0:
     dependencies:
       '@braintree/sanitize-url': 7.1.2
       '@iconify/utils': 3.1.0
-      '@mermaid-js/parser': 1.0.1
+      '@mermaid-js/parser': 1.2.0
       '@types/d3': 7.4.3
       '@upsetjs/venn.js': 2.0.0
-      cytoscape: 3.33.1
-      cytoscape-cose-bilkent: 4.1.0(cytoscape@3.33.1)
-      cytoscape-fcose: 2.2.0(cytoscape@3.33.1)
+      cytoscape: 3.34.0
+      cytoscape-cose-bilkent: 4.1.0(cytoscape@3.34.0)
+      cytoscape-fcose: 2.2.0(cytoscape@3.34.0)
       d3: 7.9.0
       d3-sankey: 0.12.3
       dagre-d3-es: 7.0.14
       dayjs: 1.11.20
-      dompurify: 3.3.3
-      katex: 0.16.40
+      dompurify: 3.4.11
+      es-toolkit: 1.49.0
+      katex: 0.16.47
       khroma: 2.1.0
-      lodash-es: 4.17.23
       marked: 16.4.2
       roughjs: 4.6.6
       stylis: 4.3.6
       ts-dedent: 2.2.0
-      uuid: 11.1.0
+      uuid: 11.1.1
 
   methods@1.1.2: {}
 
@@ -14232,7 +14300,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  multer@2.1.1:
+  multer@2.2.0:
     dependencies:
       append-field: 1.0.0
       busboy: 1.6.0
@@ -14367,7 +14435,7 @@ snapshots:
 
   path-data-parser@0.1.0: {}
 
-  path-expression-matcher@1.2.0: {}
+  path-expression-matcher@1.6.2: {}
 
   path-is-absolute@1.0.1: {}
 
@@ -14380,7 +14448,7 @@ snapshots:
       lru-cache: 10.4.3
       minipass: 7.1.3
 
-  path-to-regexp@8.3.0: {}
+  path-to-regexp@8.4.2: {}
 
   pathe@2.0.3: {}
 
@@ -14664,18 +14732,18 @@ snapshots:
       prosemirror-state: 1.4.4
       prosemirror-view: 1.41.8
 
-  protobufjs@7.5.4:
+  protobufjs@7.6.3:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2
-      '@protobufjs/codegen': 2.0.4
-      '@protobufjs/eventemitter': 1.1.0
-      '@protobufjs/fetch': 1.1.0
+      '@protobufjs/codegen': 2.0.5
+      '@protobufjs/eventemitter': 1.1.1
+      '@protobufjs/fetch': 1.1.1
       '@protobufjs/float': 1.0.2
-      '@protobufjs/inquire': 1.1.0
+      '@protobufjs/inquire': 1.1.2
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
-      '@protobufjs/utf8': 1.1.0
+      '@protobufjs/utf8': 1.1.2
       '@types/node': 25.5.0
       long: 5.3.2
 
@@ -14684,7 +14752,7 @@ snapshots:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
 
-  proxy-from-env@1.1.0: {}
+  proxy-from-env@2.1.0: {}
 
   pump@3.0.4:
     dependencies:
@@ -14693,7 +14761,7 @@ snapshots:
 
   punycode@2.3.1: {}
 
-  qs@6.15.0:
+  qs@6.15.2:
     dependencies:
       side-channel: 1.1.0
 
@@ -14834,13 +14902,13 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  react-router-dom@7.13.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  react-router-dom@7.15.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      react-router: 7.13.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react-router: 7.15.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 
-  react-router@7.13.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  react-router@7.15.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       cookie: 1.1.1
       react: 19.2.4
@@ -15030,7 +15098,7 @@ snapshots:
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
-      path-to-regexp: 8.3.0
+      path-to-regexp: 8.4.2
     transitivePeerDependencies:
       - supports-color
 
@@ -15102,6 +15170,8 @@ snapshots:
       - supports-color
 
   set-cookie-parser@2.7.2: {}
+
+  set-cookie-parser@3.1.1: {}
 
   setprototypeof@1.2.0: {}
 
@@ -15286,7 +15356,9 @@ snapshots:
     dependencies:
       js-tokens: 9.0.1
 
-  strnum@2.2.2: {}
+  strnum@2.4.1:
+    dependencies:
+      anynum: 1.0.1
 
   style-mod@4.1.3: {}
 
@@ -15312,11 +15384,11 @@ snapshots:
       cookiejar: 2.1.4
       debug: 4.4.3
       fast-safe-stringify: 2.1.1
-      form-data: 4.0.5
+      form-data: 4.0.6
       formidable: 3.5.4
       methods: 1.1.2
       mime: 2.6.0
-      qs: 6.15.0
+      qs: 6.15.2
     transitivePeerDependencies:
       - supports-color
 
@@ -15458,7 +15530,7 @@ snapshots:
 
   undici-types@7.24.5: {}
 
-  undici@7.24.5: {}
+  undici@7.28.0: {}
 
   unidiff@1.0.4:
     dependencies:
@@ -15553,7 +15625,7 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  uuid@11.1.0: {}
+  uuid@11.1.1: {}
 
   uvu@0.5.6:
     dependencies:
@@ -15587,7 +15659,7 @@ snapshots:
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
+      vite: 7.3.5(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -15608,7 +15680,7 @@ snapshots:
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
+      vite: 7.3.5(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -15653,12 +15725,12 @@ snapshots:
       lightningcss: 1.32.0
       tsx: 4.21.0
 
-  vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0):
+  vite@7.3.5(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0):
     dependencies:
       esbuild: 0.27.4
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.8
+      postcss: 8.5.15
       rollup: 4.60.0
       tinyglobby: 0.2.15
     optionalDependencies:
@@ -15668,12 +15740,12 @@ snapshots:
       lightningcss: 1.32.0
       tsx: 4.21.0
 
-  vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0):
+  vite@7.3.5(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0):
     dependencies:
       esbuild: 0.27.4
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.8
+      postcss: 8.5.15
       rollup: 4.60.0
       tinyglobby: 0.2.15
     optionalDependencies:
@@ -15683,16 +15755,16 @@ snapshots:
       lightningcss: 1.32.0
       tsx: 4.21.0
 
-  vitest@3.2.4(@types/debug@4.1.13)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(lightningcss@1.32.0)(tsx@4.21.0):
+  vitest@3.2.7(@types/debug@4.1.13)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(lightningcss@1.32.0)(tsx@4.21.0):
     dependencies:
       '@types/chai': 5.2.3
-      '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))
-      '@vitest/pretty-format': 3.2.4
-      '@vitest/runner': 3.2.4
-      '@vitest/snapshot': 3.2.4
-      '@vitest/spy': 3.2.4
-      '@vitest/utils': 3.2.4
+      '@vitest/expect': 3.2.7
+      '@vitest/mocker': 3.2.7(vite@7.3.5(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))
+      '@vitest/pretty-format': 3.2.7
+      '@vitest/runner': 3.2.7
+      '@vitest/snapshot': 3.2.7
+      '@vitest/spy': 3.2.7
+      '@vitest/utils': 3.2.7
       chai: 5.3.3
       debug: 4.4.3
       expect-type: 1.3.0
@@ -15705,7 +15777,7 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
+      vite: 7.3.5(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
       vite-node: 3.2.4(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
@@ -15726,16 +15798,16 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@3.2.4(@types/debug@4.1.13)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.32.0)(tsx@4.21.0):
+  vitest@3.2.7(@types/debug@4.1.13)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.32.0)(tsx@4.21.0):
     dependencies:
       '@types/chai': 5.2.3
-      '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))
-      '@vitest/pretty-format': 3.2.4
-      '@vitest/runner': 3.2.4
-      '@vitest/snapshot': 3.2.4
-      '@vitest/spy': 3.2.4
-      '@vitest/utils': 3.2.4
+      '@vitest/expect': 3.2.7
+      '@vitest/mocker': 3.2.7(vite@7.3.5(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))
+      '@vitest/pretty-format': 3.2.7
+      '@vitest/runner': 3.2.7
+      '@vitest/snapshot': 3.2.7
+      '@vitest/spy': 3.2.7
+      '@vitest/utils': 3.2.7
       chai: 5.3.3
       debug: 4.4.3
       expect-type: 1.3.0
@@ -15748,7 +15820,7 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
+      vite: 7.3.5(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
       vite-node: 3.2.4(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
@@ -15769,16 +15841,16 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.5.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.32.0)(tsx@4.21.0):
+  vitest@3.2.7(@types/debug@4.1.13)(@types/node@25.5.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.32.0)(tsx@4.21.0):
     dependencies:
       '@types/chai': 5.2.3
-      '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))
-      '@vitest/pretty-format': 3.2.4
-      '@vitest/runner': 3.2.4
-      '@vitest/snapshot': 3.2.4
-      '@vitest/spy': 3.2.4
-      '@vitest/utils': 3.2.4
+      '@vitest/expect': 3.2.7
+      '@vitest/mocker': 3.2.7(vite@7.3.5(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))
+      '@vitest/pretty-format': 3.2.7
+      '@vitest/runner': 3.2.7
+      '@vitest/snapshot': 3.2.7
+      '@vitest/spy': 3.2.7
+      '@vitest/utils': 3.2.7
       chai: 5.3.3
       debug: 4.4.3
       expect-type: 1.3.0
@@ -15791,7 +15863,7 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
+      vite: 7.3.5(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
       vite-node: 3.2.4(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
@@ -15811,23 +15883,6 @@ snapshots:
       - terser
       - tsx
       - yaml
-
-  vscode-jsonrpc@8.2.0: {}
-
-  vscode-languageserver-protocol@3.17.5:
-    dependencies:
-      vscode-jsonrpc: 8.2.0
-      vscode-languageserver-types: 3.17.5
-
-  vscode-languageserver-textdocument@1.0.12: {}
-
-  vscode-languageserver-types@3.17.5: {}
-
-  vscode-languageserver@9.0.1:
-    dependencies:
-      vscode-languageserver-protocol: 3.17.5
-
-  vscode-uri@3.1.0: {}
 
   vue@3.5.34(typescript@5.9.3):
     dependencies:
@@ -15895,7 +15950,7 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  ws@8.20.0: {}
+  ws@8.21.0: {}
 
   wsl-utils@0.3.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,8 +7,27 @@ packages:
   - ui
   - cli
   - desktop
+# pnpm 11 reads security overrides here; package.json mirrors them for the
+# pnpm 9 version pinned by this repository and CI.
+overrides:
+  axios: 1.16.0
+  defu: 6.1.5
+  fast-uri: 3.1.2
+  fast-xml-builder: 1.1.7
+  fast-xml-parser: 5.7.0
+  form-data: 4.0.6
+  js-yaml: 4.2.0
+  lodash-es: 4.18.1
+  path-to-regexp: 8.4.2
+  protobufjs: 7.6.3
+  qs: 6.15.2
+  set-cookie-parser: 3.1.1
+  undici: 7.28.0
+  uuid: 11.1.1
 allowBuilds:
   '@embedded-postgres/darwin-arm64': true
+  # Hydrates the packaged PostgreSQL symlinks required by Linux CI/runtime.
+  '@embedded-postgres/linux-x64': true
   electron: true
   electron-winstaller: true
   es5-ext: true

--- a/scripts/public-install-inputs.mjs
+++ b/scripts/public-install-inputs.mjs
@@ -1,0 +1,38 @@
+const PACKAGE_NAME = "@rudderhq/cli";
+const APPROVED_DIST_TAGS = new Set(["latest", "canary"]);
+const EXACT_VERSION = /^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z]+(?:[.-][0-9A-Za-z]+)*)?$/;
+const OWNER = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/;
+const REPOSITORY = /^[A-Za-z0-9_.-]{1,100}$/;
+
+export function validatePublicInstallPackageSpec(value) {
+  const packageSpec = String(value ?? "");
+  const prefix = `${PACKAGE_NAME}@`;
+  if (!packageSpec.startsWith(prefix)) {
+    throw new Error(`Package spec must target ${PACKAGE_NAME} with an exact version or approved dist-tag.`);
+  }
+
+  const selector = packageSpec.slice(prefix.length);
+  if (!EXACT_VERSION.test(selector) && !APPROVED_DIST_TAGS.has(selector)) {
+    throw new Error(
+      `Invalid package selector. Use an exact semver or one of: ${[...APPROVED_DIST_TAGS].join(", ")}.`,
+    );
+  }
+
+  return packageSpec;
+}
+
+export function validatePublicInstallReleaseRepo(value) {
+  const repo = String(value ?? "");
+  const parts = repo.split("/");
+  if (
+    parts.length !== 2 ||
+    !OWNER.test(parts[0]) ||
+    !REPOSITORY.test(parts[1]) ||
+    parts[1] === "." ||
+    parts[1] === ".."
+  ) {
+    throw new Error("Release repository must use a valid owner/repository slug.");
+  }
+
+  return repo;
+}

--- a/scripts/release-public-install-inputs.test.mjs
+++ b/scripts/release-public-install-inputs.test.mjs
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import {
+  validatePublicInstallPackageSpec,
+  validatePublicInstallReleaseRepo,
+} from "./public-install-inputs.mjs";
+
+describe("public install smoke inputs", () => {
+  it.each([
+    "@rudderhq/cli@latest",
+    "@rudderhq/cli@canary",
+    "@rudderhq/cli@1.2.3",
+    "@rudderhq/cli@1.2.3-canary.4",
+  ])("accepts an approved package spec: %s", (value) => {
+    expect(validatePublicInstallPackageSpec(value)).toBe(value);
+  });
+
+  it.each([
+    "left-pad@latest",
+    "@rudderhq/cli@next",
+    "@rudderhq/cli@^1.2.3",
+    "@rudderhq/cli@latest & whoami",
+    "@rudderhq/cli@latest|whoami",
+  ])("rejects an unsafe package spec: %s", (value) => {
+    expect(() => validatePublicInstallPackageSpec(value)).toThrow();
+  });
+
+  it("accepts a GitHub owner/repository slug", () => {
+    expect(validatePublicInstallReleaseRepo("Undertone0809/rudder")).toBe(
+      "Undertone0809/rudder",
+    );
+  });
+
+  it.each([
+    "Undertone0809/rudder & whoami",
+    "Undertone0809/rudder|whoami",
+    "Undertone0809/rudder/extra",
+    "-invalid/rudder",
+  ])("rejects an unsafe repository slug: %s", (value) => {
+    expect(() => validatePublicInstallReleaseRepo(value)).toThrow();
+  });
+});

--- a/scripts/smoke-public-install.mjs
+++ b/scripts/smoke-public-install.mjs
@@ -4,10 +4,18 @@ import { existsSync, readFileSync, rmSync } from "node:fs";
 import { mkdir, mkdtemp } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import {
+  validatePublicInstallPackageSpec,
+  validatePublicInstallReleaseRepo,
+} from "./public-install-inputs.mjs";
 
 const args = process.argv.slice(2);
-let packageSpec = "@rudderhq/cli@latest";
-let repo = process.env.GITHUB_REPOSITORY || "Undertone0809/rudder";
+let packageSpec =
+  process.env.RUDDER_PUBLIC_INSTALL_PACKAGE_SPEC || "@rudderhq/cli@latest";
+let repo =
+  process.env.RUDDER_PUBLIC_INSTALL_RELEASE_REPO ||
+  process.env.GITHUB_REPOSITORY ||
+  "Undertone0809/rudder";
 let keepTemp = process.env.RUDDER_KEEP_PUBLIC_INSTALL_SMOKE_TEMP === "1";
 let timeoutMs = Number.parseInt(process.env.RUDDER_PUBLIC_INSTALL_SMOKE_TIMEOUT_MS ?? "1800000", 10);
 
@@ -29,7 +37,13 @@ for (let index = 0; index < args.length; index += 1) {
   }
 }
 
-if (!packageSpec || !repo) usage(1);
+try {
+  packageSpec = validatePublicInstallPackageSpec(packageSpec);
+  repo = validatePublicInstallReleaseRepo(repo);
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  usage(1);
+}
 if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) timeoutMs = 1800000;
 
 const tempRoot = await mkdtemp(path.join(os.tmpdir(), "rudder-public-install-smoke."));

--- a/server/package.json
+++ b/server/package.json
@@ -64,23 +64,23 @@
     "@rudderhq/shared": "workspace:*",
     "ajv": "^8.18.0",
     "ajv-formats": "^3.0.1",
-    "better-auth": "1.4.18",
+    "better-auth": "1.6.23",
     "chokidar": "^4.0.3",
     "detect-port": "^2.1.0",
-    "dompurify": "^3.3.3",
+    "dompurify": "^3.4.11",
     "dotenv": "^17.3.1",
-    "drizzle-orm": "^0.38.4",
+    "drizzle-orm": "^0.45.2",
     "embedded-postgres": "18.1.0-beta.16",
     "express": "^5.2.1",
     "hermes-paperclip-adapter": "0.3.0",
     "jsdom": "^28.1.0",
-    "multer": "^2.1.1",
+    "multer": "^2.2.0",
     "open": "^11.0.0",
     "pino": "^9.14.0",
     "pino-http": "^10.5.0",
     "pino-pretty": "^13.1.3",
     "sharp": "^0.34.5",
-    "ws": "^8.20.0",
+    "ws": "^8.21.0",
     "zod": "^3.25.76"
   },
   "devDependencies": {
@@ -97,6 +97,6 @@
     "tsx": "^4.21.0",
     "typescript": "^5.9.3",
     "vite": "^6.4.1",
-    "vitest": "^3.2.4"
+    "vitest": "^3.2.7"
   }
 }

--- a/server/src/__tests__/activity-log-langfuse.test.ts
+++ b/server/src/__tests__/activity-log-langfuse.test.ts
@@ -83,9 +83,11 @@ describe("activity log Langfuse export", () => {
     const runId = "11111111-1111-4111-8111-111111111111";
     const values = vi
       .fn()
-      .mockRejectedValueOnce(Object.assign(new Error("missing heartbeat run"), {
-        code: "23503",
-        constraint_name: "activity_log_run_id_heartbeat_runs_id_fk",
+      .mockRejectedValueOnce(Object.assign(new Error("Failed query"), {
+        cause: Object.assign(new Error("missing heartbeat run"), {
+          code: "23503",
+          constraint_name: "activity_log_run_id_heartbeat_runs_id_fk",
+        }),
       }))
       .mockResolvedValueOnce(undefined);
     const db = {

--- a/server/src/__tests__/activity-routes.test.ts
+++ b/server/src/__tests__/activity-routes.test.ts
@@ -124,6 +124,36 @@ describe("activity routes", () => {
     });
   });
 
+  it("rejects cross-organization activity creation", async () => {
+    const res = await request(createApp())
+      .post("/api/orgs/organization-2/activity")
+      .send({
+        actorType: "user",
+        actorId: "user-1",
+        action: "project.updated",
+        entityType: "project",
+        entityId: "project-2",
+      });
+
+    expect(res.status).toBe(403);
+    expect(mockActivityService.create).not.toHaveBeenCalled();
+  });
+
+  it("rejects activity actor injection from non-admin organization members", async () => {
+    const res = await request(createApp())
+      .post("/api/orgs/organization-1/activity")
+      .send({
+        actorType: "system",
+        actorId: "forged-system",
+        action: "agent.approved",
+        entityType: "agent",
+        entityId: "agent-1",
+      });
+
+    expect(res.status).toBe(403);
+    expect(mockActivityService.create).not.toHaveBeenCalled();
+  });
+
   it("passes user activity ledger filters to the service", async () => {
     mockActivityService.listUserActivityLedger.mockResolvedValue({
       items: [],

--- a/server/src/__tests__/agent-instructions-routes.test.ts
+++ b/server/src/__tests__/agent-instructions-routes.test.ts
@@ -64,17 +64,17 @@ vi.mock("../agent-runtimes/index.js", () => ({
   listAgentRuntimeModels: vi.fn(),
 }));
 
-function createApp() {
+function createApp(actor: Record<string, unknown> = {
+  type: "board",
+  userId: "local-board",
+  orgIds: ["organization-1"],
+  source: "local_implicit",
+  isInstanceAdmin: false,
+}) {
   const app = express();
   app.use(express.json());
   app.use((req, _res, next) => {
-    (req as any).actor = {
-      type: "board",
-      userId: "local-board",
-      orgIds: ["organization-1"],
-      source: "local_implicit",
-      isInstanceAdmin: false,
-    };
+    (req as any).actor = actor;
     next();
   });
   app.use("/api", agentRoutes({} as any));
@@ -159,6 +159,28 @@ describe("agent instructions bundle routes", () => {
       },
       agentRuntimeConfig: {},
       changed: false,
+    });
+    mockAgentInstructionsService.updateBundle.mockResolvedValue({
+      bundle: {
+        agentId: "11111111-1111-4111-8111-111111111111",
+        orgId: "organization-1",
+        mode: "external",
+        rootPath: "/srv/rudder-instructions",
+        managedRootPath: "/tmp/agent-1",
+        entryFile: "SOUL.md",
+        resolvedEntryPath: "/srv/rudder-instructions/SOUL.md",
+        editable: true,
+        warnings: [],
+        legacyPromptTemplateActive: false,
+        legacyBootstrapPromptTemplateActive: false,
+        files: [],
+      },
+      agentRuntimeConfig: {
+        instructionsBundleMode: "external",
+        instructionsRootPath: "/srv/rudder-instructions",
+        instructionsEntryFile: "SOUL.md",
+        instructionsFilePath: "/srv/rudder-instructions/SOUL.md",
+      },
     });
     mockAgentInstructionsService.readFile.mockResolvedValue({
       path: "SOUL.md",
@@ -269,6 +291,191 @@ describe("agent instructions bundle routes", () => {
     );
     expect(mockAgentInstructionsService.reconcileBundle).not.toHaveBeenCalled();
     expect(mockAgentService.update).not.toHaveBeenCalled();
+  });
+
+  it("keeps relative managed bundle file edits available to the owning agent", async () => {
+    const res = await request(createApp({
+      type: "agent",
+      agentId: "11111111-1111-4111-8111-111111111111",
+      orgId: "organization-1",
+      source: "agent_key",
+    }))
+      .put("/api/agents/11111111-1111-4111-8111-111111111111/instructions-bundle/file")
+      .send({
+        path: "SOUL.md",
+        content: "# Updated Agent\n",
+      });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockAgentInstructionsService.writeFile).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "11111111-1111-4111-8111-111111111111" }),
+      "SOUL.md",
+      "# Updated Agent\n",
+      expect.any(Object),
+    );
+  });
+
+  it("rejects agent-authenticated instructions path and bundle control-plane changes", async () => {
+    const actor = {
+      type: "agent",
+      agentId: "11111111-1111-4111-8111-111111111111",
+      orgId: "organization-1",
+      source: "agent_key",
+    };
+    const app = createApp(actor);
+
+    const pathRes = await request(app)
+      .patch("/api/agents/11111111-1111-4111-8111-111111111111/instructions-path")
+      .send({ path: "/etc/passwd" });
+    const bundleRes = await request(app)
+      .patch("/api/agents/11111111-1111-4111-8111-111111111111/instructions-bundle")
+      .send({ mode: "external", rootPath: "/etc" });
+
+    expect(pathRes.status).toBe(403);
+    expect(bundleRes.status).toBe(403);
+    expect(mockAgentService.update).not.toHaveBeenCalled();
+    expect(mockAgentInstructionsService.updateBundle).not.toHaveBeenCalled();
+  });
+
+  it("rejects host filesystem instruction settings from non-admin board members", async () => {
+    const app = createApp({
+      type: "board",
+      userId: "organization-member",
+      orgIds: ["organization-1"],
+      source: "session",
+      isInstanceAdmin: false,
+    });
+
+    const pathRes = await request(app)
+      .patch("/api/agents/11111111-1111-4111-8111-111111111111/instructions-path")
+      .send({ path: "/etc/passwd" });
+    const bundleRes = await request(app)
+      .patch("/api/agents/11111111-1111-4111-8111-111111111111/instructions-bundle")
+      .send({ mode: "external", rootPath: "/etc" });
+
+    expect(pathRes.status).toBe(403);
+    expect(bundleRes.status).toBe(403);
+    expect(mockAgentService.update).not.toHaveBeenCalled();
+    expect(mockAgentInstructionsService.updateBundle).not.toHaveBeenCalled();
+  });
+
+  it("rejects external instruction paths hidden in a generic runtime config patch", async () => {
+    const res = await request(createApp({
+      type: "board",
+      userId: "organization-member",
+      orgIds: ["organization-1"],
+      source: "session",
+      isInstanceAdmin: false,
+    }))
+      .patch("/api/agents/11111111-1111-4111-8111-111111111111")
+      .send({
+        agentRuntimeConfig: {
+          instructionsBundleMode: "external",
+          instructionsRootPath: "/etc",
+          instructionsFilePath: "/etc/passwd",
+        },
+      });
+
+    expect(res.status).toBe(403);
+    expect(mockAgentService.update).not.toHaveBeenCalled();
+  });
+
+  it("allows instance admins to configure host filesystem instruction settings", async () => {
+    const app = createApp({
+      type: "board",
+      userId: "instance-admin",
+      orgIds: [],
+      source: "session",
+      isInstanceAdmin: true,
+    });
+
+    const pathRes = await request(app)
+      .patch("/api/agents/11111111-1111-4111-8111-111111111111/instructions-path")
+      .send({ path: "/srv/rudder-instructions/SOUL.md" });
+    const bundleRes = await request(app)
+      .patch("/api/agents/11111111-1111-4111-8111-111111111111/instructions-bundle")
+      .send({ mode: "external", rootPath: "/srv/rudder-instructions" });
+
+    expect(pathRes.status, JSON.stringify(pathRes.body)).toBe(200);
+    expect(bundleRes.status, JSON.stringify(bundleRes.body)).toBe(200);
+    expect(mockAgentInstructionsService.updateBundle).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "11111111-1111-4111-8111-111111111111" }),
+      expect.objectContaining({ mode: "external", rootPath: "/srv/rudder-instructions" }),
+    );
+  });
+
+  it("rejects external bundle access from non-admin board members before touching the filesystem service", async () => {
+    mockAgentService.getInternalById.mockResolvedValue({
+      ...makeAgent(),
+      agentRuntimeConfig: {
+        instructionsBundleMode: "external",
+        instructionsRootPath: "/etc",
+        instructionsEntryFile: "passwd",
+        instructionsFilePath: "/etc/passwd",
+      },
+    });
+    const app = createApp({
+      type: "board",
+      userId: "organization-member",
+      orgIds: ["organization-1"],
+      source: "session",
+      isInstanceAdmin: false,
+    });
+
+    const bundleRes = await request(app)
+      .get("/api/agents/11111111-1111-4111-8111-111111111111/instructions-bundle?orgId=organization-1");
+    const readRes = await request(app)
+      .get("/api/agents/11111111-1111-4111-8111-111111111111/instructions-bundle/file?orgId=organization-1&path=passwd");
+    const writeRes = await request(app)
+      .put("/api/agents/11111111-1111-4111-8111-111111111111/instructions-bundle/file")
+      .send({ path: "passwd", content: "blocked" });
+    const deleteRes = await request(app)
+      .delete("/api/agents/11111111-1111-4111-8111-111111111111/instructions-bundle/file?path=passwd");
+
+    expect([bundleRes.status, readRes.status, writeRes.status, deleteRes.status]).toEqual([
+      403,
+      403,
+      403,
+      403,
+    ]);
+    expect(mockAgentInstructionsService.getBundle).not.toHaveBeenCalled();
+    expect(mockAgentInstructionsService.readFile).not.toHaveBeenCalled();
+    expect(mockAgentInstructionsService.writeFile).not.toHaveBeenCalled();
+    expect(mockAgentInstructionsService.deleteFile).not.toHaveBeenCalled();
+  });
+
+  it("allows instance admins to access files in an existing external bundle", async () => {
+    mockAgentService.getInternalById.mockResolvedValue({
+      ...makeAgent(),
+      agentRuntimeConfig: {
+        instructionsBundleMode: "external",
+        instructionsRootPath: "/srv/rudder-instructions",
+        instructionsEntryFile: "SOUL.md",
+        instructionsFilePath: "/srv/rudder-instructions/SOUL.md",
+      },
+    });
+    const app = createApp({
+      type: "board",
+      userId: "instance-admin",
+      orgIds: [],
+      source: "session",
+      isInstanceAdmin: true,
+    });
+
+    const readRes = await request(app)
+      .get("/api/agents/11111111-1111-4111-8111-111111111111/instructions-bundle/file?path=SOUL.md");
+    const writeRes = await request(app)
+      .put("/api/agents/11111111-1111-4111-8111-111111111111/instructions-bundle/file")
+      .send({ path: "SOUL.md", content: "# Updated Agent\n" });
+    const deleteRes = await request(app)
+      .delete("/api/agents/11111111-1111-4111-8111-111111111111/instructions-bundle/file?path=docs%2FTOOLS.md");
+
+    expect(readRes.status, JSON.stringify(readRes.body)).toBe(200);
+    expect(writeRes.status, JSON.stringify(writeRes.body)).toBe(200);
+    expect(deleteRes.status, JSON.stringify(deleteRes.body)).toBe(200);
+    expect(mockAgentInstructionsService.readFile).toHaveBeenCalled();
+    expect(mockAgentInstructionsService.writeFile).toHaveBeenCalled();
+    expect(mockAgentInstructionsService.deleteFile).toHaveBeenCalled();
   });
 
   it("writes a bundle file and persists compatibility config", async () => {

--- a/server/src/__tests__/agent-instructions-service.test.ts
+++ b/server/src/__tests__/agent-instructions-service.test.ts
@@ -192,6 +192,21 @@ describe("agent instructions service", () => {
     await expect(fs.readFile(path.join(externalRoot, "docs", "AGENTS.md"), "utf8")).resolves.toBe("# Managed Agent\n");
   });
 
+  it("rejects relative external instruction roots", async () => {
+    const paperclipHome = await makeTempDir("rudder-agent-instructions-relative-external-");
+    cleanupDirs.add(paperclipHome);
+    process.env.RUDDER_HOME = paperclipHome;
+    process.env.RUDDER_INSTANCE_ID = "test-instance";
+
+    const svc = agentInstructionsService();
+    const agent = makeAgent({});
+
+    await expect(svc.updateBundle(agent, {
+      mode: "external",
+      rootPath: "relative/instructions",
+    })).rejects.toThrow("External instructions bundles require an absolute rootPath");
+  });
+
   it("filters junk files, dependency bundles, and python caches from bundle listings and exports", async () => {
     const externalRoot = await makeTempDir("rudder-agent-instructions-ignore-");
     cleanupDirs.add(externalRoot);
@@ -660,5 +675,37 @@ describe("agent instructions service", () => {
     expect(bundle.files).toEqual([]);
     await expect(fs.readFile(path.join(managedRoot, "AGENTS.md"), "utf8")).rejects.toMatchObject({ code: "ENOENT" });
     await expect(fs.readFile(path.join(legacyRoot, "AGENTS.md"), "utf8")).resolves.toBe("# Legacy Agent\n");
+  });
+
+  it("rejects instruction file reads and writes through symbolic links", async () => {
+    if (process.platform === "win32") return;
+
+    const paperclipHome = await makeTempDir("rudder-agent-instructions-symlink-home-");
+    const externalRoot = await makeTempDir("rudder-agent-instructions-symlink-root-");
+    const outsideRoot = await makeTempDir("rudder-agent-instructions-symlink-outside-");
+    cleanupDirs.add(paperclipHome);
+    cleanupDirs.add(externalRoot);
+    cleanupDirs.add(outsideRoot);
+    process.env.RUDDER_HOME = paperclipHome;
+    process.env.RUDDER_INSTANCE_ID = "test-instance";
+
+    const outsideFile = path.join(outsideRoot, "secret.md");
+    await fs.writeFile(outsideFile, "host secret\n", "utf8");
+    await fs.symlink(outsideFile, path.join(externalRoot, "escape.md"));
+    await fs.symlink(outsideRoot, path.join(externalRoot, "escape-dir"), "dir");
+
+    const svc = agentInstructionsService();
+    const agent = makeAgent({
+      instructionsBundleMode: "external",
+      instructionsRootPath: externalRoot,
+      instructionsEntryFile: "SOUL.md",
+      instructionsFilePath: path.join(externalRoot, "SOUL.md"),
+    });
+
+    await expect(svc.readFile(agent, "escape.md")).rejects.toThrow("cannot traverse symbolic links");
+    await expect(svc.writeFile(agent, "escape-dir/created.md", "escaped\n"))
+      .rejects.toThrow("cannot traverse symbolic links");
+    await expect(fs.readFile(outsideFile, "utf8")).resolves.toBe("host secret\n");
+    await expect(fs.stat(path.join(outsideRoot, "created.md"))).rejects.toMatchObject({ code: "ENOENT" });
   });
 });

--- a/server/src/__tests__/agent-integration-feishu-title-dispatcher.test.ts
+++ b/server/src/__tests__/agent-integration-feishu-title-dispatcher.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockDb = vi.hoisted(() => ({
-  existingBinding: null as { conversationId: string } | null,
+  existingBinding: null as { conversationId: string; createdAt: Date } | null,
   select: vi.fn(),
   insert: vi.fn(),
 }));
@@ -28,13 +28,22 @@ vi.mock("@rudderhq/db", () => ({
   agentIntegrationOutboundMessages: {},
   agentIntegrationUserBindings: {},
   agentIntegrations: {},
-  chatConversations: {},
+  chatConversations: {
+    id: "id",
+    createdAt: "created_at",
+  },
+  chatGenerations: {
+    id: "id",
+    conversationId: "conversation_id",
+    status: "status",
+  },
   organizationMemberships: {},
 }));
 
 vi.mock("drizzle-orm", () => ({
   and: vi.fn(() => ({})),
   eq: vi.fn(() => ({})),
+  inArray: vi.fn(() => ({})),
   isNull: vi.fn(() => ({})),
   or: vi.fn(() => ({})),
 }));
@@ -68,12 +77,23 @@ const insertNewBinding = {
   values: vi.fn(() => returningNewBinding),
 };
 
-function selectExistingBinding() {
-  return {
-    from: vi.fn(() => ({
-      where: vi.fn(async () => (mockDb.existingBinding ? [mockDb.existingBinding] : [])),
-    })),
+function selectRows(rows: unknown[]) {
+  const query = {
+    from: vi.fn(() => query),
+    innerJoin: vi.fn(() => query),
+    where: vi.fn(() => query),
+    limit: vi.fn(() => query),
+    then: (
+      resolve: (value: unknown[]) => unknown,
+      reject: (reason: unknown) => unknown,
+    ) => Promise.resolve(rows).then(resolve, reject),
   };
+  return query;
+}
+
+function selectExistingBinding(fields: Record<string, unknown>) {
+  const isBindingLookup = Object.prototype.hasOwnProperty.call(fields, "conversationId");
+  return selectRows(isBindingLookup && mockDb.existingBinding ? [mockDb.existingBinding] : []);
 }
 
 function integration() {
@@ -166,7 +186,7 @@ describe("Feishu DB dispatcher chat title generation", () => {
     const { createFeishuInboundDispatcherDbDeps } = await import(
       "../services/integrations/feishu/inbound-dispatcher-db.js"
     );
-    mockDb.existingBinding = { conversationId: "conversation-1" };
+    mockDb.existingBinding = { conversationId: "conversation-1", createdAt: new Date() };
     const deps = createFeishuInboundDispatcherDbDeps(mockDb as never, {
       enqueueAgentRun: false,
       createOutboundPlaceholder: false,
@@ -180,7 +200,7 @@ describe("Feishu DB dispatcher chat title generation", () => {
       commandBody: "and what else?",
     }));
 
-    expect(chat).toEqual({ conversationId: "conversation-1" });
+    expect(chat).toMatchObject({ conversationId: "conversation-1" });
     expect(mockStartAutomaticGeneration).toHaveBeenCalledWith(
       expect.objectContaining({ id: "conversation-1" }),
       expect.objectContaining({ id: "message-row-1" }),

--- a/server/src/__tests__/agent-lifecycle-service.test.ts
+++ b/server/src/__tests__/agent-lifecycle-service.test.ts
@@ -1,0 +1,79 @@
+import type { Db } from "@rudderhq/db";
+import { describe, expect, it, vi } from "vitest";
+import { agentService } from "../services/agents.js";
+
+const agentId = "11111111-1111-4111-8111-111111111111";
+
+function createPendingApprovalFixture() {
+  const pendingAgent = {
+    id: agentId,
+    orgId: "22222222-2222-4222-8222-222222222222",
+    name: "Pending Builder",
+    role: "engineer",
+    status: "pending_approval",
+    permissions: { canCreateAgents: false, canManageSkills: false },
+    metadata: null,
+    workspaceKey: "pending-builder",
+    spentMonthlyCents: 0,
+  };
+  const update = vi.fn();
+  const insert = vi.fn();
+  const db = {
+    select: vi.fn((selection?: unknown) => {
+      if (selection === undefined) {
+        return {
+          from: () => ({
+            where: () => Promise.resolve([pendingAgent]),
+          }),
+        };
+      }
+      return {
+        from: () => ({
+          where: () => ({
+            groupBy: () => Promise.resolve([]),
+          }),
+        }),
+      };
+    }),
+    update,
+    insert,
+  };
+
+  return {
+    service: agentService(db as unknown as Db),
+    update,
+    insert,
+  };
+}
+
+describe("agent pending-approval lifecycle guards", () => {
+  it("rejects pausing an agent that still requires approval", async () => {
+    const { service, update } = createPendingApprovalFixture();
+
+    await expect(service.pause(agentId)).rejects.toMatchObject({
+      status: 409,
+      message: "Pending approval agents cannot be paused",
+    });
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it("continues to reject resuming an agent that still requires approval", async () => {
+    const { service, update } = createPendingApprovalFixture();
+
+    await expect(service.resume(agentId)).rejects.toMatchObject({
+      status: 409,
+      message: "Pending approval agents cannot be resumed",
+    });
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it("continues to reject API-key creation until the agent is approved", async () => {
+    const { service, insert } = createPendingApprovalFixture();
+
+    await expect(service.createApiKey(agentId, "default")).rejects.toMatchObject({
+      status: 409,
+      message: "Cannot create keys for pending approval agents",
+    });
+    expect(insert).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/__tests__/agent-permissions-routes.test.ts
+++ b/server/src/__tests__/agent-permissions-routes.test.ts
@@ -43,8 +43,16 @@ const mockAgentService = vi.hoisted(() => ({
   update: vi.fn(),
   updatePermissions: vi.fn(),
   getChainOfCommand: vi.fn(),
+  getConfigRevision: vi.fn(),
+  rollbackConfigRevision: vi.fn(),
   resolveByReference: vi.fn(),
+  pause: vi.fn(),
   resume: vi.fn(),
+  terminate: vi.fn(),
+  remove: vi.fn(),
+  listKeys: vi.fn(),
+  createApiKey: vi.fn(),
+  revokeKey: vi.fn(),
 }));
 
 const mockAccessService = vi.hoisted(() => ({
@@ -101,6 +109,7 @@ const mockCustomIntegrationService = vi.hoisted(() => ({
   recordToolCall: vi.fn(),
 }));
 const mockCompanySkillService = vi.hoisted(() => ({
+  hasLocalPathSkills: vi.fn(),
   listRuntimeSkillEntries: vi.fn(),
   resolveRequestedSkillKeys: vi.fn(),
   resolveDesiredSkillSelectionForAgent: vi.fn(),
@@ -110,6 +119,12 @@ const mockCompanySkillService = vi.hoisted(() => ({
 }));
 const mockWorkspaceOperationService = vi.hoisted(() => ({}));
 const mockLogActivity = vi.hoisted(() => vi.fn());
+const mockRunClaudeLogin = vi.hoisted(() => vi.fn());
+
+vi.mock("@rudderhq/agent-runtime-claude-local/server", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@rudderhq/agent-runtime-claude-local/server")>()),
+  runClaudeLogin: mockRunClaudeLogin,
+}));
 
 vi.mock("../services/index.js", () => ({
   agentService: () => mockAgentService,
@@ -188,6 +203,7 @@ describe("agent permission routes", () => {
     mockAgentService.getById.mockResolvedValue(baseAgent);
     mockAgentService.getInternalById.mockResolvedValue(null);
     mockAgentService.getChainOfCommand.mockResolvedValue([]);
+    mockAgentService.getConfigRevision.mockResolvedValue(null);
     mockAgentService.resolveByReference.mockResolvedValue({ ambiguous: false, agent: baseAgent });
     mockAgentService.create.mockResolvedValue(baseAgent);
     mockAgentService.resume.mockResolvedValue(baseAgent);
@@ -205,6 +221,7 @@ describe("agent permission routes", () => {
     mockAccessService.listPrincipalGrants.mockResolvedValue([]);
     mockAccessService.ensureMembership.mockResolvedValue(undefined);
     mockAccessService.setPrincipalPermission.mockResolvedValue(undefined);
+    mockCompanySkillService.hasLocalPathSkills.mockResolvedValue(false);
     mockCompanySkillService.listRuntimeSkillEntries.mockResolvedValue([]);
     mockCompanySkillService.resolveRequestedSkillKeys.mockImplementation(async (_companyId, requested) => requested);
     mockCompanySkillService.replaceEnabledSkillKeysForAgent.mockResolvedValue(undefined);
@@ -252,7 +269,77 @@ describe("agent permission routes", () => {
     });
     mockSecretService.normalizeAdapterConfigForPersistence.mockImplementation(async (_companyId, config) => config);
     mockSecretService.resolveAdapterConfigForRuntime.mockImplementation(async (_companyId, config) => ({ config }));
+    mockRunClaudeLogin.mockResolvedValue({ status: "completed" });
     mockLogActivity.mockResolvedValue(undefined);
+  });
+
+  it("restricts Claude login to instance admins before loading an agent", async () => {
+    const res = await request(createApp({
+      type: "board",
+      userId: "organization-member",
+      source: "session",
+      isInstanceAdmin: false,
+      orgIds: [orgId],
+    })).post(`/api/agents/${agentId}/claude-login`);
+
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ error: "Instance admin access required" });
+    expect(mockAgentService.getById).not.toHaveBeenCalled();
+    expect(mockSecretService.resolveAdapterConfigForRuntime).not.toHaveBeenCalled();
+    expect(mockRunClaudeLogin).not.toHaveBeenCalled();
+  });
+
+  it.each(["pending_approval", "terminated"])(
+    "rejects %s agents before resolving Claude runtime configuration",
+    async (status) => {
+      mockAgentService.getById.mockResolvedValue({
+        ...baseAgent,
+        status,
+        agentRuntimeType: "claude_local",
+        agentRuntimeConfig: {
+          command: "sh -lc 'touch /tmp/rudder-claude-login-rce'",
+        },
+      });
+
+      const res = await request(createApp({
+        type: "board",
+        userId: "instance-admin",
+        source: "session",
+        isInstanceAdmin: true,
+        orgIds: [orgId],
+      })).post(`/api/agents/${agentId}/claude-login`);
+
+      expect(res.status).toBe(409);
+      expect(res.body.error).toContain(status);
+      expect(mockSecretService.resolveAdapterConfigForRuntime).not.toHaveBeenCalled();
+      expect(mockRunClaudeLogin).not.toHaveBeenCalled();
+    },
+  );
+
+  it("allows an instance admin to run Claude login for an approved active agent", async () => {
+    mockAgentService.getById.mockResolvedValue({
+      ...baseAgent,
+      status: "idle",
+      agentRuntimeType: "claude_local",
+      agentRuntimeConfig: { command: "claude" },
+    });
+    mockSecretService.resolveAdapterConfigForRuntime.mockResolvedValue({
+      config: { command: "/trusted/claude" },
+    });
+
+    const res = await request(createApp({
+      type: "board",
+      userId: "instance-admin",
+      source: "session",
+      isInstanceAdmin: true,
+      orgIds: [orgId],
+    })).post(`/api/agents/${agentId}/claude-login`);
+
+    expect(res.status).toBe(200);
+    expect(mockRunClaudeLogin).toHaveBeenCalledWith(expect.objectContaining({
+      agent: expect.objectContaining({ id: agentId, orgId }),
+      config: { command: "/trusted/claude" },
+    }));
   });
 
   it("replays deferred paused wakeups when an agent is resumed", async () => {
@@ -381,6 +468,50 @@ describe("agent permission routes", () => {
     );
   });
 
+  it("rejects host filesystem instruction paths when a non-admin board member creates an agent", async () => {
+    const app = createApp({
+      type: "board",
+      userId: "organization-member",
+      source: "session",
+      isInstanceAdmin: false,
+      orgIds: [orgId],
+    });
+
+    const res = await request(app)
+      .post(`/api/orgs/${orgId}/agents`)
+      .send({
+        name: "Unsafe Builder",
+        role: "engineer",
+        agentRuntimeType: "process",
+        agentRuntimeConfig: {
+          instructionsFilePath: "/etc/passwd",
+        },
+      });
+
+    expect(res.status).toBe(403);
+    expect(mockAgentService.create).not.toHaveBeenCalled();
+  });
+
+  it("rejects explicit non-default runtimes when a non-admin board member directly creates an agent", async () => {
+    const res = await request(createApp({
+      type: "board",
+      userId: "organization-member",
+      source: "session",
+      isInstanceAdmin: false,
+      orgIds: [orgId],
+    }))
+      .post(`/api/orgs/${orgId}/agents`)
+      .send({
+        name: "Configured Builder",
+        role: "engineer",
+        agentRuntimeType: "codex_local",
+        agentRuntimeConfig: {},
+      });
+
+    expect(res.status).toBe(403);
+    expect(mockAgentService.create).not.toHaveBeenCalled();
+  });
+
   it("exposes explicit task assignment access on agent detail", async () => {
     mockAccessService.listPrincipalGrants.mockResolvedValue([
       {
@@ -475,11 +606,7 @@ describe("agent permission routes", () => {
 
     expect(res.status).toBe(200);
     expect(res.body.instructionsLibraryPath).toBeNull();
-    expect(mockAgentInstructionsService.getBundle).toHaveBeenCalledWith(expect.objectContaining({
-      agentRuntimeConfig: expect.objectContaining({
-        instructionsFilePath: "/tmp/external-agent-instructions/AGENTS.md",
-      }),
-    }));
+    expect(mockAgentInstructionsService.getBundle).not.toHaveBeenCalled();
   });
 
   it("does not let a legacy agents:create grant bypass an explicit agent creation denial", async () => {
@@ -506,6 +633,244 @@ describe("agent permission routes", () => {
     expect(res.body).toEqual({ error: "Missing permission: can create agents" });
     expect(mockAccessService.hasPermission).not.toHaveBeenCalled();
     expect(mockAgentService.create).not.toHaveBeenCalled();
+  });
+
+  it("keeps agent-initiated hires pending even when the organization normally skips approval", async () => {
+    const creator = {
+      ...baseAgent,
+      permissions: { canCreateAgents: true, canManageSkills: true },
+    };
+    mockAgentService.getById.mockResolvedValue(creator);
+    mockAgentService.create.mockImplementation(async (_orgId: string, input: Record<string, unknown>) => ({
+      ...baseAgent,
+      ...input,
+      id: peerAgentId,
+      orgId,
+      agentRuntimeConfig: input.agentRuntimeConfig ?? {},
+      runtimeConfig: input.runtimeConfig ?? {},
+    }));
+    mockApprovalService.create.mockResolvedValue({
+      id: "77777777-7777-4777-8777-777777777777",
+      orgId,
+      type: "hire_agent",
+      status: "pending",
+      payload: {},
+    });
+
+    const res = await request(createApp({
+      type: "agent",
+      agentId,
+      orgId,
+      runId: "run-1",
+    }))
+      .post(`/api/orgs/${orgId}/agent-hires`)
+      .send({
+        name: "Pending Spawn",
+        role: "general",
+        agentRuntimeType: "process",
+        agentRuntimeConfig: {},
+        runtimeConfig: {},
+      });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+    expect(mockAgentService.create).toHaveBeenCalledWith(
+      orgId,
+      expect.objectContaining({ status: "pending_approval" }),
+    );
+    expect(mockApprovalService.create).toHaveBeenCalled();
+  });
+
+  it("keeps configured hires from non-admin board members pending for privileged approval", async () => {
+    mockAccessService.canUser.mockResolvedValue(true);
+    mockAgentService.create.mockImplementation(async (_orgId: string, input: Record<string, unknown>) => ({
+      ...baseAgent,
+      ...input,
+      id: peerAgentId,
+      orgId,
+      agentRuntimeConfig: input.agentRuntimeConfig ?? {},
+      runtimeConfig: input.runtimeConfig ?? {},
+    }));
+    mockApprovalService.create.mockResolvedValue({
+      id: "77777777-7777-4777-8777-777777777777",
+      orgId,
+      type: "hire_agent",
+      status: "pending",
+      payload: {},
+    });
+
+    const res = await request(createApp({
+      type: "board",
+      userId: "organization-member",
+      orgIds: [orgId],
+      source: "session",
+      isInstanceAdmin: false,
+    }))
+      .post(`/api/orgs/${orgId}/agent-hires`)
+      .send({
+        name: "Configured Spawn",
+        role: "general",
+        agentRuntimeType: "process",
+        agentRuntimeConfig: { command: "sh -lc 'touch /tmp/rudder-hire-rce'" },
+        runtimeConfig: {},
+      });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+    expect(mockAgentService.create).toHaveBeenCalledWith(
+      orgId,
+      expect.objectContaining({ status: "pending_approval" }),
+    );
+    expect(mockApprovalService.create).toHaveBeenCalled();
+  });
+
+  it("allows agent-authenticated profile edits but blocks runtime control-plane fields", async () => {
+    mockAgentService.getInternalById.mockResolvedValue(baseAgent);
+    mockAgentService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...baseAgent,
+      ...patch,
+    }));
+    const actor = {
+      type: "agent",
+      agentId,
+      orgId,
+      runId: "run-1",
+    };
+
+    const profileRes = await request(createApp(actor))
+      .patch(`/api/agents/${agentId}`)
+      .send({ title: "Updated Builder" });
+    expect(profileRes.status, JSON.stringify(profileRes.body)).toBe(200);
+    expect(mockAgentService.update).toHaveBeenCalledWith(
+      agentId,
+      expect.objectContaining({ title: "Updated Builder" }),
+      expect.any(Object),
+    );
+
+    mockAgentService.update.mockClear();
+    const runtimeRes = await request(createApp(actor))
+      .patch(`/api/agents/${agentId}`)
+      .send({
+        agentRuntimeConfig: {
+          workspaceRuntime: {
+            services: [{ name: "host-command", command: "touch /tmp/rudder-rce" }],
+          },
+        },
+      });
+    expect(runtimeRes.status).toBe(403);
+    expect(runtimeRes.body.error).toContain("blocked fields: agentRuntimeConfig");
+    expect(mockAgentService.update).not.toHaveBeenCalled();
+  });
+
+  it("rejects config revision rollback with agent authentication", async () => {
+    const res = await request(createApp({
+      type: "agent",
+      agentId,
+      orgId,
+      runId: "run-1",
+    })).post(`/api/agents/${agentId}/config-revisions/77777777-7777-4777-8777-777777777777/rollback`);
+
+    expect(res.status).toBe(403);
+    expect(mockAgentService.rollbackConfigRevision).not.toHaveBeenCalled();
+  });
+
+  it("rejects cross-organization lifecycle and API key mutations", async () => {
+    const app = createApp({
+      type: "board",
+      userId: "other-organization-member",
+      orgIds: ["99999999-9999-4999-8999-999999999999"],
+      source: "session",
+      isInstanceAdmin: false,
+    });
+
+    const responses = await Promise.all([
+      request(app).post(`/api/agents/${agentId}/pause`),
+      request(app).post(`/api/agents/${agentId}/resume`),
+      request(app).post(`/api/agents/${agentId}/terminate`),
+      request(app).delete(`/api/agents/${agentId}`),
+      request(app).get(`/api/agents/${agentId}/keys`),
+      request(app).post(`/api/agents/${agentId}/keys`).send({ name: "stolen" }),
+      request(app).delete(`/api/agents/${agentId}/keys/key-from-another-agent`),
+    ]);
+
+    expect(responses.map((response) => response.status)).toEqual([403, 403, 403, 403, 403, 403, 403]);
+    expect(mockAgentService.pause).not.toHaveBeenCalled();
+    expect(mockAgentService.resume).not.toHaveBeenCalled();
+    expect(mockAgentService.terminate).not.toHaveBeenCalled();
+    expect(mockAgentService.remove).not.toHaveBeenCalled();
+    expect(mockAgentService.listKeys).not.toHaveBeenCalled();
+    expect(mockAgentService.createApiKey).not.toHaveBeenCalled();
+    expect(mockAgentService.revokeKey).not.toHaveBeenCalled();
+  });
+
+  it("does not revoke an API key through a different agent path", async () => {
+    mockAgentService.listKeys.mockResolvedValue([{ id: "owned-key", name: "default" }]);
+    const res = await request(createApp({
+      type: "board",
+      userId: "organization-member",
+      orgIds: [orgId],
+      source: "session",
+      isInstanceAdmin: false,
+    })).delete(`/api/agents/${agentId}/keys/key-from-another-agent`);
+
+    expect(res.status).toBe(404);
+    expect(mockAgentService.revokeKey).not.toHaveBeenCalled();
+  });
+
+  it("requires instance-admin authority to roll back to external instruction config", async () => {
+    mockAgentService.getConfigRevision.mockResolvedValue({
+      id: "77777777-7777-4777-8777-777777777777",
+      afterConfig: {
+        name: "Builder",
+        agentRuntimeConfig: {
+          instructionsBundleMode: "external",
+          instructionsRootPath: "/etc",
+          instructionsFilePath: "/etc/passwd",
+        },
+      },
+    });
+
+    const res = await request(createApp({
+      type: "board",
+      userId: "organization-member",
+      orgIds: [orgId],
+      source: "session",
+      isInstanceAdmin: false,
+    })).post(`/api/agents/${agentId}/config-revisions/77777777-7777-4777-8777-777777777777/rollback`);
+
+    expect(res.status).toBe(403);
+    expect(mockAgentService.rollbackConfigRevision).not.toHaveBeenCalled();
+  });
+
+  it("allows instance admins to roll back to external instruction config", async () => {
+    mockAgentService.getConfigRevision.mockResolvedValue({
+      id: "77777777-7777-4777-8777-777777777777",
+      afterConfig: {
+        name: "Builder",
+        agentRuntimeConfig: {
+          instructionsBundleMode: "external",
+          instructionsRootPath: "/srv/rudder-instructions",
+          instructionsFilePath: "/srv/rudder-instructions/SOUL.md",
+        },
+      },
+    });
+    mockAgentService.rollbackConfigRevision.mockResolvedValue({
+      ...baseAgent,
+      agentRuntimeConfig: {
+        instructionsBundleMode: "external",
+        instructionsRootPath: "/srv/rudder-instructions",
+        instructionsFilePath: "/srv/rudder-instructions/SOUL.md",
+      },
+    });
+
+    const res = await request(createApp({
+      type: "board",
+      userId: "instance-admin",
+      orgIds: [],
+      source: "session",
+      isInstanceAdmin: true,
+    })).post(`/api/agents/${agentId}/config-revisions/77777777-7777-4777-8777-777777777777/rollback`);
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockAgentService.rollbackConfigRevision).toHaveBeenCalled();
   });
 
   it("does not let a legacy agents:create grant expose agent configurations after explicit denial", async () => {

--- a/server/src/__tests__/agent-private-skills-routes.test.ts
+++ b/server/src/__tests__/agent-private-skills-routes.test.ts
@@ -24,11 +24,13 @@ const mockAccessService = vi.hoisted(() => ({
 }));
 
 const mockOrganizationSkillService = vi.hoisted(() => ({
+  hasLocalPathSkills: vi.fn(),
   buildAgentSkillSnapshot: vi.fn(),
   createAgentPrivateSkill: vi.fn(),
   resolveDesiredSkillSelectionForAgent: vi.fn(),
   replaceEnabledSkillKeysForAgent: vi.fn(),
   getEnabledSkillKeysForAgent: vi.fn(),
+  addEnabledSkillKeysForAgent: vi.fn(),
   listRuntimeSkillEntries: vi.fn(),
 }));
 
@@ -38,6 +40,8 @@ const mockSecretService = vi.hoisted(() => ({
 }));
 
 const mockLogActivity = vi.hoisted(() => vi.fn());
+const mockAdapterTestEnvironment = vi.hoisted(() => vi.fn());
+const mockFindServerAdapter = vi.hoisted(() => vi.fn());
 
 vi.mock("../services/index.js", () => ({
   agentService: () => mockAgentService,
@@ -72,7 +76,7 @@ vi.mock("../services/index.js", () => ({
 }));
 
 vi.mock("../agent-runtimes/index.js", () => ({
-  findServerAdapter: vi.fn(() => null),
+  findServerAdapter: mockFindServerAdapter,
   listAgentRuntimeModels: vi.fn(),
 }));
 
@@ -112,6 +116,15 @@ describe("agent private skill routes", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockSecretService.resolveAdapterConfigForRuntime.mockResolvedValue({ config: { env: {} } });
+    mockOrganizationSkillService.hasLocalPathSkills.mockResolvedValue(false);
+    mockFindServerAdapter.mockReturnValue({
+      testEnvironment: mockAdapterTestEnvironment,
+    });
+    mockAdapterTestEnvironment.mockResolvedValue({
+      status: "pass",
+      agentRuntimeType: "opencode_local",
+      checks: [],
+    });
     mockOrganizationSkillService.buildAgentSkillSnapshot.mockResolvedValue({
       agentRuntimeType: "codex_local",
       supported: true,
@@ -155,7 +168,73 @@ describe("agent private skill routes", () => {
     expect(mockOrganizationSkillService.buildAgentSkillSnapshot).toHaveBeenCalled();
   });
 
-  it("allows an agent to create a private skill for itself", async () => {
+  it("blocks agents and ordinary board members from snapshots when local organization skills exist", async () => {
+    mockAgentService.getById.mockResolvedValue(makeAgent(agentId));
+    mockOrganizationSkillService.hasLocalPathSkills.mockResolvedValue(true);
+    const agentApp = createApp({
+      type: "agent",
+      agentId,
+      orgId,
+      runId: "run-1",
+    });
+    const boardApp = createApp({
+      type: "board",
+      userId: "user-1",
+      orgIds: [orgId],
+      source: "session",
+      isInstanceAdmin: false,
+    });
+
+    const agentRes = await request(agentApp).get(`/api/agents/${agentId}/skills`);
+    const boardRes = await request(boardApp).get(`/api/agents/${agentId}/skills`);
+
+    expect(agentRes.status, JSON.stringify(agentRes.body)).toBe(403);
+    expect(boardRes.status, JSON.stringify(boardRes.body)).toBe(403);
+    expect(mockSecretService.resolveAdapterConfigForRuntime).toHaveBeenCalledTimes(2);
+    expect(mockOrganizationSkillService.buildAgentSkillSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("blocks non-admin enabled-skill mutations before local catalog resolution", async () => {
+    mockAgentService.getById.mockResolvedValue(makeAgent(agentId));
+    mockOrganizationSkillService.hasLocalPathSkills.mockResolvedValue(true);
+    const app = createApp({
+      type: "agent",
+      agentId,
+      orgId,
+      runId: "run-1",
+    });
+
+    const syncRes = await request(app)
+      .post(`/api/agents/${agentId}/skills/sync`)
+      .send({ desiredSkills: ["org:linked-skill"] });
+    const enableRes = await request(app)
+      .post(`/api/agents/${agentId}/skills/enable`)
+      .send({ skills: ["org:linked-skill"] });
+
+    expect(syncRes.status, JSON.stringify(syncRes.body)).toBe(403);
+    expect(enableRes.status, JSON.stringify(enableRes.body)).toBe(403);
+    expect(mockOrganizationSkillService.resolveDesiredSkillSelectionForAgent).not.toHaveBeenCalled();
+    expect(mockOrganizationSkillService.replaceEnabledSkillKeysForAgent).not.toHaveBeenCalled();
+    expect(mockOrganizationSkillService.addEnabledSkillKeysForAgent).not.toHaveBeenCalled();
+  });
+
+  it("allows instance admins to inspect agents with local organization skills", async () => {
+    mockAgentService.getById.mockResolvedValue(makeAgent(agentId));
+    mockOrganizationSkillService.hasLocalPathSkills.mockResolvedValue(true);
+
+    const res = await request(createApp({
+      type: "board",
+      userId: "admin-1",
+      orgIds: [],
+      source: "session",
+      isInstanceAdmin: true,
+    })).get(`/api/agents/${agentId}/skills`);
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockOrganizationSkillService.buildAgentSkillSnapshot).toHaveBeenCalled();
+  });
+
+  it("blocks agents from creating a private skill through a pre-planted workspace symlink", async () => {
     mockAgentService.getById.mockResolvedValue(makeAgent(agentId));
 
     const res = await request(createApp({
@@ -171,21 +250,50 @@ describe("agent private skill routes", () => {
         description: "Private helper skill.",
       });
 
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(mockAgentService.getById).not.toHaveBeenCalled();
+    expect(mockOrganizationSkillService.createAgentPrivateSkill).not.toHaveBeenCalled();
+  });
+
+  it("blocks ordinary organization board members from private host writes", async () => {
+    const res = await request(createApp({
+      type: "board",
+      userId: "user-1",
+      orgIds: [orgId],
+      source: "session",
+      isInstanceAdmin: false,
+    }))
+      .post(`/api/agents/${agentId}/skills/private`)
+      .send({ name: "Linked Skill", slug: "linked-skill" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(mockAgentService.getById).not.toHaveBeenCalled();
+    expect(mockOrganizationSkillService.createAgentPrivateSkill).not.toHaveBeenCalled();
+  });
+
+  it("allows instance admins to create a private managed skill", async () => {
+    mockAgentService.getById.mockResolvedValue(makeAgent(agentId));
+
+    const res = await request(createApp({
+      type: "board",
+      userId: "admin-1",
+      orgIds: [],
+      source: "session",
+      isInstanceAdmin: true,
+    }))
+      .post(`/api/agents/${agentId}/skills/private`)
+      .send({
+        name: "Agent Helper",
+        slug: "agent-helper",
+        description: "Private helper skill.",
+      });
+
     expect(res.status, JSON.stringify(res.body)).toBe(201);
     expect(mockOrganizationSkillService.createAgentPrivateSkill).toHaveBeenCalledWith(
       orgId,
       agentId,
-      expect.objectContaining({
-        name: "Agent Helper",
-        slug: "agent-helper",
-        description: "Private helper skill.",
-      }),
+      expect.objectContaining({ name: "Agent Helper", slug: "agent-helper" }),
     );
-    expect(res.body).toMatchObject({
-      key: "agent-helper",
-      selectionKey: "agent:agent-helper",
-      sourceClass: "agent_home",
-    });
   });
 
   it("blocks a non-privileged agent from creating a private skill for a peer", async () => {
@@ -209,5 +317,58 @@ describe("agent private skill routes", () => {
 
     expect(res.status, JSON.stringify(res.body)).toBe(403);
     expect(mockOrganizationSkillService.createAgentPrivateSkill).not.toHaveBeenCalled();
+  });
+
+  it("blocks organization board users from testing a host adapter even with agents:create", async () => {
+    mockAccessService.canUser.mockResolvedValue(true);
+
+    const res = await request(createApp({
+      type: "board",
+      userId: "user-1",
+      orgIds: [orgId],
+      source: "session",
+      isInstanceAdmin: false,
+    }))
+      .post(`/api/orgs/${orgId}/adapters/opencode_local/test-environment`)
+      .send({
+        agentRuntimeConfig: {
+          command: "/bin/sh",
+          cwd: "/tmp/attacker-workspace",
+          model: "attacker/model",
+        },
+      });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(res.body.error).toContain("Instance admin");
+    expect(mockAccessService.canUser).not.toHaveBeenCalled();
+    expect(mockFindServerAdapter).not.toHaveBeenCalled();
+    expect(mockSecretService.normalizeAdapterConfigForPersistence).not.toHaveBeenCalled();
+    expect(mockAdapterTestEnvironment).not.toHaveBeenCalled();
+  });
+
+  it("allows an instance admin to enter the adapter environment test", async () => {
+    const inputConfig = { command: "opencode", model: "provider/model" };
+
+    const res = await request(createApp({
+      type: "board",
+      userId: "admin-1",
+      orgIds: [],
+      source: "session",
+      isInstanceAdmin: true,
+    }))
+      .post(`/api/orgs/${orgId}/adapters/opencode_local/test-environment`)
+      .send({ agentRuntimeConfig: inputConfig });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockSecretService.normalizeAdapterConfigForPersistence).toHaveBeenCalledWith(
+      orgId,
+      inputConfig,
+      { strictMode: false },
+    );
+    expect(mockAdapterTestEnvironment).toHaveBeenCalledWith({
+      orgId,
+      agentRuntimeType: "opencode_local",
+      config: { env: {} },
+    });
   });
 });

--- a/server/src/__tests__/agent-run-context.test.ts
+++ b/server/src/__tests__/agent-run-context.test.ts
@@ -152,6 +152,14 @@ describe("agentRunContextService prepareRuntimeConfig", () => {
     });
 
     expect(prepared.runtimeConfig.instructionsFilePath).toBe(instructionsFilePath);
+    expect(mockListRealizedSkillEntriesForAgent).toHaveBeenCalledWith(
+      orgId,
+      "11111111-1111-4111-8111-111111111111",
+      "codex_local",
+      baseConfig,
+      [],
+      { allowHostCatalogs: false, allowHostLocalPaths: false },
+    );
     await expect(fs.stat(instructionsFilePath)).rejects.toThrow();
   });
 
@@ -199,6 +207,7 @@ describe("agentRunContextService prepareRuntimeConfig", () => {
         id: "11111111-1111-4111-8111-111111111111",
         orgId,
         name: "Builder",
+        status: "active",
         workspaceKey,
         agentRuntimeType: "codex_local",
         agentRuntimeConfig: materializedConfig,
@@ -225,6 +234,14 @@ describe("agentRunContextService prepareRuntimeConfig", () => {
       }),
     );
     expect(prepared.runtimeConfig.instructionsFilePath).toBe(expectedInstructionsFilePath);
+    expect(mockListRealizedSkillEntriesForAgent).toHaveBeenLastCalledWith(
+      orgId,
+      "11111111-1111-4111-8111-111111111111",
+      "codex_local",
+      expect.objectContaining({ instructionsFilePath: expectedInstructionsFilePath }),
+      [],
+      { allowHostCatalogs: true, allowHostLocalPaths: false },
+    );
   });
 
   it("does not write per-run baseConfig instruction overrides into the managed bundle", async () => {

--- a/server/src/__tests__/agent-skills-routes.test.ts
+++ b/server/src/__tests__/agent-skills-routes.test.ts
@@ -43,6 +43,7 @@ const mockAgentInstructionsService = vi.hoisted(() => ({
 }));
 
 const mockCompanySkillService = vi.hoisted(() => ({
+  hasLocalPathSkills: vi.fn(),
   list: vi.fn(),
   listRuntimeSkillEntries: vi.fn(),
   mergeWithRequiredSkillKeys: vi.fn(),
@@ -153,17 +154,20 @@ function createDb(
   };
 }
 
-function createApp(db: Record<string, unknown> = createDb()) {
+function createApp(
+  db: Record<string, unknown> = createDb(),
+  actor: Record<string, unknown> = {
+    type: "board",
+    userId: "local-board",
+    orgIds: ["organization-1"],
+    source: "local_implicit",
+    isInstanceAdmin: false,
+  },
+) {
   const app = express();
   app.use(express.json());
   app.use((req, _res, next) => {
-    (req as any).actor = {
-      type: "board",
-      userId: "local-board",
-      orgIds: ["organization-1"],
-      source: "local_implicit",
-      isInstanceAdmin: false,
-    };
+    (req as any).actor = actor;
     next();
   });
   app.use("/api", agentRoutes(db as any));
@@ -286,6 +290,7 @@ describe("agent skill routes", () => {
     mockAgentService.getInternalById.mockResolvedValue(makeAgent("claude_local"));
     mockAgentService.list.mockResolvedValue([makeAgent("claude_local")]);
     mockSecretService.resolveAdapterConfigForRuntime.mockResolvedValue({ config: { env: {} } });
+    mockCompanySkillService.hasLocalPathSkills.mockResolvedValue(false);
     mockCompanySkillService.list.mockResolvedValue([
       {
         id: "skill-rudder",
@@ -406,6 +411,7 @@ describe("agent skill routes", () => {
     expect(mockCompanySkillService.buildAgentSkillSnapshot).toHaveBeenCalledWith(
       expect.objectContaining({ agentRuntimeType: "claude_local" }),
       expect.objectContaining({ env: {} }),
+      { allowHostCatalogs: true, allowHostLocalPaths: true },
     );
     expect(mockAdapter.listSkills).not.toHaveBeenCalled();
   });
@@ -420,6 +426,7 @@ describe("agent skill routes", () => {
     expect(mockCompanySkillService.buildAgentSkillSnapshot).toHaveBeenCalledWith(
       expect.objectContaining({ agentRuntimeType: "codex_local" }),
       expect.objectContaining({ env: {} }),
+      { allowHostCatalogs: true, allowHostLocalPaths: true },
     );
   });
 
@@ -657,6 +664,143 @@ describe("agent skill routes", () => {
         | undefined;
       expect(createInput?.agentRuntimeConfig?.model).toBe("deepseek/deepseek-chat");
     }
+
+    expect(mockEnsurePiModelConfiguredAndAvailable).toHaveBeenCalledWith(
+      expect.objectContaining({ model: "deepseek/deepseek-chat" }),
+    );
+    expect(mockEnsureOpenCodeModelConfiguredAndAvailable).toHaveBeenCalledWith(
+      expect.objectContaining({ model: "deepseek/deepseek-chat" }),
+    );
+  });
+
+  it("does not run OpenCode discovery for a non-admin board hire pending approval", async () => {
+    mockSecretService.resolveAdapterConfigForRuntime.mockImplementation(
+      async (_orgId: string, config: Record<string, unknown>) => ({ config }),
+    );
+
+    const res = await request(createApp(createDb(false), {
+      type: "board",
+      userId: "organization-member",
+      orgIds: ["organization-1"],
+      source: "session",
+      isInstanceAdmin: false,
+    }))
+      .post("/api/orgs/organization-1/agent-hires")
+      .send({
+        name: "Pending OpenCode Hire",
+        role: "engineer",
+        agentRuntimeType: "opencode_local",
+        agentRuntimeConfig: {
+          model: "deepseek/deepseek-chat",
+          command: "sh -lc 'touch /tmp/rudder-opencode-hire-rce'",
+        },
+      });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+    expect(mockAgentService.create).toHaveBeenCalledWith(
+      "organization-1",
+      expect.objectContaining({ status: "pending_approval" }),
+    );
+    expect(mockEnsureOpenCodeModelConfiguredAndAvailable).not.toHaveBeenCalled();
+  });
+
+  it("keeps OpenCode discovery on an instance-admin hire that can start immediately", async () => {
+    mockSecretService.resolveAdapterConfigForRuntime.mockImplementation(
+      async (_orgId: string, config: Record<string, unknown>) => ({ config }),
+    );
+
+    const res = await request(createApp(createDb(false), {
+      type: "board",
+      userId: "instance-admin",
+      orgIds: ["organization-1"],
+      source: "session",
+      isInstanceAdmin: true,
+    }))
+      .post("/api/orgs/organization-1/agent-hires")
+      .send({
+        name: "Approved OpenCode Hire",
+        role: "engineer",
+        agentRuntimeType: "opencode_local",
+        agentRuntimeConfig: {
+          model: "deepseek/deepseek-chat",
+          command: "/trusted/opencode",
+        },
+      });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+    expect(mockAgentService.create).toHaveBeenCalledWith(
+      "organization-1",
+      expect.objectContaining({ status: "idle" }),
+    );
+    expect(mockEnsureOpenCodeModelConfiguredAndAvailable).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: "deepseek/deepseek-chat",
+        command: "/trusted/opencode",
+      }),
+    );
+  });
+
+  it("does not run Pi discovery for an agent-initiated hire pending approval", async () => {
+    mockSecretService.resolveAdapterConfigForRuntime.mockImplementation(
+      async (_orgId: string, config: Record<string, unknown>) => ({ config }),
+    );
+    mockAgentService.getById.mockResolvedValue({
+      ...makeAgent("process"),
+      permissions: { canCreateAgents: true },
+    });
+
+    const res = await request(createApp(createDb(false), {
+      type: "agent",
+      agentId: "11111111-1111-4111-8111-111111111111",
+      orgId: "organization-1",
+      runId: "run-1",
+    }))
+      .post("/api/orgs/organization-1/agent-hires")
+      .send({
+        name: "Pending Pi Hire",
+        role: "engineer",
+        agentRuntimeType: "pi_local",
+        agentRuntimeConfig: {
+          model: "deepseek/deepseek-chat",
+          command: "sh -lc 'touch /tmp/rudder-pi-hire-rce'",
+        },
+      });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+    expect(mockAgentService.create).toHaveBeenCalledWith(
+      "organization-1",
+      expect.objectContaining({ status: "pending_approval" }),
+    );
+    expect(mockEnsurePiModelConfiguredAndAvailable).not.toHaveBeenCalled();
+  });
+
+  it("pure-validates pending hire model references without running discovery", async () => {
+    mockSecretService.resolveAdapterConfigForRuntime.mockImplementation(
+      async (_orgId: string, config: Record<string, unknown>) => ({ config }),
+    );
+
+    const res = await request(createApp(createDb(false), {
+      type: "board",
+      userId: "organization-member",
+      orgIds: ["organization-1"],
+      source: "session",
+      isInstanceAdmin: false,
+    }))
+      .post("/api/orgs/organization-1/agent-hires")
+      .send({
+        name: "Invalid Pending Pi Hire",
+        role: "engineer",
+        agentRuntimeType: "pi_local",
+        agentRuntimeConfig: {
+          model: "missing-provider-separator",
+          command: "sh -lc 'touch /tmp/rudder-pi-hire-rce'",
+        },
+      });
+
+    expect(res.status).toBe(422);
+    expect(res.body.error).toContain("provider/model format");
+    expect(mockEnsurePiModelConfiguredAndAvailable).not.toHaveBeenCalled();
+    expect(mockAgentService.create).not.toHaveBeenCalled();
   });
 
   it("rejects Pi updates that clear the required provider/model value", async () => {
@@ -830,6 +974,44 @@ describe("agent skill routes", () => {
           requestedConfigurationSnapshot: expect.objectContaining({
             desiredSkills: [],
           }),
+        }),
+      }),
+    );
+  });
+
+  it("keeps pending hires on organization-only skill resolution for hostile HOME input", async () => {
+    mockSecretService.resolveAdapterConfigForRuntime.mockImplementation(async (_orgId, config) => ({ config }));
+    mockAgentService.getById.mockResolvedValue({
+      ...makeAgent("process"),
+      permissions: { canCreateAgents: true },
+    });
+    const res = await request(createApp(createDb(false), {
+      type: "agent",
+      agentId: "11111111-1111-4111-8111-111111111111",
+      orgId: "organization-1",
+      runId: "run-1",
+    }))
+      .post("/api/orgs/organization-1/agent-hires")
+      .send({
+        name: "Safe Pending Hire",
+        role: "engineer",
+        agentRuntimeType: "process",
+        desiredSkills: ["alpha-test"],
+        agentRuntimeConfig: { env: { HOME: "/etc" } },
+      });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+    expect(mockCompanySkillService.resolveDesiredSkillSelectionForAgent).toHaveBeenCalledWith(
+      expect.objectContaining({ id: null, orgId: "organization-1" }),
+      expect.objectContaining({ env: { HOME: "/etc" } }),
+      ["alpha-test"],
+      { allowHostCatalogs: false, allowHostLocalPaths: false },
+    );
+    expect(mockApprovalService.create).toHaveBeenCalledWith(
+      "organization-1",
+      expect.objectContaining({
+        payload: expect.objectContaining({
+          desiredSkills: ["org:organization/organization-1/alpha-test"],
         }),
       }),
     );

--- a/server/src/__tests__/approval-routes-chat-application.test.ts
+++ b/server/src/__tests__/approval-routes-chat-application.test.ts
@@ -19,7 +19,12 @@ const mockApprovalService = vi.hoisted(() => ({
   addComment: vi.fn(),
 }));
 
+const mockAgentService = vi.hoisted(() => ({
+  getById: vi.fn(),
+}));
+
 const mockChatService = vi.hoisted(() => ({
+  getById: vi.fn(),
   applyApprovedApproval: vi.fn(),
 }));
 
@@ -48,6 +53,7 @@ const mockLogActivity = vi.hoisted(() => vi.fn());
 
 vi.mock("../services/index.js", () => ({
   accessService: () => mockAccessService,
+  agentService: () => mockAgentService,
   approvalService: () => mockApprovalService,
   chatService: () => mockChatService,
   heartbeatService: () => mockHeartbeatService,
@@ -91,6 +97,14 @@ describe("approval routes chat application", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockHeartbeatService.wakeup.mockResolvedValue(null);
+    mockAgentService.getById.mockResolvedValue({
+      id: "agent-1",
+      orgId: "organization-1",
+      agentRuntimeType: "process",
+      agentRuntimeConfig: {},
+      runtimeConfig: {},
+    });
+    mockChatService.getById.mockResolvedValue({ id: "chat-1", orgId: "organization-1" });
     mockIssueApprovalService.listIssuesForApproval.mockResolvedValue([{ id: "issue-1" }]);
     mockLogActivity.mockResolvedValue(undefined);
     mockIssueService.update.mockResolvedValue(null);
@@ -449,7 +463,7 @@ describe("approval routes chat application", () => {
     expect(res.status).toBe(200);
     expect(mockApprovalService.approve).toHaveBeenCalledWith(
       "approval-1",
-      "board",
+      "user-1",
       undefined,
       payload,
     );

--- a/server/src/__tests__/approval-routes-idempotency.test.ts
+++ b/server/src/__tests__/approval-routes-idempotency.test.ts
@@ -16,11 +16,16 @@ const mockApprovalService = vi.hoisted(() => ({
   addComment: vi.fn(),
 }));
 
+const mockAgentService = vi.hoisted(() => ({
+  getById: vi.fn(),
+}));
+
 const mockHeartbeatService = vi.hoisted(() => ({
   wakeup: vi.fn(),
 }));
 
 const mockChatService = vi.hoisted(() => ({
+  getById: vi.fn(),
   applyApprovedApproval: vi.fn(),
 }));
 
@@ -45,6 +50,7 @@ const mockLogActivity = vi.hoisted(() => vi.fn());
 
 vi.mock("../services/index.js", () => ({
   accessService: () => mockAccessService,
+  agentService: () => mockAgentService,
   approvalService: () => mockApprovalService,
   chatService: () => mockChatService,
   heartbeatService: () => mockHeartbeatService,
@@ -61,17 +67,17 @@ vi.mock("../services/index.js", () => ({
   secretService: () => mockSecretService,
 }));
 
-function createApp() {
+function createApp(actor: Record<string, unknown> = {
+  type: "board",
+  userId: "user-1",
+  orgIds: ["organization-1"],
+  source: "session",
+  isInstanceAdmin: false,
+}) {
   const app = express();
   app.use(express.json());
   app.use((req, _res, next) => {
-    (req as any).actor = {
-      type: "board",
-      userId: "user-1",
-      orgIds: ["organization-1"],
-      source: "session",
-      isInstanceAdmin: false,
-    };
+    (req as any).actor = actor;
     next();
   });
   app.use("/api", approvalRoutes({} as any));
@@ -83,11 +89,27 @@ describe("approval routes idempotent retries", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockHeartbeatService.wakeup.mockResolvedValue({ id: "wake-1" });
+    mockAgentService.getById.mockResolvedValue({
+      id: "agent-1",
+      orgId: "organization-1",
+      agentRuntimeType: "process",
+      agentRuntimeConfig: {},
+      runtimeConfig: {},
+    });
+    mockChatService.getById.mockResolvedValue({ id: "chat-1", orgId: "organization-1" });
     mockIssueApprovalService.listIssuesForApproval.mockResolvedValue([{ id: "issue-1" }]);
     mockLogActivity.mockResolvedValue(undefined);
   });
 
   it("does not emit duplicate approval side effects when approve is already resolved", async () => {
+    mockApprovalService.getById.mockResolvedValue({
+      id: "approval-1",
+      orgId: "organization-1",
+      type: "hire_agent",
+      status: "approved",
+      payload: {},
+      requestedByAgentId: "agent-1",
+    });
     mockApprovalService.approve.mockResolvedValue({
       approval: {
         id: "approval-1",
@@ -111,6 +133,13 @@ describe("approval routes idempotent retries", () => {
   });
 
   it("does not emit duplicate rejection logs when reject is already resolved", async () => {
+    mockApprovalService.getById.mockResolvedValue({
+      id: "approval-1",
+      orgId: "organization-1",
+      type: "hire_agent",
+      status: "rejected",
+      payload: {},
+    });
     mockApprovalService.reject.mockResolvedValue({
       approval: {
         id: "approval-1",
@@ -128,5 +157,315 @@ describe("approval routes idempotent retries", () => {
 
     expect(res.status).toBe(200);
     expect(mockLogActivity).not.toHaveBeenCalled();
+  });
+
+  it("rejects approval decisions outside the board member's organization scope", async () => {
+    mockApprovalService.getById.mockResolvedValue({
+      id: "approval-2",
+      orgId: "organization-2",
+      type: "hire_agent",
+      status: "pending",
+      payload: {},
+    });
+    const app = createApp();
+
+    const approveRes = await request(app).post("/api/approvals/approval-2/approve").send({});
+    const rejectRes = await request(app).post("/api/approvals/approval-2/reject").send({});
+    const revisionRes = await request(app).post("/api/approvals/approval-2/request-revision").send({});
+
+    expect([approveRes.status, rejectRes.status, revisionRes.status]).toEqual([403, 403, 403]);
+    expect(mockApprovalService.approve).not.toHaveBeenCalled();
+    expect(mockApprovalService.reject).not.toHaveBeenCalled();
+    expect(mockApprovalService.requestRevision).not.toHaveBeenCalled();
+  });
+
+  it("binds an agent-created approval to the authenticated requesting agent", async () => {
+    mockSecretService.normalizeHireApprovalPayloadForPersistence.mockImplementation(async (_orgId, payload) => payload);
+    mockApprovalService.create.mockImplementation(async (orgId, input) => ({
+      id: "approval-1",
+      orgId,
+      ...input,
+    }));
+    mockIssueApprovalService.linkManyForApproval.mockResolvedValue([]);
+
+    const res = await request(createApp({
+      type: "agent",
+      agentId: "agent-authenticated",
+      orgId: "organization-1",
+      runId: "run-1",
+    }))
+      .post("/api/orgs/organization-1/approvals")
+      .send({
+        type: "hire_agent",
+        requestedByAgentId: "00000000-0000-4000-8000-000000000002",
+        payload: {},
+      });
+
+    expect(res.status).toBe(201);
+    expect(mockApprovalService.create).toHaveBeenCalledWith(
+      "organization-1",
+      expect.objectContaining({ requestedByAgentId: "agent-authenticated" }),
+    );
+  });
+
+  it("requires instance-admin authority to approve a hire with host commands", async () => {
+    const pendingApproval = {
+      id: "approval-1",
+      orgId: "organization-1",
+      type: "hire_agent",
+      status: "pending",
+      payload: {
+        agentId: "agent-1",
+        name: "Configured Agent",
+        agentRuntimeConfig: {
+          workspaceRuntime: {
+            services: [{ name: "host-command", command: "touch /tmp/rudder-approval-rce" }],
+          },
+        },
+      },
+    };
+    mockApprovalService.getById.mockResolvedValue(pendingApproval);
+    mockApprovalService.approve.mockResolvedValue({
+      approval: { ...pendingApproval, status: "approved", requestedByAgentId: null },
+      applied: false,
+    });
+
+    const memberRes = await request(createApp())
+      .post("/api/approvals/approval-1/approve")
+      .send({});
+    expect(memberRes.status).toBe(403);
+    expect(mockApprovalService.approve).not.toHaveBeenCalled();
+
+    const adminRes = await request(createApp({
+      type: "board",
+      userId: "instance-admin",
+      orgIds: [],
+      source: "session",
+      isInstanceAdmin: true,
+    }))
+      .post("/api/approvals/approval-1/approve")
+      .send({});
+    expect(adminRes.status, JSON.stringify(adminRes.body)).toBe(200);
+    expect(mockApprovalService.approve).toHaveBeenCalled();
+  });
+
+  it("requires instance-admin authority for non-process and persisted non-empty hire runtimes", async () => {
+    mockApprovalService.getById.mockResolvedValueOnce({
+      id: "approval-1",
+      orgId: "organization-1",
+      type: "hire_agent",
+      status: "pending",
+      payload: {
+        requestedConfigurationSnapshot: {
+          agentRuntimeType: "codex_local",
+          agentRuntimeConfig: {},
+          runtimeConfig: {},
+        },
+      },
+    });
+    const snapshotRes = await request(createApp())
+      .post("/api/approvals/approval-1/approve")
+      .send({});
+    expect(snapshotRes.status).toBe(403);
+    expect(mockApprovalService.approve).not.toHaveBeenCalled();
+
+    mockApprovalService.getById.mockResolvedValueOnce({
+      id: "approval-2",
+      orgId: "organization-1",
+      type: "hire_agent",
+      status: "pending",
+      payload: {
+        agentId: "agent-2",
+        agentRuntimeType: "process",
+        agentRuntimeConfig: {},
+        runtimeConfig: {},
+      },
+    });
+    mockAgentService.getById.mockResolvedValueOnce({
+      id: "agent-2",
+      orgId: "organization-1",
+      name: "Persisted Agent",
+      agentRuntimeType: "process",
+      agentRuntimeConfig: { model: "persisted-runtime-config" },
+      runtimeConfig: {},
+    });
+    const persistedRes = await request(createApp())
+      .post("/api/approvals/approval-2/approve")
+      .send({});
+    expect(persistedRes.status).toBe(403);
+    expect(mockApprovalService.approve).not.toHaveBeenCalled();
+  });
+
+  it("rejects a hire approval that targets an agent in another organization", async () => {
+    mockApprovalService.getById.mockResolvedValue({
+      id: "approval-1",
+      orgId: "organization-1",
+      type: "hire_agent",
+      status: "pending",
+      payload: { agentId: "agent-2" },
+    });
+    mockAgentService.getById.mockResolvedValue({
+      id: "agent-2",
+      orgId: "organization-2",
+      name: "Other Organization Agent",
+      agentRuntimeType: "process",
+      agentRuntimeConfig: {},
+      runtimeConfig: {},
+    });
+
+    const res = await request(createApp())
+      .post("/api/approvals/approval-1/approve")
+      .send({});
+
+    expect(res.status).toBe(422);
+    expect(res.body.error).toContain("approval organization");
+    expect(mockApprovalService.approve).not.toHaveBeenCalled();
+  });
+
+  it("rejects a chat approval that points at another organization's conversation", async () => {
+    mockApprovalService.getById.mockResolvedValue({
+      id: "approval-1",
+      orgId: "organization-1",
+      type: "chat_operation",
+      status: "pending",
+      payload: {
+        chatConversationId: "chat-2",
+        operationProposal: {
+          targetType: "organization",
+          targetId: "organization-1",
+          summary: "Rename organization",
+          patch: { name: "Updated" },
+        },
+      },
+    });
+    mockChatService.getById.mockResolvedValue({ id: "chat-2", orgId: "organization-2" });
+
+    const res = await request(createApp())
+      .post("/api/approvals/approval-1/approve")
+      .send({});
+
+    expect(res.status).toBe(422);
+    expect(res.body.error).toContain("approval organization");
+    expect(mockApprovalService.approve).not.toHaveBeenCalled();
+  });
+
+  it("rejects chat operation patches containing database identity fields before approval", async () => {
+    mockApprovalService.getById.mockResolvedValue({
+      id: "approval-1",
+      orgId: "organization-1",
+      type: "chat_operation",
+      status: "pending",
+      payload: {
+        chatConversationId: "chat-1",
+        operationProposal: {
+          targetType: "agent",
+          targetId: "agent-1",
+          summary: "Malicious identity rewrite",
+          patch: {
+            id: "attacker-controlled-id",
+            orgId: "organization-2",
+            name: "Compromised Agent",
+          },
+        },
+      },
+    });
+
+    const res = await request(createApp())
+      .post("/api/approvals/approval-1/approve")
+      .send({});
+
+    expect(res.status).toBe(422);
+    expect(mockApprovalService.approve).not.toHaveBeenCalled();
+  });
+
+  it("requires instance-admin authority for chat operation agent runtime patches", async () => {
+    const pendingApproval = {
+      id: "approval-1",
+      orgId: "organization-1",
+      type: "chat_operation",
+      status: "pending",
+      payload: {
+        chatConversationId: "chat-1",
+        operationProposal: {
+          targetType: "agent",
+          targetId: "agent-1",
+          summary: "Change runtime",
+          patch: {
+            agentRuntimeConfig: {
+              workspaceRuntime: {
+                services: [{ name: "host-command", command: "touch /tmp/rudder-chat-rce" }],
+              },
+            },
+          },
+        },
+      },
+      requestedByAgentId: null,
+    };
+    mockApprovalService.getById.mockResolvedValue(pendingApproval);
+    mockApprovalService.approve.mockResolvedValue({
+      approval: { ...pendingApproval, status: "approved" },
+      applied: false,
+    });
+
+    const memberRes = await request(createApp())
+      .post("/api/approvals/approval-1/approve")
+      .send({});
+    expect(memberRes.status).toBe(403);
+    expect(mockApprovalService.approve).not.toHaveBeenCalled();
+
+    const adminRes = await request(createApp({
+      type: "board",
+      userId: "instance-admin",
+      orgIds: [],
+      source: "session",
+      isInstanceAdmin: true,
+    }))
+      .post("/api/approvals/approval-1/approve")
+      .send({});
+    expect(adminRes.status, JSON.stringify(adminRes.body)).toBe(200);
+  });
+
+  it("ignores spoofed decision user ids and records the authenticated board user", async () => {
+    const pendingApproval = {
+      id: "approval-1",
+      orgId: "organization-1",
+      type: "hire_agent",
+      status: "pending",
+      payload: {},
+      requestedByAgentId: null,
+    };
+    mockApprovalService.getById.mockResolvedValue(pendingApproval);
+    mockApprovalService.approve.mockResolvedValue({
+      approval: { ...pendingApproval, status: "approved" },
+      applied: false,
+    });
+    mockApprovalService.reject.mockResolvedValue({
+      approval: { ...pendingApproval, status: "rejected" },
+      applied: false,
+    });
+    mockApprovalService.requestRevision.mockResolvedValue({
+      ...pendingApproval,
+      status: "revision_requested",
+    });
+    const app = createApp();
+
+    await request(app)
+      .post("/api/approvals/approval-1/approve")
+      .send({ decidedByUserId: "spoofed-user" });
+    await request(app)
+      .post("/api/approvals/approval-1/reject")
+      .send({ decidedByUserId: "spoofed-user" });
+    await request(app)
+      .post("/api/approvals/approval-1/request-revision")
+      .send({ decidedByUserId: "spoofed-user" });
+
+    expect(mockApprovalService.approve).toHaveBeenCalledWith(
+      "approval-1",
+      "user-1",
+      undefined,
+      undefined,
+    );
+    expect(mockApprovalService.reject).toHaveBeenCalledWith("approval-1", "user-1", undefined);
+    expect(mockApprovalService.requestRevision).toHaveBeenCalledWith("approval-1", "user-1", undefined);
   });
 });

--- a/server/src/__tests__/approvals-service.test.ts
+++ b/server/src/__tests__/approvals-service.test.ts
@@ -78,6 +78,7 @@ describe("approvalService resolution idempotency", () => {
     mockAgentService.create.mockResolvedValue({ id: "agent-1" });
     mockAgentService.getById.mockResolvedValue({
       id: "agent-1",
+      orgId: "organization-1",
       agentRuntimeType: "codex_local",
       agentRuntimeConfig: { model: "gpt-5.4" },
     });
@@ -118,7 +119,10 @@ describe("approvalService resolution idempotency", () => {
 
   it("still performs side effects when the resolution update is newly applied", async () => {
     const approved = createApproval("approved");
-    const dbStub = createDbStub([[createApproval("pending")]], [approved]);
+    const dbStub = createDbStub(
+      [[createApproval("pending")], [createApproval("pending")]],
+      [approved],
+    );
 
     const svc = approvalService(dbStub.db as any);
     const result = await svc.approve("approval-1", "board", "ship it");
@@ -128,5 +132,44 @@ describe("approvalService resolution idempotency", () => {
     expect(mockOrganizationIntelligenceProfiles.ensureDefaultsFromRuntime).not.toHaveBeenCalled();
     expect(mockOrganizationIntelligenceRuntimeChain.assertUsable).not.toHaveBeenCalled();
     expect(mockNotifyHireApproved).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(["approve", "reject"] as const)(
+    "does not %s a hire target from another organization",
+    async (action) => {
+      const dbStub = createDbStub([[createApproval("pending")]], []);
+      mockAgentService.getById.mockResolvedValue({
+        id: "agent-1",
+        orgId: "organization-2",
+        agentRuntimeType: "process",
+        agentRuntimeConfig: {},
+      });
+
+      const svc = approvalService(dbStub.db as any);
+      await expect(svc[action]("approval-1", "board", "decision"))
+        .rejects.toThrow("approval organization");
+
+      expect(dbStub.returning).not.toHaveBeenCalled();
+      expect(mockAgentService.activatePendingApproval).not.toHaveBeenCalled();
+      expect(mockAgentService.terminate).not.toHaveBeenCalled();
+    },
+  );
+
+  it("does not approve a cross-organization hire target supplied through a payload override", async () => {
+    const dbStub = createDbStub([[createApproval("pending")]], []);
+    mockAgentService.getById.mockImplementation(async (agentId: string) => ({
+      id: agentId,
+      orgId: agentId === "agent-2" ? "organization-2" : "organization-1",
+      agentRuntimeType: "process",
+      agentRuntimeConfig: {},
+    }));
+
+    const svc = approvalService(dbStub.db as any);
+    await expect(
+      svc.approve("approval-1", "board", "decision", { agentId: "agent-2" }),
+    ).rejects.toThrow("approval organization");
+
+    expect(dbStub.returning).not.toHaveBeenCalled();
+    expect(mockAgentService.activatePendingApproval).not.toHaveBeenCalled();
   });
 });

--- a/server/src/__tests__/assets.test.ts
+++ b/server/src/__tests__/assets.test.ts
@@ -1,4 +1,5 @@
 import express from "express";
+import { Readable } from "node:stream";
 import request from "supertest";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { MAX_ATTACHMENT_BYTES } from "../attachment-types.js";
@@ -26,7 +27,7 @@ vi.mock("../services/index.js", () => ({
   logActivity: logActivityMock,
 }));
 
-function createAsset() {
+function createAsset(overrides: Record<string, unknown> = {}) {
   const now = new Date("2026-01-01T00:00:00.000Z");
   return {
     id: "asset-1",
@@ -41,6 +42,7 @@ function createAsset() {
     createdByUserId: "user-1",
     createdAt: now,
     updatedAt: now,
+    ...overrides,
   };
 }
 
@@ -115,29 +117,22 @@ describe("POST /api/orgs/:orgId/assets/images", () => {
     });
   });
 
-  it("allows supported non-image attachments outside the organization logo flow", async () => {
+  it.each([
+    ["text/plain", "note.txt"],
+    ["text/html", "page.html"],
+    ["image/svg+xml", "image.svg"],
+  ])("rejects non-raster uploads with type %s", async (contentType, filename) => {
     const text = createStorageService("text/plain");
     const app = createApp(text);
-
-    createAssetMock.mockResolvedValue({
-      ...createAsset(),
-      contentType: "text/plain",
-      originalFilename: "note.txt",
-    });
 
     const res = await request(app)
       .post("/api/orgs/organization-1/assets/images")
       .field("namespace", "issues/drafts")
-      .attach("file", Buffer.from("hello"), { filename: "note.txt", contentType: "text/plain" });
+      .attach("file", Buffer.from("untrusted"), { filename, contentType });
 
-    expect(res.status).toBe(201);
-    expect(text.putFile).toHaveBeenCalledWith({
-      orgId: "organization-1",
-      namespace: "assets/issues/drafts",
-      originalFilename: "note.txt",
-      contentType: "text/plain",
-      body: expect.any(Buffer),
-    });
+    expect(res.status).toBe(422);
+    expect(res.body.error).toBe(`Unsupported file type: ${contentType}`);
+    expect(text.putFile).not.toHaveBeenCalled();
   });
 });
 
@@ -170,15 +165,9 @@ describe("POST /api/orgs/:orgId/logo", () => {
     });
   });
 
-  it("sanitizes SVG logo uploads before storing them", async () => {
+  it("rejects SVG logo uploads", async () => {
     const svg = createStorageService("image/svg+xml");
     const app = createApp(svg);
-
-    createAssetMock.mockResolvedValue({
-      ...createAsset(),
-      contentType: "image/svg+xml",
-      originalFilename: "logo.svg",
-    });
 
     const res = await request(app)
       .post("/api/orgs/organization-1/logo")
@@ -190,17 +179,9 @@ describe("POST /api/orgs/:orgId/logo", () => {
         "logo.svg",
       );
 
-    expect(res.status).toBe(201);
-    expect(svg.putFile).toHaveBeenCalledTimes(1);
-    const stored = (svg.putFile as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
-    expect(stored.contentType).toBe("image/svg+xml");
-    expect(stored.originalFilename).toBe("logo.svg");
-    const body = stored.body.toString("utf8");
-    expect(body).toContain("<svg");
-    expect(body).toContain("<circle");
-    expect(body).not.toContain("<script");
-    expect(body).not.toContain("onload=");
-    expect(body).not.toContain("https://evil.example/");
+    expect(res.status).toBe(422);
+    expect(res.body.error).toBe("Unsupported image type: image/svg+xml");
+    expect(svg.putFile).not.toHaveBeenCalled();
   });
 
   it("allows logo uploads within the general attachment limit", async () => {
@@ -242,16 +223,54 @@ describe("POST /api/orgs/:orgId/logo", () => {
     expect(createAssetMock).not.toHaveBeenCalled();
   });
 
-  it("rejects SVG image uploads that cannot be sanitized", async () => {
-    const app = createApp(createStorageService("image/svg+xml"));
-    createAssetMock.mockResolvedValue(createAsset());
+});
 
-    const res = await request(app)
-      .post("/api/orgs/organization-1/logo")
-      .attach("file", Buffer.from("not actually svg"), "logo.svg");
+describe("GET /api/assets/:assetId/content", () => {
+  afterEach(() => {
+    createAssetMock.mockReset();
+    getAssetByIdMock.mockReset();
+    logActivityMock.mockReset();
+  });
 
-    expect(res.status).toBe(422);
-    expect(res.body.error).toBe("SVG could not be sanitized");
-    expect(createAssetMock).not.toHaveBeenCalled();
+  it("serves safe raster images inline with MIME sniffing disabled", async () => {
+    const body = Buffer.from("png");
+    const storage = createStorageService("image/png");
+    getAssetByIdMock.mockResolvedValue(createAsset({ byteSize: body.length }));
+    vi.mocked(storage.getObject).mockResolvedValue({
+      stream: Readable.from(body),
+      contentType: "image/png",
+      contentLength: body.length,
+    });
+
+    const res = await request(createApp(storage)).get("/api/assets/asset-1/content");
+
+    expect(res.status).toBe(200);
+    expect(res.headers["content-disposition"]).toBe('inline; filename="logo.png"');
+    expect(res.headers["x-content-type-options"]).toBe("nosniff");
+    expect(res.headers["content-security-policy"]).toBeUndefined();
+  });
+
+  it("forces legacy active content to download under a restrictive sandbox", async () => {
+    const body = Buffer.from("<script>alert(1)</script>");
+    const storage = createStorageService("text/html");
+    getAssetByIdMock.mockResolvedValue(createAsset({
+      byteSize: body.length,
+      contentType: "text/html",
+      originalFilename: "payload.html",
+    }));
+    vi.mocked(storage.getObject).mockResolvedValue({
+      stream: Readable.from(body),
+      contentType: "text/html",
+      contentLength: body.length,
+    });
+
+    const res = await request(createApp(storage)).get("/api/assets/asset-1/content");
+
+    expect(res.status).toBe(200);
+    expect(res.headers["content-disposition"]).toBe('attachment; filename="payload.html"');
+    expect(res.headers["x-content-type-options"]).toBe("nosniff");
+    expect(res.headers["content-security-policy"]).toBe(
+      "sandbox; default-src 'none'; base-uri 'none'; form-action 'none'",
+    );
   });
 });

--- a/server/src/__tests__/board-mutation-guard.test.ts
+++ b/server/src/__tests__/board-mutation-guard.test.ts
@@ -79,10 +79,46 @@ describe("boardMutationGuard", () => {
     expect(res.status).toBe(204);
   });
 
+  it.each(["local_implicit", "board_key"] as const)(
+    "blocks cross-origin browser mutations for %s boards",
+    async (source) => {
+      const app = createApp("board", source);
+      const res = await request(app)
+        .post("/mutate")
+        .set("Origin", "https://attacker.example")
+        .send({ ok: true });
+
+      expect(res.status).toBe(403);
+      expect(res.body).toEqual({ error: "Board mutation requires trusted browser origin" });
+    },
+  );
+
+  it("does not let a trusted referer override an explicitly untrusted Origin", async () => {
+    const res = await request(createApp("board", "local_implicit"))
+      .post("/mutate")
+      .set("Host", "localhost:3100")
+      .set("Origin", "https://attacker.example")
+      .set("Referer", "http://localhost:3100/activity")
+      .send({ ok: true });
+
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ error: "Board mutation requires trusted browser origin" });
+  });
+
+  it("blocks local browser mutations identified as cross-site even without Origin", async () => {
+    const res = await request(createApp("board", "local_implicit"))
+      .post("/mutate")
+      .set("Sec-Fetch-Site", "cross-site")
+      .send({ ok: true });
+
+    expect(res.status).toBe(403);
+  });
+
   it("allows board mutations from trusted origin", async () => {
     const app = createApp("board");
     const res = await request(app)
       .post("/mutate")
+      .set("Host", "localhost:3100")
       .set("Origin", "http://localhost:3100")
       .send({ ok: true });
     expect(res.status).toBe(204);
@@ -92,6 +128,7 @@ describe("boardMutationGuard", () => {
     const app = createApp("board");
     const res = await request(app)
       .post("/mutate")
+      .set("Host", "localhost:3100")
       .set("Referer", "http://localhost:3100/issues/abc")
       .send({ ok: true });
     expect(res.status).toBe(204);

--- a/server/src/__tests__/company-portability-routes.test.ts
+++ b/server/src/__tests__/company-portability-routes.test.ts
@@ -14,6 +14,7 @@ const mockCompanyService = vi.hoisted(() => ({
 
 const mockAgentService = vi.hoisted(() => ({
   getById: vi.fn(),
+  list: vi.fn(),
 }));
 
 const mockAccessService = vi.hoisted(() => ({
@@ -31,8 +32,17 @@ const mockCompanyPortabilityService = vi.hoisted(() => ({
   importBundle: vi.fn(),
 }));
 
+const mockExportJobService = vi.hoisted(() => ({
+  create: vi.fn(),
+  get: vi.fn(),
+  getResult: vi.fn(),
+  requiresInstanceAdmin: vi.fn(),
+  cancel: vi.fn(),
+}));
+
 const mockOrganizationSkillService = vi.hoisted(() => ({
   syncWorkspaceFileChange: vi.fn(),
+  hasLocalPathSkills: vi.fn(),
 }));
 const mockResourceCatalogService = vi.hoisted(() => ({
   listOrganizationResources: vi.fn(),
@@ -67,12 +77,7 @@ vi.mock("../services/index.js", () => ({
   accessService: () => mockAccessService,
   agentService: () => mockAgentService,
   budgetService: () => mockBudgetService,
-  organizationExportJobService: () => ({
-    create: vi.fn(),
-    get: vi.fn(),
-    getResult: vi.fn(),
-    cancel: vi.fn(),
-  }),
+  organizationExportJobService: () => mockExportJobService,
   organizationPortabilityService: () => mockCompanyPortabilityService,
   organizationSkillService: () => mockOrganizationSkillService,
   resourceCatalogService: () => mockResourceCatalogService,
@@ -90,13 +95,15 @@ vi.mock("../services/index.js", () => ({
   logActivity: mockLogActivity,
 }));
 
-async function createApp(actor: Record<string, unknown>) {
+async function createApp(
+  actor: Record<string, unknown> | ((req: express.Request) => Record<string, unknown>),
+) {
   const { organizationRoutes } = await import("../routes/orgs.js");
   const { errorHandler } = await import("../middleware/index.js");
   const app = express();
   app.use(express.json());
   app.use((req, _res, next) => {
-    (req as any).actor = actor;
+    (req as any).actor = typeof actor === "function" ? actor(req) : actor;
     next();
   });
   app.use("/api/orgs", organizationRoutes({} as any));
@@ -108,10 +115,17 @@ describe("organization portability routes", () => {
   beforeEach(() => {
     vi.resetModules();
     mockAgentService.getById.mockReset();
+    mockAgentService.list.mockReset().mockResolvedValue([]);
     mockCompanyPortabilityService.exportBundle.mockReset();
     mockCompanyPortabilityService.previewExport.mockReset();
     mockCompanyPortabilityService.previewImport.mockReset();
     mockCompanyPortabilityService.importBundle.mockReset();
+    mockExportJobService.create.mockReset();
+    mockExportJobService.get.mockReset();
+    mockExportJobService.getResult.mockReset();
+    mockExportJobService.requiresInstanceAdmin.mockReset().mockReturnValue(false);
+    mockExportJobService.cancel.mockReset();
+    mockOrganizationSkillService.hasLocalPathSkills.mockReset().mockResolvedValue(false);
     mockLogActivity.mockReset();
   });
 
@@ -144,6 +158,13 @@ describe("organization portability routes", () => {
       orgId: "11111111-1111-4111-8111-111111111111",
       role: "ceo",
     });
+    mockAgentService.list.mockResolvedValue([{
+      id: "agent-1",
+      orgId: "11111111-1111-4111-8111-111111111111",
+      name: "CEO",
+      status: "active",
+      agentRuntimeConfig: {},
+    }]);
     mockCompanyPortabilityService.previewExport.mockResolvedValue({
       rootPath: "rudder",
       manifest: { agents: [], skills: [], projects: [], issues: [], envInputs: [], includes: { organization: true, agents: true, projects: true, issues: false, skills: false }, organization: null, schemaVersion: 1, generatedAt: new Date().toISOString(), source: null },
@@ -169,6 +190,188 @@ describe("organization portability routes", () => {
     expect(mockCompanyPortabilityService.previewExport).toHaveBeenCalledWith("11111111-1111-4111-8111-111111111111", {
       include: { organization: true, agents: true, projects: true },
     });
+  });
+
+  it("rejects external instruction exports from CEO agents and non-admin board members", { timeout: 10000 }, async () => {
+    mockAgentService.getById.mockResolvedValue({
+      id: "agent-1",
+      orgId: "11111111-1111-4111-8111-111111111111",
+      role: "ceo",
+    });
+    mockAgentService.list.mockResolvedValue([{
+      id: "agent-1",
+      orgId: "11111111-1111-4111-8111-111111111111",
+      name: "CEO",
+      status: "active",
+      agentRuntimeConfig: {
+        instructionsBundleMode: "external",
+        instructionsRootPath: "/etc",
+        instructionsFilePath: "/etc/passwd",
+      },
+    }]);
+
+    const agentApp = await createApp({
+      type: "agent",
+      agentId: "agent-1",
+      orgId: "11111111-1111-4111-8111-111111111111",
+      source: "agent_key",
+      runId: "run-1",
+    });
+    const boardApp = await createApp({
+      type: "board",
+      userId: "organization-member",
+      orgIds: ["11111111-1111-4111-8111-111111111111"],
+      source: "session",
+      isInstanceAdmin: false,
+    });
+
+    const agentRes = await request(agentApp)
+      .post("/api/orgs/11111111-1111-4111-8111-111111111111/exports/preview")
+      .send({ include: { organization: true, agents: true } });
+    const boardRes = await request(boardApp)
+      .post("/api/orgs/11111111-1111-4111-8111-111111111111/export")
+      .send({ include: { organization: true, agents: true } });
+
+    expect(agentRes.status).toBe(403);
+    expect(boardRes.status).toBe(403);
+    expect(mockCompanyPortabilityService.previewExport).not.toHaveBeenCalled();
+    expect(mockCompanyPortabilityService.exportBundle).not.toHaveBeenCalled();
+  });
+
+  it("allows instance admins to export agents with external instructions", async () => {
+    mockOrganizationSkillService.hasLocalPathSkills.mockResolvedValue(true);
+    mockAgentService.list.mockResolvedValue([{
+      id: "agent-1",
+      orgId: "11111111-1111-4111-8111-111111111111",
+      name: "External Agent",
+      status: "active",
+      agentRuntimeConfig: {
+        instructionsBundleMode: "external",
+        instructionsRootPath: "/srv/rudder-instructions",
+        instructionsFilePath: "/srv/rudder-instructions/SOUL.md",
+      },
+    }]);
+    mockCompanyPortabilityService.exportBundle.mockResolvedValue({
+      rootPath: "rudder",
+      manifest: {},
+      files: {},
+      warnings: [],
+    });
+    const app = await createApp({
+      type: "board",
+      userId: "instance-admin",
+      orgIds: [],
+      source: "session",
+      isInstanceAdmin: true,
+    });
+
+    const res = await request(app)
+      .post("/api/orgs/11111111-1111-4111-8111-111111111111/export")
+      .send({ include: { organization: true, agents: true } });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockCompanyPortabilityService.exportBundle).toHaveBeenCalled();
+  });
+
+  it("blocks local skill export and safe-import surfaces for CEO agents and ordinary boards", { timeout: 10000 }, async () => {
+    mockOrganizationSkillService.hasLocalPathSkills.mockResolvedValue(true);
+    mockAgentService.getById.mockResolvedValue({
+      id: "agent-1",
+      orgId: "11111111-1111-4111-8111-111111111111",
+      role: "ceo",
+    });
+    const agentApp = await createApp({
+      type: "agent",
+      agentId: "agent-1",
+      orgId: "11111111-1111-4111-8111-111111111111",
+      source: "agent_key",
+      runId: "run-1",
+    });
+    const boardApp = await createApp({
+      type: "board",
+      userId: "organization-member",
+      orgIds: ["11111111-1111-4111-8111-111111111111"],
+      source: "session",
+      isInstanceAdmin: false,
+    });
+
+    const agentExport = await request(agentApp)
+      .post("/api/orgs/11111111-1111-4111-8111-111111111111/exports/preview")
+      .send({ include: { organization: true, agents: false, skills: true } });
+    const boardExport = await request(boardApp)
+      .post("/api/orgs/11111111-1111-4111-8111-111111111111/export")
+      .send({ include: { organization: true, agents: false, skills: true } });
+    const agentImport = await request(agentApp)
+      .post("/api/orgs/11111111-1111-4111-8111-111111111111/imports/preview")
+      .send({
+        source: { type: "inline", files: { "ORGANIZATION.md": "---\nname: Test\n---\n" } },
+        include: { organization: true, agents: false, projects: false, issues: false, skills: true },
+        target: { mode: "existing_organization", orgId: "11111111-1111-4111-8111-111111111111" },
+        collisionStrategy: "rename",
+      });
+
+    expect(agentExport.status, JSON.stringify(agentExport.body)).toBe(403);
+    expect(boardExport.status, JSON.stringify(boardExport.body)).toBe(403);
+    expect(agentImport.status, JSON.stringify(agentImport.body)).toBe(403);
+    expect(mockCompanyPortabilityService.previewExport).not.toHaveBeenCalled();
+    expect(mockCompanyPortabilityService.exportBundle).not.toHaveBeenCalled();
+    expect(mockCompanyPortabilityService.previewImport).not.toHaveBeenCalled();
+  });
+
+  it("keeps external-instruction export job results restricted to instance admins", async () => {
+    mockAgentService.list.mockResolvedValue([{
+      id: "agent-1",
+      orgId: "11111111-1111-4111-8111-111111111111",
+      name: "External Agent",
+      status: "active",
+      agentRuntimeConfig: {
+        instructionsBundleMode: "external",
+        instructionsRootPath: "/srv/rudder-instructions",
+        instructionsFilePath: "/srv/rudder-instructions/SOUL.md",
+      },
+    }]);
+    const job = {
+      id: "77777777-7777-4777-8777-777777777777",
+      orgId: "11111111-1111-4111-8111-111111111111",
+      status: "succeeded",
+      resultAvailable: true,
+    };
+    mockExportJobService.create.mockReturnValue(job);
+    mockExportJobService.get.mockReturnValue(job);
+    mockExportJobService.requiresInstanceAdmin.mockReturnValue(true);
+    mockExportJobService.getResult.mockReturnValue({ files: { "agents/external/SOUL.md": "secret" } });
+
+    const app = await createApp((req) => req.header("x-test-admin") === "true"
+      ? {
+          type: "board",
+          userId: "instance-admin",
+          orgIds: [],
+          source: "session",
+          isInstanceAdmin: true,
+        }
+      : {
+          type: "board",
+          userId: "organization-member",
+          orgIds: ["11111111-1111-4111-8111-111111111111"],
+          source: "session",
+          isInstanceAdmin: false,
+        });
+
+    const createRes = await request(app)
+      .post("/api/orgs/11111111-1111-4111-8111-111111111111/exports/jobs")
+      .set("x-test-admin", "true")
+      .send({ include: { organization: true, agents: true } });
+    const memberResultRes = await request(app)
+      .get("/api/orgs/11111111-1111-4111-8111-111111111111/exports/jobs/77777777-7777-4777-8777-777777777777/result");
+
+    expect(createRes.status, JSON.stringify(createRes.body)).toBe(202);
+    expect(mockExportJobService.create).toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      expect.any(Function),
+      { requiresInstanceAdmin: true },
+    );
+    expect(memberResultRes.status).toBe(403);
+    expect(mockExportJobService.getResult).not.toHaveBeenCalled();
   });
 
   it("rejects replace collision strategy on CEO-safe import routes", { timeout: 10000 }, async () => {
@@ -219,5 +422,27 @@ describe("organization portability routes", () => {
 
     expect(res.status).toBe(403);
     expect(res.body.error).toContain("Board access required");
+  });
+
+  it("requires instance-admin authority for board-full imports containing executable entities", async () => {
+    const app = await createApp({
+      type: "board",
+      userId: "organization-member",
+      orgIds: ["11111111-1111-4111-8111-111111111111"],
+      source: "session",
+      isInstanceAdmin: false,
+    });
+
+    const res = await request(app)
+      .post("/api/orgs/import/preview")
+      .send({
+        source: { type: "inline", files: { "ORGANIZATION.md": "---\nname: Test\n---\n" } },
+        include: { organization: true, agents: true, projects: false, issues: false },
+        target: { mode: "existing_organization", orgId: "11111111-1111-4111-8111-111111111111" },
+        collisionStrategy: "rename",
+      });
+
+    expect(res.status).toBe(403);
+    expect(mockCompanyPortabilityService.previewImport).not.toHaveBeenCalled();
   });
 });

--- a/server/src/__tests__/company-portability-routes.test.ts
+++ b/server/src/__tests__/company-portability-routes.test.ts
@@ -445,4 +445,31 @@ describe("organization portability routes", () => {
     expect(res.status).toBe(403);
     expect(mockCompanyPortabilityService.previewImport).not.toHaveBeenCalled();
   });
+
+  it.each([
+    ["preview", "/api/orgs/import/preview"],
+    ["apply", "/api/orgs/import"],
+  ])("requires instance-admin authority for organization-and-skill-only replace %s", async (_label, route) => {
+    const app = await createApp({
+      type: "board",
+      userId: "organization-member",
+      orgIds: ["11111111-1111-4111-8111-111111111111"],
+      source: "session",
+      isInstanceAdmin: false,
+    });
+
+    const res = await request(app)
+      .post(route)
+      .send({
+        source: { type: "inline", files: { "ORGANIZATION.md": "---\nname: Test\n---\n" } },
+        include: { organization: true, agents: false, projects: false, issues: false, skills: true },
+        target: { mode: "existing_organization", orgId: "11111111-1111-4111-8111-111111111111" },
+        collisionStrategy: "replace",
+      });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toContain("Instance admin access required");
+    expect(mockCompanyPortabilityService.previewImport).not.toHaveBeenCalled();
+    expect(mockCompanyPortabilityService.importBundle).not.toHaveBeenCalled();
+  });
 });

--- a/server/src/__tests__/company-portability.test.ts
+++ b/server/src/__tests__/company-portability.test.ts
@@ -1906,17 +1906,8 @@ describe("organization portability", () => {
     });
   });
 
-  it("copies source organization memberships for safe new-organization imports", async () => {
+  it("rejects agent imports through safe portability routes", async () => {
     const portability = organizationPortabilityService({} as any);
-
-    companySvc.create.mockResolvedValue({
-      id: "organization-imported",
-      name: "Imported Rudder",
-    });
-    agentSvc.create.mockResolvedValue({
-      id: "agent-created",
-      name: "ClaudeCoder",
-    });
 
     const exported = await portability.exportBundle("organization-1", {
       include: {
@@ -1929,36 +1920,136 @@ describe("organization portability", () => {
 
     agentSvc.list.mockResolvedValue([]);
 
-    await portability.importBundle({
-      source: {
-        type: "inline",
-        rootPath: exported.rootPath,
-        files: exported.files,
-      },
-      include: {
-        organization: true,
-        agents: true,
-        projects: false,
-        issues: false,
-      },
-      target: {
-        mode: "new_organization",
-        newOrganizationName: "Imported Rudder",
-      },
-      agents: "all",
-      collisionStrategy: "rename",
-    }, null, {
-      mode: "agent_safe",
-      sourceOrganizationId: "organization-1",
-    });
+    await expect(portability.importBundle({
+        source: {
+          type: "inline",
+          rootPath: exported.rootPath,
+          files: exported.files,
+        },
+        include: {
+          organization: true,
+          agents: true,
+          projects: false,
+          issues: false,
+        },
+        target: {
+          mode: "new_organization",
+          newOrganizationName: "Imported Rudder",
+        },
+        agents: "all",
+        collisionStrategy: "rename",
+      }, null, {
+        mode: "agent_safe",
+        sourceOrganizationId: "organization-1",
+      })).rejects.toThrow("Safe import routes do not allow importing agents");
 
-    expect(accessSvc.listActiveUserMemberships).toHaveBeenCalledWith("organization-1");
-    expect(accessSvc.copyActiveUserMemberships).toHaveBeenCalledWith("organization-1", "organization-imported");
-    expect(accessSvc.ensureMembership).not.toHaveBeenCalledWith("organization-imported", "user", expect.anything(), "owner", "active");
-    const textOnlyFiles = Object.fromEntries(Object.entries(exported.files).filter(([, v]) => typeof v === "string"));
-    expect(organizationSkillSvc.importPackageFiles).toHaveBeenCalledWith("organization-imported", textOnlyFiles, {
-      onConflict: "rename",
+    expect(companySvc.create).not.toHaveBeenCalled();
+    expect(agentSvc.create).not.toHaveBeenCalled();
+  });
+
+  it("rejects execution-sensitive project and issue data through safe portability routes", async () => {
+    const portability = organizationPortabilityService({} as any);
+    const target = { mode: "existing_organization" as const, orgId: "organization-1" };
+
+    projectSvc.list.mockResolvedValue([{
+      id: "project-1",
+      name: "Unsafe Project",
+      urlKey: "unsafe-project",
+      description: null,
+      leadAgentId: null,
+      targetDate: null,
+      color: null,
+      status: "planned",
+      executionWorkspacePolicy: {
+        enabled: true,
+        workspaceStrategy: {
+          type: "git_worktree",
+          provisionCommand: "touch /tmp/rudder-rce",
+        },
+      },
+      workspaces: [],
+      archivedAt: null,
+    }]);
+    const policyExport = await portability.exportBundle("organization-1", {
+      include: { organization: false, agents: false, projects: true, issues: false },
     });
+    await expect(portability.previewImport({
+      source: { type: "inline", rootPath: policyExport.rootPath, files: policyExport.files },
+      include: { organization: false, agents: false, projects: true, issues: false },
+      target,
+      collisionStrategy: "rename",
+    }, { mode: "agent_safe", sourceOrganizationId: "organization-1" }))
+      .rejects.toThrow("do not allow project executionWorkspacePolicy");
+
+    projectSvc.list.mockResolvedValue([{
+      id: "project-1",
+      name: "Workspace Commands",
+      urlKey: "workspace-commands",
+      description: null,
+      leadAgentId: null,
+      targetDate: null,
+      color: null,
+      status: "planned",
+      executionWorkspacePolicy: null,
+      workspaces: [{
+        id: "workspace-1",
+        orgId: "organization-1",
+        projectId: "project-1",
+        name: "Main",
+        sourceType: "git_repo",
+        cwd: null,
+        repoUrl: "https://github.com/example/repo.git",
+        repoRef: "main",
+        defaultRef: "main",
+        visibility: "default",
+        setupCommand: "id",
+        cleanupCommand: null,
+        metadata: null,
+        isPrimary: true,
+      }],
+      archivedAt: null,
+    }]);
+    const commandExport = await portability.exportBundle("organization-1", {
+      include: { organization: false, agents: false, projects: true, issues: false },
+    });
+    await expect(portability.previewImport({
+      source: { type: "inline", rootPath: commandExport.rootPath, files: commandExport.files },
+      include: { organization: false, agents: false, projects: true, issues: false },
+      target,
+      collisionStrategy: "rename",
+    }, { mode: "agent_safe", sourceOrganizationId: "organization-1" }))
+      .rejects.toThrow("do not allow workspace setup/cleanup commands");
+
+    projectSvc.list.mockResolvedValue([]);
+    issueSvc.list.mockResolvedValue([{
+      id: "issue-1",
+      identifier: "PAP-1",
+      title: "Unsafe Issue",
+      description: null,
+      projectId: null,
+      projectWorkspaceId: null,
+      assigneeAgentId: null,
+      status: "todo",
+      priority: "medium",
+      labelIds: [],
+      billingCode: null,
+      executionWorkspaceSettings: {
+        workspaceRuntime: {
+          services: [{ name: "host-command", command: "touch /tmp/rudder-rce" }],
+        },
+      },
+      assigneeAgentRuntimeOverrides: null,
+    }]);
+    const issueExport = await portability.exportBundle("organization-1", {
+      include: { organization: false, agents: false, projects: false, issues: true },
+    });
+    await expect(portability.previewImport({
+      source: { type: "inline", rootPath: issueExport.rootPath, files: issueExport.files },
+      include: { organization: false, agents: false, projects: false, issues: true },
+      target,
+      collisionStrategy: "rename",
+    }, { mode: "agent_safe", sourceOrganizationId: "organization-1" }))
+      .rejects.toThrow("do not allow issue runtime overrides");
   });
 
   it("disables timer heartbeats on imported agents", async () => {

--- a/server/src/__tests__/company-skills-routes.test.ts
+++ b/server/src/__tests__/company-skills-routes.test.ts
@@ -14,7 +14,19 @@ const mockAccessService = vi.hoisted(() => ({
 }));
 
 const mockCompanySkillService = vi.hoisted(() => ({
+  list: vi.fn(),
+  hasLocalPathSkills: vi.fn(),
+  getById: vi.fn(),
+  detail: vi.fn(),
+  updateStatus: vi.fn(),
+  readFile: vi.fn(),
+  createLocalSkill: vi.fn(),
+  updateFile: vi.fn(),
   importFromSource: vi.fn(),
+  scanProjectWorkspaces: vi.fn(),
+  scanLocalSkillRoots: vi.fn(),
+  deleteSkill: vi.fn(),
+  installUpdate: vi.fn(),
 }));
 
 const mockLogActivity = vi.hoisted(() => vi.fn());
@@ -48,10 +60,38 @@ function createApp(actor: Record<string, unknown>) {
 describe("organization skill mutation permissions", () => {
   beforeEach(() => {
     vi.resetAllMocks();
+    mockCompanySkillService.list.mockResolvedValue([]);
+    mockCompanySkillService.hasLocalPathSkills.mockResolvedValue(false);
+    mockCompanySkillService.getById.mockResolvedValue(null);
+    mockCompanySkillService.detail.mockResolvedValue(null);
+    mockCompanySkillService.updateStatus.mockResolvedValue(null);
+    mockCompanySkillService.readFile.mockResolvedValue(null);
+    mockCompanySkillService.updateFile.mockResolvedValue(null);
     mockCompanySkillService.importFromSource.mockResolvedValue({
       imported: [],
       warnings: [],
     });
+    mockCompanySkillService.scanProjectWorkspaces.mockResolvedValue({
+      scannedProjects: 0,
+      scannedWorkspaces: 0,
+      discovered: 0,
+      imported: [],
+      updated: [],
+      skipped: [],
+      conflicts: [],
+      warnings: [],
+    });
+    mockCompanySkillService.scanLocalSkillRoots.mockResolvedValue({
+      scannedRoots: 0,
+      discovered: 0,
+      imported: [],
+      updated: [],
+      skipped: [],
+      conflicts: [],
+      warnings: [],
+    });
+    mockCompanySkillService.deleteSkill.mockResolvedValue(null);
+    mockCompanySkillService.installUpdate.mockResolvedValue(null);
     mockLogActivity.mockResolvedValue(undefined);
     mockAccessService.canUser.mockResolvedValue(true);
     mockAccessService.hasPermission.mockResolvedValue(false);
@@ -181,5 +221,232 @@ describe("organization skill mutation permissions", () => {
       "organization-1",
       "https://github.com/vercel-labs/agent-browser",
     );
+  });
+
+  it.each([
+    "/etc/rudder-skill/SKILL.md",
+    "/tmp/linked-skill",
+    "file:///etc/rudder-skill/SKILL.md",
+  ])("blocks non-admin board users from importing host source %s", async (source) => {
+    const res = await request(createApp({
+      type: "board",
+      userId: "board-user",
+      orgIds: ["organization-1"],
+      source: "session",
+      isInstanceAdmin: false,
+    }))
+      .post("/api/orgs/organization-1/skills/import")
+      .send({ source });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(res.body.error).toBe("Instance admin access required");
+    expect(mockCompanySkillService.importFromSource).not.toHaveBeenCalled();
+  });
+
+  it("blocks same-organization agents from importing host paths", async () => {
+    mockAgentService.getById.mockResolvedValue({
+      id: "agent-1",
+      orgId: "organization-1",
+      permissions: { canManageSkills: true },
+    });
+
+    const res = await request(createApp({
+      type: "agent",
+      agentId: "agent-1",
+      orgId: "organization-1",
+      runId: "run-1",
+    }))
+      .post("/api/orgs/organization-1/skills/import")
+      .send({ source: "/tmp/linked-skill" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(res.body.error).toBe("Board access required");
+    expect(mockCompanySkillService.importFromSource).not.toHaveBeenCalled();
+  });
+
+  it("blocks non-admin boards and agents from every host-scanning route", async () => {
+    mockAgentService.getById.mockResolvedValue({
+      id: "agent-1",
+      orgId: "organization-1",
+      permissions: { canManageSkills: true },
+    });
+    const boardApp = createApp({
+      type: "board",
+      userId: "board-user",
+      orgIds: ["organization-1"],
+      source: "session",
+      isInstanceAdmin: false,
+    });
+    const agentApp = createApp({
+      type: "agent",
+      agentId: "agent-1",
+      orgId: "organization-1",
+      runId: "run-1",
+    });
+
+    for (const app of [boardApp, agentApp]) {
+      const projectScan = await request(app)
+        .post("/api/orgs/organization-1/skills/scan-projects")
+        .send({});
+      const localScan = await request(app)
+        .post("/api/orgs/organization-1/skills/scan-local")
+        .send({ roots: ["/tmp/linked-skills"] });
+
+      expect(projectScan.status, JSON.stringify(projectScan.body)).toBe(403);
+      expect(localScan.status, JSON.stringify(localScan.body)).toBe(403);
+    }
+
+    expect(mockCompanySkillService.scanProjectWorkspaces).not.toHaveBeenCalled();
+    expect(mockCompanySkillService.scanLocalSkillRoots).not.toHaveBeenCalled();
+  });
+
+  it("permits instance admins to import and scan explicit host paths", async () => {
+    const app = createApp({
+      type: "board",
+      userId: "instance-admin",
+      orgIds: [],
+      source: "session",
+      isInstanceAdmin: true,
+    });
+
+    const importRes = await request(app)
+      .post("/api/orgs/organization-1/skills/import")
+      .send({ source: "/tmp/linked-skill" });
+    const scanRes = await request(app)
+      .post("/api/orgs/organization-1/skills/scan-local")
+      .send({ roots: ["/tmp/linked-skills"] });
+
+    expect(importRes.status, JSON.stringify(importRes.body)).toBe(201);
+    expect(scanRes.status, JSON.stringify(scanRes.body)).toBe(200);
+    expect(mockCompanySkillService.importFromSource).toHaveBeenCalledWith(
+      "organization-1",
+      "/tmp/linked-skill",
+    );
+    expect(mockCompanySkillService.scanLocalSkillRoots).toHaveBeenCalledWith(
+      "organization-1",
+      { roots: ["/tmp/linked-skills"] },
+    );
+  });
+
+  it("rejects all original-path skill actions before filesystem-capable service dispatch", async () => {
+    const skillId = "11111111-1111-4111-8111-111111111111";
+    mockCompanySkillService.getById.mockResolvedValue({
+      id: skillId,
+      orgId: "organization-1",
+      sourceType: "local_path",
+      sourceLocator: "/tmp/linked-skill",
+    });
+    mockAgentService.getById.mockResolvedValue({
+      id: "agent-1",
+      orgId: "organization-1",
+      permissions: { canManageSkills: true },
+    });
+    const actors = [
+      {
+        type: "board",
+        userId: "board-user",
+        orgIds: ["organization-1"],
+        source: "session",
+        isInstanceAdmin: false,
+      },
+      {
+        type: "agent",
+        agentId: "agent-1",
+        orgId: "organization-1",
+        runId: "run-1",
+      },
+    ];
+
+    for (const actor of actors) {
+      const app = createApp(actor);
+      const results = [
+        await request(app).get(`/api/orgs/organization-1/skills/${skillId}`),
+        await request(app).get(`/api/orgs/organization-1/skills/${skillId}/update-status`),
+        await request(app).get(`/api/orgs/organization-1/skills/${skillId}/files?path=SKILL.md`),
+        await request(app)
+          .patch(`/api/orgs/organization-1/skills/${skillId}/files`)
+          .send({ path: "SKILL.md", content: "changed" }),
+        await request(app).delete(`/api/orgs/organization-1/skills/${skillId}`),
+        await request(app).post(`/api/orgs/organization-1/skills/${skillId}/install-update`),
+      ];
+
+      expect(results.map((result) => result.status)).toEqual([403, 403, 403, 403, 403, 403]);
+    }
+
+    expect(mockCompanySkillService.detail).not.toHaveBeenCalled();
+    expect(mockCompanySkillService.updateStatus).not.toHaveBeenCalled();
+    expect(mockCompanySkillService.readFile).not.toHaveBeenCalled();
+    expect(mockCompanySkillService.updateFile).not.toHaveBeenCalled();
+    expect(mockCompanySkillService.deleteSkill).not.toHaveBeenCalled();
+    expect(mockCompanySkillService.installUpdate).not.toHaveBeenCalled();
+  });
+
+  it("allows instance admins to read and update local skill files", async () => {
+    const skillId = "11111111-1111-4111-8111-111111111111";
+    mockCompanySkillService.getById.mockResolvedValue({
+      id: skillId,
+      orgId: "organization-1",
+      sourceType: "local_path",
+      sourceLocator: "/tmp/linked-skill",
+    });
+    mockCompanySkillService.readFile.mockResolvedValue({
+      skillId,
+      path: "SKILL.md",
+      content: "original",
+    });
+    mockCompanySkillService.updateFile.mockResolvedValue({
+      skillId,
+      path: "SKILL.md",
+      content: "changed",
+      markdown: true,
+    });
+    const app = createApp({
+      type: "board",
+      userId: "instance-admin",
+      orgIds: [],
+      source: "session",
+      isInstanceAdmin: true,
+    });
+
+    const readRes = await request(app)
+      .get(`/api/orgs/organization-1/skills/${skillId}/files?path=SKILL.md`);
+    const updateRes = await request(app)
+      .patch(`/api/orgs/organization-1/skills/${skillId}/files`)
+      .send({ path: "SKILL.md", content: "changed" });
+
+    expect(readRes.status, JSON.stringify(readRes.body)).toBe(200);
+    expect(updateRes.status, JSON.stringify(updateRes.body)).toBe(200);
+    expect(mockCompanySkillService.readFile).toHaveBeenCalledWith(
+      "organization-1",
+      skillId,
+      "SKILL.md",
+    );
+    expect(mockCompanySkillService.updateFile).toHaveBeenCalledWith(
+      "organization-1",
+      skillId,
+      "SKILL.md",
+      "changed",
+    );
+  });
+
+  it("blocks local-skill list disclosure and managed host writes for non-admin managers", async () => {
+    mockCompanySkillService.hasLocalPathSkills.mockResolvedValue(true);
+    const app = createApp({
+      type: "board",
+      userId: "board-user",
+      orgIds: ["organization-1"],
+      source: "session",
+      isInstanceAdmin: false,
+    });
+
+    const listRes = await request(app).get("/api/orgs/organization-1/skills");
+    const createRes = await request(app)
+      .post("/api/orgs/organization-1/skills")
+      .send({ name: "Linked Skill", slug: "linked-skill" });
+
+    expect(listRes.status, JSON.stringify(listRes.body)).toBe(403);
+    expect(createRes.status, JSON.stringify(createRes.body)).toBe(403);
+    expect(mockCompanySkillService.list).not.toHaveBeenCalled();
+    expect(mockCompanySkillService.createLocalSkill).not.toHaveBeenCalled();
   });
 });

--- a/server/src/__tests__/company-skills.test.ts
+++ b/server/src/__tests__/company-skills.test.ts
@@ -2,7 +2,11 @@ import { resolveOrganizationStorageKey } from "@rudderhq/agent-runtime-utils";
 import { promises as fs } from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  filterRuntimeSafeOrganizationSkills,
+  readHostSkillCatalogsWhenAllowed,
+} from "../services/knowledge-portability/organization-skills.catalog.js";
 import { createOrganizationSkillScanHandlers } from "../services/knowledge-portability/organization-skills.scans.js";
 import {
   discoverProjectWorkspaceSkillDirectories,
@@ -30,6 +34,50 @@ async function writeSkillDir(skillDir: string, name: string) {
   await fs.mkdir(skillDir, { recursive: true });
   await fs.writeFile(path.join(skillDir, "SKILL.md"), `---\nname: ${name}\n---\n\n# ${name}\n`, "utf8");
 }
+
+describe("organization skill runtime path isolation", () => {
+  it("excludes existing host-local rows unless trusted host authority is explicit", () => {
+    const maliciousLocal = {
+      id: "local-skill",
+      sourceType: "local_path" as const,
+      sourceLocator: "/etc/rudder-linked-skill",
+    };
+    const safeCatalog = {
+      id: "catalog-skill",
+      sourceType: "catalog" as const,
+      sourceLocator: "/managed/catalog-skill",
+    };
+
+    expect(filterRuntimeSafeOrganizationSkills([maliciousLocal, safeCatalog]))
+      .toEqual([safeCatalog]);
+    expect(filterRuntimeSafeOrganizationSkills(
+      [maliciousLocal, safeCatalog],
+      { allowHostLocalPaths: true },
+    )).toEqual([maliciousLocal, safeCatalog]);
+  });
+
+  it("does not enumerate or read a hostile HOME unless host catalog access is explicit", async () => {
+    const readdir = vi.fn(async () => ["linked-skill"]);
+    const readFile = vi.fn(async () => "# secret");
+    const reader = vi.fn(async () => {
+      await readdir("/etc/.agents/skills");
+      await readFile("/etc/.agents/skills/linked-skill/SKILL.md");
+      return ["linked-skill"];
+    });
+
+    await expect(readHostSkillCatalogsWhenAllowed({}, reader)).resolves.toEqual([]);
+    expect(reader).not.toHaveBeenCalled();
+    expect(readdir).not.toHaveBeenCalled();
+    expect(readFile).not.toHaveBeenCalled();
+
+    await expect(readHostSkillCatalogsWhenAllowed(
+      { allowHostCatalogs: true },
+      reader,
+    )).resolves.toEqual(["linked-skill"]);
+    expect(readdir).toHaveBeenCalledWith("/etc/.agents/skills");
+    expect(readFile).toHaveBeenCalledWith("/etc/.agents/skills/linked-skill/SKILL.md");
+  });
+});
 
 describe("organization skill import source parsing", () => {
   it("parses a skills.sh command without executing shell input", () => {

--- a/server/src/__tests__/content-response-policy.test.ts
+++ b/server/src/__tests__/content-response-policy.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import {
+  ACTIVE_CONTENT_SANDBOX_CSP,
+  buildContentResponsePolicy,
+  isSafeInlineRasterContentType,
+} from "../content-response-policy.js";
+
+describe("content response policy", () => {
+  it.each(["image/png", "image/jpeg", "image/webp", "image/avif", "image/bmp", "image/x-icon"])(
+    "allows safe raster content inline: %s",
+    (contentType) => {
+      expect(isSafeInlineRasterContentType(contentType)).toBe(true);
+      expect(buildContentResponsePolicy(contentType, "preview.png", "file")).toEqual({
+        inline: true,
+        contentDisposition: 'inline; filename="preview.png"',
+        contentSecurityPolicy: null,
+      });
+    },
+  );
+
+  it.each(["image/svg+xml", "IMAGE/SVG+XML; charset=utf-8", "text/html", "application/pdf"])(
+    "forces potentially active content to download in a sandbox: %s",
+    (contentType) => {
+      expect(isSafeInlineRasterContentType(contentType)).toBe(false);
+      expect(buildContentResponsePolicy(contentType, "preview.svg", "file")).toEqual({
+        inline: false,
+        contentDisposition: 'attachment; filename="preview.svg"',
+        contentSecurityPolicy: ACTIVE_CONTENT_SANDBOX_CSP,
+      });
+    },
+  );
+
+  it("removes control characters from response filenames", () => {
+    expect(buildContentResponsePolicy("text/html", "payload\r\n\".html", "file").contentDisposition).toBe(
+      'attachment; filename="payload.html"',
+    );
+  });
+});

--- a/server/src/__tests__/export-jobs.test.ts
+++ b/server/src/__tests__/export-jobs.test.ts
@@ -58,6 +58,14 @@ describe("organizationExportJobService", () => {
     expect(completed?.resultAvailable).toBe(true);
     expect(completed?.progress.stage).toBe("ready");
     expect(jobs.getResult(created.id)).toEqual(result);
+    expect(jobs.requiresInstanceAdmin(created.id)).toBe(false);
+  });
+
+  it("retains instance-admin sensitivity for the lifetime of an export job", () => {
+    const jobs = organizationExportJobService();
+    const created = jobs.create("org-1", async () => result, { requiresInstanceAdmin: true });
+
+    expect(jobs.requiresInstanceAdmin(created.id)).toBe(true);
   });
 
   it("cancels a pending export job", async () => {

--- a/server/src/__tests__/invite-accept-replay.test.ts
+++ b/server/src/__tests__/invite-accept-replay.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
   buildJoinDefaultsPayloadForAccept,
+  canMutateJoinRequestOnInviteReplay,
   canReplayOpenClawGatewayInviteAccept,
+  joinRequestRequiresInstanceAdmin,
   mergeJoinDefaultsPayloadForReplay,
 } from "../routes/access.js";
 
@@ -54,6 +56,34 @@ describe("canReplayOpenClawGatewayInviteAccept", () => {
         },
       }),
     ).toBe(false);
+  });
+});
+
+describe("canMutateJoinRequestOnInviteReplay", () => {
+  it("keeps approved join requests immutable when an invite token is replayed", () => {
+    expect(canMutateJoinRequestOnInviteReplay("pending_approval")).toBe(true);
+    expect(canMutateJoinRequestOnInviteReplay("approved")).toBe(false);
+    expect(canMutateJoinRequestOnInviteReplay("rejected")).toBe(false);
+  });
+});
+
+describe("joinRequestRequiresInstanceAdmin", () => {
+  it("treats non-default runtimes and non-empty adapter defaults as privileged", () => {
+    expect(joinRequestRequiresInstanceAdmin({
+      requestType: "agent",
+      agentRuntimeType: "openclaw_gateway",
+      agentDefaultsPayload: { url: "ws://gateway.example" },
+    })).toBe(true);
+    expect(joinRequestRequiresInstanceAdmin({
+      requestType: "agent",
+      agentRuntimeType: "process",
+      agentDefaultsPayload: { command: "touch /tmp/rudder-join-rce" },
+    })).toBe(true);
+    expect(joinRequestRequiresInstanceAdmin({
+      requestType: "agent",
+      agentRuntimeType: "process",
+      agentDefaultsPayload: {},
+    })).toBe(false);
   });
 });
 

--- a/server/src/__tests__/invite-resolution-probe.test.ts
+++ b/server/src/__tests__/invite-resolution-probe.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { probeInviteResolutionTarget } from "../routes/access-onboarding.helpers.js";
+
+vi.mock("node:dns/promises", () => ({
+  lookup: vi.fn(),
+}));
+
+const dnsPromises = await import("node:dns/promises");
+const lookupMock = vi.mocked(dnsPromises.lookup);
+
+describe("probeInviteResolutionTarget", () => {
+  afterEach(() => {
+    lookupMock.mockReset();
+    vi.restoreAllMocks();
+  });
+
+  it.each([
+    "http://127.0.0.1:8080/health",
+    "http://169.254.169.254/latest/meta-data/",
+    "http://[::1]:8080/health",
+    "http://[::ffff:127.0.0.1]:8080/health",
+    "http://[fe80::1]:8080/health",
+  ])("rejects a non-public literal without opening a connection: %s", async (url) => {
+    const pinnedFetchImpl = vi.fn();
+
+    const probe = await probeInviteResolutionTarget(new URL(url), 1_000, {
+      pinnedFetchImpl,
+    });
+
+    expect(probe).toMatchObject({
+      status: "unreachable",
+      method: "HEAD",
+      httpStatus: null,
+      message: "Private network URLs cannot be inspected",
+    });
+    expect(lookupMock).not.toHaveBeenCalled();
+    expect(pinnedFetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("rejects a hostname when any DNS answer is non-public", async () => {
+    lookupMock.mockResolvedValue([
+      { address: "93.184.216.34", family: 4 },
+      { address: "169.254.169.254", family: 4 },
+    ]);
+    const pinnedFetchImpl = vi.fn();
+
+    const probe = await probeInviteResolutionTarget(
+      new URL("https://probe.example/health"),
+      1_000,
+      { pinnedFetchImpl },
+    );
+
+    expect(probe).toMatchObject({
+      status: "unreachable",
+      httpStatus: null,
+      message: "Private network URLs cannot be inspected",
+    });
+    expect(pinnedFetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("rejects a public hostname resolving to a non-public IPv6 address", async () => {
+    lookupMock.mockResolvedValue([{ address: "fd12:3456::1", family: 6 }]);
+    const pinnedFetchImpl = vi.fn();
+
+    const probe = await probeInviteResolutionTarget(
+      new URL("https://probe.example/health"),
+      1_000,
+      { pinnedFetchImpl },
+    );
+
+    expect(probe).toMatchObject({
+      status: "unreachable",
+      httpStatus: null,
+      message: "Private network URLs cannot be inspected",
+    });
+    expect(pinnedFetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("pins the validated DNS answer and keeps HEAD redirects manual", async () => {
+    lookupMock.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
+    const pinnedFetchImpl = vi.fn(
+      async (
+        _url: URL,
+        init: RequestInit,
+        addresses: ReadonlyArray<{ address: string; family: 4 | 6 }>,
+      ) => {
+        expect(init.method).toBe("HEAD");
+        expect(init.redirect).toBe("manual");
+        expect(addresses).toEqual([{ address: "93.184.216.34", family: 4 }]);
+        return new Response(null, {
+          status: 302,
+          headers: { location: "http://127.0.0.1/private" },
+        });
+      },
+    );
+
+    const probe = await probeInviteResolutionTarget(
+      new URL("https://probe.example/health"),
+      1_000,
+      { pinnedFetchImpl },
+    );
+
+    expect(probe).toMatchObject({
+      status: "unreachable",
+      method: "HEAD",
+      httpStatus: 302,
+    });
+    expect(pinnedFetchImpl).toHaveBeenCalledTimes(1);
+  });
+});

--- a/server/src/__tests__/issue-lifecycle-routes.test.ts
+++ b/server/src/__tests__/issue-lifecycle-routes.test.ts
@@ -749,6 +749,69 @@ describe("issue lifecycle routes", () => {
     expect(res.body.createdByAgentId).toBe(ASSIGNEE_AGENT_ID);
   });
 
+  it("rejects agent-supplied runtime overrides when creating issues", async () => {
+    const res = await request(createApp(createAgentActor(ASSIGNEE_AGENT_ID)))
+      .post("/api/orgs/organization-1/issues")
+      .send({
+        title: "Host command issue",
+        status: "todo",
+        runWorkspaceSettings: {
+          mode: "shared_workspace",
+          workspaceRuntime: {
+            services: [{ name: "host-command", command: "touch /tmp/rudder-rce" }],
+          },
+        },
+      });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toContain("runWorkspaceSettings");
+    expect(mockIssueService.create).not.toHaveBeenCalled();
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
+  });
+
+  it("rejects issue runtime overrides from non-admin board members", async () => {
+    const res = await request(createApp({
+      type: "board",
+      userId: "organization-member",
+      orgIds: ["organization-1"],
+      source: "session",
+      isInstanceAdmin: false,
+    }))
+      .post("/api/orgs/organization-1/issues")
+      .send({
+        title: "Host command issue",
+        status: "todo",
+        runWorkspaceSettings: {
+          mode: "shared_workspace",
+          workspaceRuntime: {
+            services: [{ name: "host-command", command: "touch /tmp/rudder-board-rce" }],
+          },
+        },
+      });
+
+    expect(res.status).toBe(403);
+    expect(mockIssueService.create).not.toHaveBeenCalled();
+  });
+
+  it("rejects agent-supplied assignee runtime overrides when updating issues", async () => {
+    const res = await request(createApp(createAgentActor(ASSIGNEE_AGENT_ID)))
+      .patch("/api/issues/11111111-1111-4111-8111-111111111111")
+      .send({
+        assigneeAgentRuntimeOverrides: {
+          agentRuntimeConfig: {
+            workspaceRuntime: {
+              services: [{ name: "host-command", command: "touch /tmp/rudder-rce" }],
+            },
+          },
+        },
+      });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toContain("assigneeAgentRuntimeOverrides");
+    expect(mockIssueService.getById).not.toHaveBeenCalled();
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
   it("preserves explicit assignee and explicit null on agent-created issues", async () => {
     mockAccessService.hasPermission.mockResolvedValue(true);
     mockIssueService.create.mockImplementation(async (_orgId: string, data: Record<string, unknown>) =>

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -1593,6 +1593,66 @@ describe("issueService.list participantAgentId", () => {
     });
   });
 
+  it("rejects project and creator-agent links outside the organization", async () => {
+    const orgId = randomUUID();
+    const otherOrgId = randomUUID();
+    await db.insert(organizations).values([
+      {
+        id: orgId,
+        name: "Issue Boundary Org",
+        urlKey: deriveOrganizationUrlKey("Issue Boundary Org"),
+        issuePrefix: `I${orgId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+        requireBoardApprovalForNewAgents: false,
+      },
+      {
+        id: otherOrgId,
+        name: "Other Issue Boundary Org",
+        urlKey: deriveOrganizationUrlKey("Other Issue Boundary Org"),
+        issuePrefix: `J${otherOrgId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+        requireBoardApprovalForNewAgents: false,
+      },
+    ]);
+    const [foreignProject] = await db.insert(projects).values({
+      orgId: otherOrgId,
+      name: "Foreign Project",
+      slug: `foreign-${randomUUID()}`,
+      status: "active",
+    }).returning();
+    const [foreignAgent] = await db.insert(agents).values({
+      orgId: otherOrgId,
+      name: "Foreign Creator",
+      role: "engineer",
+      status: "active",
+      agentRuntimeType: "process",
+      agentRuntimeConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    }).returning();
+
+    await expect(svc.create(orgId, {
+      title: "Cross-org project",
+      status: "todo",
+      priority: "medium",
+      projectId: foreignProject!.id,
+    })).rejects.toThrow("Project must belong to same organization");
+    await expect(svc.create(orgId, {
+      title: "Cross-org creator",
+      status: "todo",
+      priority: "medium",
+      createdByAgentId: foreignAgent!.id,
+    })).rejects.toThrow("Creator agent must belong to same organization");
+
+    const issue = await svc.create(orgId, {
+      title: "Local issue",
+      status: "todo",
+      priority: "medium",
+    });
+    await expect(svc.update(issue.id, { projectId: foreignProject!.id }))
+      .rejects.toThrow("Project must belong to same organization");
+    await expect(svc.update(issue.id, { createdByAgentId: foreignAgent!.id }))
+      .rejects.toThrow("Creator agent must belong to same organization");
+  });
+
   it("persists an explicit goal clear for projectless issues with a default organization goal", async () => {
     const orgId = randomUUID();
 

--- a/server/src/__tests__/organization-intelligence-profiles-routes.test.ts
+++ b/server/src/__tests__/organization-intelligence-profiles-routes.test.ts
@@ -87,17 +87,17 @@ vi.mock("../services/index.js", () => ({
   logActivity: mockLogActivity,
 }));
 
-async function createApp() {
+async function createApp(actor: Record<string, unknown> = {
+  type: "board",
+  source: "local_implicit",
+  userId: "user-1",
+  orgIds: ["org-1"],
+}) {
   const { organizationRoutes } = await import("../routes/orgs.js");
   const app = express();
   app.use(express.json());
   app.use((req, _res, next) => {
-    (req as any).actor = {
-      type: "board",
-      source: "local_implicit",
-      userId: "user-1",
-      orgIds: ["org-1"],
-    };
+    (req as any).actor = actor;
     next();
   });
   app.use("/api/orgs", organizationRoutes({} as any));
@@ -211,6 +211,30 @@ describe("organization intelligence profile routes", () => {
 
     expect(res.status).toBe(422);
     expect(res.body.error).toContain("Runtime chain test failed for Primary");
+    expect(mockOrganizationIntelligenceProfiles.upsert).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-admins before validating or testing a runtime configuration", async () => {
+    const app = await createApp({
+      type: "board",
+      source: "session",
+      userId: "organization-member",
+      orgIds: ["org-1"],
+      isInstanceAdmin: false,
+    });
+
+    const res = await request(app)
+      .put("/api/orgs/org-1/intelligence-profiles/lightweight")
+      .send({
+        agentRuntimeConfig: {
+          command: "sh -lc 'touch /tmp/rudder-profile-rce'",
+        },
+      });
+
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ error: "Instance admin access required" });
+    expect(mockOrganizationIntelligenceRuntimeChain.assertUsable).not.toHaveBeenCalled();
+    expect(mockTestEnvironment).not.toHaveBeenCalled();
     expect(mockOrganizationIntelligenceProfiles.upsert).not.toHaveBeenCalled();
   });
 });

--- a/server/src/__tests__/organization-skill-fetch-security.test.ts
+++ b/server/src/__tests__/organization-skill-fetch-security.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fetchText } from "../services/knowledge-portability/organization-skills.sources.js";
+
+vi.mock("node:dns/promises", () => ({
+  lookup: vi.fn(),
+}));
+
+const dnsPromises = await import("node:dns/promises");
+const lookupMock = vi.mocked(dnsPromises.lookup);
+const publicAddresses = [{ address: "93.184.216.34", family: 4 as const }];
+
+describe("organization skill public URL fetching", () => {
+  afterEach(() => {
+    lookupMock.mockReset();
+    vi.restoreAllMocks();
+  });
+
+  it.each([
+    "http://localhost:3000/SKILL.md",
+    "http://127.0.0.1:3000/SKILL.md",
+    "http://169.254.169.254/latest/meta-data",
+    "http://[::1]/SKILL.md",
+    "http://[::ffff:127.0.0.1]/SKILL.md",
+  ])("rejects literal local, metadata, and non-public IPv6 sources: %s", async (url) => {
+    const pinnedFetchImpl = vi.fn();
+
+    await expect(fetchText(url, { pinnedFetchImpl })).rejects.toMatchObject({
+      status: 422,
+      message: "Private network URLs cannot be inspected",
+    });
+    expect(lookupMock).not.toHaveBeenCalled();
+    expect(pinnedFetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("rejects a hostname when any DNS answer is private", async () => {
+    lookupMock.mockResolvedValue([
+      ...publicAddresses,
+      { address: "10.0.0.7", family: 4 },
+    ]);
+    const pinnedFetchImpl = vi.fn();
+
+    await expect(fetchText("https://skills.example/SKILL.md", { pinnedFetchImpl }))
+      .rejects.toMatchObject({ status: 422, message: "Private network URLs cannot be inspected" });
+    expect(pinnedFetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("rejects a public hostname resolving to a non-public IPv6 address", async () => {
+    lookupMock.mockResolvedValue([{ address: "fe80::1", family: 6 }]);
+    const pinnedFetchImpl = vi.fn();
+
+    await expect(fetchText("https://skills.example/SKILL.md", { pinnedFetchImpl }))
+      .rejects.toMatchObject({ status: 422, message: "Private network URLs cannot be inspected" });
+    expect(pinnedFetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("validates and pins every hop of a public redirect", async () => {
+    lookupMock.mockResolvedValue(publicAddresses);
+    const pinnedFetchImpl = vi.fn(async (url: URL) => {
+      if (url.href === "https://skills.example/SKILL.md") {
+        return new Response(null, {
+          status: 302,
+          headers: { location: "https://cdn.example/final/SKILL.md" },
+        });
+      }
+      if (url.href === "https://cdn.example/final/SKILL.md") {
+        return new Response("# Safe skill", { status: 200 });
+      }
+      throw new Error(`Unexpected fetch ${url.href}`);
+    });
+
+    await expect(fetchText("https://skills.example/SKILL.md", { pinnedFetchImpl }))
+      .resolves.toBe("# Safe skill");
+
+    expect(lookupMock).toHaveBeenNthCalledWith(1, "skills.example", { all: true, verbatim: true });
+    expect(lookupMock).toHaveBeenNthCalledWith(2, "cdn.example", { all: true, verbatim: true });
+    expect(pinnedFetchImpl).toHaveBeenCalledTimes(2);
+    expect(pinnedFetchImpl.mock.calls[0]?.[2]).toEqual(publicAddresses);
+    expect(pinnedFetchImpl.mock.calls[1]?.[2]).toEqual(publicAddresses);
+    expect(pinnedFetchImpl.mock.calls[0]?.[1]).toMatchObject({ method: "GET", redirect: "manual" });
+    expect(pinnedFetchImpl.mock.calls[1]?.[1]).toMatchObject({ method: "GET", redirect: "manual" });
+  });
+
+  it("rejects a redirect to metadata before opening a second connection", async () => {
+    lookupMock.mockResolvedValue(publicAddresses);
+    const pinnedFetchImpl = vi.fn(async () => new Response(null, {
+      status: 302,
+      headers: { location: "http://169.254.169.254/latest/meta-data" },
+    }));
+
+    await expect(fetchText("https://skills.example/SKILL.md", { pinnedFetchImpl }))
+      .rejects.toMatchObject({ status: 422, message: "Private network URLs cannot be inspected" });
+    expect(lookupMock).toHaveBeenCalledTimes(1);
+    expect(pinnedFetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes only the validated DNS address set to the pinned transport", async () => {
+    lookupMock.mockResolvedValue(publicAddresses);
+    const globalFetch = vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("global fetch must not be used"));
+    const pinnedFetchImpl = vi.fn(async (
+      url: URL,
+      init: RequestInit,
+      addresses: ReadonlyArray<{ address: string; family: 4 | 6 }>,
+    ) => {
+      expect(url.href).toBe("https://skills.example/SKILL.md");
+      expect(init.redirect).toBe("manual");
+      expect(addresses).toEqual(publicAddresses);
+      return new Response("# DNS-pinned skill", { status: 200 });
+    });
+
+    await expect(fetchText("https://skills.example/SKILL.md", { pinnedFetchImpl }))
+      .resolves.toBe("# DNS-pinned skill");
+    expect(pinnedFetchImpl).toHaveBeenCalledTimes(1);
+    expect(globalFetch).not.toHaveBeenCalled();
+  });
+
+  it("rejects a response body that exceeds the configured size limit", async () => {
+    lookupMock.mockResolvedValue(publicAddresses);
+    const pinnedFetchImpl = vi.fn(async () => new Response("12345", { status: 200 }));
+
+    await expect(fetchText("https://skills.example/SKILL.md", {
+      maxBytes: 4,
+      pinnedFetchImpl,
+    })).rejects.toMatchObject({
+      status: 422,
+      message: "Response exceeds public text size limit",
+    });
+  });
+
+  it("times out even when DNS resolution stalls", async () => {
+    lookupMock.mockImplementation(() => new Promise<never>(() => undefined));
+    const pinnedFetchImpl = vi.fn();
+
+    await expect(fetchText("https://skills.example/SKILL.md", {
+      timeoutMs: 20,
+      pinnedFetchImpl,
+    })).rejects.toMatchObject({ status: 422 });
+    expect(pinnedFetchImpl).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/__tests__/organization-skills-reference.test.ts
+++ b/server/src/__tests__/organization-skills-reference.test.ts
@@ -277,7 +277,11 @@ describe("organization skill references", () => {
           },
         },
       };
-      const snapshot = await skillSvc.buildAgentSkillSnapshot(agent, { env: { HOME: home } });
+      const snapshot = await skillSvc.buildAgentSkillSnapshot(
+        agent,
+        { env: { HOME: home } },
+        { allowHostCatalogs: true },
+      );
 
       expect(snapshot.entries).toContainEqual(expect.objectContaining({
         key: "build-advisor",
@@ -300,9 +304,14 @@ describe("organization skill references", () => {
       const enabledSnapshot = await skillSvc.buildAgentSkillSnapshot(
         agent,
         { env: { HOME: home } },
+        { allowHostCatalogs: true },
       );
       await skillSvc.replaceEnabledSkillKeysForAgent(orgId, agentId, enabledSelection);
-      const refreshedSnapshot = await skillSvc.buildAgentSkillSnapshot(agent, { env: { HOME: home } });
+      const refreshedSnapshot = await skillSvc.buildAgentSkillSnapshot(
+        agent,
+        { env: { HOME: home } },
+        { allowHostCatalogs: true },
+      );
       expect(refreshedSnapshot.entries).toContainEqual(expect.objectContaining({
         selectionKey: "adapter:codex_local:build-advisor",
         state: "configured",
@@ -316,6 +325,7 @@ describe("organization skill references", () => {
         "claude_local",
         { env: { HOME: home } },
         enabledSelection,
+        { allowHostCatalogs: true },
       );
       expect(runtimeEntries).toContainEqual(expect.objectContaining({
         key: "adapter:codex_local:build-advisor",

--- a/server/src/__tests__/organization-workspace-browser-security.test.ts
+++ b/server/src/__tests__/organization-workspace-browser-security.test.ts
@@ -1,0 +1,90 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { organizationWorkspaceBrowserService } from "../services/organization-workspace-browser.js";
+
+const mocks = vi.hoisted(() => ({
+  rootPath: "",
+  getOrganization: vi.fn(),
+  getOrCreateWorkspaceFileEntry: vi.fn(),
+}));
+
+vi.mock("../home-paths.js", () => ({
+  ensureOrganizationWorkspaceLayout: vi.fn(),
+  resolveOrganizationWorkspaceRoot: vi.fn(() => mocks.rootPath),
+}));
+
+vi.mock("../services/orgs.js", () => ({
+  organizationService: () => ({ getById: mocks.getOrganization }),
+}));
+
+vi.mock("../services/library-entries.js", () => ({
+  libraryEntryService: () => ({
+    getOrCreateWorkspaceFileEntry: mocks.getOrCreateWorkspaceFileEntry,
+  }),
+}));
+
+describe("organization workspace browser filesystem boundaries", () => {
+  const cleanupDirs = new Set<string>();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getOrganization.mockResolvedValue({ id: "organization-1" });
+    mocks.getOrCreateWorkspaceFileEntry.mockResolvedValue({ id: "library-entry-1" });
+  });
+
+  afterEach(async () => {
+    await Promise.all([...cleanupDirs].map(async (dir) => {
+      await fs.rm(dir, { recursive: true, force: true });
+      cleanupDirs.delete(dir);
+    }));
+  });
+
+  it("rejects reads, attachments, updates, and creates through symbolic links", async () => {
+    if (process.platform === "win32") return;
+
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "rudder-workspace-browser-root-"));
+    const outsideRoot = await fs.mkdtemp(path.join(os.tmpdir(), "rudder-workspace-browser-outside-"));
+    cleanupDirs.add(root);
+    cleanupDirs.add(outsideRoot);
+    mocks.rootPath = root;
+
+    const projectRoot = path.join(root, "projects", "linked");
+    const outsideFile = path.join(outsideRoot, "secret.md");
+    await fs.mkdir(projectRoot, { recursive: true });
+    await fs.writeFile(outsideFile, "host secret\n", "utf8");
+    await fs.symlink(outsideFile, path.join(projectRoot, "secret.md"));
+    await fs.symlink(outsideRoot, path.join(projectRoot, "outside"), "dir");
+
+    const workspaceBrowser = organizationWorkspaceBrowserService({} as any);
+    await expect(workspaceBrowser.readFile("organization-1", "projects/linked/secret.md"))
+      .rejects.toThrow("cannot traverse symbolic links");
+    await expect(workspaceBrowser.readAttachmentFile("organization-1", "projects/linked/secret.md"))
+      .rejects.toThrow("cannot traverse symbolic links");
+    await expect(workspaceBrowser.writeFile("organization-1", "projects/linked/secret.md", "overwritten\n"))
+      .rejects.toThrow("cannot traverse symbolic links");
+    await expect(workspaceBrowser.createFile("organization-1", "projects/linked/outside/created.md", "escaped\n"))
+      .rejects.toThrow("cannot traverse symbolic links");
+
+    await expect(fs.readFile(outsideFile, "utf8")).resolves.toBe("host secret\n");
+    await expect(fs.stat(path.join(outsideRoot, "created.md"))).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("continues to read and update regular files inside the Library root", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "rudder-workspace-browser-regular-"));
+    cleanupDirs.add(root);
+    mocks.rootPath = root;
+
+    const filePath = path.join(root, "projects", "safe", "notes.md");
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(filePath, "before\n", "utf8");
+
+    const workspaceBrowser = organizationWorkspaceBrowserService({} as any);
+    await expect(workspaceBrowser.readFile("organization-1", "projects/safe/notes.md"))
+      .resolves.toMatchObject({ content: "before\n" });
+    await expect(workspaceBrowser.writeFile("organization-1", "projects/safe/notes.md", "after\n"))
+      .resolves.toMatchObject({ content: "after\n" });
+    await expect(fs.readFile(filePath, "utf8")).resolves.toBe("after\n");
+  });
+});

--- a/server/src/__tests__/organization-workspace-browser.test.ts
+++ b/server/src/__tests__/organization-workspace-browser.test.ts
@@ -813,4 +813,43 @@ describe("organization workspace browser", () => {
     await expect(workspaceBrowser.deleteLegacyHeartbeatInstructions(orgId)).resolves.toEqual({ deleted: [] });
   });
 
+  it("rejects Library reads and writes through symbolic links", async () => {
+    if (process.platform === "win32") return;
+
+    const rudderHome = await fs.mkdtemp(path.join(os.tmpdir(), "rudder-org-workspace-symlink-home-"));
+    const outsideRoot = await fs.mkdtemp(path.join(os.tmpdir(), "rudder-org-workspace-symlink-outside-"));
+    cleanupDirs.add(rudderHome);
+    cleanupDirs.add(outsideRoot);
+    process.env.RUDDER_HOME = rudderHome;
+    process.env.RUDDER_INSTANCE_ID = "test-instance";
+
+    const orgId = randomUUID();
+    await db.insert(organizations).values({
+      id: orgId,
+      name: "Workspace Browser Symlink Org",
+      urlKey: deriveOrganizationUrlKey("Workspace Browser Symlink Org"),
+      issuePrefix: "WBS",
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    const root = resolveOrganizationWorkspaceRoot(orgId);
+    const projectRoot = path.join(root, "projects", "linked");
+    const outsideFile = path.join(outsideRoot, "secret.md");
+    await fs.mkdir(projectRoot, { recursive: true });
+    await fs.writeFile(outsideFile, "host secret\n", "utf8");
+    await fs.symlink(outsideFile, path.join(projectRoot, "secret.md"));
+    await fs.symlink(outsideRoot, path.join(projectRoot, "outside"), "dir");
+
+    await expect(workspaceBrowser.readFile(orgId, "projects/linked/secret.md"))
+      .rejects.toThrow("cannot traverse symbolic links");
+    await expect(workspaceBrowser.readAttachmentFile(orgId, "projects/linked/secret.md"))
+      .rejects.toThrow("cannot traverse symbolic links");
+    await expect(workspaceBrowser.writeFile(orgId, "projects/linked/secret.md", "overwritten\n"))
+      .rejects.toThrow("cannot traverse symbolic links");
+    await expect(workspaceBrowser.createFile(orgId, "projects/linked/outside/created.md", "escaped\n"))
+      .rejects.toThrow("cannot traverse symbolic links");
+    await expect(fs.readFile(outsideFile, "utf8")).resolves.toBe("host secret\n");
+    await expect(fs.stat(path.join(outsideRoot, "created.md"))).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
 });

--- a/server/src/__tests__/plugin-admin-routes.test.ts
+++ b/server/src/__tests__/plugin-admin-routes.test.ts
@@ -1,0 +1,126 @@
+import express from "express";
+import request from "supertest";
+import { describe, expect, it } from "vitest";
+import { errorHandler } from "../middleware/index.js";
+import { pluginRoutes } from "../routes/plugins.js";
+
+function createApp(actor: Record<string, unknown>) {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as typeof req & { actor: Record<string, unknown> }).actor = actor;
+    next();
+  });
+  app.use("/api", pluginRoutes({} as any, {} as any));
+  app.use(errorHandler);
+  return app;
+}
+
+const memberActor = {
+  type: "board",
+  userId: "member-1",
+  orgIds: ["organization-1"],
+  isInstanceAdmin: false,
+  source: "session",
+};
+
+describe("instance-global plugin administration", () => {
+  it.each([
+    ["install", (app: ReturnType<typeof createApp>) => request(app).post("/api/plugins/install").send({})],
+    ["uninstall", (app: ReturnType<typeof createApp>) => request(app).delete("/api/plugins/plugin-1")],
+    ["enable", (app: ReturnType<typeof createApp>) => request(app).post("/api/plugins/plugin-1/enable")],
+    ["disable", (app: ReturnType<typeof createApp>) => request(app).post("/api/plugins/plugin-1/disable")],
+    ["upgrade", (app: ReturnType<typeof createApp>) => request(app).post("/api/plugins/plugin-1/upgrade")],
+    ["read config", (app: ReturnType<typeof createApp>) => request(app).get("/api/plugins/plugin-1/config")],
+    ["write config", (app: ReturnType<typeof createApp>) => request(app).post("/api/plugins/plugin-1/config").send({})],
+    ["test config", (app: ReturnType<typeof createApp>) => request(app).post("/api/plugins/plugin-1/config/test").send({})],
+    ["read logs", (app: ReturnType<typeof createApp>) => request(app).get("/api/plugins/plugin-1/logs")],
+    ["list jobs", (app: ReturnType<typeof createApp>) => request(app).get("/api/plugins/plugin-1/jobs")],
+    ["read job runs", (app: ReturnType<typeof createApp>) => request(app).get("/api/plugins/plugin-1/jobs/job-1/runs")],
+    ["trigger a job", (app: ReturnType<typeof createApp>) => request(app).post("/api/plugins/plugin-1/jobs/job-1/trigger")],
+    ["read the operational dashboard", (app: ReturnType<typeof createApp>) => request(app).get("/api/plugins/plugin-1/dashboard")],
+    ["call a global data bridge", (app: ReturnType<typeof createApp>) => request(app).post("/api/plugins/plugin-1/data/status").send({})],
+    ["call a global action bridge", (app: ReturnType<typeof createApp>) => request(app).post("/api/plugins/plugin-1/actions/run").send({})],
+    ["call the legacy data bridge", (app: ReturnType<typeof createApp>) => request(app).post("/api/plugins/plugin-1/bridge/data").send({ key: "status" })],
+    ["call the legacy action bridge", (app: ReturnType<typeof createApp>) => request(app).post("/api/plugins/plugin-1/bridge/action").send({ key: "run" })],
+  ])("rejects a non-admin board member attempting to %s", async (_label, sendRequest) => {
+    const response = await sendRequest(createApp(memberActor));
+
+    expect(response.status).toBe(403);
+    expect(response.body).toEqual({ error: "Instance admin access required" });
+  });
+
+  it("lets an instance admin reach plugin install validation", async () => {
+    const response = await request(createApp({
+      ...memberActor,
+      isInstanceAdmin: true,
+    })).post("/api/plugins/install").send({});
+
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({
+      error: "packageName is required and must be a string",
+    });
+  });
+
+  it.each([
+    ["data", "/api/plugins/plugin-1/data/state-value"],
+    ["action", "/api/plugins/plugin-1/actions/write-scoped-state"],
+  ])("rejects a non-admin organization member's %s bridge request targeting another organization", async (_label, route) => {
+    const response = await request(createApp(memberActor)).post(route).send({
+      orgId: "organization-1",
+      params: {
+        orgId: "organization-1",
+        scopeKind: "organization",
+        scopeId: "organization-2",
+        stateKey: "private-state",
+      },
+    });
+
+    expect(response.status).toBe(403);
+    expect(response.body).toEqual({ error: "Instance admin access required" });
+  });
+
+  it.each([
+    ["read instance state", "/api/plugins/plugin-1/data/state-value", { scopeKind: "instance", stateKey: "private-state" }],
+    ["write instance state", "/api/plugins/plugin-1/actions/write-scoped-state", { scopeKind: "instance", stateKey: "private-state", value: "owned" }],
+    ["delete instance state", "/api/plugins/plugin-1/actions/delete-scoped-state", { scopeKind: "instance", stateKey: "private-state" }],
+    ["upsert an instance entity", "/api/plugins/plugin-1/actions/upsert-entity", { scopeKind: "instance", entityType: "private-entity", data: {} }],
+    ["list organizations", "/api/plugins/plugin-1/data/organizations", { limit: 100 }],
+    ["read the global overview", "/api/plugins/plugin-1/data/overview", { orgId: "organization-1" }],
+  ])("rejects a non-admin organization member attempting to %s", async (_label, route, params) => {
+    const response = await request(createApp(memberActor))
+      .post(route)
+      .send({ orgId: "organization-1", params });
+
+    expect(response.status).toBe(403);
+    expect(response.body).toEqual({ error: "Instance admin access required" });
+  });
+
+  it("lets an instance admin reach a global bridge", async () => {
+    const response = await request(createApp({
+      ...memberActor,
+      isInstanceAdmin: true,
+    })).post("/api/plugins/plugin-1/actions/run").send({});
+
+    expect(response.status).toBe(501);
+    expect(response.body).toEqual({ error: "Plugin bridge is not enabled" });
+  });
+
+  it("rejects plugin tool parameters that name a different organization", async () => {
+    const response = await request(createApp(memberActor)).post("/api/plugins/tools/execute").send({
+      tool: "example:run",
+      parameters: { orgId: "organization-2" },
+      runContext: {
+        agentId: "agent-1",
+        runId: "run-1",
+        orgId: "organization-1",
+        projectId: "project-1",
+      },
+    });
+
+    expect(response.status).toBe(403);
+    expect(response.body).toEqual({
+      error: "Plugin tool parameters must use the authorized organization scope",
+    });
+  });
+});

--- a/server/src/__tests__/plugin-host-http-security.test.ts
+++ b/server/src/__tests__/plugin-host-http-security.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fetchPluginHttp } from "../services/plugin-host-services.js";
+
+vi.mock("node:dns/promises", () => ({
+  lookup: vi.fn(),
+}));
+
+const dnsPromises = await import("node:dns/promises");
+const lookupMock = vi.mocked(dnsPromises.lookup);
+const publicAddresses = [{ address: "93.184.216.34", family: 4 as const }];
+
+describe("plugin host HTTP security", () => {
+  afterEach(() => {
+    lookupMock.mockReset();
+    vi.restoreAllMocks();
+  });
+
+  it.each([
+    "http://0.1.2.3/data",
+    "http://100.64.0.1/data",
+    "http://192.0.0.1/data",
+    "http://198.18.0.1/data",
+    "http://224.0.0.1/data",
+    "http://[::ffff:127.0.0.1]/data",
+    "http://[::192.168.1.1]/data",
+    "http://[64:ff9b::a00:1]/data",
+    "http://[2001:db8::1]/data",
+  ])("rejects non-public literal address %s", async (url) => {
+    const pinnedFetchImpl = vi.fn();
+
+    await expect(fetchPluginHttp(
+      { url },
+      { publicHttpOptions: { pinnedFetchImpl } },
+    )).rejects.toThrow("Private network URLs cannot be inspected");
+
+    expect(lookupMock).not.toHaveBeenCalled();
+    expect(pinnedFetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("rejects a hostname if any DNS answer is non-public", async () => {
+    lookupMock.mockResolvedValue([
+      ...publicAddresses,
+      { address: "10.0.0.7", family: 4 },
+    ]);
+    const pinnedFetchImpl = vi.fn();
+
+    await expect(fetchPluginHttp(
+      { url: "https://plugins.example/data" },
+      { publicHttpOptions: { pinnedFetchImpl } },
+    )).rejects.toThrow("Private network URLs cannot be inspected");
+
+    expect(pinnedFetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("pins every public redirect hop and strips cross-origin credentials", async () => {
+    lookupMock.mockResolvedValue(publicAddresses);
+    const pinnedFetchImpl = vi.fn(async (url: URL, init: RequestInit) => {
+      if (url.hostname === "plugins.example") {
+        expect(new Headers(init.headers).get("authorization")).toBe("Bearer secret");
+        return new Response(null, {
+          status: 302,
+          headers: { location: "https://cdn.example/final" },
+        });
+      }
+      expect(url.hostname).toBe("cdn.example");
+      expect(new Headers(init.headers).has("authorization")).toBe(false);
+      return new Response("safe response", { status: 200 });
+    });
+
+    await expect(fetchPluginHttp(
+      {
+        url: "https://plugins.example/start",
+        init: { headers: { authorization: "Bearer secret" } },
+      },
+      { publicHttpOptions: { pinnedFetchImpl } },
+    )).resolves.toMatchObject({ status: 200, body: "safe response" });
+
+    expect(lookupMock).toHaveBeenNthCalledWith(1, "plugins.example", { all: true, verbatim: true });
+    expect(lookupMock).toHaveBeenNthCalledWith(2, "cdn.example", { all: true, verbatim: true });
+    expect(pinnedFetchImpl).toHaveBeenCalledTimes(2);
+    expect(pinnedFetchImpl.mock.calls[0]?.[2]).toEqual(publicAddresses);
+    expect(pinnedFetchImpl.mock.calls[1]?.[2]).toEqual(publicAddresses);
+  });
+
+  it("rejects a redirect to metadata before opening another connection", async () => {
+    lookupMock.mockResolvedValue(publicAddresses);
+    const pinnedFetchImpl = vi.fn(async () => new Response(null, {
+      status: 302,
+      headers: { location: "http://169.254.169.254/latest/meta-data" },
+    }));
+
+    await expect(fetchPluginHttp(
+      { url: "https://plugins.example/start" },
+      { publicHttpOptions: { pinnedFetchImpl } },
+    )).rejects.toThrow("Private network URLs cannot be inspected");
+
+    expect(pinnedFetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects an oversized request before DNS or transport work", async () => {
+    const pinnedFetchImpl = vi.fn();
+
+    await expect(fetchPluginHttp(
+      { url: "https://plugins.example/data", init: { method: "POST", body: "12345" } },
+      { maxRequestBytes: 4, publicHttpOptions: { pinnedFetchImpl } },
+    )).rejects.toThrow("request body exceeded 4 bytes");
+
+    expect(lookupMock).not.toHaveBeenCalled();
+    expect(pinnedFetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("cancels and rejects an oversized response body", async () => {
+    lookupMock.mockResolvedValue(publicAddresses);
+    const pinnedFetchImpl = vi.fn(async () => new Response("12345", { status: 200 }));
+
+    await expect(fetchPluginHttp(
+      { url: "https://plugins.example/data" },
+      { maxResponseBytes: 4, publicHttpOptions: { pinnedFetchImpl } },
+    )).rejects.toThrow("response body exceeded 4 bytes");
+  });
+
+  it("times out even if DNS resolution never settles", async () => {
+    lookupMock.mockImplementation(() => new Promise<never>(() => undefined));
+    const pinnedFetchImpl = vi.fn();
+
+    await expect(fetchPluginHttp(
+      { url: "https://plugins.example/data" },
+      { timeoutMs: 20, publicHttpOptions: { pinnedFetchImpl } },
+    )).rejects.toThrow();
+
+    expect(pinnedFetchImpl).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/__tests__/plugin-webhook-security.test.ts
+++ b/server/src/__tests__/plugin-webhook-security.test.ts
@@ -1,0 +1,193 @@
+import express, { Router } from "express";
+import request from "supertest";
+import { describe, expect, it, vi } from "vitest";
+import { errorHandler } from "../middleware/index.js";
+import {
+  createPluginWebhookIngressMiddleware,
+  MAX_PLUGIN_WEBHOOK_FAILURE_BYTES,
+} from "../middleware/plugin-webhook-security.js";
+import { registerPluginOperationsRoutes } from "../routes/plugins.operations-routes.js";
+
+const PLUGIN_ID = "11111111-1111-4111-8111-111111111111";
+const DELIVERY_ID = "22222222-2222-4222-8222-222222222222";
+
+function createWebhookTestApp(input?: {
+  maxBodyBytes?: number;
+  rateLimitMax?: number;
+  workerError?: Error;
+}) {
+  const insertReturning = vi.fn(async () => [{ id: DELIVERY_ID }]);
+  const insertValues = vi.fn(() => ({ returning: insertReturning }));
+  const insert = vi.fn(() => ({ values: insertValues }));
+  const updateWhere = vi.fn(async () => []);
+  const updateSet = vi.fn(() => ({ where: updateWhere }));
+  const update = vi.fn(() => ({ set: updateSet }));
+  const db = { insert, update } as any;
+
+  const workerCall = input?.workerError
+    ? vi.fn().mockRejectedValue(input.workerError)
+    : vi.fn().mockResolvedValue(undefined);
+  const router = Router();
+  registerPluginOperationsRoutes({
+    router,
+    db,
+    registry: {},
+    loader: {},
+    lifecycle: {},
+    bridgeDeps: null,
+    jobDeps: null,
+    webhookDeps: { workerManager: { call: workerCall } },
+    resolvePlugin: vi.fn(async () => ({
+      id: PLUGIN_ID,
+      pluginKey: "webhook-test",
+      version: "1.0.0",
+      status: "ready",
+      manifestJson: {
+        capabilities: ["webhooks.receive"],
+        webhooks: [{ endpointKey: "events", displayName: "Events" }],
+      },
+    })),
+    logPluginMutationActivity: vi.fn(),
+    mapRpcErrorToBridgeError: vi.fn(),
+  });
+
+  const app = express();
+  const ingress = createPluginWebhookIngressMiddleware({
+    maxBodyBytes: input?.maxBodyBytes ?? 64 * 1024,
+    rateLimitMax: input?.rateLimitMax ?? 100,
+    sourceRateLimitMax: 400,
+    rateLimitWindowMs: 60_000,
+    maxRateLimitBuckets: 100,
+  });
+  app.use(
+    "/api/plugins/:pluginId/webhooks/:endpointKey",
+    ingress.rateLimit,
+    ingress.rawBody,
+    ingress.rawBodyError,
+    ingress.decodeBody,
+  );
+  // Mirrors the production parser order. The webhook parser above must consume
+  // the stream so this broader application limit never replaces its raw body.
+  app.use(express.json({ limit: "10mb" }));
+  app.use("/api", router);
+  app.use(errorHandler);
+
+  return { app, insertValues, updateSet, workerCall };
+}
+
+describe("plugin webhook ingress security", () => {
+  it("accepts a normal webhook while persisting only bounded non-sensitive headers", async () => {
+    const { app, insertValues, workerCall } = createWebhookTestApp();
+    const rawBody = JSON.stringify({ action: "opened", number: 42 });
+
+    const response = await request(app)
+      .post(`/api/plugins/${PLUGIN_ID}/webhooks/events`)
+      .set("Content-Type", "application/json")
+      .set("Authorization", "Bearer should-not-be-stored")
+      .set("Cookie", "session=should-not-be-stored")
+      .set("X-Hub-Signature-256", "sha256=should-not-be-stored")
+      .set("X-GitHub-Delivery", "delivery-123")
+      .set("X-GitHub-Event", "x".repeat(1_500))
+      .send(rawBody);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ deliveryId: DELIVERY_ID, status: "success" });
+    expect(insertValues).toHaveBeenCalledTimes(1);
+    const inserted = insertValues.mock.calls[0]?.[0] as Record<string, any>;
+    expect(inserted.payload).toEqual({ action: "opened", number: 42 });
+    expect(inserted.headers).toEqual(expect.objectContaining({
+      "content-type": "application/json",
+      "x-github-delivery": "delivery-123",
+    }));
+    expect(inserted.headers).not.toHaveProperty("authorization");
+    expect(inserted.headers).not.toHaveProperty("cookie");
+    expect(inserted.headers).not.toHaveProperty("x-hub-signature-256");
+    expect(inserted.headers).not.toHaveProperty("x-github-event");
+
+    expect(workerCall).toHaveBeenCalledTimes(1);
+    expect(workerCall).toHaveBeenCalledWith(
+      PLUGIN_ID,
+      "handleWebhook",
+      expect.objectContaining({
+        endpointKey: "events",
+        rawBody,
+        parsedBody: { action: "opened", number: 42 },
+        headers: expect.objectContaining({
+          authorization: "Bearer should-not-be-stored",
+          "x-hub-signature-256": "sha256=should-not-be-stored",
+        }),
+      }),
+    );
+  });
+
+  it("returns 413 before database or worker dispatch when the raw body exceeds the webhook cap", async () => {
+    const { app, insertValues, workerCall } = createWebhookTestApp({ maxBodyBytes: 64 });
+
+    const response = await request(app)
+      .post(`/api/plugins/${PLUGIN_ID}/webhooks/events`)
+      .set("Content-Type", "application/json")
+      .send(JSON.stringify({ payload: "x".repeat(256) }));
+
+    expect(response.status).toBe(413);
+    expect(response.body).toEqual({ error: "Webhook payload too large" });
+    expect(insertValues).not.toHaveBeenCalled();
+    expect(workerCall).not.toHaveBeenCalled();
+  });
+
+  it("returns 429 before database or worker dispatch after an endpoint/source exceeds its quota", async () => {
+    const { app, insertValues, workerCall } = createWebhookTestApp({ rateLimitMax: 1 });
+
+    const first = await request(app)
+      .post(`/api/plugins/${PLUGIN_ID}/webhooks/events`)
+      .send({ delivery: 1 });
+    const second = await request(app)
+      .post(`/api/plugins/${PLUGIN_ID}/webhooks/events`)
+      .send({ delivery: 2 });
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(429);
+    expect(second.headers["retry-after"]).toBeDefined();
+    expect(second.body).toEqual({ error: "Webhook rate limit exceeded" });
+    expect(insertValues).toHaveBeenCalledTimes(1);
+    expect(workerCall).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not let an untrusted caller rotate X-Forwarded-For to bypass rate limits", async () => {
+    const { app, insertValues, workerCall } = createWebhookTestApp({ rateLimitMax: 1 });
+
+    const first = await request(app)
+      .post(`/api/plugins/${PLUGIN_ID}/webhooks/events`)
+      .set("X-Forwarded-For", "198.51.100.10")
+      .send({ delivery: 1 });
+    const second = await request(app)
+      .post(`/api/plugins/${PLUGIN_ID}/webhooks/events`)
+      .set("X-Forwarded-For", "203.0.113.20")
+      .send({ delivery: 2 });
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(429);
+    expect(insertValues).toHaveBeenCalledTimes(1);
+    expect(workerCall).toHaveBeenCalledTimes(1);
+  });
+
+  it("bounds persisted worker failures and does not reflect handler details", async () => {
+    const workerError = new Error(`sensitive-prefix:${"x".repeat(10_000)}`);
+    const { app, updateSet } = createWebhookTestApp({ workerError });
+
+    const response = await request(app)
+      .post(`/api/plugins/${PLUGIN_ID}/webhooks/events`)
+      .send({ delivery: "failure" });
+
+    expect(response.status).toBe(502);
+    expect(response.body).toEqual({
+      deliveryId: DELIVERY_ID,
+      status: "failed",
+      error: "Plugin webhook handler failed",
+    });
+    const failureUpdate = updateSet.mock.calls.at(-1)?.[0] as Record<string, unknown>;
+    expect(failureUpdate.status).toBe("failed");
+    expect(Buffer.byteLength(String(failureUpdate.error), "utf8")).toBeLessThanOrEqual(
+      MAX_PLUGIN_WEBHOOK_FAILURE_BYTES,
+    );
+  });
+});

--- a/server/src/__tests__/postgres-errors.test.ts
+++ b/server/src/__tests__/postgres-errors.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { isPostgresError } from "../services/postgres-errors.js";
+
+describe("isPostgresError", () => {
+  it("matches direct and ORM-wrapped PostgreSQL errors", () => {
+    expect(isPostgresError({ code: "23505" }, "23505")).toBe(true);
+    expect(isPostgresError({
+      cause: {
+        code: "23505",
+        constraint_name: "organizations_issue_prefix_idx",
+      },
+    }, "23505", "organizations_issue_prefix_idx")).toBe(true);
+    expect(isPostgresError({ cause: { code: "22P02" } }, "22P02")).toBe(true);
+  });
+
+  it("accepts both driver constraint fields and a message fallback", () => {
+    expect(isPostgresError({
+      code: "23505",
+      constraint: "heartbeat_runs_active_chat_conversation_uq",
+    }, "23505", "heartbeat_runs_active_chat_conversation_uq")).toBe(true);
+    expect(isPostgresError({
+      code: "23505",
+      message: "duplicate heartbeat_runs_active_chat_conversation_uq",
+    }, "23505", "heartbeat_runs_active_chat_conversation_uq")).toBe(true);
+  });
+
+  it("rejects unrelated codes and constraints", () => {
+    expect(isPostgresError({ code: "23503" }, "23505")).toBe(false);
+    expect(isPostgresError({
+      cause: { code: "23505", constraint_name: "some_other_constraint" },
+    }, "23505", "organizations_issue_prefix_idx")).toBe(false);
+    expect(isPostgresError({
+      code: "23505",
+      constraint: "some_other_constraint",
+      message: "duplicate organizations_issue_prefix_idx",
+    }, "23505", "organizations_issue_prefix_idx")).toBe(false);
+    expect(isPostgresError({
+      code: "23505",
+      constraint_name: "some_other_constraint",
+      message: "duplicate organizations_issue_prefix_idx",
+    }, "23505", "organizations_issue_prefix_idx")).toBe(false);
+  });
+
+  it("stops safely on cyclic and excessively deep cause chains", () => {
+    const cyclic: { code?: string; cause?: unknown } = {};
+    cyclic.cause = cyclic;
+    expect(isPostgresError(cyclic, "23505")).toBe(false);
+
+    const target = { code: "23505" };
+    let wrapped: { cause: unknown } = { cause: target };
+    for (let depth = 0; depth < 8; depth += 1) wrapped = { cause: wrapped };
+    expect(isPostgresError(wrapped, "23505")).toBe(false);
+  });
+});

--- a/server/src/__tests__/private-hostname-guard.test.ts
+++ b/server/src/__tests__/private-hostname-guard.test.ts
@@ -1,7 +1,7 @@
 import express from "express";
 import request from "supertest";
 import { describe, expect, it } from "vitest";
-import { privateHostnameGuard } from "../middleware/private-hostname-guard.js";
+import { isSameOriginHost, privateHostnameGuard } from "../middleware/private-hostname-guard.js";
 
 function createApp(opts: { enabled: boolean; allowedHostnames?: string[]; bindHost?: string }) {
   const app = express();
@@ -22,6 +22,14 @@ function createApp(opts: { enabled: boolean; allowedHostnames?: string[]; bindHo
 }
 
 describe("privateHostnameGuard", () => {
+  it("accepts only matching HTTP(S) websocket origins", () => {
+    expect(isSameOriginHost("http://localhost:3100", "localhost:3100")).toBe(true);
+    expect(isSameOriginHost("https://rudder.example", "rudder.example")).toBe(true);
+    expect(isSameOriginHost("https://attacker.example", "localhost:3100")).toBe(false);
+    expect(isSameOriginHost("null", "localhost:3100")).toBe(false);
+    expect(isSameOriginHost(undefined, "localhost:3100")).toBe(false);
+  });
+
   it("allows requests when disabled", async () => {
     const app = createApp({ enabled: false });
     const res = await request(app).get("/api/health").set("Host", "dotta-macbook-pro:3100");
@@ -30,8 +38,12 @@ describe("privateHostnameGuard", () => {
 
   it("allows loopback hostnames", async () => {
     const app = createApp({ enabled: true });
-    const res = await request(app).get("/api/health").set("Host", "localhost:3100");
-    expect(res.status).toBe(200);
+    const [localhost, ipv6] = await Promise.all([
+      request(app).get("/api/health").set("Host", "localhost:3100"),
+      request(app).get("/api/health").set("Host", "[::1]:3100"),
+    ]);
+    expect(localhost.status).toBe(200);
+    expect(ipv6.status).toBe(200);
   });
 
   it("allows explicitly configured hostnames", async () => {
@@ -45,6 +57,16 @@ describe("privateHostnameGuard", () => {
     const res = await request(app).get("/api/health").set("Host", "dotta-macbook-pro:3100");
     expect(res.status).toBe(403);
     expect(res.body?.error).toContain("please run pnpm rudder allowed-hostname dotta-macbook-pro");
+  });
+
+  it("does not trust a spoofed X-Forwarded-Host header", async () => {
+    const app = createApp({ enabled: true });
+    const res = await request(app)
+      .get("/api/health")
+      .set("Host", "attacker.example:3100")
+      .set("X-Forwarded-Host", "localhost:3100");
+
+    expect(res.status).toBe(403);
   });
 
   it("blocks unknown hostnames on page routes with plain-text remediation command", async () => {

--- a/server/src/__tests__/project-routes.test.ts
+++ b/server/src/__tests__/project-routes.test.ts
@@ -175,6 +175,63 @@ describe("POST /api/orgs/:orgId/projects", () => {
     );
   });
 
+  it("rejects agent-authenticated project execution policies on create and update", async () => {
+    const actor = {
+      type: "agent",
+      agentId: "agent-1",
+      orgId: "organization-1",
+      source: "agent_key",
+      runId: "run-1",
+    };
+    const policy = {
+      enabled: true,
+      workspaceStrategy: {
+        type: "git_worktree",
+        provisionCommand: "touch /tmp/rudder-rce",
+      },
+    };
+
+    const createRes = await request(createApp(actor))
+      .post("/api/orgs/organization-1/projects")
+      .send({ name: "Unsafe Project", executionWorkspacePolicy: policy });
+
+    expect(createRes.status).toBe(403);
+    expect(createRes.body.error).toContain("cannot set project execution workspace policy");
+    expect(mockProjectService.create).not.toHaveBeenCalled();
+
+    mockProjectService.getById.mockResolvedValue(createProject());
+    const updateRes = await request(createApp(actor))
+      .patch("/api/projects/project-1")
+      .send({ executionWorkspacePolicy: policy });
+
+    expect(updateRes.status).toBe(403);
+    expect(mockProjectService.update).not.toHaveBeenCalled();
+  });
+
+  it("rejects project execution policies from non-admin board members", async () => {
+    const res = await request(createApp({
+      type: "board",
+      userId: "organization-member",
+      orgIds: ["organization-1"],
+      source: "session",
+      isInstanceAdmin: false,
+    }))
+      .post("/api/orgs/organization-1/projects")
+      .send({
+        name: "Unsafe Project",
+        executionWorkspacePolicy: {
+          enabled: true,
+          workspaceStrategy: {
+            type: "git_worktree",
+            provisionCommand: "touch /tmp/rudder-board-rce",
+          },
+        },
+      });
+
+    expect(res.status).toBe(403);
+    expect(mockProjectService.create).not.toHaveBeenCalled();
+  });
+
   it("passes project icon tokens through create and update payload validation", async () => {
     mockProjectService.create.mockResolvedValue({ ...createProject(), icon: "plane" });
     mockProjectService.getById.mockResolvedValue({ ...createProject(), icon: "plane" });

--- a/server/src/__tests__/projects-service.test.ts
+++ b/server/src/__tests__/projects-service.test.ts
@@ -95,6 +95,29 @@ describe("project service workspace resolution", () => {
   const cleanupDirs = new Set<string>();
   const originalRudderHome = process.env.RUDDER_HOME;
   const originalRudderInstanceId = process.env.RUDDER_INSTANCE_ID;
+  const invalidProjectResourceMessage = "One or more project resources are invalid for this organization.";
+
+  async function createTestOrganization(name: string, issuePrefix: string) {
+    const id = randomUUID();
+    await db.insert(organizations).values({
+      id,
+      name,
+      urlKey: deriveOrganizationUrlKey(name),
+      issuePrefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+    return id;
+  }
+
+  async function createTestResource(orgId: string, name: string) {
+    return db.insert(organizationResources).values({
+      orgId,
+      name,
+      kind: "url",
+      sourceType: "external",
+      locator: `https://example.invalid/${randomUUID()}`,
+    }).returning().then((rows) => rows[0]!);
+  }
 
   beforeAll(async () => {
     const started = await startTempDatabase();
@@ -577,5 +600,117 @@ describe("project service workspace resolution", () => {
       .from(organizationResources)
       .where(eq(organizationResources.orgId, orgId));
     expect(persistedOrgResources).toHaveLength(1);
+  });
+
+  it("rejects cross-organization resources during bulk replacement without removing existing attachments", async () => {
+    const orgAId = await createTestOrganization("Attachment Org A", "AOA");
+    const orgBId = await createTestOrganization("Attachment Org B", "AOB");
+    const originalResource = await createTestResource(orgAId, "Original resource");
+    const crossOrganizationResource = await createTestResource(orgBId, "Other organization resource");
+    const project = await projectSvc.create(orgAId, {
+      name: "Tenant Bound Project",
+      status: "planned",
+      resourceAttachments: [{ resourceId: originalResource.id }],
+    });
+
+    await expect(projectSvc.update(project.id, {
+      resourceAttachments: [{ resourceId: crossOrganizationResource.id }],
+    })).rejects.toMatchObject({
+      status: 422,
+      message: invalidProjectResourceMessage,
+    });
+
+    const persistedAttachments = await db
+      .select({ resourceId: projectResourceAttachments.resourceId })
+      .from(projectResourceAttachments)
+      .where(eq(projectResourceAttachments.projectId, project.id));
+    expect(persistedAttachments).toEqual([{ resourceId: originalResource.id }]);
+  });
+
+  it("returns the same validation error for a missing resource UUID and preserves existing attachments", async () => {
+    const orgId = await createTestOrganization("Missing Attachment Org", "MAO");
+    const originalResource = await createTestResource(orgId, "Original resource");
+    const project = await projectSvc.create(orgId, {
+      name: "Missing Resource Project",
+      status: "planned",
+      resourceAttachments: [{ resourceId: originalResource.id }],
+    });
+
+    await expect(projectSvc.update(project.id, {
+      resourceAttachments: [{ resourceId: randomUUID() }],
+    })).rejects.toMatchObject({
+      status: 422,
+      message: invalidProjectResourceMessage,
+    });
+
+    const persistedAttachments = await db
+      .select({ resourceId: projectResourceAttachments.resourceId })
+      .from(projectResourceAttachments)
+      .where(eq(projectResourceAttachments.projectId, project.id));
+    expect(persistedAttachments).toEqual([{ resourceId: originalResource.id }]);
+  });
+
+  it("allows replacement with a resource from the same organization", async () => {
+    const orgId = await createTestOrganization("Valid Attachment Org", "VAO");
+    const originalResource = await createTestResource(orgId, "Original resource");
+    const replacementResource = await createTestResource(orgId, "Replacement resource");
+    const project = await projectSvc.create(orgId, {
+      name: "Same Organization Project",
+      status: "planned",
+      resourceAttachments: [{ resourceId: originalResource.id }],
+    });
+
+    const updated = await projectSvc.update(project.id, {
+      resourceAttachments: [{
+        resourceId: replacementResource.id,
+        role: "working_set",
+        note: "Use this resource",
+      }],
+    });
+
+    expect(updated?.resources).toEqual([
+      expect.objectContaining({
+        resourceId: replacementResource.id,
+        role: "working_set",
+        note: "Use this resource",
+      }),
+    ]);
+  });
+
+  it("replaces a project's complete attachment set with multiple same-organization resources", async () => {
+    const orgId = await createTestOrganization("Bulk Attachment Org", "BAO");
+    const originalResource = await createTestResource(orgId, "Original resource");
+    const firstReplacement = await createTestResource(orgId, "First replacement");
+    const secondReplacement = await createTestResource(orgId, "Second replacement");
+    const project = await projectSvc.create(orgId, {
+      name: "Bulk Resource Project",
+      status: "planned",
+      resourceAttachments: [{ resourceId: originalResource.id }],
+    });
+
+    const updated = await projectSvc.update(project.id, {
+      resourceAttachments: [
+        { resourceId: firstReplacement.id, role: "reference", sortOrder: 1 },
+        { resourceId: secondReplacement.id, role: "deliverable", sortOrder: 0 },
+      ],
+    });
+
+    expect(updated?.resources.map((attachment) => ({
+      resourceId: attachment.resourceId,
+      role: attachment.role,
+      sortOrder: attachment.sortOrder,
+    }))).toEqual([
+      { resourceId: secondReplacement.id, role: "deliverable", sortOrder: 0 },
+      { resourceId: firstReplacement.id, role: "reference", sortOrder: 1 },
+    ]);
+
+    const persistedAttachments = await db
+      .select({ resourceId: projectResourceAttachments.resourceId })
+      .from(projectResourceAttachments)
+      .where(eq(projectResourceAttachments.projectId, project.id));
+    expect(persistedAttachments.map((attachment) => attachment.resourceId).sort()).toEqual([
+      firstReplacement.id,
+      secondReplacement.id,
+    ].sort());
   });
 });

--- a/server/src/__tests__/run-workspace-routes.test.ts
+++ b/server/src/__tests__/run-workspace-routes.test.ts
@@ -3,11 +3,17 @@ import request from "supertest";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { errorHandler } from "../middleware/index.js";
 import { runWorkspaceRoutes } from "../routes/execution-workspaces.js";
+import { runWorkspaceService } from "../services/execution-workspaces.js";
 
 const mockRunWorkspaceService = vi.hoisted(() => ({
   list: vi.fn(),
   getById: vi.fn(),
   update: vi.fn(),
+}));
+
+const mockWorkspaceRuntime = vi.hoisted(() => ({
+  cleanupExecutionWorkspaceArtifacts: vi.fn(),
+  stopRuntimeServicesForExecutionWorkspace: vi.fn(),
 }));
 
 vi.mock("../services/index.js", () => ({
@@ -18,7 +24,9 @@ vi.mock("../services/index.js", () => ({
   logActivity: vi.fn(),
 }));
 
-function createApp() {
+vi.mock("../services/workspace-runtime.js", () => mockWorkspaceRuntime);
+
+function createApp(db: any = {}) {
   const app = express();
   app.use(express.json());
   app.use((req, _res, next) => {
@@ -31,7 +39,7 @@ function createApp() {
     };
     next();
   });
-  app.use("/api", runWorkspaceRoutes({} as any));
+  app.use("/api", runWorkspaceRoutes(db));
   app.use(errorHandler);
   return app;
 }
@@ -39,6 +47,11 @@ function createApp() {
 describe("run workspace routes", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockWorkspaceRuntime.cleanupExecutionWorkspaceArtifacts.mockResolvedValue({
+      cleaned: true,
+      warnings: [],
+    });
+    mockWorkspaceRuntime.stopRuntimeServicesForExecutionWorkspace.mockResolvedValue(undefined);
   });
 
   it("serves the canonical run workspace list route", async () => {
@@ -73,5 +86,66 @@ describe("run workspace routes", () => {
 
     expect(res.status).toBe(404);
     expect(res.body).toEqual({ error: "Run workspace not found" });
+  });
+
+  it("blocks the two-step runtime provenance forgery before an archive cleanup", async () => {
+    const existing = {
+      id: "workspace-1",
+      orgId: "organization-1",
+      projectId: "project-1",
+      projectWorkspaceId: null,
+      sourceIssueId: null,
+      status: "active",
+      cwd: "/tmp/shared-organization-workspace",
+      providerType: "local_fs",
+      providerRef: null,
+      branchName: null,
+      repoUrl: null,
+      baseRef: null,
+      metadata: { source: "project_primary", createdByRuntime: false },
+    };
+    mockRunWorkspaceService.getById.mockResolvedValue(existing);
+    mockRunWorkspaceService.update.mockImplementation(async (_id, patch) => ({
+      ...existing,
+      ...patch,
+    }));
+    const selectWhere = vi.fn(async () => []);
+    const db = {
+      select: vi.fn(() => ({
+        from: vi.fn(() => ({ where: selectWhere })),
+      })),
+    };
+    const app = createApp(db);
+
+    const forged = await request(app)
+      .patch("/api/run-workspaces/workspace-1")
+      .send({ metadata: { createdByRuntime: true, source: "runtime" } });
+    expect(forged.status).toBe(400);
+    expect(mockRunWorkspaceService.update).not.toHaveBeenCalled();
+
+    const archived = await request(app)
+      .patch("/api/run-workspaces/workspace-1")
+      .send({ status: "archived" });
+    expect(archived.status).toBe(200);
+    expect(mockWorkspaceRuntime.cleanupExecutionWorkspaceArtifacts).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspace: expect.objectContaining({
+          metadata: { source: "project_primary", createdByRuntime: false },
+        }),
+      }),
+    );
+  });
+
+  it("rejects runtime metadata updates in the service unless an internal caller opts in", async () => {
+    const update = vi.fn();
+    const svc = runWorkspaceService({ update } as any);
+
+    await expect(svc.update("workspace-1", {
+      metadata: { createdByRuntime: true, source: "runtime" },
+    })).rejects.toMatchObject({
+      status: 422,
+      message: "Run workspace runtime metadata is managed internally",
+    });
+    expect(update).not.toHaveBeenCalled();
   });
 });

--- a/server/src/__tests__/website-metadata-routes.test.ts
+++ b/server/src/__tests__/website-metadata-routes.test.ts
@@ -77,7 +77,26 @@ describe("website metadata routes", () => {
     expect(fetchWebsiteIcon).toHaveBeenCalledWith(iconUrl);
     expect(iconRes.headers["content-type"]).toContain("image/x-icon");
     expect(iconRes.headers["cache-control"]).toBe("public, max-age=86400");
+    expect(iconRes.headers["x-content-type-options"]).toBe("nosniff");
+    expect(iconRes.headers["content-security-policy"]).toBe(
+      "sandbox; default-src 'none'; base-uri 'none'; form-action 'none'",
+    );
     expect(iconRes.body).toEqual(Buffer.from("ico"));
+  });
+
+  it("rejects proxied SVG icons even when the icon fetcher returns one", async () => {
+    const fetchWebsiteIcon = vi.fn().mockResolvedValue({
+      contentType: "image/svg+xml",
+      body: Buffer.from("<svg onload='alert(1)'/>"),
+    });
+    const app = createApp({ fetchWebsiteIcon });
+
+    const iconRes = await request(app)
+      .get("/api/website-metadata/icon")
+      .query({ url: "https://static.example.com/favicon.svg" });
+
+    expect(iconRes.status).toBe(415);
+    expect(iconRes.body.error).toBe("Unsupported website icon type");
   });
 
   it("rejects private-network metadata targets before fetching", async () => {

--- a/server/src/__tests__/website-metadata.test.ts
+++ b/server/src/__tests__/website-metadata.test.ts
@@ -119,8 +119,8 @@ describe("resolveWebsiteMetadata", () => {
 
   it("falls back to a server-side favicon provider for public pages without discoverable origin icons", async () => {
     lookupMock.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
-    vi.spyOn(globalThis, "fetch").mockImplementation(async (url) => {
-      const href = url instanceof URL ? url.href : String(url);
+    const pinnedFetchImpl = vi.fn(async (url: URL) => {
+      const href = url.href;
       if (href === "https://example.com/post") {
         return new Response("<!doctype html><title>No Origin Icon</title>", {
           status: 200,
@@ -142,7 +142,7 @@ describe("resolveWebsiteMetadata", () => {
       throw new Error(`Unexpected fetch ${href}`);
     });
 
-    await expect(resolveWebsiteMetadata("https://example.com/post")).resolves.toMatchObject({
+    await expect(resolveWebsiteMetadata("https://example.com/post", { pinnedFetchImpl })).resolves.toMatchObject({
       siteName: "No Origin Icon",
       iconUrl: "https://www.google.com/s2/favicons?domain_url=https%3A%2F%2Fexample.com&sz=64",
     });
@@ -175,18 +175,27 @@ describe("resolveWebsiteMetadata", () => {
     });
   });
 
+  it("rejects fetched SVG icons", async () => {
+    const fetchImpl = async () => new Response("<svg onload='alert(1)'/>", {
+      status: 200,
+      headers: { "content-type": "image/svg+xml" },
+    });
+
+    await expect(fetchWebsiteIcon("https://static.example.com/favicon.svg", { fetchImpl })).resolves.toBeNull();
+  });
+
   it("extracts declared icons from large pages without failing the metadata request", async () => {
     const fixture = await startFixtureServer((req, res) => {
-      if (req.url === "/favicon.svg") {
-        res.setHeader("content-type", "image/svg+xml");
-        res.end("<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 16 16\"><rect width=\"16\" height=\"16\"/></svg>");
+      if (req.url === "/favicon.png") {
+        res.setHeader("content-type", "image/png");
+        res.end(Buffer.from("png"));
         return;
       }
       res.setHeader("content-type", "text/html; charset=utf-8");
       res.end(`
         <!doctype html>
         <title>Large Metadata Page</title>
-        <link rel="icon" href="/favicon.svg">
+        <link rel="icon" href="/favicon.png">
         ${"x".repeat(300 * 1024)}
       `);
     });
@@ -194,7 +203,7 @@ describe("resolveWebsiteMetadata", () => {
 
     await expect(resolveWebsiteMetadata(`${fixture.origin}/large`, { allowPrivateHosts: true })).resolves.toMatchObject({
       siteName: "Large Metadata Page",
-      iconUrl: `${fixture.origin}/favicon.svg`,
+      iconUrl: `${fixture.origin}/favicon.png`,
     });
   });
 
@@ -216,30 +225,96 @@ describe("resolveWebsiteMetadata", () => {
     await expect(resolveWebsiteMetadata("http://198.18.0.42/post")).rejects.toThrow("Private network URLs");
   });
 
-  it("allows public hostnames that resolve through local 198.18/15 proxy addresses", async () => {
+  it.each([
+    "http://224.0.0.1/post",
+    "http://239.255.255.250/post",
+    "http://240.0.0.1/post",
+    "http://255.255.255.255/post",
+    "http://198.51.100.1/post",
+    "http://203.0.113.1/post",
+  ])("rejects non-public IPv4 literal targets: %s", async (url) => {
+    await expect(resolveWebsiteMetadata(url)).rejects.toThrow("Private network URLs");
+  });
+
+  it.each(["224.0.0.1", "240.0.0.1", "255.255.255.255", "198.51.100.1", "203.0.113.1"])(
+    "rejects public hostnames resolving to non-public IPv4 addresses: %s",
+    async (address) => {
+      lookupMock.mockResolvedValue([{ address, family: 4 }]);
+      const fetchSpy = vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("fetch should not be called"));
+
+      await expect(resolveWebsiteMetadata("https://example.com/post")).rejects.toThrow("Private network URLs");
+      expect(fetchSpy).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    "http://[::]:12345/post",
+    "http://[::1]:12345/post",
+    "http://[::ffff:127.0.0.1]:12345/post",
+    "http://[::ffff:7f00:1]:12345/post",
+    "http://[0:0:0:0:0:ffff:7f00:1]:12345/post",
+    "http://[64:ff9b::7f00:1]:12345/post",
+    "http://[::ffff:0:7f00:1]:12345/post",
+    "http://[fe80::1]:12345/post",
+    "http://[fc00::1]:12345/post",
+    "http://[fd12:3456::1]:12345/post",
+  ])("rejects non-public IPv6 literal targets: %s", async (url) => {
+    await expect(resolveWebsiteMetadata(url)).rejects.toThrow("Private network URLs");
+  });
+
+  it.each([
+    "::ffff:7f00:1",
+    "0:0:0:0:0:ffff:7f00:1",
+    "64:ff9b::7f00:1",
+    "::ffff:0:7f00:1",
+    "fe80::1",
+    "fd12:3456::1",
+  ])(
+    "rejects public hostnames resolving to non-public IPv6 addresses: %s",
+    async (address) => {
+      lookupMock.mockResolvedValue([{ address, family: 6 }]);
+      const fetchSpy = vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("fetch should not be called"));
+
+      await expect(resolveWebsiteMetadata("https://example.com/post")).rejects.toThrow("Private network URLs");
+      expect(fetchSpy).not.toHaveBeenCalled();
+    },
+  );
+
+  it("rejects public hostnames that resolve through benchmark-network addresses", async () => {
     lookupMock.mockResolvedValue([{ address: "198.18.0.42", family: 4 }]);
-    vi.spyOn(globalThis, "fetch").mockImplementation(async (url) => {
-      const href = url instanceof URL ? url.href : String(url);
-      if (href === "https://example.com/favicon.ico") {
-        return new Response(Buffer.from("ico"), {
-          status: 200,
-          headers: { "content-type": "image/x-icon" },
-        });
-      }
-      return new Response(`
-        <!doctype html>
-        <title>Proxy Mapped Site</title>
-        <link rel="icon" href="/favicon.ico">
-      `, {
+    const pinnedFetchImpl = vi.fn();
+
+    await expect(resolveWebsiteMetadata("https://example.com/post", { pinnedFetchImpl }))
+      .rejects.toThrow("Private network URLs");
+    expect(pinnedFetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("pins the validated DNS addresses into the connection transport", async () => {
+    lookupMock.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
+    const pinnedFetchImpl = vi.fn(async (_url: URL, _init: RequestInit, addresses: ReadonlyArray<{ address: string }>) => {
+      expect(addresses).toEqual([{ address: "93.184.216.34", family: 4 }]);
+      return new Response("<!doctype html><title>Pinned Site</title>", {
         status: 200,
-        headers: { "content-type": "text/html; charset=utf-8" },
+        headers: { "content-type": "text/html" },
       });
     });
 
-    await expect(resolveWebsiteMetadata("https://example.com/post")).resolves.toMatchObject({
-      siteName: "Proxy Mapped Site",
-      iconUrl: "https://example.com/favicon.ico",
+    await expect(resolveWebsiteMetadata("https://example.com/post", { pinnedFetchImpl })).resolves.toMatchObject({
+      siteName: "Pinned Site",
     });
+    expect(pinnedFetchImpl).toHaveBeenCalled();
+  });
+
+  it("rejects a hostname when any resolved address is non-public", async () => {
+    lookupMock.mockResolvedValue([
+      { address: "93.184.216.34", family: 4 },
+      { address: "127.0.0.1", family: 4 },
+    ]);
+    const pinnedFetchImpl = vi.fn();
+
+    await expect(resolveWebsiteMetadata("https://example.com/post", { pinnedFetchImpl }))
+      .rejects.toThrow("Private network URLs");
+    expect(pinnedFetchImpl).not.toHaveBeenCalled();
   });
 
   it.each([
@@ -279,21 +354,21 @@ describe("resolveWebsiteMetadata", () => {
     process.env.RUDDER_HOME = tempHome;
     process.env.RUDDER_INSTANCE_ID = "test";
     lookupMock.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
-    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(Buffer.from("ico"), {
+    const pinnedFetchImpl = vi.fn(async () => new Response(Buffer.from("ico"), {
       status: 200,
       headers: { "content-type": "image/x-icon" },
     }));
 
     try {
-      await expect(fetchWebsiteIcon("https://static.example.com/favicon.ico")).resolves.toMatchObject({
+      await expect(fetchWebsiteIcon("https://static.example.com/favicon.ico", { pinnedFetchImpl })).resolves.toMatchObject({
         contentType: "image/x-icon",
         body: Buffer.from("ico"),
       });
-      await expect(fetchWebsiteIcon("https://static.example.com/favicon.ico")).resolves.toMatchObject({
+      await expect(fetchWebsiteIcon("https://static.example.com/favicon.ico", { pinnedFetchImpl })).resolves.toMatchObject({
         contentType: "image/x-icon",
         body: Buffer.from("ico"),
       });
-      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(pinnedFetchImpl).toHaveBeenCalledTimes(1);
     } finally {
       await rm(tempHome, { recursive: true, force: true });
     }

--- a/server/src/__tests__/work-products.test.ts
+++ b/server/src/__tests__/work-products.test.ts
@@ -28,6 +28,51 @@ function createWorkProductRow(overrides: Partial<Record<string, unknown>> = {}) 
   };
 }
 
+function createWorkProductInput(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    type: "pull_request",
+    provider: "github",
+    title: "PR 1",
+    status: "active",
+    reviewState: "none",
+    isPrimary: false,
+    healthStatus: "unknown",
+    ...overrides,
+  };
+}
+
+function createTransactionHarness(input: {
+  selectResults?: Array<Array<Record<string, unknown>>>;
+  insertedRow?: Record<string, unknown>;
+  updatedRow?: Record<string, unknown>;
+} = {}) {
+  const selectResults = [...(input.selectResults ?? [])];
+  const selectWhere = vi.fn(async () => selectResults.shift() ?? []);
+  const selectFrom = vi.fn(() => ({ where: selectWhere }));
+  const select = vi.fn(() => ({ from: selectFrom }));
+
+  const insertReturning = vi.fn(async () => [input.insertedRow ?? createWorkProductRow()]);
+  const insertValues = vi.fn(() => ({ returning: insertReturning }));
+  const insert = vi.fn(() => ({ values: insertValues }));
+
+  const updateReturning = vi.fn(async () => [input.updatedRow ?? createWorkProductRow()]);
+  const updateWhere = vi.fn(() => ({ returning: updateReturning }));
+  const updateSet = vi.fn(() => ({ where: updateWhere }));
+  const update = vi.fn(() => ({ set: updateSet }));
+
+  const tx = { select, insert, update };
+  const transaction = vi.fn(async (callback: (value: typeof tx) => Promise<unknown>) => callback(tx));
+  return {
+    db: { transaction } as any,
+    tx,
+    select,
+    insert,
+    insertValues,
+    update,
+    updateSet,
+  };
+}
+
 describe("workProductService", () => {
   it("uses a transaction when creating a new primary work product", async () => {
     const updatedWhere = vi.fn(async () => undefined);
@@ -88,8 +133,158 @@ describe("workProductService", () => {
     });
 
     expect(transaction).toHaveBeenCalledTimes(1);
-    expect(txSelect).toHaveBeenCalledTimes(1);
+    expect(txSelect).toHaveBeenCalledTimes(2);
     expect(txUpdate).toHaveBeenCalledTimes(2);
     expect(result?.reviewState).toBe("ready_for_review");
+  });
+
+  it.each([
+    ["project", { projectId: "foreign-project" }],
+    ["run workspace alias", { runWorkspaceId: "foreign-workspace" }],
+    ["runtime service", { runtimeServiceId: "foreign-service" }],
+    ["creator run", { createdByRunId: "foreign-run" }],
+  ])("rejects a foreign-organization %s when creating", async (_label, referencePatch) => {
+    const harness = createTransactionHarness({ selectResults: [[]] });
+    const svc = workProductService(harness.db);
+
+    await expect(
+      svc.createForIssue(
+        "issue-1",
+        "organization-1",
+        createWorkProductInput(referencePatch) as any,
+      ),
+    ).rejects.toMatchObject({
+      status: 422,
+      message: "One or more work product references are invalid for this organization",
+    });
+    expect(harness.insert).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["project", { projectId: "foreign-project" }],
+    ["run workspace alias", { runWorkspaceId: "foreign-workspace" }],
+    ["runtime service", { runtimeServiceId: "foreign-service" }],
+    ["creator run", { createdByRunId: "foreign-run" }],
+  ])("rejects a foreign-organization %s when updating", async (_label, referencePatch) => {
+    const existing = createWorkProductRow({
+      projectId: null,
+      executionWorkspaceId: null,
+      runtimeServiceId: null,
+      createdByRunId: null,
+    });
+    const harness = createTransactionHarness({ selectResults: [[existing], []] });
+    const svc = workProductService(harness.db);
+
+    await expect(svc.update("work-product-1", referencePatch as any)).rejects.toMatchObject({
+      status: 422,
+      message: "One or more work product references are invalid for this organization",
+    });
+    expect(harness.update).not.toHaveBeenCalled();
+  });
+
+  it("accepts same-organization references and stores runWorkspaceId in the legacy column", async () => {
+    const inserted = createWorkProductRow({
+      projectId: "project-1",
+      executionWorkspaceId: "workspace-1",
+      runtimeServiceId: "service-1",
+      createdByRunId: "run-1",
+    });
+    const harness = createTransactionHarness({
+      selectResults: [
+        [{ id: "project-1" }],
+        [{ id: "workspace-1" }],
+        [{ id: "service-1" }],
+        [{ id: "run-1" }],
+      ],
+      insertedRow: inserted,
+    });
+    const svc = workProductService(harness.db);
+
+    await expect(svc.createForIssue("issue-1", "organization-1", createWorkProductInput({
+      projectId: "project-1",
+      runWorkspaceId: "workspace-1",
+      runtimeServiceId: "service-1",
+      createdByRunId: "run-1",
+    }) as any)).resolves.toMatchObject({
+      projectId: "project-1",
+      runWorkspaceId: "workspace-1",
+      runtimeServiceId: "service-1",
+      createdByRunId: "run-1",
+    });
+
+    expect(harness.select).toHaveBeenCalledTimes(4);
+    expect(harness.insertValues).toHaveBeenCalledWith(expect.objectContaining({
+      orgId: "organization-1",
+      issueId: "issue-1",
+      executionWorkspaceId: "workspace-1",
+    }));
+    expect(harness.insertValues.mock.calls[0]?.[0]).not.toHaveProperty("runWorkspaceId");
+  });
+
+  it("validates references preserved by an unrelated update", async () => {
+    const existing = createWorkProductRow({
+      projectId: "project-1",
+      executionWorkspaceId: "workspace-1",
+      runtimeServiceId: "service-1",
+      createdByRunId: "run-1",
+    });
+    const updated = createWorkProductRow({ ...existing, title: "Updated" });
+    const harness = createTransactionHarness({
+      selectResults: [
+        [existing],
+        [{ id: "project-1" }],
+        [{ id: "workspace-1" }],
+        [{ id: "service-1" }],
+        [{ id: "run-1" }],
+      ],
+      updatedRow: updated,
+    });
+    const svc = workProductService(harness.db);
+
+    await expect(svc.update("work-product-1", { title: "Updated" })).resolves.toMatchObject({
+      title: "Updated",
+    });
+    expect(harness.select).toHaveBeenCalledTimes(5);
+  });
+
+  it("allows every optional reference to be cleared through the run workspace alias", async () => {
+    const existing = createWorkProductRow({
+      projectId: "project-1",
+      executionWorkspaceId: "workspace-1",
+      runtimeServiceId: "service-1",
+      createdByRunId: "run-1",
+    });
+    const updated = createWorkProductRow({
+      projectId: null,
+      executionWorkspaceId: null,
+      runtimeServiceId: null,
+      createdByRunId: null,
+    });
+    const harness = createTransactionHarness({
+      selectResults: [[existing]],
+      updatedRow: updated,
+    });
+    const svc = workProductService(harness.db);
+
+    await expect(svc.update("work-product-1", {
+      projectId: null,
+      runWorkspaceId: null,
+      runtimeServiceId: null,
+      createdByRunId: null,
+    })).resolves.toMatchObject({
+      projectId: null,
+      runWorkspaceId: null,
+      runtimeServiceId: null,
+      createdByRunId: null,
+    });
+
+    expect(harness.select).toHaveBeenCalledTimes(1);
+    expect(harness.updateSet).toHaveBeenCalledWith(expect.objectContaining({
+      projectId: null,
+      executionWorkspaceId: null,
+      runtimeServiceId: null,
+      createdByRunId: null,
+    }));
+    expect(harness.updateSet.mock.calls.at(-1)?.[0]).not.toHaveProperty("runWorkspaceId");
   });
 });

--- a/server/src/__tests__/workspace-runtime.test.ts
+++ b/server/src/__tests__/workspace-runtime.test.ts
@@ -5,6 +5,10 @@ import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
 import { afterEach, describe, expect, it } from "vitest";
+import {
+  resolveManagedRunWorkspacesRoot,
+  resolveOrganizationWorkspaceRoot,
+} from "../home-paths.ts";
 import type { WorkspaceOperationRecorder } from "../services/workspace-operations.ts";
 import {
   cleanupExecutionWorkspaceArtifacts,
@@ -615,6 +619,129 @@ describe("realizeExecutionWorkspace", () => {
     ).resolves.toMatchObject({
       stdout: expect.stringContaining(workspace.branchName!),
     });
+  });
+
+  it("removes a runtime-created local workspace only from its managed runtime root", async () => {
+    const rudderHome = await fs.mkdtemp(path.join(os.tmpdir(), "rudder-managed-runtime-cleanup-"));
+    process.env.RUDDER_HOME = rudderHome;
+    process.env.RUDDER_INSTANCE_ID = "workspace-cleanup-test";
+    const orgId = "organization-1";
+    const workspacePath = path.join(resolveManagedRunWorkspacesRoot(orgId), "run-workspace-1");
+    await fs.mkdir(workspacePath, { recursive: true });
+    await fs.writeFile(path.join(workspacePath, "result.txt"), "done\n", "utf8");
+
+    try {
+      const cleanup = await cleanupExecutionWorkspaceArtifacts({
+        workspace: {
+          id: "execution-workspace-1",
+          orgId,
+          cwd: workspacePath,
+          providerType: "local_fs",
+          providerRef: null,
+          branchName: null,
+          repoUrl: null,
+          baseRef: null,
+          projectId: "project-1",
+          projectWorkspaceId: null,
+          sourceIssueId: "issue-1",
+          metadata: { createdByRuntime: true },
+        },
+        projectWorkspace: null,
+      });
+
+      expect(cleanup.cleaned).toBe(true);
+      expect(cleanup.warnings).toEqual([]);
+      await expect(fs.lstat(workspacePath)).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      await fs.rm(rudderHome, { recursive: true, force: true });
+    }
+  });
+
+  it("refuses to recursively remove the managed root, its ancestor, or the organization workspace root", async () => {
+    const rudderHome = await fs.mkdtemp(path.join(os.tmpdir(), "rudder-runtime-root-guard-"));
+    process.env.RUDDER_HOME = rudderHome;
+    process.env.RUDDER_INSTANCE_ID = "workspace-root-guard-test";
+    const orgId = "organization-1";
+    const managedRoot = resolveManagedRunWorkspacesRoot(orgId);
+    const managedRootAncestor = path.dirname(managedRoot);
+    const organizationWorkspaceRoot = resolveOrganizationWorkspaceRoot(orgId);
+    await fs.mkdir(managedRoot, { recursive: true });
+    await fs.mkdir(organizationWorkspaceRoot, { recursive: true });
+
+    try {
+      for (const guardedPath of [managedRoot, managedRootAncestor, organizationWorkspaceRoot]) {
+        const cleanup = await cleanupExecutionWorkspaceArtifacts({
+          workspace: {
+            id: "execution-workspace-1",
+            orgId,
+            cwd: guardedPath,
+            providerType: "local_fs",
+            providerRef: null,
+            branchName: null,
+            repoUrl: null,
+            baseRef: null,
+            projectId: "project-1",
+            projectWorkspaceId: null,
+            sourceIssueId: "issue-1",
+            metadata: { createdByRuntime: true },
+          },
+          projectWorkspace: null,
+        });
+
+        expect(cleanup.cleaned).toBe(false);
+        expect(cleanup.warnings.join(" ")).toContain("managed runtime workspace root");
+        await expect(fs.lstat(guardedPath)).resolves.toBeDefined();
+      }
+    } finally {
+      await fs.rm(rudderHome, { recursive: true, force: true });
+    }
+  });
+
+  it("refuses local cleanup through a symlink target or symlink ancestor", async () => {
+    const rudderHome = await fs.mkdtemp(path.join(os.tmpdir(), "rudder-runtime-symlink-guard-"));
+    const externalRoot = await fs.mkdtemp(path.join(os.tmpdir(), "rudder-runtime-external-"));
+    process.env.RUDDER_HOME = rudderHome;
+    process.env.RUDDER_INSTANCE_ID = "workspace-symlink-guard-test";
+    const orgId = "organization-1";
+    const managedRoot = resolveManagedRunWorkspacesRoot(orgId);
+    const symlinkTarget = path.join(managedRoot, "target-link");
+    const symlinkAncestor = path.join(managedRoot, "ancestor-link");
+    const nestedExternalPath = path.join(externalRoot, "nested-workspace");
+    await fs.mkdir(managedRoot, { recursive: true });
+    await fs.mkdir(nestedExternalPath, { recursive: true });
+    await fs.writeFile(path.join(externalRoot, "keep.txt"), "keep\n", "utf8");
+    await fs.symlink(externalRoot, symlinkTarget, "dir");
+    await fs.symlink(externalRoot, symlinkAncestor, "dir");
+
+    try {
+      for (const guardedPath of [symlinkTarget, path.join(symlinkAncestor, "nested-workspace")]) {
+        const cleanup = await cleanupExecutionWorkspaceArtifacts({
+          workspace: {
+            id: "execution-workspace-1",
+            orgId,
+            cwd: guardedPath,
+            providerType: "local_fs",
+            providerRef: null,
+            branchName: null,
+            repoUrl: null,
+            baseRef: null,
+            projectId: "project-1",
+            projectWorkspaceId: null,
+            sourceIssueId: "issue-1",
+            metadata: { createdByRuntime: true },
+          },
+          projectWorkspace: null,
+        });
+
+        expect(cleanup.cleaned).toBe(false);
+        expect(cleanup.warnings.join(" ")).toContain("symbolic link");
+      }
+      await expect(fs.readFile(path.join(externalRoot, "keep.txt"), "utf8")).resolves.toBe("keep\n");
+      await expect(fs.lstat(nestedExternalPath)).resolves.toBeDefined();
+    } finally {
+      await fs.rm(rudderHome, { recursive: true, force: true });
+      await fs.rm(externalRoot, { recursive: true, force: true });
+    }
   });
 
   it("records teardown and cleanup operations when a recorder is provided", async () => {

--- a/server/src/auth/better-auth.ts
+++ b/server/src/auth/better-auth.ts
@@ -23,8 +23,6 @@ export type BetterAuthSessionResult = {
   user: BetterAuthSessionUser | null;
 };
 
-type BetterAuthInstance = ReturnType<typeof betterAuth>;
-
 function headersFromNodeHeaders(rawHeaders: IncomingHttpHeaders): Headers {
   const headers = new Headers();
   for (const [key, raw] of Object.entries(rawHeaders)) {
@@ -65,7 +63,7 @@ export function deriveAuthTrustedOrigins(config: Config): string[] {
   return Array.from(trustedOrigins);
 }
 
-export function createBetterAuthInstance(db: Db, config: Config, trustedOrigins?: string[]): BetterAuthInstance {
+export function createBetterAuthInstance(db: Db, config: Config, trustedOrigins?: string[]) {
   const baseUrl = config.authBaseUrlMode === "explicit" ? config.authPublicBaseUrl : undefined;
   const secret = process.env.BETTER_AUTH_SECRET ?? process.env.RUDDER_AGENT_JWT_SECRET ?? "rudder-dev-secret";
   const effectiveTrustedOrigins = trustedOrigins ?? deriveAuthTrustedOrigins(config);
@@ -91,7 +89,7 @@ export function createBetterAuthInstance(db: Db, config: Config, trustedOrigins?
       requireEmailVerification: false,
       disableSignUp: config.authDisableSignUp,
     },
-    ...(isHttpOnly ? { advanced: { useSecureCookies: false } } : {}),
+    ...(isHttpOnly ? { advanced: { useSecureCookies: false as const } } : {}),
   };
 
   if (!baseUrl) {
@@ -100,6 +98,8 @@ export function createBetterAuthInstance(db: Db, config: Config, trustedOrigins?
 
   return betterAuth(authConfig);
 }
+
+type BetterAuthInstance = ReturnType<typeof createBetterAuthInstance>;
 
 export function createBetterAuthHandler(auth: BetterAuthInstance): RequestHandler {
   const handler = toNodeHandler(auth);

--- a/server/src/bootstrap/create-http-app.ts
+++ b/server/src/bootstrap/create-http-app.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { actorMiddleware } from "../middleware/auth.js";
 import { errorHandler, httpLogger } from "../middleware/index.js";
+import { createPluginWebhookIngressMiddleware } from "../middleware/plugin-webhook-security.js";
 import { privateHostnameGuard, resolvePrivateHostnameAllowSet } from "../middleware/private-hostname-guard.js";
 import { llmRoutes } from "../routes/llms.js";
 import { pluginUiStaticRoutes } from "../routes/plugin-ui-static.js";
@@ -27,13 +28,31 @@ export async function createHttpApp(
   pluginRuntime: PluginHostRuntime,
 ) {
   const app = express();
-  const privateHostnameGateEnabled =
-    opts.deploymentMode === "authenticated" && opts.deploymentExposure === "private";
+  app.disable("x-powered-by");
+  app.use((_req, res, next) => {
+    // The desktop side-panel browser can load arbitrary sites. Prevent those
+    // sites (and regular web origins) from framing an authenticated/local board
+    // and clickjacking privileged actions.
+    res.setHeader("X-Frame-Options", "SAMEORIGIN");
+    res.setHeader("Content-Security-Policy", "frame-ancestors 'self'");
+    next();
+  });
+  // Private authenticated and local-trusted instances are both vulnerable to
+  // DNS rebinding unless requests are restricted to configured hostnames.
+  const privateHostnameGateEnabled = opts.deploymentExposure === "private";
   const privateHostnameAllowSet = resolvePrivateHostnameAllowSet({
     allowedHostnames: opts.allowedHostnames,
     bindHost: opts.bindHost,
   });
 
+  const pluginWebhookIngress = createPluginWebhookIngressMiddleware();
+  app.use(
+    "/api/plugins/:pluginId/webhooks/:endpointKey",
+    pluginWebhookIngress.rateLimit,
+    pluginWebhookIngress.rawBody,
+    pluginWebhookIngress.rawBodyError,
+    pluginWebhookIngress.decodeBody,
+  );
   app.use(express.json({
     // Organization import/export payloads can inline full portable packages.
     limit: "10mb",

--- a/server/src/content-response-policy.ts
+++ b/server/src/content-response-policy.ts
@@ -1,0 +1,35 @@
+export const ACTIVE_CONTENT_SANDBOX_CSP = "sandbox; default-src 'none'; base-uri 'none'; form-action 'none'";
+
+const SAFE_INLINE_RASTER_CONTENT_TYPES = new Set([
+  "image/avif",
+  "image/bmp",
+  "image/gif",
+  "image/jpeg",
+  "image/jpg",
+  "image/png",
+  "image/vnd.microsoft.icon",
+  "image/webp",
+  "image/x-icon",
+]);
+
+export function normalizeResponseContentType(value: string) {
+  return value.split(";")[0]?.trim().toLowerCase() ?? "";
+}
+
+export function isSafeInlineRasterContentType(value: string) {
+  return SAFE_INLINE_RASTER_CONTENT_TYPES.has(normalizeResponseContentType(value));
+}
+
+function safeContentDispositionFilename(value: string, fallback: string) {
+  return value.replace(/[\u0000-\u001f\u007f"]/gu, "").trim() || fallback;
+}
+
+export function buildContentResponsePolicy(contentType: string, filename: string, fallbackFilename: string) {
+  const inline = isSafeInlineRasterContentType(contentType);
+  const safeFilename = safeContentDispositionFilename(filename, fallbackFilename);
+  return {
+    inline,
+    contentDisposition: `${inline ? "inline" : "attachment"}; filename=\"${safeFilename}\"`,
+    contentSecurityPolicy: inline ? null : ACTIVE_CONTENT_SANDBOX_CSP,
+  };
+}

--- a/server/src/home-paths.ts
+++ b/server/src/home-paths.ts
@@ -103,6 +103,10 @@ export function resolveDefaultBackupDir(): string {
   return path.resolve(resolveRudderInstanceRoot(), "data", "backups");
 }
 
+export function resolveManagedRunWorkspacesRoot(orgId: string): string {
+  return path.resolve(resolveOrganizationRoot(orgId), "runtime-workspaces");
+}
+
 export function resolveOrganizationRoot(orgId: string): string {
   const normalizedOrgId = resolveOrganizationStorageKey(orgId);
   return path.resolve(

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1002,6 +1002,9 @@ export async function startServer(options: StartServerOptions = {}): Promise<Sta
   
   setupLiveEventsWebSocketServer(server, db as any, {
     deploymentMode: config.deploymentMode,
+    deploymentExposure: config.deploymentExposure,
+    allowedHostnames: config.allowedHostnames,
+    bindHost: config.host,
     resolveSessionFromHeaders,
   });
 

--- a/server/src/middleware/board-mutation-guard.ts
+++ b/server/src/middleware/board-mutation-guard.ts
@@ -1,10 +1,6 @@
 import type { Request, RequestHandler } from "express";
 
 const SAFE_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
-const DEFAULT_DEV_ORIGINS = [
-  "http://localhost:3100",
-  "http://127.0.0.1:3100",
-];
 
 function parseOrigin(value: string | undefined) {
   if (!value) return null;
@@ -17,7 +13,7 @@ function parseOrigin(value: string | undefined) {
 }
 
 function trustedOriginsForRequest(req: Request) {
-  const origins = new Set(DEFAULT_DEV_ORIGINS.map((value) => value.toLowerCase()));
+  const origins = new Set<string>();
   const host = req.header("host")?.trim();
   if (host) {
     origins.add(`http://${host}`.toLowerCase());
@@ -28,8 +24,11 @@ function trustedOriginsForRequest(req: Request) {
 
 function isTrustedBoardMutationRequest(req: Request) {
   const allowedOrigins = trustedOriginsForRequest(req);
-  const origin = parseOrigin(req.header("origin"));
-  if (origin && allowedOrigins.has(origin)) return true;
+  const rawOrigin = req.header("origin");
+  if (rawOrigin !== undefined) {
+    const origin = parseOrigin(rawOrigin);
+    return origin !== null && allowedOrigins.has(origin);
+  }
 
   const refererOrigin = parseOrigin(req.header("referer"));
   if (refererOrigin && allowedOrigins.has(refererOrigin)) return true;
@@ -49,11 +48,20 @@ export function boardMutationGuard(): RequestHandler {
       return;
     }
 
-    // Local-trusted mode and board bearer keys are not browser-session requests.
-    // In these modes, origin/referer headers can be absent; do not block those mutations.
+    // Local-trusted mode and board bearer keys also support non-browser clients,
+    // where Origin/Referer can legitimately be absent. When either header is
+    // present, however, treat the request as browser-originated and enforce the
+    // same-origin check so arbitrary websites cannot mutate a localhost board.
     if (req.actor.source === "local_implicit" || req.actor.source === "board_key") {
-      next();
-      return;
+      const fetchSite = req.header("sec-fetch-site")?.trim().toLowerCase();
+      if (
+        !req.header("origin")
+        && !req.header("referer")
+        && (!fetchSite || fetchSite === "same-origin" || fetchSite === "none")
+      ) {
+        next();
+        return;
+      }
     }
 
     if (!isTrustedBoardMutationRequest(req)) {

--- a/server/src/middleware/plugin-webhook-security.ts
+++ b/server/src/middleware/plugin-webhook-security.ts
@@ -1,0 +1,343 @@
+import express, {
+  type ErrorRequestHandler,
+  type Request,
+  type RequestHandler,
+} from "express";
+import { createHash } from "node:crypto";
+import type { IncomingHttpHeaders } from "node:http";
+
+const KIB = 1024;
+const DEFAULT_MAX_BODY_BYTES = 256 * KIB;
+const MAX_CONFIGURABLE_BODY_BYTES = 2 * 1024 * KIB;
+const DEFAULT_RATE_LIMIT_MAX = 120;
+const DEFAULT_RATE_LIMIT_WINDOW_MS = 60_000;
+const DEFAULT_RATE_LIMIT_BUCKETS = 4_096;
+const DEFAULT_MAX_PERSISTED_HEADER_BYTES = 4 * KIB;
+const DEFAULT_MAX_PERSISTED_HEADER_VALUE_BYTES = KIB;
+
+export const MAX_PLUGIN_WEBHOOK_FAILURE_BYTES = 2 * KIB;
+
+const PERSISTED_WEBHOOK_HEADER_ALLOWLIST = new Set([
+  "accept",
+  "content-length",
+  "content-type",
+  "user-agent",
+  "webhook-id",
+  "webhook-timestamp",
+  "x-github-delivery",
+  "x-github-event",
+  "x-gitlab-event",
+  "x-gitlab-event-uuid",
+  "x-linear-delivery",
+  "x-linear-event",
+  "x-request-id",
+  "x-shopify-topic",
+  "x-shopify-webhook-id",
+  "x-slack-request-timestamp",
+  "svix-id",
+  "svix-timestamp",
+]);
+
+export type PluginWebhookIngressOptions = {
+  maxBodyBytes: number;
+  rateLimitMax: number;
+  sourceRateLimitMax: number;
+  rateLimitWindowMs: number;
+  maxRateLimitBuckets: number;
+};
+
+type RateLimitBucket = {
+  count: number;
+  windowStartedAt: number;
+};
+
+type RateLimitDecision = {
+  allowed: boolean;
+  remaining: number;
+  retryAfterMs: number;
+};
+
+function boundedInteger(
+  value: unknown,
+  fallback: number,
+  min: number,
+  max: number,
+) {
+  const parsed = typeof value === "number" ? value : Number.parseInt(String(value ?? ""), 10);
+  if (!Number.isFinite(parsed)) return fallback;
+  return Math.min(Math.max(Math.floor(parsed), min), max);
+}
+
+export function resolvePluginWebhookIngressOptions(
+  env: NodeJS.ProcessEnv = process.env,
+): PluginWebhookIngressOptions {
+  const rateLimitMax = boundedInteger(
+    env.RUDDER_PLUGIN_WEBHOOK_RATE_LIMIT_MAX,
+    DEFAULT_RATE_LIMIT_MAX,
+    1,
+    10_000,
+  );
+  return {
+    maxBodyBytes: boundedInteger(
+      env.RUDDER_PLUGIN_WEBHOOK_MAX_BODY_BYTES,
+      DEFAULT_MAX_BODY_BYTES,
+      1,
+      MAX_CONFIGURABLE_BODY_BYTES,
+    ),
+    rateLimitMax,
+    sourceRateLimitMax: boundedInteger(
+      env.RUDDER_PLUGIN_WEBHOOK_SOURCE_RATE_LIMIT_MAX,
+      rateLimitMax * 4,
+      rateLimitMax,
+      40_000,
+    ),
+    rateLimitWindowMs: boundedInteger(
+      env.RUDDER_PLUGIN_WEBHOOK_RATE_LIMIT_WINDOW_MS,
+      DEFAULT_RATE_LIMIT_WINDOW_MS,
+      1_000,
+      60 * 60_000,
+    ),
+    maxRateLimitBuckets: boundedInteger(
+      env.RUDDER_PLUGIN_WEBHOOK_RATE_LIMIT_BUCKETS,
+      DEFAULT_RATE_LIMIT_BUCKETS,
+      64,
+      65_536,
+    ),
+  };
+}
+
+class FixedWindowRateLimiter {
+  private readonly buckets = new Map<string, RateLimitBucket>();
+  private nextSweepAt = 0;
+
+  constructor(private readonly maxBuckets: number) {}
+
+  consume(key: string, limit: number, windowMs: number, now: number): RateLimitDecision {
+    if (now >= this.nextSweepAt) {
+      for (const [bucketKey, bucket] of this.buckets) {
+        if (now - bucket.windowStartedAt >= windowMs) {
+          this.buckets.delete(bucketKey);
+        }
+      }
+      this.nextSweepAt = now + Math.min(windowMs, 30_000);
+    }
+
+    let bucket = this.buckets.get(key);
+    if (bucket && now - bucket.windowStartedAt >= windowMs) {
+      this.buckets.delete(key);
+      bucket = undefined;
+    }
+
+    if (!bucket) {
+      if (this.buckets.size >= this.maxBuckets) {
+        // Fail closed instead of evicting a live bucket, which would let an
+        // attacker rotate endpoint strings to reset their own quota.
+        return { allowed: false, remaining: 0, retryAfterMs: windowMs };
+      }
+      bucket = { count: 0, windowStartedAt: now };
+      this.buckets.set(key, bucket);
+    }
+
+    const retryAfterMs = Math.max(1, windowMs - (now - bucket.windowStartedAt));
+    if (bucket.count >= limit) {
+      return { allowed: false, remaining: 0, retryAfterMs };
+    }
+
+    bucket.count += 1;
+    return {
+      allowed: true,
+      remaining: Math.max(0, limit - bucket.count),
+      retryAfterMs,
+    };
+  }
+}
+
+function hashRateLimitKey(parts: string[]) {
+  const hash = createHash("sha256");
+  for (const part of parts) {
+    hash.update(part);
+    hash.update("\0");
+  }
+  return hash.digest("hex");
+}
+
+function requestSource(req: Request) {
+  // Express derives req.ip from its configured `trust proxy` function. With
+  // the safe default (trust proxy disabled), X-Forwarded-For is ignored and
+  // the socket peer is used. Deployments may opt into a narrowly trusted proxy
+  // without this middleware ever parsing an attacker-controlled XFF directly.
+  return req.ip || req.socket.remoteAddress || "unknown";
+}
+
+function endpointIdentity(req: Request) {
+  const pluginId = typeof req.params.pluginId === "string" ? req.params.pluginId : "";
+  const endpointKey = typeof req.params.endpointKey === "string" ? req.params.endpointKey : "";
+  return pluginId || endpointKey ? `${pluginId}/${endpointKey}` : req.baseUrl;
+}
+
+function isJsonContentType(req: Request) {
+  const value = req.headers["content-type"];
+  const mediaType = (Array.isArray(value) ? value[0] : value)?.split(";", 1)[0]?.trim().toLowerCase();
+  return mediaType === "application/json" || Boolean(mediaType?.endsWith("+json"));
+}
+
+function isPayloadTooLargeError(err: unknown) {
+  if (!err || typeof err !== "object") return false;
+  const candidate = err as { type?: unknown; status?: unknown; statusCode?: unknown };
+  return candidate.type === "entity.too.large" || candidate.status === 413 || candidate.statusCode === 413;
+}
+
+export function createPluginWebhookIngressMiddleware(
+  overrides: Partial<PluginWebhookIngressOptions> = {},
+): {
+  rateLimit: RequestHandler;
+  rawBody: RequestHandler;
+  rawBodyError: ErrorRequestHandler;
+  decodeBody: RequestHandler;
+} {
+  const configured = { ...resolvePluginWebhookIngressOptions(), ...overrides };
+  const options: PluginWebhookIngressOptions = {
+    maxBodyBytes: boundedInteger(configured.maxBodyBytes, DEFAULT_MAX_BODY_BYTES, 1, MAX_CONFIGURABLE_BODY_BYTES),
+    rateLimitMax: boundedInteger(configured.rateLimitMax, DEFAULT_RATE_LIMIT_MAX, 1, 10_000),
+    sourceRateLimitMax: boundedInteger(
+      configured.sourceRateLimitMax,
+      DEFAULT_RATE_LIMIT_MAX * 4,
+      1,
+      40_000,
+    ),
+    rateLimitWindowMs: boundedInteger(
+      configured.rateLimitWindowMs,
+      DEFAULT_RATE_LIMIT_WINDOW_MS,
+      1,
+      60 * 60_000,
+    ),
+    maxRateLimitBuckets: boundedInteger(
+      configured.maxRateLimitBuckets,
+      DEFAULT_RATE_LIMIT_BUCKETS,
+      1,
+      65_536,
+    ),
+  };
+  options.sourceRateLimitMax = Math.max(options.rateLimitMax, options.sourceRateLimitMax);
+
+  const endpointLimiter = new FixedWindowRateLimiter(options.maxRateLimitBuckets);
+  const sourceLimiter = new FixedWindowRateLimiter(options.maxRateLimitBuckets);
+
+  const rateLimit: RequestHandler = (req, res, next) => {
+    if (req.method !== "POST") {
+      next();
+      return;
+    }
+
+    const source = requestSource(req);
+    const now = Date.now();
+    const sourceDecision = sourceLimiter.consume(
+      hashRateLimitKey([source]),
+      options.sourceRateLimitMax,
+      options.rateLimitWindowMs,
+      now,
+    );
+    const endpointDecision = sourceDecision.allowed
+      ? endpointLimiter.consume(
+          hashRateLimitKey([endpointIdentity(req), source]),
+          options.rateLimitMax,
+          options.rateLimitWindowMs,
+          now,
+        )
+      : sourceDecision;
+    const decision = sourceDecision.allowed ? endpointDecision : sourceDecision;
+
+    res.setHeader("RateLimit-Limit", String(options.rateLimitMax));
+    res.setHeader("RateLimit-Remaining", String(decision.remaining));
+    if (!decision.allowed) {
+      res.setHeader("Retry-After", String(Math.max(1, Math.ceil(decision.retryAfterMs / 1_000))));
+      res.status(429).json({ error: "Webhook rate limit exceeded" });
+      return;
+    }
+    next();
+  };
+
+  const rawBody = express.raw({
+    inflate: true,
+    limit: options.maxBodyBytes,
+    type: () => true,
+  });
+
+  const rawBodyError: ErrorRequestHandler = (err, _req, res, next) => {
+    if (isPayloadTooLargeError(err)) {
+      res.status(413).json({ error: "Webhook payload too large" });
+      return;
+    }
+    next(err);
+  };
+
+  const decodeBody: RequestHandler = (req, res, next) => {
+    const body = Buffer.isBuffer(req.body) ? req.body : Buffer.alloc(0);
+    (req as unknown as { rawBody: Buffer }).rawBody = body;
+
+    if (!isJsonContentType(req) || body.length === 0) {
+      req.body = {};
+      next();
+      return;
+    }
+
+    try {
+      req.body = JSON.parse(body.toString("utf8")) as unknown;
+      next();
+    } catch {
+      res.status(400).json({ error: "Invalid JSON webhook payload" });
+    }
+  };
+
+  return { rateLimit, rawBody, rawBodyError, decodeBody };
+}
+
+export function selectPersistedPluginWebhookHeaders(
+  headers: IncomingHttpHeaders,
+  options?: { maxTotalBytes?: number; maxValueBytes?: number },
+) {
+  const maxTotalBytes = boundedInteger(
+    options?.maxTotalBytes,
+    DEFAULT_MAX_PERSISTED_HEADER_BYTES,
+    1,
+    64 * KIB,
+  );
+  const maxValueBytes = boundedInteger(
+    options?.maxValueBytes,
+    DEFAULT_MAX_PERSISTED_HEADER_VALUE_BYTES,
+    1,
+    16 * KIB,
+  );
+  const selected: Record<string, string> = {};
+  let totalBytes = 0;
+
+  for (const [rawName, rawValue] of Object.entries(headers)) {
+    const name = rawName.toLowerCase();
+    if (!PERSISTED_WEBHOOK_HEADER_ALLOWLIST.has(name)) continue;
+    const value = Array.isArray(rawValue) ? rawValue.join(", ") : rawValue;
+    if (typeof value !== "string") continue;
+
+    const valueBytes = Buffer.byteLength(value, "utf8");
+    const entryBytes = Buffer.byteLength(name, "utf8") + valueBytes;
+    if (valueBytes > maxValueBytes || totalBytes + entryBytes > maxTotalBytes) continue;
+    selected[name] = value;
+    totalBytes += entryBytes;
+  }
+
+  return selected;
+}
+
+export function boundedPluginWebhookFailureMessage(err: unknown) {
+  const raw = err instanceof Error ? err.message : String(err);
+  const normalized = raw.replace(/[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/g, " ");
+  const encoded = Buffer.from(normalized, "utf8");
+  if (encoded.length <= MAX_PLUGIN_WEBHOOK_FAILURE_BYTES) return normalized;
+
+  const suffix = "...";
+  const maxPrefixBytes = MAX_PLUGIN_WEBHOOK_FAILURE_BYTES - Buffer.byteLength(suffix);
+  let prefix = encoded.subarray(0, maxPrefixBytes).toString("utf8");
+  while (Buffer.byteLength(prefix, "utf8") > maxPrefixBytes) {
+    prefix = prefix.slice(0, -1);
+  }
+  return `${prefix}${suffix}`;
+}

--- a/server/src/middleware/private-hostname-guard.ts
+++ b/server/src/middleware/private-hostname-guard.ts
@@ -5,23 +5,36 @@ function isLoopbackHostname(hostname: string): boolean {
   return normalized === "localhost" || normalized === "127.0.0.1" || normalized === "::1";
 }
 
-function extractHostname(req: Request): string | null {
-  const forwardedHost = req.header("x-forwarded-host")?.split(",")[0]?.trim();
-  const hostHeader = req.header("host")?.trim();
-  const raw = forwardedHost || hostHeader;
+function normalizeHostname(hostname: string): string {
+  const normalized = hostname.trim().toLowerCase().replace(/\.$/, "");
+  if (normalized.startsWith("[") && normalized.endsWith("]")) {
+    return normalized.slice(1, -1);
+  }
+  return normalized;
+}
+
+export function extractHostnameFromHostHeader(rawHost: string | undefined): string | null {
+  const raw = rawHost?.trim();
   if (!raw) return null;
 
   try {
-    return new URL(`http://${raw}`).hostname.trim().toLowerCase();
+    return normalizeHostname(new URL(`http://${raw}`).hostname);
   } catch {
-    return raw.trim().toLowerCase();
+    return normalizeHostname(raw);
   }
+}
+
+function extractHostname(req: Request): string | null {
+  // Do not trust X-Forwarded-Host here. This server does not configure a
+  // trusted proxy boundary, so a direct client could otherwise spoof it and
+  // bypass the DNS-rebinding guard.
+  return extractHostnameFromHostHeader(req.header("host"));
 }
 
 function normalizeAllowedHostnames(values: string[]): string[] {
   const unique = new Set<string>();
   for (const value of values) {
-    const trimmed = value.trim().toLowerCase();
+    const trimmed = normalizeHostname(value);
     if (!trimmed) continue;
     unique.add(trimmed);
   }
@@ -30,7 +43,7 @@ function normalizeAllowedHostnames(values: string[]): string[] {
 
 export function resolvePrivateHostnameAllowSet(opts: { allowedHostnames: string[]; bindHost: string }): Set<string> {
   const configuredAllow = normalizeAllowedHostnames(opts.allowedHostnames);
-  const bindHost = opts.bindHost.trim().toLowerCase();
+  const bindHost = normalizeHostname(opts.bindHost);
   const allowSet = new Set<string>(configuredAllow);
 
   if (bindHost && bindHost !== "0.0.0.0") {
@@ -40,6 +53,32 @@ export function resolvePrivateHostnameAllowSet(opts: { allowedHostnames: string[
   allowSet.add("127.0.0.1");
   allowSet.add("::1");
   return allowSet;
+}
+
+export function isPrivateHostnameAllowed(rawHost: string | undefined, allowSet: ReadonlySet<string>): boolean {
+  const hostname = extractHostnameFromHostHeader(rawHost);
+  return hostname !== null && (isLoopbackHostname(hostname) || allowSet.has(hostname));
+}
+
+export function isSameOriginHost(origin: string | undefined, rawHost: string | undefined): boolean {
+  if (!origin || !rawHost) return false;
+  try {
+    const parsedOrigin = new URL(origin);
+    if (
+      (parsedOrigin.protocol !== "http:" && parsedOrigin.protocol !== "https:")
+      || parsedOrigin.username
+      || parsedOrigin.password
+      || parsedOrigin.pathname !== "/"
+      || parsedOrigin.search
+      || parsedOrigin.hash
+    ) {
+      return false;
+    }
+    const parsedHost = new URL(`${parsedOrigin.protocol}//${rawHost}`);
+    return parsedOrigin.host.toLowerCase() === parsedHost.host.toLowerCase();
+  } catch {
+    return false;
+  }
 }
 
 function blockedHostnameMessage(hostname: string): string {
@@ -77,7 +116,7 @@ export function privateHostnameGuard(opts: {
       return;
     }
 
-    if (isLoopbackHostname(hostname) || allowSet.has(hostname)) {
+    if (isPrivateHostnameAllowed(req.header("host"), allowSet)) {
       next();
       return;
     }

--- a/server/src/network/public-address.ts
+++ b/server/src/network/public-address.ts
@@ -1,0 +1,140 @@
+import { isIP } from "node:net";
+
+function normalizeIpLiteral(value: string) {
+  return value.replace(/^\[|\]$/gu, "").toLowerCase();
+}
+
+function parseIpv4Octets(value: string): [number, number, number, number] | null {
+  const parts = normalizeIpLiteral(value).split(".");
+  if (parts.length !== 4 || parts.some((part) => !/^\d{1,3}$/u.test(part))) return null;
+  const octets = parts.map((part) => Number(part));
+  if (octets.some((octet) => octet < 0 || octet > 255)) return null;
+  return octets as [number, number, number, number];
+}
+
+function parseIpv6Segments(value: string): number[] | null {
+  let normalized = normalizeIpLiteral(value);
+  if (!normalized || normalized.includes("%")) return null;
+
+  if (normalized.includes(".")) {
+    const lastColon = normalized.lastIndexOf(":");
+    if (lastColon < 0) return null;
+    const ipv4 = parseIpv4Octets(normalized.slice(lastColon + 1));
+    if (!ipv4) return null;
+    const high = (ipv4[0] << 8) | ipv4[1];
+    const low = (ipv4[2] << 8) | ipv4[3];
+    normalized = `${normalized.slice(0, lastColon)}:${high.toString(16)}:${low.toString(16)}`;
+  }
+
+  const halves = normalized.split("::");
+  if (halves.length > 2) return null;
+  const parseHalf = (half: string) => {
+    if (!half) return [];
+    const pieces = half.split(":");
+    if (pieces.some((piece) => !/^[\da-f]{1,4}$/u.test(piece))) return null;
+    return pieces.map((piece) => Number.parseInt(piece, 16));
+  };
+  const left = parseHalf(halves[0] ?? "");
+  const right = parseHalf(halves[1] ?? "");
+  if (!left || !right) return null;
+
+  if (halves.length === 1) return left.length === 8 ? left : null;
+  if (left.length + right.length >= 8) return null;
+  return [...left, ...Array<number>(8 - left.length - right.length).fill(0), ...right];
+}
+
+function mappedIpv4Octets(segments: number[]): [number, number, number, number] | null {
+  if (segments.length !== 8) return null;
+  const isIpv4Mapped = segments.slice(0, 5).every((segment) => segment === 0) && segments[5] === 0xffff;
+  const isIpv4Compatible = segments.slice(0, 6).every((segment) => segment === 0);
+  if (!isIpv4Mapped && !isIpv4Compatible) return null;
+  return [segments[6] >> 8, segments[6] & 0xff, segments[7] >> 8, segments[7] & 0xff];
+}
+
+function translatedIpv4Octets(segments: number[]): [number, number, number, number] | null {
+  if (segments.length !== 8) return null;
+  const isWellKnownNat64 = segments[0] === 0x0064
+    && segments[1] === 0xff9b
+    && segments.slice(2, 6).every((segment) => segment === 0);
+  const isIpv4Translated = segments.slice(0, 4).every((segment) => segment === 0)
+    && segments[4] === 0xffff
+    && segments[5] === 0;
+  if (!isWellKnownNat64 && !isIpv4Translated) return null;
+  return [segments[6] >> 8, segments[6] & 0xff, segments[7] >> 8, segments[7] & 0xff];
+}
+
+function isNonPublicIpv4(octets: [number, number, number, number]) {
+  const [a, b, c] = octets;
+  if (a === 0 || a === 10 || a === 127) return true;
+  if (a === 100 && b >= 64 && b <= 127) return true;
+  if (a === 169 && b === 254) return true;
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  if (a === 192 && (b === 0 || b === 168)) return true;
+  if (a === 192 && b === 88 && c === 99) return true;
+  if (a === 198 && (b === 18 || b === 19)) return true;
+  if (a === 198 && b === 51 && c === 100) return true;
+  if (a === 203 && b === 0 && c === 113) return true;
+  return a >= 224;
+}
+
+/**
+ * Returns true for private, loopback, link-local, documentation, benchmark,
+ * multicast, transition, and otherwise non-routable IP literals.
+ */
+export function isNonPublicIpAddress(value: string) {
+  const normalized = normalizeIpLiteral(value);
+  const ipv4 = parseIpv4Octets(normalized);
+  if (ipv4) return isNonPublicIpv4(ipv4);
+
+  const segments = parseIpv6Segments(normalized);
+  if (!segments) return true;
+  const embeddedIpv4 = mappedIpv4Octets(segments) ?? translatedIpv4Octets(segments);
+  if (embeddedIpv4 && isNonPublicIpv4(embeddedIpv4)) return true;
+
+  const first = segments[0] ?? 0;
+  const isUnspecified = segments.every((segment) => segment === 0);
+  const isLoopback = segments.slice(0, 7).every((segment) => segment === 0) && segments[7] === 1;
+  const isUniqueLocal = (first & 0xfe00) === 0xfc00;
+  const isLinkLocal = (first & 0xffc0) === 0xfe80;
+  const isDeprecatedSiteLocal = (first & 0xffc0) === 0xfec0;
+  const isMulticast = (first & 0xff00) === 0xff00;
+  const isDocumentation = first === 0x2001 && segments[1] === 0x0db8;
+  const isBenchmark = first === 0x2001 && segments[1] === 0x0002 && segments[2] === 0;
+  const isTeredo = first === 0x2001 && segments[1] === 0;
+  const isSixToFour = first === 0x2002;
+  const isDiscardOnly = first === 0x0100 && segments.slice(1, 4).every((segment) => segment === 0);
+  const isLocalNat64 = first === 0x0064 && segments[1] === 0xff9b && segments[2] === 1;
+  return isUnspecified
+    || isLoopback
+    || isUniqueLocal
+    || isLinkLocal
+    || isDeprecatedSiteLocal
+    || isMulticast
+    || isDocumentation
+    || isBenchmark
+    || isTeredo
+    || isSixToFour
+    || isDiscardOnly
+    || isLocalNat64;
+}
+
+export function isPrivateHostname(hostname: string) {
+  const normalized = normalizeIpLiteral(hostname);
+  if (normalized === "localhost" || normalized.endsWith(".localhost")) return true;
+  return isIP(normalized) !== 0 && isNonPublicIpAddress(normalized);
+}
+
+export function isPublicDnsHostname(hostname: string) {
+  const normalized = normalizeIpLiteral(hostname);
+  if (normalized === "localhost" || normalized.endsWith(".localhost")) return false;
+  if (
+    normalized.endsWith(".local")
+    || normalized.endsWith(".lan")
+    || normalized.endsWith(".home")
+    || normalized.endsWith(".internal")
+    || normalized.endsWith(".corp")
+    || normalized.endsWith(".intranet")
+  ) return false;
+  if (!normalized.includes(".")) return false;
+  return isIP(normalized) === 0;
+}

--- a/server/src/realtime/live-events-ws.ts
+++ b/server/src/realtime/live-events-ws.ts
@@ -8,6 +8,11 @@ import { createRequire } from "node:module";
 import type { Duplex } from "node:stream";
 import type { BetterAuthSessionResult } from "../auth/better-auth.js";
 import { logger } from "../middleware/logger.js";
+import {
+  isPrivateHostnameAllowed,
+  isSameOriginHost,
+  resolvePrivateHostnameAllowSet,
+} from "../middleware/private-hostname-guard.js";
 import { subscribeCompanyLiveEvents } from "../services/live-events.js";
 
 interface WsSocket {
@@ -180,10 +185,18 @@ export function setupLiveEventsWebSocketServer(
   db: Db,
   opts: {
     deploymentMode: DeploymentMode;
+    deploymentExposure: "private" | "public";
+    allowedHostnames: string[];
+    bindHost: string;
     resolveSessionFromHeaders?: (headers: Headers) => Promise<BetterAuthSessionResult | null>;
   },
 ) {
   const wss = new WebSocketServer({ noServer: true });
+  const enforcePrivateHostname = opts.deploymentExposure === "private";
+  const privateHostnameAllowSet = resolvePrivateHostnameAllowSet({
+    allowedHostnames: opts.allowedHostnames,
+    bindHost: opts.bindHost,
+  });
   const cleanupByClient = new Map<WsSocket, () => void>();
   const aliveByClient = new Map<WsSocket, boolean>();
 
@@ -234,6 +247,11 @@ export function setupLiveEventsWebSocketServer(
   });
 
   server.on("upgrade", (req, socket, head) => {
+    if (enforcePrivateHostname && !isPrivateHostnameAllowed(req.headers.host, privateHostnameAllowSet)) {
+      rejectUpgrade(socket, "403 Forbidden", "hostname not allowed");
+      return;
+    }
+
     if (!req.url) {
       rejectUpgrade(socket, "400 Bad Request", "missing url");
       return;
@@ -243,6 +261,16 @@ export function setupLiveEventsWebSocketServer(
     const orgId = parseCompanyId(url.pathname);
     if (!orgId) {
       socket.destroy();
+      return;
+    }
+
+    const token = parseBearerToken(req.headers.authorization) ?? url.searchParams.get("token")?.trim();
+    const origin = req.headers.origin;
+    // Browsers always send Origin for WebSocket handshakes. Require it to
+    // match Host for cookie/local-implicit auth, and reject a mismatched Origin
+    // even when a token is present. Non-browser bearer clients may omit it.
+    if ((origin && !isSameOriginHost(origin, req.headers.host)) || (!origin && !token)) {
+      rejectUpgrade(socket, "403 Forbidden", "origin not allowed");
       return;
     }
 

--- a/server/src/routes/access-onboarding.helpers.ts
+++ b/server/src/routes/access-onboarding.helpers.ts
@@ -9,6 +9,7 @@ import {
 } from "@rudderhq/shared";
 import { eq } from "drizzle-orm";
 import type { Request } from "express";
+import { isPostgresError } from "../services/postgres-errors.js";
 import {
   fetchPublicHttpUrlOnce,
   type WebsiteMetadataOptions,
@@ -846,29 +847,7 @@ export function resolveJoinRequestAgentManagerId(
 }
 
 export function isInviteTokenHashCollisionError(error: unknown) {
-  const candidates = [
-    error,
-    (error as { cause?: unknown } | null)?.cause ?? null
-  ];
-  for (const candidate of candidates) {
-    if (!candidate || typeof candidate !== "object") continue;
-    const code =
-      "code" in candidate && typeof candidate.code === "string"
-        ? candidate.code
-        : null;
-    const message =
-      "message" in candidate && typeof candidate.message === "string"
-        ? candidate.message
-        : "";
-    const constraint =
-      "constraint" in candidate && typeof candidate.constraint === "string"
-        ? candidate.constraint
-        : null;
-    if (code !== "23505") continue;
-    if (constraint === "invites_token_hash_unique_idx") return true;
-    if (message.includes("invites_token_hash_unique_idx")) return true;
-  }
-  return false;
+  return isPostgresError(error, "23505", "invites_token_hash_unique_idx");
 }
 
 export function isAbortError(error: unknown) {
@@ -957,4 +936,3 @@ export async function probeInviteResolutionTarget(
     clearTimeout(timeout);
   }
 }
-

--- a/server/src/routes/access-onboarding.helpers.ts
+++ b/server/src/routes/access-onboarding.helpers.ts
@@ -9,6 +9,10 @@ import {
 } from "@rudderhq/shared";
 import { eq } from "drizzle-orm";
 import type { Request } from "express";
+import {
+  fetchPublicHttpUrlOnce,
+  type WebsiteMetadataOptions,
+} from "../services/website-metadata.js";
 import { generateEd25519PrivateKeyPem, headerMapGetIgnoreCase, headerMapHasKeyIgnoreCase, isLoopbackHost, isPlainObject, JoinDiagnostic, nonEmptyTrimmedString, normalizeHeaderMap, normalizeHostname, parseBooleanLike, requestBaseUrl, tokenFromAuthorizationHeader } from "./access.helpers.js";
 
 export function normalizeAgentDefaultsForJoin(input: {
@@ -881,17 +885,27 @@ export type InviteResolutionProbe = {
 
 export async function probeInviteResolutionTarget(
   url: URL,
-  timeoutMs: number
+  timeoutMs: number,
+  /** Test-only transport override; production always uses validated, pinned DNS addresses. */
+  publicHttpOptions: WebsiteMetadataOptions = {},
 ): Promise<InviteResolutionProbe> {
   const startedAt = Date.now();
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    const response = await fetch(url, {
-      method: "HEAD",
-      redirect: "manual",
-      signal: controller.signal
-    });
+    const { response } = await fetchPublicHttpUrlOnce(
+      url,
+      publicHttpOptions,
+      {
+        method: "HEAD",
+        redirect: "manual",
+        signal: controller.signal,
+        headers: {
+          accept: "*/*",
+          "user-agent": "RudderInviteResolutionProbe/1.0",
+        },
+      },
+    );
     const durationMs = Date.now() - startedAt;
     if (
       response.ok ||
@@ -943,5 +957,4 @@ export async function probeInviteResolutionTarget(
     clearTimeout(timeout);
   }
 }
-
 

--- a/server/src/routes/access.helpers.ts
+++ b/server/src/routes/access.helpers.ts
@@ -524,6 +524,22 @@ export function canReplayOpenClawGatewayInviteAccept(input: {
   );
 }
 
+export function canMutateJoinRequestOnInviteReplay(status: string) {
+  return status === "pending_approval";
+}
+
+export function joinRequestRequiresInstanceAdmin(input: {
+  requestType: string;
+  agentRuntimeType?: string | null;
+  agentDefaultsPayload?: unknown;
+}) {
+  return input.requestType === "agent"
+    && (
+      (input.agentRuntimeType ?? "process") !== "process"
+      || (isPlainObject(input.agentDefaultsPayload) && Object.keys(input.agentDefaultsPayload).length > 0)
+    );
+}
+
 export function summarizeSecretForLog(
   value: unknown
 ): { present: true; length: number; sha256Prefix: string } | null {
@@ -572,4 +588,3 @@ export function summarizeOpenClawGatewayDefaultsForLog(defaultsPayload: unknown)
     gatewayToken: summarizeSecretForLog(gatewayTokenValue)
   };
 }
-

--- a/server/src/routes/access.ts
+++ b/server/src/routes/access.ts
@@ -41,10 +41,10 @@ import {
   notifyHireApproved
 } from "../services/index.js";
 import { buildInviteOnboardingManifest, buildInviteOnboardingTextDocument, grantsFromDefaults, inviteExpired, isInviteTokenHashCollisionError, isLocalImplicit, mergeInviteDefaults, normalizeAgentDefaultsForJoin, probeInviteResolutionTarget, requestIp, resolveActorEmail, resolveJoinRequestAgentManagerId, toInviteSummaryResponse } from "./access-onboarding.helpers.js";
-import { buildCliAuthApprovalPath, buildJoinDefaultsPayloadForAccept, canReplayOpenClawGatewayInviteAccept, companyInviteExpiresAt, createClaimSecret, createInviteToken, hashToken, INVITE_TOKEN_MAX_RETRIES, isPlainObject, JoinDiagnostic, listAvailableSkills, mergeJoinDefaultsPayloadForReplay, readSkillMarkdown, requestBaseUrl, summarizeOpenClawGatewayDefaultsForLog, toJoinRequestResponse, tokenHashesMatch } from "./access.helpers.js";
+import { buildCliAuthApprovalPath, buildJoinDefaultsPayloadForAccept, canMutateJoinRequestOnInviteReplay, canReplayOpenClawGatewayInviteAccept, companyInviteExpiresAt, createClaimSecret, createInviteToken, hashToken, INVITE_TOKEN_MAX_RETRIES, JoinDiagnostic, joinRequestRequiresInstanceAdmin, listAvailableSkills, mergeJoinDefaultsPayloadForReplay, readSkillMarkdown, requestBaseUrl, summarizeOpenClawGatewayDefaultsForLog, toJoinRequestResponse, tokenHashesMatch } from "./access.helpers.js";
 import { assertCompanyAccess } from "./authz.js";
 export { buildInviteOnboardingTextDocument, normalizeAgentDefaultsForJoin, resolveJoinRequestAgentManagerId } from "./access-onboarding.helpers.js";
-export { buildJoinDefaultsPayloadForAccept, canReplayOpenClawGatewayInviteAccept, companyInviteExpiresAt, mergeJoinDefaultsPayloadForReplay } from "./access.helpers.js";
+export { buildJoinDefaultsPayloadForAccept, canMutateJoinRequestOnInviteReplay, canReplayOpenClawGatewayInviteAccept, companyInviteExpiresAt, joinRequestRequiresInstanceAdmin, mergeJoinDefaultsPayloadForReplay } from "./access.helpers.js";
 
 export function accessRoutes(
   db: Db,
@@ -800,7 +800,9 @@ export function accessRoutes(
               .then((rows) => rows[0]);
             return row;
           })
-        : await db
+        : !canMutateJoinRequestOnInviteReplay(existingJoinRequestForInvite?.status ?? "")
+          ? existingJoinRequestForInvite
+          : await db
             .update(joinRequests)
             .set({
               requestIp: requestIp(req),
@@ -827,45 +829,6 @@ export function accessRoutes(
 
       if (!created) {
         throw conflict("Join request not found");
-      }
-
-      if (
-        inviteAlreadyAccepted &&
-        requestType === "agent" &&
-        agentRuntimeType === "openclaw_gateway" &&
-        created.status === "approved" &&
-        created.createdAgentId
-      ) {
-        const existingAgent = await agents.getById(created.createdAgentId);
-        if (!existingAgent) {
-          throw conflict("Approved join request agent not found");
-        }
-        const existingAdapterConfig = isPlainObject(existingAgent.agentRuntimeConfig)
-          ? (existingAgent.agentRuntimeConfig as Record<string, unknown>)
-          : {};
-        const nextAdapterConfig = {
-          ...existingAdapterConfig,
-          ...(joinDefaults.normalized ?? {})
-        };
-        const updatedAgent = await agents.update(created.createdAgentId, {
-          agentRuntimeType,
-          agentRuntimeConfig: nextAdapterConfig
-        });
-        if (!updatedAgent) {
-          throw conflict("Approved join request agent not found");
-        }
-        await logActivity(db, {
-          orgId,
-          actorType: req.actor.type === "agent" ? "agent" : "user",
-          actorId:
-            req.actor.type === "agent"
-              ? req.actor.agentId ?? "invite-agent"
-              : req.actor.userId ?? "board",
-          action: "agent.updated_from_join_replay",
-          entityType: "agent",
-          entityId: updatedAgent.id,
-          details: { inviteId: invite.id, joinRequestId: created.id }
-        });
       }
 
       if (requestType === "agent" && agentRuntimeType === "openclaw_gateway") {
@@ -1055,6 +1018,9 @@ export function accessRoutes(
       if (!existing) throw notFound("Join request not found");
       if (existing.status !== "pending_approval")
         throw conflict("Join request is not pending");
+      if (joinRequestRequiresInstanceAdmin(existing)) {
+        await assertInstanceAdmin(req);
+      }
 
       const invite = await db
         .select()

--- a/server/src/routes/activity.ts
+++ b/server/src/routes/activity.ts
@@ -8,7 +8,7 @@ import { sanitizeRecord } from "../redaction.js";
 import { activityService } from "../services/activity.js";
 import { resolveHeartbeatRunIdReference } from "../services/heartbeat-run-reference.js";
 import { issueService } from "../services/index.js";
-import { assertBoard, assertCompanyAccess, getAuthorizedOrgScope } from "./authz.js";
+import { assertCompanyAccess, assertInstanceAdmin, getAuthorizedOrgScope } from "./authz.js";
 
 const USER_ACTIVITY_INCLUDES = new Set(["chat", "comments", "issues", "approvals", "activity"]);
 
@@ -139,8 +139,9 @@ export function activityRoutes(db: Db) {
   });
 
   router.post("/orgs/:orgId/activity", validate(createActivitySchema), async (req, res) => {
-    assertBoard(req);
+    assertInstanceAdmin(req);
     const orgId = req.params.orgId as string;
+    assertCompanyAccess(req, orgId);
     const event = await svc.create({
       orgId,
       ...req.body,

--- a/server/src/routes/agents.management-routes.ts
+++ b/server/src/routes/agents.management-routes.ts
@@ -19,7 +19,7 @@ import { Router, type Request } from "express";
 import multer from "multer";
 import { randomUUID } from "node:crypto";
 import { MAX_ATTACHMENT_BYTES } from "../attachment-types.js";
-import { notFound } from "../errors.js";
+import { conflict, forbidden, notFound } from "../errors.js";
 import { redactCurrentUserValue } from "../log-redaction.js";
 import { validate } from "../middleware/validate.js";
 import { redactEventPayload } from "../redaction.js";
@@ -31,7 +31,13 @@ import {
   syncInstructionsBundleConfigFromFilePath
 } from "../services/index.js";
 import type { StorageService } from "../storage/types.js";
-import { assertBoard, assertCompanyAccess, getActorInfo, getAuthorizedOrgScope } from "./authz.js";
+import {
+  assertBoard,
+  assertCompanyAccess,
+  assertInstanceAdmin,
+  getActorInfo,
+  getAuthorizedOrgScope,
+} from "./authz.js";
 
 type AgentManagementRouteContext = {
   router: Router;
@@ -74,6 +80,7 @@ export function registerAgentManagementRoutes(ctx: AgentManagementRouteContext) 
     parseSourceIssueIds,
     applyCreateDefaultsByAdapterType,
     resolveDesiredSkillAssignment,
+    assertAdapterConfigShape,
     assertAdapterConfigConstraints,
     assertAgentAvatarAssetBelongsToOrg,
     materializeDefaultInstructionsBundleForNewAgent,
@@ -84,6 +91,9 @@ export function registerAgentManagementRoutes(ctx: AgentManagementRouteContext) 
     AGENT_AVATAR_CONTENT_TYPES,
     compressAgentAvatar,
     assertCanManageInstructionsPath,
+    assertCanAccessInstructionsFile,
+    isCanonicalManagedInstructionsRoot,
+    isCanonicalManagedInstructionsConfig,
     asRecord,
     asNonEmptyString,
     resolveInstructionsFilePath,
@@ -98,6 +108,59 @@ export function registerAgentManagementRoutes(ctx: AgentManagementRouteContext) 
     KNOWN_INSTRUCTIONS_PATH_KEYS,
     KNOWN_INSTRUCTIONS_BUNDLE_KEYS,
   } = ctx;
+
+  const AGENT_PROFILE_PATCH_FIELDS = new Set([
+    "name",
+    "title",
+    "icon",
+    "capabilities",
+  ]);
+
+  function assertAgentProfilePatch(req: Request) {
+    if (req.actor.type !== "agent") return;
+    const blockedFields = Object.keys(req.body as Record<string, unknown>)
+      .filter((field) => !AGENT_PROFILE_PATCH_FIELDS.has(field))
+      .sort();
+    if (blockedFields.length === 0) return;
+    throw forbidden(
+      `Agent authentication can only update profile fields; blocked fields: ${blockedFields.join(", ")}`,
+    );
+  }
+
+  function isNonEmptyRecord(value: unknown) {
+    return typeof value === "object"
+      && value !== null
+      && !Array.isArray(value)
+      && Object.keys(value as Record<string, unknown>).length > 0;
+  }
+
+  function selectsHostRuntimeConfiguration(input: {
+    agentRuntimeType?: unknown;
+    agentRuntimeConfig?: unknown;
+    runtimeConfig?: unknown;
+  }) {
+    return (
+      (typeof input.agentRuntimeType === "string" && input.agentRuntimeType !== "process")
+      || isNonEmptyRecord(input.agentRuntimeConfig)
+      || isNonEmptyRecord(input.runtimeConfig)
+    );
+  }
+
+  function assertCanSelectHostRuntimeConfiguration(req: Request, input: {
+    agentRuntimeType?: unknown;
+    agentRuntimeConfig?: unknown;
+    runtimeConfig?: unknown;
+  }) {
+    if (selectsHostRuntimeConfiguration(input)) assertInstanceAdmin(req);
+  }
+
+  async function getAuthorizedBoardAgent(req: Request, id: string) {
+    assertBoard(req);
+    const agent = await svc.getById(id);
+    if (!agent) throw notFound("Agent not found");
+    assertCompanyAccess(req, agent.orgId);
+    return agent;
+  }
 
   async function ensureFirstAgentIntelligenceDefaults(
     orgId: string,
@@ -147,22 +210,20 @@ export function registerAgentManagementRoutes(ctx: AgentManagementRouteContext) 
       orgId,
       normalizedAdapterConfig,
     );
+    assertAdapterConfigShape(hireInput.agentRuntimeType, runtimeAdapterConfig);
     const desiredSkillAssignment = await resolveDesiredSkillAssignment(
+      req,
       orgId,
       hireInput.agentRuntimeType,
       runtimeAdapterConfig,
       Array.isArray(requestedDesiredSkills) ? requestedDesiredSkills : undefined,
-    );
-    await assertAdapterConfigConstraints(
-      orgId,
-      hireInput.agentRuntimeType,
-      normalizedAdapterConfig,
     );
     const normalizedHireInput = {
       ...hireInput,
       icon: normalizeCreatedAgentAvatarIcon(hireInput.icon),
       agentRuntimeConfig: normalizedAdapterConfig,
     };
+    const hireSelectsHostRuntime = selectsHostRuntimeConfiguration(normalizedHireInput);
     await assertAgentAvatarAssetBelongsToOrg(orgId, normalizedHireInput.icon);
 
     const organization = await db
@@ -175,8 +236,26 @@ export function registerAgentManagementRoutes(ctx: AgentManagementRouteContext) 
       return;
     }
 
-    const requiresApproval = organization.requireBoardApprovalForNewAgents;
+    // Agent-initiated hires always require a human decision. Otherwise an
+    // agent with creation permission can materialize a new runtime before the
+    // board has reviewed its execution-sensitive configuration.
+    const requiresApproval =
+      req.actor.type === "agent"
+      || organization.requireBoardApprovalForNewAgents
+      || (
+        hireSelectsHostRuntime
+        && req.actor.type === "board"
+        && req.actor.source !== "local_implicit"
+        && !req.actor.isInstanceAdmin
+      );
     const status = requiresApproval ? "pending_approval" : "idle";
+    if (!requiresApproval) {
+      await assertAdapterConfigConstraints(
+        orgId,
+        hireInput.agentRuntimeType,
+        normalizedAdapterConfig,
+      );
+    }
     const createdAgent = await svc.create(orgId, {
       ...normalizedHireInput,
       status,
@@ -326,6 +405,7 @@ export function registerAgentManagementRoutes(ctx: AgentManagementRouteContext) 
       createInput.agentRuntimeType,
       ((createInput.agentRuntimeConfig ?? {}) as Record<string, unknown>),
     );
+    assertCanSelectHostRuntimeConfiguration(req, createInput);
     const normalizedAdapterConfig = await secretsSvc.normalizeAdapterConfigForPersistence(
       orgId,
       stripPersistedSkillSyncConfig(requestedAdapterConfig),
@@ -336,6 +416,7 @@ export function registerAgentManagementRoutes(ctx: AgentManagementRouteContext) 
       normalizedAdapterConfig,
     );
     const desiredSkillAssignment = await resolveDesiredSkillAssignment(
+      req,
       orgId,
       createInput.agentRuntimeType,
       runtimeAdapterConfig,
@@ -552,6 +633,7 @@ export function registerAgentManagementRoutes(ctx: AgentManagementRouteContext) 
   });
 
   router.patch("/agents/:id/instructions-path", validate(updateAgentInstructionsPathSchema), async (req, res) => {
+    assertInstanceAdmin(req);
     const id = req.params.id as string;
     const existing = await svc.getInternalById(id);
     if (!existing) {
@@ -636,11 +718,12 @@ export function registerAgentManagementRoutes(ctx: AgentManagementRouteContext) 
       res.status(404).json({ error: "Agent not found" });
       return;
     }
-    await assertCanReadAgent(req, existing);
+    await assertCanAccessInstructionsFile(req, existing);
     res.json(await instructions.getBundle(existing));
   });
 
   router.patch("/agents/:id/instructions-bundle", validate(updateAgentInstructionsBundleSchema), async (req, res) => {
+    assertBoard(req);
     const id = req.params.id as string;
     const existing = await svc.getInternalById(id);
     if (!existing) {
@@ -648,6 +731,16 @@ export function registerAgentManagementRoutes(ctx: AgentManagementRouteContext) 
       return;
     }
     await assertCanManageInstructionsPath(req, existing);
+    if (
+      !isCanonicalManagedInstructionsConfig(existing)
+      || req.body.mode === "external"
+      || (
+        typeof req.body.rootPath === "string"
+        && !isCanonicalManagedInstructionsRoot(existing, req.body.rootPath)
+      )
+    ) {
+      assertInstanceAdmin(req);
+    }
 
     const actor = getActorInfo(req);
     const { bundle, agentRuntimeConfig } = await instructions.updateBundle(existing, req.body);
@@ -695,7 +788,7 @@ export function registerAgentManagementRoutes(ctx: AgentManagementRouteContext) 
       res.status(404).json({ error: "Agent not found" });
       return;
     }
-    await assertCanReadAgent(req, existing);
+    await assertCanAccessInstructionsFile(req, existing);
 
     const relativePath = typeof req.query.path === "string" ? req.query.path : "";
     if (!relativePath.trim()) {
@@ -713,6 +806,7 @@ export function registerAgentManagementRoutes(ctx: AgentManagementRouteContext) 
       return;
     }
     await assertCanManageInstructionsPath(req, existing);
+    await assertCanAccessInstructionsFile(req, existing);
 
     const actor = getActorInfo(req);
     const result = await instructions.writeFile(existing, req.body.path, req.body.content, {
@@ -762,6 +856,7 @@ export function registerAgentManagementRoutes(ctx: AgentManagementRouteContext) 
       return;
     }
     await assertCanManageInstructionsPath(req, existing);
+    await assertCanAccessInstructionsFile(req, existing);
 
     const relativePath = typeof req.query.path === "string" ? req.query.path : "";
     if (!relativePath.trim()) {
@@ -811,7 +906,19 @@ export function registerAgentManagementRoutes(ctx: AgentManagementRouteContext) 
       res.status(404).json({ error: "Agent not found" });
       return;
     }
+    assertAgentProfilePatch(req);
     await assertCanUpdateAgent(req, existing);
+    if (req.actor.type === "board") {
+      assertCanSelectHostRuntimeConfiguration(req, req.body as Record<string, unknown>);
+      if (
+        existing.status === "pending_approval"
+        && typeof req.body.status === "string"
+        && req.body.status !== "pending_approval"
+        && selectsHostRuntimeConfiguration(existing)
+      ) {
+        assertInstanceAdmin(req);
+      }
+    }
 
     if (Object.prototype.hasOwnProperty.call(req.body, "permissions")) {
       res.status(422).json({ error: "Use /api/agents/:id/permissions for permission changes" });
@@ -871,6 +978,16 @@ export function registerAgentManagementRoutes(ctx: AgentManagementRouteContext) 
         requestedAdapterType,
         rawEffectiveAdapterConfig,
       );
+      if (
+        req.actor.type === "board"
+        && Object.prototype.hasOwnProperty.call(patchData, "agentRuntimeType")
+        && isNonEmptyRecord(effectiveAdapterConfig)
+      ) {
+        assertInstanceAdmin(req);
+      }
+      if (!isCanonicalManagedInstructionsConfig(existing, effectiveAdapterConfig)) {
+        assertInstanceAdmin(req);
+      }
       const normalizedEffectiveAdapterConfig = await secretsSvc.normalizeAdapterConfigForPersistence(
         existing.orgId,
         effectiveAdapterConfig,
@@ -922,8 +1039,8 @@ export function registerAgentManagementRoutes(ctx: AgentManagementRouteContext) 
   });
 
   router.post("/agents/:id/pause", async (req, res) => {
-    assertBoard(req);
     const id = req.params.id as string;
+    await getAuthorizedBoardAgent(req, id);
     const agent = await svc.pause(id);
     if (!agent) {
       res.status(404).json({ error: "Agent not found" });
@@ -945,8 +1062,8 @@ export function registerAgentManagementRoutes(ctx: AgentManagementRouteContext) 
   });
 
   router.post("/agents/:id/resume", async (req, res) => {
-    assertBoard(req);
     const id = req.params.id as string;
+    await getAuthorizedBoardAgent(req, id);
     const agent = await svc.resume(id);
     if (!agent) {
       res.status(404).json({ error: "Agent not found" });
@@ -968,8 +1085,8 @@ export function registerAgentManagementRoutes(ctx: AgentManagementRouteContext) 
   });
 
   router.post("/agents/:id/terminate", async (req, res) => {
-    assertBoard(req);
     const id = req.params.id as string;
+    await getAuthorizedBoardAgent(req, id);
     const agent = await svc.terminate(id);
     if (!agent) {
       res.status(404).json({ error: "Agent not found" });
@@ -991,8 +1108,8 @@ export function registerAgentManagementRoutes(ctx: AgentManagementRouteContext) 
   });
 
   router.delete("/agents/:id", async (req, res) => {
-    assertBoard(req);
     const id = req.params.id as string;
+    await getAuthorizedBoardAgent(req, id);
     const agent = await svc.remove(id);
     if (!agent) {
       res.status(404).json({ error: "Agent not found" });
@@ -1012,36 +1129,39 @@ export function registerAgentManagementRoutes(ctx: AgentManagementRouteContext) 
   });
 
   router.get("/agents/:id/keys", async (req, res) => {
-    assertBoard(req);
     const id = req.params.id as string;
+    await getAuthorizedBoardAgent(req, id);
     const keys = await svc.listKeys(id);
     res.json(keys);
   });
 
   router.post("/agents/:id/keys", validate(createAgentKeySchema), async (req, res) => {
-    assertBoard(req);
     const id = req.params.id as string;
+    const agent = await getAuthorizedBoardAgent(req, id);
     const key = await svc.createApiKey(id, req.body.name);
 
-    const agent = await svc.getById(id);
-    if (agent) {
-      await logActivity(db, {
-        orgId: agent.orgId,
-        actorType: "user",
-        actorId: req.actor.userId ?? "board",
-        action: "agent.key_created",
-        entityType: "agent",
-        entityId: agent.id,
-        details: { keyId: key.id, name: key.name },
-      });
-    }
+    await logActivity(db, {
+      orgId: agent.orgId,
+      actorType: "user",
+      actorId: req.actor.userId ?? "board",
+      action: "agent.key_created",
+      entityType: "agent",
+      entityId: agent.id,
+      details: { keyId: key.id, name: key.name },
+    });
 
     res.status(201).json(key);
   });
 
   router.delete("/agents/:id/keys/:keyId", async (req, res) => {
-    assertBoard(req);
+    const id = req.params.id as string;
+    await getAuthorizedBoardAgent(req, id);
     const keyId = req.params.keyId as string;
+    const keys = await svc.listKeys(id);
+    if (!keys.some((key: { id: string }) => key.id === keyId)) {
+      res.status(404).json({ error: "Key not found" });
+      return;
+    }
     const revoked = await svc.revokeKey(keyId);
     if (!revoked) {
       res.status(404).json({ error: "Key not found" });
@@ -1150,7 +1270,7 @@ export function registerAgentManagementRoutes(ctx: AgentManagementRouteContext) 
   });
 
   router.post("/agents/:id/claude-login", async (req, res) => {
-    assertBoard(req);
+    assertInstanceAdmin(req);
     const id = req.params.id as string;
     const agent = await svc.getById(id);
     if (!agent) {
@@ -1158,6 +1278,9 @@ export function registerAgentManagementRoutes(ctx: AgentManagementRouteContext) 
       return;
     }
     assertCompanyAccess(req, agent.orgId);
+    if (agent.status === "pending_approval" || agent.status === "terminated") {
+      throw conflict(`Claude login is unavailable for ${agent.status} agents`);
+    }
     if (agent.agentRuntimeType !== "claude_local") {
       res.status(400).json({ error: "Login is only supported for claude_local agents" });
       return;

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -49,9 +49,11 @@ import { findServerAdapter, listAgentRuntimeModels } from "../agent-runtimes/ind
 import { resolveStoredOrDerivedAgentWorkspaceKey } from "../agent-workspace-key.js";
 import { MAX_ATTACHMENT_BYTES } from "../attachment-types.js";
 import { conflict, forbidden, notFound, unprocessable } from "../errors.js";
+import { resolveAgentInstructionsDir, resolveHomeAwarePath } from "../home-paths.js";
 import { logger } from "../middleware/logger.js";
 import { validate } from "../middleware/validate.js";
 import { redactEventPayload } from "../redaction.js";
+import { isCanonicalManagedAgentInstructionsConfig } from "../services/agent-instructions.js";
 import { listAgentRuntimeAvailability } from "../services/agent-runtime-availability.js";
 import { assetService } from "../services/assets.js";
 import {
@@ -559,9 +561,11 @@ export function agentRoutes(db: Db, storage?: StorageService) {
     const publicAgent = internalAgent
       ? (({ workspaceKey: _workspaceKey, ...rest }) => rest)(internalAgent)
       : agent;
+    const instructionsAgent = internalAgent ?? agent;
     const instructionsBundle = options?.restricted
+      || !isCanonicalManagedAgentInstructionsConfig(instructionsAgent)
       ? null
-      : await instructions.getBundle(internalAgent ?? agent);
+      : await instructions.getBundle(instructionsAgent);
     const instructionsLibraryPath = instructionsBundle?.mode === "managed"
       ? `agents/${resolveStoredOrDerivedAgentWorkspaceKey(internalAgent ?? agent)}/instructions`
       : null;
@@ -860,6 +864,7 @@ export function agentRoutes(db: Db, storage?: StorageService) {
   ) {
     if (agentRuntimeType !== "opencode_local" && agentRuntimeType !== "pi_local") return;
     const { config: runtimeConfig } = await secretsSvc.resolveAdapterConfigForRuntime(orgId, agentRuntimeConfig);
+    assertAdapterConfigShape(agentRuntimeType, runtimeConfig);
     const runtimeEnv = asRecord(runtimeConfig.env) ?? {};
     try {
       const ensureModelConfigured =
@@ -876,6 +881,23 @@ export function agentRoutes(db: Db, storage?: StorageService) {
       const reason = err instanceof Error ? err.message : String(err);
       throw unprocessable(`Invalid ${agentRuntimeType} agentRuntimeConfig: ${reason}`);
     }
+  }
+
+  function assertAdapterConfigShape(
+    agentRuntimeType: string | null | undefined,
+    agentRuntimeConfig: Record<string, unknown>,
+  ) {
+    if (agentRuntimeType !== "opencode_local" && agentRuntimeType !== "pi_local") return;
+    const model = typeof agentRuntimeConfig.model === "string"
+      ? agentRuntimeConfig.model.trim()
+      : "";
+    const [provider, modelId] = model.split("/", 2).map((part) => part.trim());
+    if (provider && modelId) return;
+    const runtimeLabel = agentRuntimeType === "pi_local" ? "Pi" : "OpenCode";
+    throw unprocessable(
+      `Invalid ${agentRuntimeType} agentRuntimeConfig: ${runtimeLabel} requires `
+        + "`agentRuntimeConfig.model` in provider/model format.",
+    );
   }
 
   function resolveInstructionsFilePath(candidatePath: string, agentRuntimeConfig: Record<string, unknown>) {
@@ -954,6 +976,39 @@ export function agentRoutes(db: Db, storage?: StorageService) {
     throw forbidden("Only the target agent or an ancestor manager can update instructions path");
   }
 
+  function isCanonicalManagedInstructionsRoot(
+    targetAgent: { id: string; orgId: string; name?: string | null; workspaceKey?: string | null },
+    candidateRootPath: string,
+  ) {
+    if (
+      !path.isAbsolute(candidateRootPath)
+      && candidateRootPath !== "~"
+      && !candidateRootPath.startsWith("~/")
+    ) {
+      return false;
+    }
+    const managedRootPath = resolveAgentInstructionsDir(targetAgent.orgId, targetAgent);
+    return path.resolve(resolveHomeAwarePath(candidateRootPath)) === path.resolve(managedRootPath);
+  }
+
+  async function assertCanAccessInstructionsFile(
+    req: Request,
+    targetAgent: {
+      id: string;
+      orgId: string;
+      name?: string | null;
+      workspaceKey?: string | null;
+      agentRuntimeConfig: unknown;
+    },
+  ) {
+    await assertCanReadAgent(req, targetAgent);
+    if (isCanonicalManagedAgentInstructionsConfig(targetAgent)) return;
+
+    // External roots grant access to arbitrary host filesystem locations, so
+    // even organization board members need host-global authority to use them.
+    assertInstanceAdmin(req);
+  }
+
   function summarizeAgentUpdateDetails(patch: Record<string, unknown>) {
     const changedTopLevelKeys = Object.keys(patch).sort();
     const details: Record<string, unknown> = { changedTopLevelKeys };
@@ -986,11 +1041,13 @@ export function agentRoutes(db: Db, storage?: StorageService) {
   }
 
   async function resolveDesiredSkillAssignment(
+    req: Request,
     orgId: string,
     agentRuntimeType: string,
     runtimeConfig: Record<string, unknown>,
     requestedDesiredSkills: string[] | undefined,
   ) {
+    const catalogAccess = skillCatalogAccessForRequest(req);
     return organizationSkills.resolveDesiredSkillSelectionForAgent(
       {
         id: null,
@@ -1000,10 +1057,12 @@ export function agentRoutes(db: Db, storage?: StorageService) {
       },
       runtimeConfig,
       requestedDesiredSkills,
+      catalogAccess,
     );
   }
 
   async function resolveDesiredSkillAssignmentForAgent(
+    req: Request,
     agent: Awaited<ReturnType<typeof svc.getById>>,
     runtimeConfig: Record<string, unknown>,
     requestedDesiredSkills: string[] | undefined,
@@ -1014,25 +1073,48 @@ export function agentRoutes(db: Db, storage?: StorageService) {
         warnings: [] as string[],
       };
     }
+    const catalogAccess = await assertCanUseOrganizationLocalSkills(req, agent.orgId);
     return organizationSkills.resolveDesiredSkillSelectionForAgent(
       agent,
       runtimeConfig,
       requestedDesiredSkills,
+      catalogAccess,
     );
   }
 
   async function buildAgentSkillSnapshot(
+    req: Request,
     agent: Awaited<ReturnType<typeof svc.getById>>,
     runtimeConfig: Record<string, unknown>,
   ) {
     if (!agent) {
       return buildUnsupportedSkillSnapshot("", []);
     }
-    const snapshot = await organizationSkills.buildAgentSkillSnapshot(agent, runtimeConfig);
+    const catalogAccess = await assertCanUseOrganizationLocalSkills(req, agent.orgId);
+    const snapshot = await organizationSkills.buildAgentSkillSnapshot(agent, runtimeConfig, catalogAccess);
     if (!snapshot.supported) {
       return buildUnsupportedSkillSnapshot(agent.agentRuntimeType, snapshot.desiredSkills);
     }
     return snapshot;
+  }
+
+  function skillCatalogAccessForRequest(req: Request) {
+    const trustedHostAuthority = req.actor.type === "board"
+      && (req.actor.source === "local_implicit" || req.actor.isInstanceAdmin);
+    return {
+      allowHostLocalPaths: trustedHostAuthority,
+      allowHostCatalogs: trustedHostAuthority,
+    };
+  }
+
+  async function assertCanUseOrganizationLocalSkills(req: Request, orgId: string) {
+    const catalogAccess = skillCatalogAccessForRequest(req);
+    if (!catalogAccess.allowHostLocalPaths && await organizationSkills.hasLocalPathSkills(orgId)) {
+      // Catalog resolution exposes local source paths and enabling a skill
+      // causes later adapter runs to consume that host directory.
+      assertInstanceAdmin(req);
+    }
+    return catalogAccess;
   }
 
   function redactForRestrictedAgentView(agent: Awaited<ReturnType<typeof svc.getById>>) {
@@ -1135,6 +1217,10 @@ export function agentRoutes(db: Db, storage?: StorageService) {
     "/orgs/:orgId/adapters/:type/test-environment",
     validate(testAgentRuntimeEnvironmentSchema),
     async (req, res) => {
+      // Environment tests may create directories and spawn a caller-selected
+      // local command, so they require host-global authority before any input
+      // is parsed or resolved.
+      assertInstanceAdmin(req);
       const orgId = req.params.orgId as string;
       const type = req.params.type as string;
       await assertCanReadConfigurations(req, orgId);
@@ -1180,7 +1266,7 @@ export function agentRoutes(db: Db, storage?: StorageService) {
       agent.orgId,
       agent.agentRuntimeConfig,
     );
-    const snapshot = await buildAgentSkillSnapshot(agent, runtimeConfig);
+    const snapshot = await buildAgentSkillSnapshot(req, agent, runtimeConfig);
     res.json(snapshot);
   });
 
@@ -1215,6 +1301,10 @@ export function agentRoutes(db: Db, storage?: StorageService) {
     "/agents/:id/skills/private",
     validate(organizationSkillCreateSchema),
     async (req, res) => {
+      // This endpoint creates directories and writes SKILL.md below an agent
+      // workspace. A pre-planted symlink must never turn an agent key or org
+      // manager into a host-filesystem write primitive.
+      assertInstanceAdmin(req);
       const id = req.params.id as string;
       const agent = await svc.getById(id);
       if (!agent) {
@@ -1256,6 +1346,7 @@ export function agentRoutes(db: Db, storage?: StorageService) {
         return;
       }
       await assertCanUpdateAgent(req, agent);
+      await assertCanUseOrganizationLocalSkills(req, agent.orgId);
 
       const requestedSkills = Array.from(
         new Set(
@@ -1269,6 +1360,7 @@ export function agentRoutes(db: Db, storage?: StorageService) {
         agent.agentRuntimeConfig,
       );
       const { desiredSkills } = await resolveDesiredSkillAssignmentForAgent(
+        req,
         agent,
         runtimeConfig,
         requestedSkills,
@@ -1296,7 +1388,7 @@ export function agentRoutes(db: Db, storage?: StorageService) {
         updated.orgId,
         updated.agentRuntimeConfig,
       );
-      const snapshot = await buildAgentSkillSnapshot(updated, updatedRuntimeConfig);
+      const snapshot = await buildAgentSkillSnapshot(req, updated, updatedRuntimeConfig);
 
       await logActivity(db, {
         orgId: updated.orgId,
@@ -1332,6 +1424,7 @@ export function agentRoutes(db: Db, storage?: StorageService) {
         return;
       }
       await assertCanUpdateAgent(req, agent);
+      await assertCanUseOrganizationLocalSkills(req, agent.orgId);
 
       const requestedSkills = Array.from(
         new Set(
@@ -1346,6 +1439,7 @@ export function agentRoutes(db: Db, storage?: StorageService) {
       );
       const currentDesiredSkills = await organizationSkills.getEnabledSkillKeysForAgent(agent.orgId, agent);
       const { desiredSkills } = await resolveDesiredSkillAssignmentForAgent(
+        req,
         agent,
         runtimeConfig,
         [...currentDesiredSkills, ...requestedSkills],
@@ -1354,7 +1448,7 @@ export function agentRoutes(db: Db, storage?: StorageService) {
       const actor = getActorInfo(req);
       await organizationSkills.addEnabledSkillKeysForAgent(agent.orgId, agent.id, desiredSkills);
 
-      const snapshot = await buildAgentSkillSnapshot(agent, runtimeConfig);
+      const snapshot = await buildAgentSkillSnapshot(req, agent, runtimeConfig);
 
       await logActivity(db, {
         orgId: agent.orgId,
@@ -1875,6 +1969,7 @@ export function agentRoutes(db: Db, storage?: StorageService) {
   });
 
   router.post("/agents/:id/config-revisions/:revisionId/rollback", async (req, res) => {
+    assertBoard(req);
     const id = req.params.id as string;
     const revisionId = req.params.revisionId as string;
     const existing = await svc.getById(id);
@@ -1883,6 +1978,30 @@ export function agentRoutes(db: Db, storage?: StorageService) {
       return;
     }
     await assertCanUpdateAgent(req, existing);
+
+    const revision = await svc.getConfigRevision(id, revisionId);
+    if (!revision) {
+      res.status(404).json({ error: "Revision not found" });
+      return;
+    }
+    const revisionSnapshot = asRecord(revision.afterConfig) ?? {};
+    const prospectiveAgent = {
+      ...existing,
+      name: asNonEmptyString(revisionSnapshot.name) ?? existing.name,
+      agentRuntimeConfig: asRecord(revisionSnapshot.agentRuntimeConfig) ?? {},
+    };
+    const revisionRuntimeConfig = asRecord(revisionSnapshot.runtimeConfig) ?? {};
+    const revisionSelectsHostRuntime = (
+      (typeof revisionSnapshot.agentRuntimeType === "string" && revisionSnapshot.agentRuntimeType !== "process")
+      || Object.keys(prospectiveAgent.agentRuntimeConfig).length > 0
+      || Object.keys(revisionRuntimeConfig).length > 0
+    );
+    if (revisionSelectsHostRuntime) {
+      assertInstanceAdmin(req);
+    }
+    if (!isCanonicalManagedAgentInstructionsConfig(prospectiveAgent)) {
+      assertInstanceAdmin(req);
+    }
 
     const actor = getActorInfo(req);
     const updated = await svc.rollbackConfigRevision(id, revisionId, {
@@ -1999,6 +2118,7 @@ export function agentRoutes(db: Db, storage?: StorageService) {
     parseSourceIssueIds,
     applyCreateDefaultsByAdapterType,
     resolveDesiredSkillAssignment,
+    assertAdapterConfigShape,
     assertAdapterConfigConstraints,
     assertAgentAvatarAssetBelongsToOrg,
     materializeDefaultInstructionsBundleForNewAgent,
@@ -2009,6 +2129,9 @@ export function agentRoutes(db: Db, storage?: StorageService) {
     AGENT_AVATAR_CONTENT_TYPES,
     compressAgentAvatar,
     assertCanManageInstructionsPath,
+    assertCanAccessInstructionsFile,
+    isCanonicalManagedInstructionsRoot,
+    isCanonicalManagedInstructionsConfig: isCanonicalManagedAgentInstructionsConfig,
     asRecord,
     asNonEmptyString,
     resolveInstructionsFilePath,

--- a/server/src/routes/approvals.ts
+++ b/server/src/routes/approvals.ts
@@ -16,7 +16,12 @@ import { logger } from "../middleware/logger.js";
 import { validate } from "../middleware/validate.js";
 import { redactEventPayload } from "../redaction.js";
 import {
+  operationProposalFromPayload,
+  validateOperationProposalPatch,
+} from "../services/chats.helpers.js";
+import {
   accessService,
+  agentService,
   approvalService,
   chatService,
   heartbeatService,
@@ -25,7 +30,7 @@ import {
   logActivity,
   secretService,
 } from "../services/index.js";
-import { assertBoard, assertCompanyAccess, getActorInfo } from "./authz.js";
+import { assertBoard, assertCompanyAccess, assertInstanceAdmin, getActorInfo } from "./authz.js";
 import {
   wakeIssueAssigneeAfterChatConversion,
   type ChatConvertedIssue,
@@ -149,12 +154,142 @@ export function approvalRoutes(db: Db) {
   const router = Router();
   const svc = approvalService(db);
   const access = accessService(db);
+  const agentsSvc = agentService(db);
   const heartbeat = heartbeatService(db);
   const chatsSvc = chatService(db);
   const issueApprovalsSvc = issueApprovalService(db);
   const issuesSvc = issueService(db);
   const secretsSvc = secretService(db);
   const strictSecretsMode = process.env.RUDDER_SECRETS_STRICT_MODE === "true";
+
+  function asRecord(value: unknown): Record<string, unknown> | null {
+    if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+    return value as Record<string, unknown>;
+  }
+
+  async function assertAgentBelongsToApprovalOrganization(
+    orgId: string,
+    agentId: string,
+    label: string,
+  ) {
+    const agent = await agentsSvc.getById(agentId);
+    if (!agent || agent.orgId !== orgId) {
+      throw unprocessable(`${label} must belong to the approval organization`);
+    }
+    return agent;
+  }
+
+  async function assertApprovalAgentReferences(approval: {
+    orgId: string;
+    type: string;
+    payload: Record<string, unknown>;
+    requestedByAgentId?: string | null;
+  }) {
+    if (approval.requestedByAgentId) {
+      await assertAgentBelongsToApprovalOrganization(
+        approval.orgId,
+        approval.requestedByAgentId,
+        "Requesting agent",
+      );
+    }
+    if (approval.type === "chat_issue_creation") {
+      const proposedByAgentId = typeof approval.payload.proposedByAgentId === "string"
+        ? approval.payload.proposedByAgentId.trim()
+        : "";
+      if (proposedByAgentId) {
+        await assertAgentBelongsToApprovalOrganization(
+          approval.orgId,
+          proposedByAgentId,
+          "Proposing agent",
+        );
+      }
+    }
+  }
+
+  async function assertHireApprovalTargetScope(approval: {
+    orgId: string;
+    type: string;
+    payload: Record<string, unknown>;
+  }) {
+    if (approval.type !== "hire_agent") return null;
+    const agentId = typeof approval.payload.agentId === "string"
+      ? approval.payload.agentId.trim()
+      : "";
+    return agentId
+      ? await assertAgentBelongsToApprovalOrganization(approval.orgId, agentId, "Hire approval target agent")
+      : null;
+  }
+
+  async function assertCanApproveHireAgent(req: Request, approval: {
+    id: string;
+    orgId: string;
+    type: string;
+    payload: Record<string, unknown>;
+  }) {
+    if (approval.type !== "hire_agent") return;
+    const payload = asRecord(approval.payload) ?? {};
+    const requestedSnapshot = asRecord(payload.requestedConfigurationSnapshot) ?? {};
+    const persistedAgent = await assertHireApprovalTargetScope(approval);
+    const agentRuntimeConfigs = [
+      asRecord(payload.agentRuntimeConfig),
+      asRecord(requestedSnapshot.agentRuntimeConfig),
+      asRecord(persistedAgent?.agentRuntimeConfig),
+    ].filter((value): value is Record<string, unknown> => value !== null);
+    const runtimeConfigs = [
+      asRecord(payload.runtimeConfig),
+      asRecord(requestedSnapshot.runtimeConfig),
+      asRecord(persistedAgent?.runtimeConfig),
+    ].filter((value): value is Record<string, unknown> => value !== null);
+    const runtimeTypes = [
+      payload.agentRuntimeType,
+      requestedSnapshot.agentRuntimeType,
+      persistedAgent?.agentRuntimeType,
+    ].filter((value): value is string => typeof value === "string");
+
+    if (
+      runtimeTypes.some((runtimeType) => runtimeType !== "process")
+      || [...agentRuntimeConfigs, ...runtimeConfigs].some((config) => Object.keys(config).length > 0)
+    ) {
+      assertInstanceAdmin(req);
+    }
+  }
+
+  function assertCanApproveChatOperation(req: Request, approval: {
+    type: string;
+    payload: Record<string, unknown>;
+  }) {
+    if (approval.type !== "chat_operation") return;
+    const payload = asRecord(approval.payload) ?? {};
+    const proposal = operationProposalFromPayload(
+      asRecord(payload.operationProposal) ?? payload,
+    );
+    if (!proposal) throw unprocessable("Chat operation approval payload was incomplete");
+    const patch = validateOperationProposalPatch(proposal.targetType, proposal.patch);
+    if (
+      proposal.targetType === "agent"
+      && ["agentRuntimeType", "agentRuntimeConfig", "runtimeConfig"].some((key) =>
+        Object.prototype.hasOwnProperty.call(patch, key)
+      )
+    ) {
+      assertInstanceAdmin(req);
+    }
+  }
+
+  async function assertChatApprovalConversationScope(approval: {
+    orgId: string;
+    type: string;
+    payload: Record<string, unknown>;
+  }) {
+    if (approval.type !== "chat_issue_creation" && approval.type !== "chat_operation") return;
+    const conversationId = typeof approval.payload.chatConversationId === "string"
+      ? approval.payload.chatConversationId.trim()
+      : "";
+    if (!conversationId) throw unprocessable("Chat approval missing chatConversationId");
+    const conversation = await chatsSvc.getById(conversationId);
+    if (!conversation || conversation.orgId !== approval.orgId) {
+      throw unprocessable("Chat approval conversation must belong to the approval organization");
+    }
+  }
 
   function proposalAssignsOrReviewsIssue(proposal: Record<string, unknown> | null | undefined) {
     if (!proposal) return false;
@@ -289,12 +424,30 @@ export function approvalRoutes(db: Db) {
         : approvalInput.payload;
 
     const actor = getActorInfo(req);
+    const requestedByAgentId = actor.actorType === "agent"
+      ? actor.actorId
+      : approvalInput.requestedByAgentId ?? null;
+    await assertApprovalAgentReferences({
+      orgId,
+      type: approvalInput.type,
+      payload: normalizedPayload,
+      requestedByAgentId,
+    });
+    await assertHireApprovalTargetScope({
+      orgId,
+      type: approvalInput.type,
+      payload: normalizedPayload,
+    });
+    await assertChatApprovalConversationScope({
+      orgId,
+      type: approvalInput.type,
+      payload: normalizedPayload,
+    });
     const approval = await svc.create(orgId, {
       ...approvalInput,
       payload: normalizedPayload,
       requestedByUserId: actor.actorType === "user" ? actor.actorId : null,
-      requestedByAgentId:
-        approvalInput.requestedByAgentId ?? (actor.actorType === "agent" ? actor.actorId : null),
+      requestedByAgentId,
       status: "pending",
       decisionNote: null,
       decidedByUserId: null,
@@ -355,14 +508,23 @@ export function approvalRoutes(db: Db) {
     assertBoard(req);
     const id = req.params.id as string;
     const pendingApproval = await svc.getById(id);
+    if (!pendingApproval) {
+      res.status(404).json({ error: "Approval not found" });
+      return;
+    }
+    assertCompanyAccess(req, pendingApproval.orgId);
+    await assertApprovalAgentReferences(pendingApproval);
+    await assertCanApproveHireAgent(req, pendingApproval);
+    assertCanApproveChatOperation(req, pendingApproval);
+    await assertChatApprovalConversationScope(pendingApproval);
     const payloadOverride =
-      pendingApproval?.type === "chat_issue_creation"
+      pendingApproval.type === "chat_issue_creation"
       && req.body.payload
       && typeof req.body.payload === "object"
       && !Array.isArray(req.body.payload)
         ? (req.body.payload as Record<string, unknown>)
         : undefined;
-    const approvalForValidation = pendingApproval && payloadOverride
+    const approvalForValidation = payloadOverride
       ? { ...pendingApproval, payload: payloadOverride }
       : pendingApproval;
     if (approvalForValidation?.type === "chat_issue_creation") {
@@ -371,7 +533,7 @@ export function approvalRoutes(db: Db) {
     }
     const { approval, applied } = await svc.approve(
       id,
-      req.body.decidedByUserId ?? "board",
+      req.actor.userId ?? "local-board",
       req.body.decisionNote,
       payloadOverride,
     );
@@ -548,6 +710,7 @@ export function approvalRoutes(db: Db) {
 
       if (approval.requestedByAgentId) {
         try {
+          await assertApprovalAgentReferences(approval);
           const wakeRun = await heartbeat.wakeup(approval.requestedByAgentId, {
             source: "automation",
             triggerDetail: "system",
@@ -616,9 +779,15 @@ export function approvalRoutes(db: Db) {
   router.post("/approvals/:id/reject", validate(resolveApprovalSchema), async (req, res) => {
     assertBoard(req);
     const id = req.params.id as string;
+    const pendingApproval = await svc.getById(id);
+    if (!pendingApproval) {
+      res.status(404).json({ error: "Approval not found" });
+      return;
+    }
+    assertCompanyAccess(req, pendingApproval.orgId);
     const { approval, applied } = await svc.reject(
       id,
-      req.body.decidedByUserId ?? "board",
+      req.actor.userId ?? "local-board",
       req.body.decisionNote,
     );
 
@@ -643,9 +812,15 @@ export function approvalRoutes(db: Db) {
     async (req, res) => {
       assertBoard(req);
       const id = req.params.id as string;
+      const pendingApproval = await svc.getById(id);
+      if (!pendingApproval) {
+        res.status(404).json({ error: "Approval not found" });
+        return;
+      }
+      assertCompanyAccess(req, pendingApproval.orgId);
       const approval = await svc.requestRevision(
         id,
-        req.body.decidedByUserId ?? "board",
+        req.actor.userId ?? "local-board",
         req.body.decisionNote,
       );
 
@@ -686,6 +861,10 @@ export function approvalRoutes(db: Db) {
           )
         : req.body.payload
       : undefined;
+    const nextPayload = normalizedPayload ?? existing.payload;
+    await assertApprovalAgentReferences({ ...existing, payload: nextPayload });
+    await assertHireApprovalTargetScope({ ...existing, payload: nextPayload });
+    await assertChatApprovalConversationScope({ ...existing, payload: nextPayload });
     const approval = await svc.resubmit(id, normalizedPayload);
     const actor = getActorInfo(req);
     await logActivity(db, {

--- a/server/src/routes/assets.ts
+++ b/server/src/routes/assets.ts
@@ -1,86 +1,20 @@
 import type { Db } from "@rudderhq/db";
 import { createAssetImageMetadataSchema } from "@rudderhq/shared";
-import createDOMPurify from "dompurify";
 import { Router, type Request, type Response } from "express";
-import { JSDOM } from "jsdom";
 import multer from "multer";
-import { isAllowedContentType, MAX_ATTACHMENT_BYTES } from "../attachment-types.js";
+import { MAX_ATTACHMENT_BYTES } from "../attachment-types.js";
+import { buildContentResponsePolicy } from "../content-response-policy.js";
 import { assetService, logActivity } from "../services/index.js";
 import type { StorageService } from "../storage/types.js";
 import { assertCompanyAccess, getActorInfo } from "./authz.js";
-const SVG_CONTENT_TYPE = "image/svg+xml";
-const ALLOWED_COMPANY_LOGO_CONTENT_TYPES = new Set([
+
+const SAFE_RASTER_IMAGE_CONTENT_TYPES = new Set([
   "image/png",
   "image/jpeg",
   "image/jpg",
   "image/webp",
   "image/gif",
-  SVG_CONTENT_TYPE,
 ]);
-
-function sanitizeSvgBuffer(input: Buffer): Buffer | null {
-  const raw = input.toString("utf8").trim();
-  if (!raw) return null;
-
-  const baseDom = new JSDOM("");
-  const domPurify = createDOMPurify(
-    baseDom.window as unknown as Parameters<typeof createDOMPurify>[0],
-  );
-  domPurify.addHook("uponSanitizeAttribute", (_node, data) => {
-    const attrName = data.attrName.toLowerCase();
-    const attrValue = (data.attrValue ?? "").trim();
-
-    if (attrName.startsWith("on")) {
-      data.keepAttr = false;
-      return;
-    }
-
-    if ((attrName === "href" || attrName === "xlink:href") && attrValue && !attrValue.startsWith("#")) {
-      data.keepAttr = false;
-    }
-  });
-
-  let parsedDom: JSDOM | null = null;
-  try {
-    const sanitized = domPurify.sanitize(raw, {
-      USE_PROFILES: { svg: true, svgFilters: true, html: false },
-      FORBID_TAGS: ["script", "foreignObject"],
-      FORBID_CONTENTS: ["script", "foreignObject"],
-      RETURN_TRUSTED_TYPE: false,
-    });
-
-    parsedDom = new JSDOM(sanitized, { contentType: SVG_CONTENT_TYPE });
-    const document = parsedDom.window.document;
-    const root = document.documentElement;
-    if (!root || root.tagName.toLowerCase() !== "svg") return null;
-
-    for (const el of Array.from(root.querySelectorAll("script, foreignObject"))) {
-      el.remove();
-    }
-    for (const el of Array.from(root.querySelectorAll("*"))) {
-      for (const attr of Array.from(el.attributes)) {
-        const attrName = attr.name.toLowerCase();
-        const attrValue = attr.value.trim();
-        if (attrName.startsWith("on")) {
-          el.removeAttribute(attr.name);
-          continue;
-        }
-        if ((attrName === "href" || attrName === "xlink:href") && attrValue && !attrValue.startsWith("#")) {
-          el.removeAttribute(attr.name);
-        }
-      }
-    }
-
-    const output = root.outerHTML.trim();
-    if (!output || !/^<svg[\s>]/i.test(output)) return null;
-    return Buffer.from(output, "utf8");
-  } catch {
-    return null;
-  } finally {
-    parsedDom?.window.close();
-    baseDom.window.close();
-  }
-}
 
 export function assetRoutes(db: Db, storage: StorageService) {
   const router = Router();
@@ -139,19 +73,11 @@ export function assetRoutes(db: Db, storage: StorageService) {
 
     const namespaceSuffix = parsedMeta.data.namespace ?? "general";
     const contentType = (file.mimetype || "").toLowerCase();
-    if (contentType !== SVG_CONTENT_TYPE && !isAllowedContentType(contentType)) {
+    if (!SAFE_RASTER_IMAGE_CONTENT_TYPES.has(contentType)) {
       res.status(422).json({ error: `Unsupported file type: ${contentType || "unknown"}` });
       return;
     }
-    let fileBody = file.buffer;
-    if (contentType === SVG_CONTENT_TYPE) {
-      const sanitized = sanitizeSvgBuffer(file.buffer);
-      if (!sanitized || sanitized.length <= 0) {
-        res.status(422).json({ error: "SVG could not be sanitized" });
-        return;
-      }
-      fileBody = sanitized;
-    }
+    const fileBody = file.buffer;
     if (fileBody.length <= 0) {
       res.status(422).json({ error: "Image is empty" });
       return;
@@ -235,20 +161,12 @@ export function assetRoutes(db: Db, storage: StorageService) {
     }
 
     const contentType = (file.mimetype || "").toLowerCase();
-    if (!ALLOWED_COMPANY_LOGO_CONTENT_TYPES.has(contentType)) {
+    if (!SAFE_RASTER_IMAGE_CONTENT_TYPES.has(contentType)) {
       res.status(422).json({ error: `Unsupported image type: ${contentType || "unknown"}` });
       return;
     }
 
-    let fileBody = file.buffer;
-    if (contentType === SVG_CONTENT_TYPE) {
-      const sanitized = sanitizeSvgBuffer(file.buffer);
-      if (!sanitized || sanitized.length <= 0) {
-        res.status(422).json({ error: "SVG could not be sanitized" });
-        return;
-      }
-      fileBody = sanitized;
-    }
+    const fileBody = file.buffer;
 
     if (fileBody.length <= 0) {
       res.status(422).json({ error: "Image is empty" });
@@ -320,15 +238,19 @@ export function assetRoutes(db: Db, storage: StorageService) {
 
     const object = await storage.getObject(asset.orgId, asset.objectKey);
     const responseContentType = asset.contentType || object.contentType || "application/octet-stream";
+    const responsePolicy = buildContentResponsePolicy(
+      responseContentType,
+      asset.originalFilename ?? "asset",
+      "asset",
+    );
     res.setHeader("Content-Type", responseContentType);
     res.setHeader("Content-Length", String(asset.byteSize || object.contentLength || 0));
     res.setHeader("Cache-Control", "private, max-age=60");
     res.setHeader("X-Content-Type-Options", "nosniff");
-    if (responseContentType === SVG_CONTENT_TYPE) {
-      res.setHeader("Content-Security-Policy", "sandbox; default-src 'none'; img-src 'self' data:; style-src 'unsafe-inline'");
+    if (responsePolicy.contentSecurityPolicy) {
+      res.setHeader("Content-Security-Policy", responsePolicy.contentSecurityPolicy);
     }
-    const filename = asset.originalFilename ?? "asset";
-    res.setHeader("Content-Disposition", `inline; filename=\"${filename.replaceAll("\"", "")}\"`);
+    res.setHeader("Content-Disposition", responsePolicy.contentDisposition);
 
     object.stream.on("error", (err) => {
       next(err);

--- a/server/src/routes/execution-workspaces.ts
+++ b/server/src/routes/execution-workspaces.ts
@@ -52,8 +52,11 @@ export function runWorkspaceRoutes(db: Db) {
     }
     assertCompanyAccess(req, existing.orgId);
     const patch: Record<string, unknown> = {
-      ...req.body,
-      ...(req.body.cleanupEligibleAt ? { cleanupEligibleAt: new Date(req.body.cleanupEligibleAt) } : {}),
+      ...(req.body.status !== undefined ? { status: req.body.status } : {}),
+      ...(req.body.cleanupEligibleAt !== undefined
+        ? { cleanupEligibleAt: req.body.cleanupEligibleAt ? new Date(req.body.cleanupEligibleAt) : null }
+        : {}),
+      ...(req.body.cleanupReason !== undefined ? { cleanupReason: req.body.cleanupReason } : {}),
     };
     let workspace = existing;
     let cleanupWarnings: string[] = [];

--- a/server/src/routes/issues.comments-attachments.ts
+++ b/server/src/routes/issues.comments-attachments.ts
@@ -9,6 +9,7 @@ import {
 import { Router, type Request } from "express";
 import multer from "multer";
 import { isAllowedContentType, MAX_ATTACHMENT_BYTES } from "../attachment-types.js";
+import { buildContentResponsePolicy } from "../content-response-policy.js";
 import { logger } from "../middleware/logger.js";
 import { validate } from "../middleware/validate.js";
 import {
@@ -613,11 +614,20 @@ export function registerIssueCommentAttachmentRoutes(ctx: IssueCommentAttachment
     assertCompanyAccess(req, attachment.orgId);
 
     const object = await storage.getObject(attachment.orgId, attachment.objectKey);
-    res.setHeader("Content-Type", attachment.contentType || object.contentType || "application/octet-stream");
+    const responseContentType = attachment.contentType || object.contentType || "application/octet-stream";
+    const responsePolicy = buildContentResponsePolicy(
+      responseContentType,
+      attachment.originalFilename ?? "attachment",
+      "attachment",
+    );
+    res.setHeader("Content-Type", responseContentType);
     res.setHeader("Content-Length", String(attachment.byteSize || object.contentLength || 0));
     res.setHeader("Cache-Control", "private, max-age=60");
-    const filename = attachment.originalFilename ?? "attachment";
-    res.setHeader("Content-Disposition", `inline; filename=\"${filename.replaceAll("\"", "")}\"`);
+    res.setHeader("X-Content-Type-Options", "nosniff");
+    if (responsePolicy.contentSecurityPolicy) {
+      res.setHeader("Content-Security-Policy", responsePolicy.contentSecurityPolicy);
+    }
+    res.setHeader("Content-Disposition", responsePolicy.contentDisposition);
 
     object.stream.on("error", (err) => {
       next(err);

--- a/server/src/routes/issues.mutations.ts
+++ b/server/src/routes/issues.mutations.ts
@@ -6,7 +6,7 @@ import {
   reportIssueCommitSchema,
   updateIssueSchema
 } from "@rudderhq/shared";
-import { Router } from "express";
+import { Router, type Request } from "express";
 import { forbidden, HttpError, unprocessable } from "../errors.js";
 import { logger } from "../middleware/logger.js";
 import { validate } from "../middleware/validate.js";
@@ -17,7 +17,7 @@ import { queueIssueAssignmentWakeup } from "../services/issue-assignment-wakeup.
 import { buildIssueReviewWakeupOptions, queueIssueReviewWakeup } from "../services/issue-review-wakeup.js";
 import { publishLiveEvent } from "../services/live-events.js";
 import type { StorageService } from "../storage/types.js";
-import { assertCompanyAccess, getActorInfo } from "./authz.js";
+import { assertCompanyAccess, assertInstanceAdmin, getActorInfo } from "./authz.js";
 import { shouldWakeAssigneeOnCheckout } from "./issues-checkout-wakeup.js";
 
 
@@ -39,6 +39,27 @@ const RUN_WORKSPACE_FIELD_ALIASES = [
   ["runWorkspacePreference", "executionWorkspacePreference"],
   ["runWorkspaceSettings", "executionWorkspaceSettings"],
 ] as const;
+
+const AGENT_FORBIDDEN_ISSUE_RUNTIME_FIELDS = [
+  "assigneeAgentRuntimeOverrides",
+  "runWorkspaceSettings",
+  "executionWorkspaceSettings",
+] as const;
+
+function assertAgentIssueRuntimeFieldsAllowed(
+  req: Request,
+  body: Record<string, unknown>,
+) {
+  const blockedFields = AGENT_FORBIDDEN_ISSUE_RUNTIME_FIELDS
+    .filter((field) => Object.prototype.hasOwnProperty.call(body, field));
+  if (blockedFields.length === 0) return;
+  if (req.actor.type === "agent") {
+    throw forbidden(
+      `Agent authentication cannot set issue runtime overrides: ${blockedFields.join(", ")}`,
+    );
+  }
+  assertInstanceAdmin(req);
+}
 
 function mutationValueEquals(a: unknown, b: unknown) {
   return JSON.stringify(a ?? null) === JSON.stringify(b ?? null);
@@ -203,6 +224,7 @@ export function registerIssueMutationRoutes(ctx: IssueMutationRouteContext) {
   router.post("/orgs/:orgId/issues", validate(createIssueSchema), async (req, res) => {
     const orgId = req.params.orgId as string;
     assertCompanyAccess(req, orgId);
+    assertAgentIssueRuntimeFieldsAllowed(req, req.body as Record<string, unknown>);
     const body = normalizeIssueRunWorkspaceFields(req.body);
     if (body.assigneeAgentId || body.assigneeUserId || body.reviewerAgentId || body.reviewerUserId) {
       await assertCanAssignTasks(req, orgId);
@@ -262,6 +284,7 @@ export function registerIssueMutationRoutes(ctx: IssueMutationRouteContext) {
 
   router.patch("/issues/:id", validate(updateIssueSchema), async (req, res) => {
     const id = req.params.id as string;
+    assertAgentIssueRuntimeFieldsAllowed(req, req.body as Record<string, unknown>);
     const body = normalizeIssueRunWorkspaceFields(req.body);
     const existing = await svc.getById(id);
     if (!existing) {

--- a/server/src/routes/organization-skills.ts
+++ b/server/src/routes/organization-skills.ts
@@ -10,7 +10,8 @@ import { Router, type Request } from "express";
 import { forbidden } from "../errors.js";
 import { validate } from "../middleware/validate.js";
 import { accessService, agentService, logActivity, organizationSkillService } from "../services/index.js";
-import { assertCompanyAccess, getActorInfo } from "./authz.js";
+import { parseSkillImportSourceInput } from "../services/organization-skills.js";
+import { assertCompanyAccess, assertInstanceAdmin, getActorInfo } from "./authz.js";
 
 export function organizationSkillRoutes(db: Db) {
   const router = Router();
@@ -55,9 +56,23 @@ export function organizationSkillRoutes(db: Db) {
     throw forbidden("Missing permission: can manage skills");
   }
 
+  async function getSkillWithHostBoundary(req: Request, orgId: string, skillId: string) {
+    const skill = await svc.getById(skillId);
+    if (!skill || skill.orgId !== orgId) return null;
+    if (skill.sourceType === "local_path") {
+      assertInstanceAdmin(req);
+    }
+    return skill;
+  }
+
   router.get("/orgs/:orgId/skills", async (req, res) => {
     const orgId = req.params.orgId as string;
     assertCompanyAccess(req, orgId);
+    if (await svc.hasLocalPathSkills(orgId)) {
+      // Local skill rows carry host paths and metadata. Keep even the list
+      // boundary host-global so it cannot become a filesystem disclosure.
+      assertInstanceAdmin(req);
+    }
     const result = await svc.list(orgId);
     res.json(result);
   });
@@ -66,6 +81,11 @@ export function organizationSkillRoutes(db: Db) {
     const orgId = req.params.orgId as string;
     const skillId = req.params.skillId as string;
     assertCompanyAccess(req, orgId);
+    const storedSkill = await getSkillWithHostBoundary(req, orgId, skillId);
+    if (!storedSkill) {
+      res.status(404).json({ error: "Skill not found" });
+      return;
+    }
     const result = await svc.detail(orgId, skillId);
     if (!result) {
       res.status(404).json({ error: "Skill not found" });
@@ -78,6 +98,11 @@ export function organizationSkillRoutes(db: Db) {
     const orgId = req.params.orgId as string;
     const skillId = req.params.skillId as string;
     assertCompanyAccess(req, orgId);
+    const storedSkill = await getSkillWithHostBoundary(req, orgId, skillId);
+    if (!storedSkill) {
+      res.status(404).json({ error: "Skill not found" });
+      return;
+    }
     const result = await svc.updateStatus(orgId, skillId);
     if (!result) {
       res.status(404).json({ error: "Skill not found" });
@@ -91,6 +116,11 @@ export function organizationSkillRoutes(db: Db) {
     const skillId = req.params.skillId as string;
     const relativePath = String(req.query.path ?? "SKILL.md");
     assertCompanyAccess(req, orgId);
+    const storedSkill = await getSkillWithHostBoundary(req, orgId, skillId);
+    if (!storedSkill) {
+      res.status(404).json({ error: "Skill not found" });
+      return;
+    }
     const result = await svc.readFile(orgId, skillId, relativePath);
     if (!result) {
       res.status(404).json({ error: "Skill not found" });
@@ -105,6 +135,9 @@ export function organizationSkillRoutes(db: Db) {
     async (req, res) => {
       const orgId = req.params.orgId as string;
       await assertCanMutateOrganizationSkills(req, orgId);
+      // Creating a managed local skill writes to the host filesystem. This
+      // shares the same authority boundary as importing or scanning a path.
+      assertInstanceAdmin(req);
       const result = await svc.createLocalSkill(orgId, req.body);
 
       const actor = getActorInfo(req);
@@ -134,6 +167,11 @@ export function organizationSkillRoutes(db: Db) {
       const orgId = req.params.orgId as string;
       const skillId = req.params.skillId as string;
       await assertCanMutateOrganizationSkills(req, orgId);
+      const storedSkill = await getSkillWithHostBoundary(req, orgId, skillId);
+      if (!storedSkill) {
+        res.status(404).json({ error: "Skill not found" });
+        return;
+      }
       const result = await svc.updateFile(
         orgId,
         skillId,
@@ -168,6 +206,10 @@ export function organizationSkillRoutes(db: Db) {
       const orgId = req.params.orgId as string;
       await assertCanMutateOrganizationSkills(req, orgId);
       const source = String(req.body.source ?? "");
+      const parsedSource = parseSkillImportSourceInput(source);
+      if (!/^https?:\/\//i.test(parsedSource.resolvedSource)) {
+        assertInstanceAdmin(req);
+      }
       const result = await svc.importFromSource(orgId, source);
 
       const actor = getActorInfo(req);
@@ -198,6 +240,7 @@ export function organizationSkillRoutes(db: Db) {
     async (req, res) => {
       const orgId = req.params.orgId as string;
       await assertCanMutateOrganizationSkills(req, orgId);
+      assertInstanceAdmin(req);
       const result = await svc.scanProjectWorkspaces(orgId, req.body);
 
       const actor = getActorInfo(req);
@@ -231,6 +274,7 @@ export function organizationSkillRoutes(db: Db) {
     async (req, res) => {
       const orgId = req.params.orgId as string;
       await assertCanMutateOrganizationSkills(req, orgId);
+      assertInstanceAdmin(req);
       const result = await svc.scanLocalSkillRoots(orgId, req.body);
 
       const actor = getActorInfo(req);
@@ -261,6 +305,11 @@ export function organizationSkillRoutes(db: Db) {
     const orgId = req.params.orgId as string;
     const skillId = req.params.skillId as string;
     await assertCanMutateOrganizationSkills(req, orgId);
+    const storedSkill = await getSkillWithHostBoundary(req, orgId, skillId);
+    if (!storedSkill) {
+      res.status(404).json({ error: "Skill not found" });
+      return;
+    }
     const result = await svc.deleteSkill(orgId, skillId);
     if (!result) {
       res.status(404).json({ error: "Skill not found" });
@@ -290,6 +339,11 @@ export function organizationSkillRoutes(db: Db) {
     const orgId = req.params.orgId as string;
     const skillId = req.params.skillId as string;
     await assertCanMutateOrganizationSkills(req, orgId);
+    const storedSkill = await getSkillWithHostBoundary(req, orgId, skillId);
+    if (!storedSkill) {
+      res.status(404).json({ error: "Skill not found" });
+      return;
+    }
     const result = await svc.installUpdate(orgId, skillId);
     if (!result) {
       res.status(404).json({ error: "Skill not found" });

--- a/server/src/routes/orgs.ts
+++ b/server/src/routes/orgs.ts
@@ -8,6 +8,7 @@ import {
   createOrganizationWorkspaceFileSchema,
   createWorkspaceBackupSchema,
   moveOrganizationWorkspaceEntrySchema,
+  normalizeAgentUrlKey,
   organizationIntelligenceProfilePurposeSchema,
   organizationPortabilityExportSchema,
   organizationPortabilityImportSchema,
@@ -24,8 +25,10 @@ import {
 } from "@rudderhq/shared";
 import { Router, type Request } from "express";
 import path from "node:path";
+import { buildContentResponsePolicy, normalizeResponseContentType } from "../content-response-policy.js";
 import { forbidden, unprocessable } from "../errors.js";
 import { validate } from "../middleware/validate.js";
+import { isCanonicalManagedAgentInstructionsConfig } from "../services/agent-instructions.js";
 import {
   accessService,
   agentService,
@@ -45,7 +48,7 @@ import {
 import { libraryEntryService } from "../services/library-entries.js";
 import { organizationWorkspaceBrowserService } from "../services/organization-workspace-browser.js";
 import type { StorageService } from "../storage/types.js";
-import { assertBoard, assertCompanyAccess, getActorInfo } from "./authz.js";
+import { assertBoard, assertCompanyAccess, assertInstanceAdmin, getActorInfo } from "./authz.js";
 
 const EMBEDDED_IMAGE_DATA_URL_RE = /data:image\/[a-z0-9.+-]+(?:;[a-z0-9.+_-]+(?:=[a-z0-9.+_-]+)?)*,/i;
 const EMBEDDED_IMAGE_DATA_URL_ERROR =
@@ -102,6 +105,75 @@ export function organizationRoutes(db: Db, storage?: StorageService) {
     if (actorAgent.role !== "ceo") {
       throw forbidden(`Only CEO agents can manage organization ${capability}`);
     }
+  }
+
+  function assertCanRunBoardFullImport(
+    req: Request,
+    input: { include?: { agents?: boolean; projects?: boolean; issues?: boolean } },
+  ) {
+    const importsAgents = input.include?.agents ?? true;
+    const importsProjects = input.include?.projects ?? false;
+    const importsIssues = input.include?.issues ?? false;
+    if (importsAgents || importsProjects || importsIssues) assertInstanceAdmin(req);
+  }
+
+  async function assertCanAccessLocalSkillRows(req: Request, orgId: string) {
+    if (await organizationSkills.hasLocalPathSkills(orgId)) {
+      assertInstanceAdmin(req);
+      return true;
+    }
+    return false;
+  }
+
+  async function assertCanExportSelectedInstructions(
+    req: Request,
+    orgId: string,
+    input: {
+      include?: { agents?: boolean; skills?: boolean };
+      agents?: string[];
+      skills?: string[];
+    },
+  ) {
+    let requiresInstanceAdmin = false;
+    const agentSelectors = input.agents ?? [];
+    const includesAgents = agentSelectors.length > 0 || (input.include?.agents ?? true);
+    const includesSkills = (input.skills?.length ?? 0) > 0
+      || (input.include?.skills ?? true)
+      || includesAgents;
+    if (includesSkills) {
+      requiresInstanceAdmin = await assertCanAccessLocalSkillRows(req, orgId);
+    }
+    if (!includesAgents) return requiresInstanceAdmin;
+
+    const liveAgents = (await agents.list(orgId, { includeTerminated: true }))
+      .filter((agent) => agent.status !== "terminated");
+    let selectedAgents = liveAgents;
+    if (agentSelectors.length > 0) {
+      const byReference = new Map<string, typeof liveAgents[number]>();
+      for (const agent of liveAgents) {
+        byReference.set(agent.id, agent);
+        byReference.set(agent.name, agent);
+        const normalizedName = normalizeAgentUrlKey(agent.name);
+        if (normalizedName) byReference.set(normalizedName, agent);
+      }
+      const matched = new Map<string, typeof liveAgents[number]>();
+      for (const selector of agentSelectors) {
+        const trimmed = selector.trim();
+        if (!trimmed) continue;
+        const normalized = normalizeAgentUrlKey(trimmed) ?? trimmed;
+        const agent = byReference.get(trimmed) ?? byReference.get(normalized);
+        if (agent) matched.set(agent.id, agent);
+      }
+      // Mirror the exporter: when no selector resolves, it falls back to all
+      // live agents instead of producing an empty agent set.
+      if (matched.size > 0) selectedAgents = [...matched.values()];
+    }
+
+    if (selectedAgents.some((agent) => !isCanonicalManagedAgentInstructionsConfig(agent))) {
+      assertInstanceAdmin(req);
+      return true;
+    }
+    return requiresInstanceAdmin;
   }
 
   async function assertCanWriteWorkspaceFile(req: Request, orgId: string) {
@@ -376,11 +448,15 @@ export function organizationRoutes(db: Db, storage?: StorageService) {
 
   router.put(
     "/:orgId/intelligence-profiles/:purpose",
+    (req, _res, next) => {
+      const orgId = req.params.orgId as string;
+      assertCompanyAccess(req, orgId);
+      assertInstanceAdmin(req);
+      next();
+    },
     validate(upsertOrganizationIntelligenceProfileSchema),
     async (req, res) => {
       const orgId = req.params.orgId as string;
-      assertCompanyAccess(req, orgId);
-      assertBoard(req);
       const purpose = organizationIntelligenceProfilePurposeSchema.safeParse(req.params.purpose);
       if (!purpose.success) {
         res.status(404).json({ error: "Unknown intelligence profile purpose" });
@@ -527,20 +603,25 @@ export function organizationRoutes(db: Db, storage?: StorageService) {
     const filePath = typeof req.query.path === "string" ? req.query.path : "";
     assertAgentLibraryProjectPath(req, filePath, "file");
     const workspaceFile = await workspaceBrowser.readAttachmentFile(orgId, filePath);
-    const normalizedContentType = workspaceFile.contentType.toLowerCase();
+    const normalizedContentType = normalizeResponseContentType(workspaceFile.contentType);
     if (!normalizedContentType.startsWith("image/") && normalizedContentType !== "application/pdf") {
       res.status(415).json({ error: "Workspace file is not an inline preview" });
       return;
     }
+    const responsePolicy = buildContentResponsePolicy(
+      normalizedContentType,
+      workspaceFile.originalFilename,
+      "workspace-file",
+    );
 
-    res.setHeader("Content-Type", workspaceFile.contentType);
+    res.setHeader("Content-Type", normalizedContentType);
     res.setHeader("Content-Length", String(workspaceFile.buffer.length));
     res.setHeader("Cache-Control", "private, max-age=60");
     res.setHeader("X-Content-Type-Options", "nosniff");
-    if (workspaceFile.contentType === "image/svg+xml") {
-      res.setHeader("Content-Security-Policy", "sandbox; default-src 'none'; img-src 'self' data:; style-src 'unsafe-inline'");
+    if (responsePolicy.contentSecurityPolicy) {
+      res.setHeader("Content-Security-Policy", responsePolicy.contentSecurityPolicy);
     }
-    res.setHeader("Content-Disposition", `inline; filename="${workspaceFile.originalFilename.replaceAll("\"", "")}"`);
+    res.setHeader("Content-Disposition", responsePolicy.contentDisposition);
     res.send(workspaceFile.buffer);
   });
 
@@ -886,14 +967,17 @@ export function organizationRoutes(db: Db, storage?: StorageService) {
   router.post("/:orgId/export", validate(organizationPortabilityExportSchema), async (req, res) => {
     const orgId = req.params.orgId as string;
     assertCompanyAccess(req, orgId);
+    await assertCanExportSelectedInstructions(req, orgId, req.body);
     const result = await portability.exportBundle(orgId, req.body);
     res.json(result);
   });
 
   router.post("/import/preview", validate(organizationPortabilityPreviewSchema), async (req, res) => {
     assertBoard(req);
+    assertCanRunBoardFullImport(req, req.body);
     if (req.body.target.mode === "existing_organization") {
       assertCompanyAccess(req, req.body.target.orgId);
+      await assertCanAccessLocalSkillRows(req, req.body.target.orgId);
     }
     const preview = await portability.previewImport(req.body);
     res.json(preview);
@@ -901,8 +985,10 @@ export function organizationRoutes(db: Db, storage?: StorageService) {
 
   router.post("/import", validate(organizationPortabilityImportSchema), async (req, res) => {
     assertBoard(req);
+    assertCanRunBoardFullImport(req, req.body);
     if (req.body.target.mode === "existing_organization") {
       assertCompanyAccess(req, req.body.target.orgId);
+      await assertCanAccessLocalSkillRows(req, req.body.target.orgId);
     }
     const actor = getActorInfo(req);
     const result = await portability.importBundle(req.body, req.actor.type === "board" ? req.actor.userId : null);
@@ -928,6 +1014,7 @@ export function organizationRoutes(db: Db, storage?: StorageService) {
   router.post("/:orgId/exports/preview", validate(organizationPortabilityExportSchema), async (req, res) => {
     const orgId = req.params.orgId as string;
     await assertCanManagePortability(req, orgId, "exports");
+    await assertCanExportSelectedInstructions(req, orgId, req.body);
     const preview = await portability.previewExport(orgId, req.body);
     res.json(preview);
   });
@@ -935,8 +1022,11 @@ export function organizationRoutes(db: Db, storage?: StorageService) {
   router.post("/:orgId/exports/jobs", validate(organizationPortabilityExportSchema), async (req, res) => {
     const orgId = req.params.orgId as string;
     await assertCanManagePortability(req, orgId, "exports");
-    const job = exportJobs.create(orgId, ({ signal, onProgress }) =>
-      portability.exportBundle(orgId, req.body, { signal, onProgress })
+    const requiresInstanceAdmin = await assertCanExportSelectedInstructions(req, orgId, req.body);
+    const job = exportJobs.create(
+      orgId,
+      ({ signal, onProgress }) => portability.exportBundle(orgId, req.body, { signal, onProgress }),
+      { requiresInstanceAdmin },
     );
     res.status(202).json({ job });
   });
@@ -950,6 +1040,7 @@ export function organizationRoutes(db: Db, storage?: StorageService) {
       res.status(404).json({ error: "Export job not found" });
       return;
     }
+    if (exportJobs.requiresInstanceAdmin(jobId)) assertInstanceAdmin(req);
     res.json(job);
   });
 
@@ -962,6 +1053,7 @@ export function organizationRoutes(db: Db, storage?: StorageService) {
       res.status(404).json({ error: "Export job not found" });
       return;
     }
+    if (exportJobs.requiresInstanceAdmin(jobId)) assertInstanceAdmin(req);
     const job = exportJobs.cancel(jobId);
     res.json(job);
   });
@@ -975,6 +1067,7 @@ export function organizationRoutes(db: Db, storage?: StorageService) {
       res.status(404).json({ error: "Export job not found" });
       return;
     }
+    if (exportJobs.requiresInstanceAdmin(jobId)) assertInstanceAdmin(req);
     if (job.status !== "succeeded") {
       res.status(409).json({ error: "Export job is not ready" });
       return;
@@ -990,6 +1083,7 @@ export function organizationRoutes(db: Db, storage?: StorageService) {
   router.post("/:orgId/exports", validate(organizationPortabilityExportSchema), async (req, res) => {
     const orgId = req.params.orgId as string;
     await assertCanManagePortability(req, orgId, "exports");
+    await assertCanExportSelectedInstructions(req, orgId, req.body);
     const result = await portability.exportBundle(orgId, req.body);
     res.json(result);
   });
@@ -997,6 +1091,7 @@ export function organizationRoutes(db: Db, storage?: StorageService) {
   router.post("/:orgId/imports/preview", validate(organizationPortabilityPreviewSchema), async (req, res) => {
     const orgId = req.params.orgId as string;
     await assertCanManagePortability(req, orgId, "imports");
+    await assertCanAccessLocalSkillRows(req, orgId);
     if (req.body.target.mode === "existing_organization" && req.body.target.orgId !== orgId) {
       throw forbidden("Safe import route can only target the route organization");
     }
@@ -1013,6 +1108,7 @@ export function organizationRoutes(db: Db, storage?: StorageService) {
   router.post("/:orgId/imports/apply", validate(organizationPortabilityImportSchema), async (req, res) => {
     const orgId = req.params.orgId as string;
     await assertCanManagePortability(req, orgId, "imports");
+    await assertCanAccessLocalSkillRows(req, orgId);
     if (req.body.target.mode === "existing_organization" && req.body.target.orgId !== orgId) {
       throw forbidden("Safe import route can only target the route organization");
     }

--- a/server/src/routes/orgs.ts
+++ b/server/src/routes/orgs.ts
@@ -109,12 +109,18 @@ export function organizationRoutes(db: Db, storage?: StorageService) {
 
   function assertCanRunBoardFullImport(
     req: Request,
-    input: { include?: { agents?: boolean; projects?: boolean; issues?: boolean } },
+    input: {
+      include?: { agents?: boolean; projects?: boolean; issues?: boolean };
+      collisionStrategy?: string;
+    },
   ) {
     const importsAgents = input.include?.agents ?? true;
     const importsProjects = input.include?.projects ?? false;
     const importsIssues = input.include?.issues ?? false;
-    if (importsAgents || importsProjects || importsIssues) assertInstanceAdmin(req);
+    const replacesExistingState = input.collisionStrategy === "replace";
+    if (importsAgents || importsProjects || importsIssues || replacesExistingState) {
+      assertInstanceAdmin(req);
+    }
   }
 
   async function assertCanAccessLocalSkillRows(req: Request, orgId: string) {

--- a/server/src/routes/plugin-ui-static.ts
+++ b/server/src/routes/plugin-ui-static.ts
@@ -39,6 +39,7 @@ import {
   type PluginPackageResolutionOptions,
 } from "../services/plugin-loader.worker-paths.js";
 import { pluginRegistryService } from "../services/plugin-registry.js";
+import { isPostgresError } from "../services/postgres-errors.js";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -221,11 +222,7 @@ export function pluginUiStaticRoutes(db: Db, options: PluginUiStaticRouteOptions
     try {
       plugin = await registry.getById(pluginId);
     } catch (error) {
-      const maybeCode =
-        typeof error === "object" && error !== null && "code" in error
-          ? (error as { code?: unknown }).code
-          : undefined;
-      if (maybeCode !== "22P02") {
+      if (!isPostgresError(error, "22P02")) {
         throw error;
       }
     }

--- a/server/src/routes/plugins.operations-routes.ts
+++ b/server/src/routes/plugins.operations-routes.ts
@@ -11,7 +11,8 @@
  * - Retrieving UI slot contributions for frontend rendering
  * - Discovering and executing plugin-contributed agent tools
  *
- * All routes require board-level authentication (assertBoard middleware).
+ * Runtime inspection routes require board-level authentication. Instance-
+ * global lifecycle and configuration routes require instance-admin access.
  *
  * @module server/routes/plugins
  * @see doc/engineering/PLUGIN_RUNTIME_CONTRACT.md for the current plugin runtime contract
@@ -23,9 +24,13 @@ import { JsonRpcCallError, PLUGIN_RPC_ERROR_CODES } from "@rudderhq/plugin-sdk";
 import { and, desc, eq, gte } from "drizzle-orm";
 import { Router } from "express";
 import { randomUUID } from "node:crypto";
+import {
+  boundedPluginWebhookFailureMessage,
+  selectPersistedPluginWebhookHeaders,
+} from "../middleware/plugin-webhook-security.js";
 import { publishGlobalLiveEvent } from "../services/live-events.js";
 import { validateInstanceConfig } from "../services/plugin-config-validator.js";
-import { assertBoard } from "./authz.js";
+import { assertInstanceAdmin } from "./authz.js";
 
 interface PluginHealthCheckResult {
   pluginId: string;
@@ -60,7 +65,7 @@ export function registerPluginOperationsRoutes(ctx: PluginOperationsRouteContext
     mapRpcErrorToBridgeError,
   } = ctx;
   router.get("/plugins/:pluginId/logs", async (req, res) => {
-    assertBoard(req);
+    assertInstanceAdmin(req);
     const { pluginId } = req.params;
 
     const plugin = await resolvePlugin(registry, pluginId);
@@ -110,7 +115,7 @@ export function registerPluginOperationsRoutes(ctx: PluginOperationsRouteContext
    * Errors: 404 if plugin not found, 400 for lifecycle errors
    */
   router.post("/plugins/:pluginId/upgrade", async (req, res) => {
-    assertBoard(req);
+    assertInstanceAdmin(req);
     const { pluginId } = req.params;
     const body = req.body as { version?: string } | undefined;
     const version = body?.version;
@@ -159,7 +164,7 @@ export function registerPluginOperationsRoutes(ctx: PluginOperationsRouteContext
    * Errors: 404 if plugin not found
    */
   router.get("/plugins/:pluginId/config", async (req, res) => {
-    assertBoard(req);
+    assertInstanceAdmin(req);
     const { pluginId } = req.params;
 
     const plugin = await resolvePlugin(registry, pluginId);
@@ -189,7 +194,7 @@ export function registerPluginOperationsRoutes(ctx: PluginOperationsRouteContext
    * - 404 if plugin not found
    */
   router.post("/plugins/:pluginId/config", async (req, res) => {
-    assertBoard(req);
+    assertInstanceAdmin(req);
     const { pluginId } = req.params;
 
     const plugin = await resolvePlugin(registry, pluginId);
@@ -294,7 +299,7 @@ export function registerPluginOperationsRoutes(ctx: PluginOperationsRouteContext
    * - 502 if the worker is unavailable
    */
   router.post("/plugins/:pluginId/config/test", async (req, res) => {
-    assertBoard(req);
+    assertInstanceAdmin(req);
 
     if (!bridgeDeps) {
       res.status(501).json({ error: "Plugin bridge is not enabled" });
@@ -391,7 +396,7 @@ export function registerPluginOperationsRoutes(ctx: PluginOperationsRouteContext
    * Errors: 404 if plugin not found
    */
   router.get("/plugins/:pluginId/jobs", async (req, res) => {
-    assertBoard(req);
+    assertInstanceAdmin(req);
     if (!jobDeps) {
       res.status(501).json({ error: "Job scheduling is not enabled" });
       return;
@@ -437,7 +442,7 @@ export function registerPluginOperationsRoutes(ctx: PluginOperationsRouteContext
    * Errors: 404 if plugin not found
    */
   router.get("/plugins/:pluginId/jobs/:jobId/runs", async (req, res) => {
-    assertBoard(req);
+    assertInstanceAdmin(req);
     if (!jobDeps) {
       res.status(501).json({ error: "Job scheduling is not enabled" });
       return;
@@ -485,7 +490,7 @@ export function registerPluginOperationsRoutes(ctx: PluginOperationsRouteContext
    * - 400 if job not found, not active, already running, or worker unavailable
    */
   router.post("/plugins/:pluginId/jobs/:jobId/trigger", async (req, res) => {
-    assertBoard(req);
+    assertInstanceAdmin(req);
     if (!jobDeps) {
       res.status(501).json({ error: "Job scheduling is not enabled" });
       return;
@@ -539,6 +544,8 @@ export function registerPluginOperationsRoutes(ctx: PluginOperationsRouteContext
    * Errors:
    * - 404 if plugin not found or endpointKey not declared
    * - 400 if plugin is not in ready state or lacks webhooks.receive capability
+   * - 413 if the request body exceeds the webhook-specific limit
+   * - 429 if the source exceeds its webhook delivery rate limit
    * - 502 if the worker is unavailable or the RPC call fails
    */
   router.post("/plugins/:pluginId/webhooks/:endpointKey", async (req, res) => {
@@ -593,14 +600,10 @@ export function registerPluginOperationsRoutes(ctx: PluginOperationsRouteContext
 
     // Step 5: Extract request data
     const requestId = randomUUID();
-    const rawHeaders: Record<string, string> = {};
-    for (const [key, value] of Object.entries(req.headers)) {
-      if (typeof value === "string") {
-        rawHeaders[key] = value;
-      } else if (Array.isArray(value)) {
-        rawHeaders[key] = value.join(", ");
-      }
-    }
+    // Workers receive the original headers for provider-specific signature
+    // verification, but the delivery audit row stores only bounded,
+    // non-sensitive routing metadata.
+    const persistedHeaders = selectPersistedPluginWebhookHeaders(req.headers);
 
     // Use the raw buffer stashed by the express.json() `verify` callback.
     // This preserves the exact bytes the provider signed, whereas
@@ -619,7 +622,7 @@ export function registerPluginOperationsRoutes(ctx: PluginOperationsRouteContext
         webhookKey: endpointKey,
         status: "pending",
         payload,
-        headers: rawHeaders,
+        headers: persistedHeaders,
         startedAt,
       })
       .returning({ id: pluginWebhookDeliveries.id });
@@ -654,7 +657,7 @@ export function registerPluginOperationsRoutes(ctx: PluginOperationsRouteContext
       // Step 8 (error): Update delivery record to failed
       const finishedAt = new Date();
       const durationMs = finishedAt.getTime() - startedAt.getTime();
-      const errorMessage = err instanceof Error ? err.message : String(err);
+      const errorMessage = boundedPluginWebhookFailureMessage(err);
 
       await db
         .update(pluginWebhookDeliveries)
@@ -669,7 +672,7 @@ export function registerPluginOperationsRoutes(ctx: PluginOperationsRouteContext
       res.status(502).json({
         deliveryId: delivery.id,
         status: "failed",
-        error: errorMessage,
+        error: "Plugin webhook handler failed",
       });
     }
   });
@@ -691,7 +694,7 @@ export function registerPluginOperationsRoutes(ctx: PluginOperationsRouteContext
    * Errors: 404 if plugin not found
    */
   router.get("/plugins/:pluginId/dashboard", async (req, res) => {
-    assertBoard(req);
+    assertInstanceAdmin(req);
     const { pluginId } = req.params;
 
     const plugin = await resolvePlugin(registry, pluginId);

--- a/server/src/routes/plugins.ts
+++ b/server/src/routes/plugins.ts
@@ -11,14 +11,16 @@
  * - Retrieving UI slot contributions for frontend rendering
  * - Discovering and executing plugin-contributed agent tools
  *
- * All routes require board-level authentication (assertBoard middleware).
+ * Read routes require board-level authentication. Plugin UI bridges and
+ * instance-global lifecycle mutations require instance-admin authentication
+ * because they can execute plugin code against instance-global host services.
  *
  * @module server/routes/plugins
  * @see doc/engineering/PLUGIN_RUNTIME_CONTRACT.md for the current plugin runtime contract
  */
 
 import type { Db } from "@rudderhq/db";
-import { organizations } from "@rudderhq/db";
+import { agents, organizations, projects } from "@rudderhq/db";
 import type { ToolRunContext } from "@rudderhq/plugin-sdk";
 import { JsonRpcCallError, PLUGIN_RPC_ERROR_CODES } from "@rudderhq/plugin-sdk";
 import type {
@@ -30,11 +32,13 @@ import type {
 import {
   PLUGIN_STATUSES,
 } from "@rudderhq/shared";
+import { eq } from "drizzle-orm";
 import type { Request } from "express";
 import { Router } from "express";
 import { existsSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { badRequest, forbidden } from "../errors.js";
 import { logActivity } from "../services/activity-log.js";
 import { publishGlobalLiveEvent } from "../services/live-events.js";
 import type { PluginJobScheduler } from "../services/plugin-job-scheduler.js";
@@ -45,7 +49,7 @@ import { pluginRegistryService } from "../services/plugin-registry.js";
 import type { PluginStreamBus } from "../services/plugin-stream-bus.js";
 import type { PluginToolDispatcher } from "../services/plugin-tool-dispatcher.js";
 import type { PluginWorkerManager } from "../services/plugin-worker-manager.js";
-import { assertBoard, assertCompanyAccess, getActorInfo } from "./authz.js";
+import { assertBoard, assertCompanyAccess, assertInstanceAdmin, getActorInfo } from "./authz.js";
 import { registerPluginOperationsRoutes } from "./plugins.operations-routes.js";
 
 /** UI slot declaration extracted from plugin manifest */
@@ -370,6 +374,99 @@ export function pluginRoutes(
       })));
   }
 
+  function normalizePluginBridgeParams(
+    req: Request,
+    orgIdValue: unknown,
+    paramsValue: unknown,
+  ): Record<string, unknown> {
+    if (
+      paramsValue !== undefined
+      && (
+        typeof paramsValue !== "object"
+        || paramsValue === null
+        || Array.isArray(paramsValue)
+      )
+    ) {
+      throw badRequest('"params" must be an object when provided');
+    }
+
+    const params = { ...((paramsValue ?? {}) as Record<string, unknown>) };
+    const outerOrgId = typeof orgIdValue === "string" && orgIdValue.trim()
+      ? orgIdValue.trim()
+      : null;
+    const parameterOrgId = typeof params.orgId === "string" && params.orgId.trim()
+      ? params.orgId.trim()
+      : null;
+    if (outerOrgId && parameterOrgId && outerOrgId !== parameterOrgId) {
+      throw forbidden("Plugin parameters must use the authorized organization scope");
+    }
+    const orgId = outerOrgId ?? parameterOrgId;
+
+    // An organization-less bridge call operates in instance-global plugin
+    // context. Keep that surface reserved for the host administrator.
+    if (!orgId) {
+      assertInstanceAdmin(req);
+      return params;
+    }
+
+    assertCompanyAccess(req, orgId);
+    for (const key of ["orgId", "organizationId", "companyId"] as const) {
+      const parameterScope = params[key];
+      if (
+        parameterScope !== undefined
+        && (typeof parameterScope !== "string" || parameterScope !== orgId)
+      ) {
+        throw forbidden("Plugin parameters must use the authorized organization scope");
+      }
+    }
+
+    // The worker protocol does not carry a separate trusted organization
+    // context, so bind the authorized scope into the parameters it receives.
+    params.orgId = orgId;
+    return params;
+  }
+
+  function assertPluginToolParameterScope(
+    req: Request,
+    orgId: string,
+    parameters: unknown,
+  ) {
+    assertCompanyAccess(req, orgId);
+    if (typeof parameters !== "object" || parameters === null || Array.isArray(parameters)) return;
+
+    const params = parameters as Record<string, unknown>;
+    for (const key of ["orgId", "organizationId", "companyId"] as const) {
+      const parameterScope = params[key];
+      if (
+        parameterScope !== undefined
+        && (typeof parameterScope !== "string" || parameterScope !== orgId)
+      ) {
+        throw forbidden("Plugin tool parameters must use the authorized organization scope");
+      }
+    }
+  }
+
+  async function assertPluginToolRunContextEntities(runContext: ToolRunContext) {
+    const [agentRows, projectRows] = await Promise.all([
+      db
+        .select({ orgId: agents.orgId })
+        .from(agents)
+        .where(eq(agents.id, runContext.agentId))
+        .limit(1),
+      db
+        .select({ orgId: projects.orgId })
+        .from(projects)
+        .where(eq(projects.id, runContext.projectId))
+        .limit(1),
+    ]);
+    if (
+      agentRows[0]?.orgId !== runContext.orgId
+      || projectRows[0]?.orgId !== runContext.orgId
+    ) {
+      throw forbidden("Plugin tool run context must stay within the authorized organization");
+    }
+  }
+
   /**
    * GET /api/plugins
    *
@@ -543,11 +640,6 @@ export function pluginRoutes(
   router.post("/plugins/tools/execute", async (req, res) => {
     assertBoard(req);
 
-    if (!toolDeps) {
-      res.status(501).json({ error: "Plugin tool dispatch is not enabled" });
-      return;
-    }
-
     const body = (req.body as PluginToolExecuteRequest | undefined);
     if (!body) {
       res.status(400).json({ error: "Request body is required" });
@@ -567,14 +659,23 @@ export function pluginRoutes(
       return;
     }
 
-    if (!runContext.agentId || !runContext.runId || !runContext.orgId || !runContext.projectId) {
+    if (
+      ![runContext.agentId, runContext.runId, runContext.orgId, runContext.projectId]
+        .every((value) => typeof value === "string" && value.trim().length > 0)
+    ) {
       res.status(400).json({
         error: '"runContext" must include agentId, runId, orgId, and projectId',
       });
       return;
     }
 
-    assertCompanyAccess(req, runContext.orgId);
+    assertPluginToolParameterScope(req, runContext.orgId, parameters);
+
+    if (!toolDeps) {
+      res.status(501).json({ error: "Plugin tool dispatch is not enabled" });
+      return;
+    }
+    await assertPluginToolRunContextEntities(runContext);
 
     // Verify the tool exists
     const registeredTool = toolDeps.toolDispatcher.getTool(tool);
@@ -625,7 +726,7 @@ export function pluginRoutes(
    * - `500` — installation succeeded but manifest is missing (indicates a loader bug)
    */
   router.post("/plugins/install", async (req, res) => {
-    assertBoard(req);
+    assertInstanceAdmin(req);
     const { packageName, version, isLocalPath } = req.body as PluginInstallRequest;
 
     // Input validation
@@ -817,23 +918,28 @@ export function pluginRoutes(
    * @see doc/engineering/PLUGIN_RUNTIME_CONTRACT.md — Error Propagation Through The Bridge
    */
   router.post("/plugins/:pluginId/bridge/data", async (req, res) => {
-    assertBoard(req);
+    assertInstanceAdmin(req);
 
+    // Validate request body
+    const body = req.body as PluginBridgeDataRequest | undefined;
+    if (!body || !body.key || typeof body.key !== "string") {
+      res.status(400).json({ error: '"key" is required and must be a string' });
+      return;
+    }
+
+    const params = normalizePluginBridgeParams(req, body.orgId, body.params);
     if (!bridgeDeps) {
       res.status(501).json({ error: "Plugin bridge is not enabled" });
       return;
     }
 
     const { pluginId } = req.params;
-
-    // Resolve plugin
     const plugin = await resolvePlugin(registry, pluginId);
     if (!plugin) {
       res.status(404).json({ error: "Plugin not found" });
       return;
     }
 
-    // Validate plugin is in ready state
     if (plugin.status !== "ready") {
       const bridgeError: PluginBridgeErrorResponse = {
         code: "WORKER_UNAVAILABLE",
@@ -843,24 +949,13 @@ export function pluginRoutes(
       return;
     }
 
-    // Validate request body
-    const body = req.body as PluginBridgeDataRequest | undefined;
-    if (!body || !body.key || typeof body.key !== "string") {
-      res.status(400).json({ error: '"key" is required and must be a string' });
-      return;
-    }
-
-    if (body.orgId) {
-      assertCompanyAccess(req, body.orgId);
-    }
-
     try {
       const result = await bridgeDeps.workerManager.call(
         plugin.id,
         "getData",
         {
           key: body.key,
-          params: body.params ?? {},
+          params,
           renderEnvironment: body.renderEnvironment ?? null,
         },
       );
@@ -900,23 +995,28 @@ export function pluginRoutes(
    * @see doc/engineering/PLUGIN_RUNTIME_CONTRACT.md — Error Propagation Through The Bridge
    */
   router.post("/plugins/:pluginId/bridge/action", async (req, res) => {
-    assertBoard(req);
+    assertInstanceAdmin(req);
 
+    // Validate request body
+    const body = req.body as PluginBridgeActionRequest | undefined;
+    if (!body || !body.key || typeof body.key !== "string") {
+      res.status(400).json({ error: '"key" is required and must be a string' });
+      return;
+    }
+
+    const params = normalizePluginBridgeParams(req, body.orgId, body.params);
     if (!bridgeDeps) {
       res.status(501).json({ error: "Plugin bridge is not enabled" });
       return;
     }
 
     const { pluginId } = req.params;
-
-    // Resolve plugin
     const plugin = await resolvePlugin(registry, pluginId);
     if (!plugin) {
       res.status(404).json({ error: "Plugin not found" });
       return;
     }
 
-    // Validate plugin is in ready state
     if (plugin.status !== "ready") {
       const bridgeError: PluginBridgeErrorResponse = {
         code: "WORKER_UNAVAILABLE",
@@ -926,24 +1026,13 @@ export function pluginRoutes(
       return;
     }
 
-    // Validate request body
-    const body = req.body as PluginBridgeActionRequest | undefined;
-    if (!body || !body.key || typeof body.key !== "string") {
-      res.status(400).json({ error: '"key" is required and must be a string' });
-      return;
-    }
-
-    if (body.orgId) {
-      assertCompanyAccess(req, body.orgId);
-    }
-
     try {
       const result = await bridgeDeps.workerManager.call(
         plugin.id,
         "performAction",
         {
           key: body.key,
-          params: body.params ?? {},
+          params,
           renderEnvironment: body.renderEnvironment ?? null,
         },
       );
@@ -984,23 +1073,27 @@ export function pluginRoutes(
    * @see doc/engineering/PLUGIN_RUNTIME_CONTRACT.md — Error Propagation Through The Bridge
    */
   router.post("/plugins/:pluginId/data/:key", async (req, res) => {
-    assertBoard(req);
+    assertInstanceAdmin(req);
 
+    const body = req.body as {
+      orgId?: string;
+      params?: Record<string, unknown>;
+      renderEnvironment?: PluginLauncherRenderContextSnapshot | null;
+    } | undefined;
+
+    const params = normalizePluginBridgeParams(req, body?.orgId, body?.params);
     if (!bridgeDeps) {
       res.status(501).json({ error: "Plugin bridge is not enabled" });
       return;
     }
 
     const { pluginId, key } = req.params;
-
-    // Resolve plugin
     const plugin = await resolvePlugin(registry, pluginId);
     if (!plugin) {
       res.status(404).json({ error: "Plugin not found" });
       return;
     }
 
-    // Validate plugin is in ready state
     if (plugin.status !== "ready") {
       const bridgeError: PluginBridgeErrorResponse = {
         code: "WORKER_UNAVAILABLE",
@@ -1010,23 +1103,13 @@ export function pluginRoutes(
       return;
     }
 
-    const body = req.body as {
-      orgId?: string;
-      params?: Record<string, unknown>;
-      renderEnvironment?: PluginLauncherRenderContextSnapshot | null;
-    } | undefined;
-
-    if (body?.orgId) {
-      assertCompanyAccess(req, body.orgId);
-    }
-
     try {
       const result = await bridgeDeps.workerManager.call(
         plugin.id,
         "getData",
         {
           key,
-          params: body?.params ?? {},
+          params,
           renderEnvironment: body?.renderEnvironment ?? null,
         },
       );
@@ -1063,23 +1146,27 @@ export function pluginRoutes(
    * @see doc/engineering/PLUGIN_RUNTIME_CONTRACT.md — Error Propagation Through The Bridge
    */
   router.post("/plugins/:pluginId/actions/:key", async (req, res) => {
-    assertBoard(req);
+    assertInstanceAdmin(req);
 
+    const body = req.body as {
+      orgId?: string;
+      params?: Record<string, unknown>;
+      renderEnvironment?: PluginLauncherRenderContextSnapshot | null;
+    } | undefined;
+
+    const params = normalizePluginBridgeParams(req, body?.orgId, body?.params);
     if (!bridgeDeps) {
       res.status(501).json({ error: "Plugin bridge is not enabled" });
       return;
     }
 
     const { pluginId, key } = req.params;
-
-    // Resolve plugin
     const plugin = await resolvePlugin(registry, pluginId);
     if (!plugin) {
       res.status(404).json({ error: "Plugin not found" });
       return;
     }
 
-    // Validate plugin is in ready state
     if (plugin.status !== "ready") {
       const bridgeError: PluginBridgeErrorResponse = {
         code: "WORKER_UNAVAILABLE",
@@ -1089,23 +1176,13 @@ export function pluginRoutes(
       return;
     }
 
-    const body = req.body as {
-      orgId?: string;
-      params?: Record<string, unknown>;
-      renderEnvironment?: PluginLauncherRenderContextSnapshot | null;
-    } | undefined;
-
-    if (body?.orgId) {
-      assertCompanyAccess(req, body.orgId);
-    }
-
     try {
       const result = await bridgeDeps.workerManager.call(
         plugin.id,
         "performAction",
         {
           key,
-          params: body?.params ?? {},
+          params,
           renderEnvironment: body?.renderEnvironment ?? null,
         },
       );
@@ -1252,7 +1329,7 @@ export function pluginRoutes(
    * Errors: 404 if plugin not found, 400 for lifecycle errors
    */
   router.delete("/plugins/:pluginId", async (req, res) => {
-    assertBoard(req);
+    assertInstanceAdmin(req);
     const { pluginId } = req.params;
     const purge = req.query.purge === "true";
 
@@ -1288,7 +1365,7 @@ export function pluginRoutes(
    * Errors: 404 if plugin not found, 400 for lifecycle errors
    */
   router.post("/plugins/:pluginId/enable", async (req, res) => {
-    assertBoard(req);
+    assertInstanceAdmin(req);
     const { pluginId } = req.params;
 
     const plugin = await resolvePlugin(registry, pluginId);
@@ -1326,7 +1403,7 @@ export function pluginRoutes(
    * Errors: 404 if plugin not found, 400 for lifecycle errors
    */
   router.post("/plugins/:pluginId/disable", async (req, res) => {
-    assertBoard(req);
+    assertInstanceAdmin(req);
     const { pluginId } = req.params;
     const body = req.body as { reason?: string } | undefined;
     const reason = body?.reason;

--- a/server/src/routes/plugins.ts
+++ b/server/src/routes/plugins.ts
@@ -49,6 +49,7 @@ import { pluginRegistryService } from "../services/plugin-registry.js";
 import type { PluginStreamBus } from "../services/plugin-stream-bus.js";
 import type { PluginToolDispatcher } from "../services/plugin-tool-dispatcher.js";
 import type { PluginWorkerManager } from "../services/plugin-worker-manager.js";
+import { isPostgresError } from "../services/postgres-errors.js";
 import { assertBoard, assertCompanyAccess, assertInstanceAdmin, getActorInfo } from "./authz.js";
 import { registerPluginOperationsRoutes } from "./plugins.operations-routes.js";
 
@@ -196,12 +197,8 @@ async function resolvePlugin(
     const byId = await registry.getById(pluginId);
     if (byId) return byId;
   } catch (error) {
-    const maybeCode =
-      typeof error === "object" && error !== null && "code" in error
-        ? (error as { code?: unknown }).code
-        : undefined;
     // Ignore invalid UUID cast errors and continue with key lookup.
-    if (maybeCode !== "22P02") {
+    if (!isPostgresError(error, "22P02")) {
       throw error;
     }
   }

--- a/server/src/routes/projects.ts
+++ b/server/src/routes/projects.ts
@@ -7,15 +7,23 @@ import {
   updateProjectSchema,
 } from "@rudderhq/shared";
 import { Router, type Request } from "express";
-import { conflict } from "../errors.js";
+import { conflict, forbidden } from "../errors.js";
 import { validate } from "../middleware/validate.js";
 import { logActivity, projectService, resourceCatalogService } from "../services/index.js";
-import { assertCompanyAccess, getActorInfo } from "./authz.js";
+import { assertCompanyAccess, assertInstanceAdmin, getActorInfo } from "./authz.js";
 
 export function projectRoutes(db: Db) {
   const router = Router();
   const svc = projectService(db);
   const resources = resourceCatalogService(db);
+
+  function assertAgentProjectPolicyAllowed(req: Request, body: Record<string, unknown>) {
+    if (!Object.prototype.hasOwnProperty.call(body, "executionWorkspacePolicy")) return;
+    if (req.actor.type === "agent") {
+      throw forbidden("Agent authentication cannot set project execution workspace policy");
+    }
+    assertInstanceAdmin(req);
+  }
 
   async function resolveOrgIdForProjectReference(req: Request) {
     const orgIdQuery = req.query.orgId;
@@ -85,6 +93,7 @@ export function projectRoutes(db: Db) {
   router.post("/orgs/:orgId/projects", validate(createProjectSchema), async (req, res) => {
     const orgId = req.params.orgId as string;
     assertCompanyAccess(req, orgId);
+    assertAgentProjectPolicyAllowed(req, req.body as Record<string, unknown>);
     // Legacy project workspace creation used a nested `workspace` body. Current
     // project creation ignores that old shape; workspaces are resolved through
     // organization Library/codebase and run workspace paths.
@@ -118,6 +127,7 @@ export function projectRoutes(db: Db) {
       return;
     }
     assertCompanyAccess(req, existing.orgId);
+    assertAgentProjectPolicyAllowed(req, req.body as Record<string, unknown>);
     const body = { ...req.body };
     if (typeof body.archivedAt === "string") {
       body.archivedAt = new Date(body.archivedAt);

--- a/server/src/routes/website-metadata.ts
+++ b/server/src/routes/website-metadata.ts
@@ -1,4 +1,8 @@
 import { Router } from "express";
+import {
+  ACTIVE_CONTENT_SANDBOX_CSP,
+  normalizeResponseContentType,
+} from "../content-response-policy.js";
 import { badRequest } from "../errors.js";
 import {
   fetchWebsiteIcon,
@@ -8,6 +12,16 @@ import {
   type WebsiteMetadataOptions,
 } from "../services/website-metadata.js";
 import { assertBoard } from "./authz.js";
+
+const SAFE_WEBSITE_ICON_CONTENT_TYPES = new Set([
+  "image/gif",
+  "image/jpeg",
+  "image/jpg",
+  "image/png",
+  "image/vnd.microsoft.icon",
+  "image/webp",
+  "image/x-icon",
+]);
 
 export interface WebsiteMetadataRouteOptions {
   resolveWebsiteMetadata?: (url: string) => Promise<WebsiteMetadata>;
@@ -72,9 +86,16 @@ export function websiteMetadataRoutes(options: WebsiteMetadataRouteOptions = {})
       res.status(404).json({ error: "Website icon not found" });
       return;
     }
+    const contentType = normalizeResponseContentType(icon.contentType);
+    if (!SAFE_WEBSITE_ICON_CONTENT_TYPES.has(contentType)) {
+      res.status(415).json({ error: "Unsupported website icon type" });
+      return;
+    }
 
-    res.setHeader("content-type", icon.contentType);
+    res.setHeader("content-type", contentType);
     res.setHeader("cache-control", "public, max-age=86400");
+    res.setHeader("x-content-type-options", "nosniff");
+    res.setHeader("content-security-policy", ACTIVE_CONTENT_SANDBOX_CSP);
     res.send(icon.body);
   });
 

--- a/server/src/services/activity-log.ts
+++ b/server/src/services/activity-log.ts
@@ -10,6 +10,7 @@ import { sanitizeRecord } from "../redaction.js";
 import { instanceSettingsService } from "./instance-settings.js";
 import { publishLiveEvent } from "./live-events.js";
 import type { PluginEventBus } from "./plugin-event-bus.js";
+import { isPostgresError } from "./postgres-errors.js";
 
 const PLUGIN_EVENT_SET: ReadonlySet<string> = new Set(PLUGIN_EVENT_TYPES);
 const LANGFUSE_ACTIVITY_EXPORT_ALLOWLIST: ReadonlySet<string> = new Set();
@@ -55,9 +56,7 @@ function normalizeHeartbeatRunId(runId: string | null | undefined): string | nul
 }
 
 function isActivityRunIdPersistenceError(error: unknown): boolean {
-  if (typeof error !== "object" || error === null) return false;
-  const record = error as Record<string, unknown>;
-  return record.code === "23503" && record.constraint_name === ACTIVITY_RUN_ID_FK_CONSTRAINT;
+  return isPostgresError(error, "23503", ACTIVITY_RUN_ID_FK_CONSTRAINT);
 }
 
 export async function logActivity(db: Db, input: LogActivityInput) {

--- a/server/src/services/agent-instructions.ts
+++ b/server/src/services/agent-instructions.ts
@@ -6,6 +6,7 @@
  * @see doc/product/domains/agents/identity-config.md - durable agent runtime configuration
  * @see doc/engineering/DEVELOPING.md - contributor expectations for local runtime work
  */
+import { constants as fsConstants } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { notFound, unprocessable } from "../errors.js";
@@ -46,7 +47,7 @@ type BundleMode = "managed" | "external";
 type AgentLike = {
   id: string;
   orgId: string;
-  name: string;
+  name?: string | null;
   role?: string | null;
   workspaceKey?: string | null;
   agentRuntimeConfig: unknown;
@@ -169,19 +170,203 @@ function resolveLegacyInstructionsPath(candidatePath: string, config: Record<str
   return path.resolve(cwd, candidatePath);
 }
 
+function isPathWithinRoot(rootPath: string, candidatePath: string) {
+  const relativePath = path.relative(path.resolve(rootPath), path.resolve(candidatePath));
+  return relativePath === ""
+    || (relativePath !== ".." && !relativePath.startsWith(`..${path.sep}`) && !path.isAbsolute(relativePath));
+}
+
+export function isCanonicalManagedAgentInstructionsConfig(
+  agent: AgentLike,
+  candidateConfig: unknown = agent.agentRuntimeConfig,
+) {
+  const config = asRecord(candidateConfig);
+  if (
+    config[MODE_KEY] !== undefined
+    && config[MODE_KEY] !== "managed"
+  ) {
+    return false;
+  }
+
+  const managedRootPath = resolveManagedInstructionsRoot(agent);
+  const configuredRootPath = asString(config[ROOT_KEY]);
+  if (configuredRootPath) {
+    if (
+      !path.isAbsolute(configuredRootPath)
+      && configuredRootPath !== "~"
+      && !configuredRootPath.startsWith("~/")
+    ) {
+      return false;
+    }
+    if (path.resolve(resolveHomeAwarePath(configuredRootPath)) !== path.resolve(managedRootPath)) {
+      return false;
+    }
+  }
+
+  for (const key of [FILE_KEY, "agentsMdPath"]) {
+    const configuredPath = asString(config[key]);
+    if (!configuredPath) continue;
+    let resolvedPath: string;
+    try {
+      resolvedPath = resolveLegacyInstructionsPath(configuredPath, config);
+    } catch {
+      return false;
+    }
+    if (!isPathWithinRoot(managedRootPath, resolvedPath)) return false;
+  }
+
+  return true;
+}
+
 async function statIfExists(targetPath: string) {
   return fs.stat(targetPath).catch(() => null);
+}
+
+async function lstatIfExists(targetPath: string) {
+  try {
+    return await fs.lstat(targetPath);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw err;
+  }
+}
+
+function symlinkBoundaryError() {
+  return unprocessable(
+    "Instructions file path must stay within the bundle root and cannot traverse symbolic links",
+  );
+}
+
+async function assertSafeBundleRoot(rootPath: string): Promise<string> {
+  const absoluteRoot = path.resolve(rootPath);
+  const rootStat = await lstatIfExists(absoluteRoot);
+  if (!rootStat) throw notFound("Agent instructions bundle is not configured");
+  if (!rootStat.isDirectory() || rootStat.isSymbolicLink()) {
+    throw symlinkBoundaryError();
+  }
+  return absoluteRoot;
+}
+
+async function inspectExistingPathWithinRoot(rootPath: string, relativePath: string) {
+  const normalizedPath = normalizeRelativeFilePath(relativePath);
+  const absoluteRoot = await assertSafeBundleRoot(rootPath);
+  const pathSegments = normalizedPath.split("/");
+  let currentPath = absoluteRoot;
+  let targetStat: Awaited<ReturnType<typeof fs.lstat>> | null = null;
+
+  for (let index = 0; index < pathSegments.length; index += 1) {
+    currentPath = path.join(currentPath, pathSegments[index]!);
+    const currentStat = await lstatIfExists(currentPath);
+    if (!currentStat) return null;
+    if (currentStat.isSymbolicLink()) throw symlinkBoundaryError();
+    if (index < pathSegments.length - 1 && !currentStat.isDirectory()) {
+      throw unprocessable("Instructions file path has a non-directory parent");
+    }
+    targetStat = currentStat;
+  }
+
+  return {
+    absolutePath: resolvePathWithinRoot(absoluteRoot, normalizedPath),
+    normalizedPath,
+    stat: targetStat!,
+  };
+}
+
+async function prepareWritablePathWithinRoot(rootPath: string, relativePath: string) {
+  const normalizedPath = normalizeRelativeFilePath(relativePath);
+  const absoluteRoot = await assertSafeBundleRoot(rootPath);
+  const pathSegments = normalizedPath.split("/");
+  let currentPath = absoluteRoot;
+
+  for (const segment of pathSegments.slice(0, -1)) {
+    currentPath = path.join(currentPath, segment);
+    let currentStat = await lstatIfExists(currentPath);
+    if (!currentStat) {
+      try {
+        await fs.mkdir(currentPath);
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code !== "EEXIST") throw err;
+      }
+      currentStat = await lstatIfExists(currentPath);
+    }
+    if (!currentStat?.isDirectory() || currentStat.isSymbolicLink()) {
+      throw symlinkBoundaryError();
+    }
+  }
+
+  const absolutePath = resolvePathWithinRoot(absoluteRoot, normalizedPath);
+  const targetStat = await lstatIfExists(absolutePath);
+  if (targetStat?.isSymbolicLink()) throw symlinkBoundaryError();
+  return { absolutePath, normalizedPath };
+}
+
+async function readUtf8FileWithinRoot(rootPath: string, relativePath: string) {
+  const inspected = await inspectExistingPathWithinRoot(rootPath, relativePath);
+  if (!inspected) return null;
+
+  let handle: Awaited<ReturnType<typeof fs.open>>;
+  try {
+    handle = await fs.open(
+      inspected.absolutePath,
+      fsConstants.O_RDONLY | (fsConstants.O_NOFOLLOW ?? 0),
+    );
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ELOOP") throw symlinkBoundaryError();
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw err;
+  }
+  try {
+    const stat = await handle.stat();
+    if (!stat.isFile()) return null;
+    const content = await handle.readFile({ encoding: "utf8" });
+    return { ...inspected, content, stat };
+  } finally {
+    await handle.close();
+  }
+}
+
+async function writeUtf8FileWithinRoot(
+  rootPath: string,
+  relativePath: string,
+  content: string,
+) {
+  const prepared = await prepareWritablePathWithinRoot(rootPath, relativePath);
+  let handle: Awaited<ReturnType<typeof fs.open>>;
+  try {
+    handle = await fs.open(
+      prepared.absolutePath,
+      fsConstants.O_WRONLY
+        | fsConstants.O_CREAT
+        | fsConstants.O_TRUNC
+        | (fsConstants.O_NOFOLLOW ?? 0),
+      0o600,
+    );
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ELOOP") throw symlinkBoundaryError();
+    throw err;
+  }
+  try {
+    await handle.writeFile(content, { encoding: "utf8" });
+  } finally {
+    await handle.close();
+  }
+  return prepared;
 }
 
 async function copyLegacyRootMemoryIntoManagedInstructions(agent: AgentLike): Promise<boolean> {
   const layout = await ensureAgentWorkspaceLayout(agent);
   const sourcePath = path.join(layout.root, MEMORY_FILE_NAME);
   const targetPath = path.join(layout.instructionsDir, MEMORY_FILE_NAME);
-  const targetStat = await statIfExists(targetPath);
+  const targetStat = await lstatIfExists(targetPath);
   if (targetStat?.isFile()) return false;
-  const sourceStat = await statIfExists(sourcePath);
-  if (!sourceStat?.isFile()) return false;
-  await fs.copyFile(sourcePath, targetPath);
+  if (targetStat?.isSymbolicLink()) throw symlinkBoundaryError();
+  const sourceStat = await lstatIfExists(sourcePath);
+  if (!sourceStat?.isFile() || sourceStat.isSymbolicLink()) return false;
+  await writeUtf8FileWithinRoot(
+    layout.instructionsDir,
+    MEMORY_FILE_NAME,
+    await fs.readFile(sourcePath, "utf8"),
+  );
   return true;
 }
 
@@ -201,6 +386,7 @@ function shouldIgnoreInstructionsEntry(entry: { name: string; isDirectory(): boo
 
 async function listFilesRecursive(rootPath: string): Promise<string[]> {
   const output: string[] = [];
+  const safeRootPath = await assertSafeBundleRoot(rootPath);
 
   async function walk(currentPath: string, relativeDir: string) {
     const entries = await fs.readdir(currentPath, { withFileTypes: true }).catch(() => []);
@@ -219,13 +405,14 @@ async function listFilesRecursive(rootPath: string): Promise<string[]> {
     }
   }
 
-  await walk(rootPath, "");
+  await walk(safeRootPath, "");
   return output.sort((left, right) => left.localeCompare(right));
 }
 
 async function readFileSummary(rootPath: string, relativePath: string, entryFile: string): Promise<AgentInstructionsFileSummary> {
-  const absolutePath = resolvePathWithinRoot(rootPath, relativePath);
-  const stat = await fs.stat(absolutePath);
+  const inspected = await inspectExistingPathWithinRoot(rootPath, relativePath);
+  if (!inspected) throw notFound("Instructions file not found");
+  const stat = inspected.stat;
   return {
     path: relativePath,
     size: stat.size,
@@ -504,11 +691,10 @@ async function writeBundleFiles(
 ) {
   for (const [relativePath, content] of Object.entries(files)) {
     const normalizedPath = normalizeRelativeFilePath(relativePath);
-    const absolutePath = resolvePathWithinRoot(rootPath, normalizedPath);
-    const existingStat = await statIfExists(absolutePath);
+    const existing = await inspectExistingPathWithinRoot(rootPath, normalizedPath);
+    const existingStat = existing?.stat ?? null;
     if (existingStat?.isFile() && !options?.overwriteExisting) continue;
-    await fs.mkdir(path.dirname(absolutePath), { recursive: true });
-    await fs.writeFile(absolutePath, content, "utf8");
+    await writeUtf8FileWithinRoot(rootPath, normalizedPath, content);
   }
 }
 
@@ -545,6 +731,7 @@ export function agentInstructionsService() {
         warnings: [...state.warnings, `Instructions root does not exist: ${state.rootPath}`],
       }, []);
     }
+    await assertSafeBundleRoot(state.rootPath);
     const files = await listFilesRecursive(state.rootPath);
     const summaries = await Promise.all(files.map((relativePath) => readFileSummary(state.rootPath!, relativePath, state.entryFile)));
     return toBundle(agent, state, summaries);
@@ -592,13 +779,9 @@ export function agentInstructionsService() {
       };
     }
     if (!state.rootPath) throw notFound("Agent instructions bundle is not configured");
-    const absolutePath = resolvePathWithinRoot(state.rootPath, relativePath);
-    const [content, stat] = await Promise.all([
-      fs.readFile(absolutePath, "utf8").catch(() => null),
-      fs.stat(absolutePath).catch(() => null),
-    ]);
-    if (content === null || !stat?.isFile()) throw notFound("Instructions file not found");
-    const normalizedPath = normalizeRelativeFilePath(relativePath);
+    const file = await readUtf8FileWithinRoot(state.rootPath, relativePath);
+    if (!file) throw notFound("Instructions file not found");
+    const { content, stat, normalizedPath } = file;
     return {
       path: normalizedPath,
       size: stat.size,
@@ -639,12 +822,15 @@ export function agentInstructionsService() {
     await ensureAgentWorkspaceLayout(agent);
     await fs.mkdir(managedRoot, { recursive: true });
 
-    const entryPath = resolvePathWithinRoot(managedRoot, entryFile);
-    const entryStat = await statIfExists(entryPath);
+    const existingEntry = await inspectExistingPathWithinRoot(managedRoot, entryFile);
+    const entryStat = existingEntry?.stat ?? null;
     if (!entryStat?.isFile()) {
       const legacyInstructions = await readLegacyInstructions(agent, current.config);
-      await fs.mkdir(path.dirname(entryPath), { recursive: true });
-      await fs.writeFile(entryPath, legacyInstructions.trim().length > 0 ? legacyInstructions : "", "utf8");
+      await writeUtf8FileWithinRoot(
+        managedRoot,
+        entryFile,
+        legacyInstructions.trim().length > 0 ? legacyInstructions : "",
+      );
     }
 
     return {
@@ -677,10 +863,14 @@ export function agentInstructionsService() {
       if (!rootPath) {
         throw unprocessable("External instructions bundles require an absolute rootPath");
       }
-      const resolvedRoot = resolveHomeAwarePath(rootPath);
-      if (!path.isAbsolute(resolvedRoot)) {
+      if (
+        !path.isAbsolute(rootPath)
+        && rootPath !== "~"
+        && !rootPath.startsWith("~/")
+      ) {
         throw unprocessable("External instructions bundles require an absolute rootPath");
       }
+      const resolvedRoot = resolveHomeAwarePath(rootPath);
       nextRootPath = resolvedRoot;
     }
 
@@ -732,9 +922,7 @@ export function agentInstructionsService() {
     }
 
     const prepared = await ensureWritableBundle(agent, options);
-    const absolutePath = resolvePathWithinRoot(prepared.state.rootPath!, relativePath);
-    await fs.mkdir(path.dirname(absolutePath), { recursive: true });
-    await fs.writeFile(absolutePath, content, "utf8");
+    await writeUtf8FileWithinRoot(prepared.state.rootPath!, relativePath, content);
     const nextAgent = { ...agent, agentRuntimeConfig: prepared.agentRuntimeConfig };
     const [bundle, file] = await Promise.all([
       getBundle(nextAgent),
@@ -759,8 +947,8 @@ export function agentInstructionsService() {
     if (normalizedPath === state.entryFile) {
       throw unprocessable("Cannot delete the bundle entry file");
     }
-    const absolutePath = resolvePathWithinRoot(state.rootPath, normalizedPath);
-    await fs.rm(absolutePath, { force: true });
+    const inspected = await inspectExistingPathWithinRoot(state.rootPath, normalizedPath);
+    if (inspected) await fs.rm(inspected.absolutePath, { force: true });
     const agentRuntimeConfig = buildPersistedBundleConfig(derived, state);
     const bundle = await getBundle({ ...agent, agentRuntimeConfig });
     return { bundle, agentRuntimeConfig };
@@ -777,9 +965,9 @@ export function agentInstructionsService() {
       if (stat?.isDirectory()) {
         const relativePaths = await listFilesRecursive(state.rootPath);
         const files = Object.fromEntries(await Promise.all(relativePaths.map(async (relativePath) => {
-          const absolutePath = resolvePathWithinRoot(state.rootPath!, relativePath);
-          const content = await fs.readFile(absolutePath, "utf8");
-          return [relativePath, content] as const;
+          const file = await readUtf8FileWithinRoot(state.rootPath!, relativePath);
+          if (!file) throw notFound("Instructions file not found");
+          return [relativePath, file.content] as const;
         })));
         if (Object.keys(files).length > 0) {
           return { files, entryFile: state.entryFile, warnings: state.warnings };
@@ -818,13 +1006,11 @@ export function agentInstructionsService() {
       content,
     ] as const);
     for (const [relativePath, content] of normalizedEntries) {
-      const absolutePath = resolvePathWithinRoot(rootPath, relativePath);
-      await fs.mkdir(path.dirname(absolutePath), { recursive: true });
-      await fs.writeFile(absolutePath, content, "utf8");
+      await writeUtf8FileWithinRoot(rootPath, relativePath, content);
     }
     await copyLegacyRootMemoryIntoManagedInstructions(agent);
     if (!normalizedEntries.some(([relativePath]) => relativePath === entryFile)) {
-      await fs.writeFile(resolvePathWithinRoot(rootPath, entryFile), "", "utf8");
+      await writeUtf8FileWithinRoot(rootPath, entryFile, "");
     }
 
     const agentRuntimeConfig = applyBundleConfig(asRecord(agent.agentRuntimeConfig), {

--- a/server/src/services/agent-run-context.ts
+++ b/server/src/services/agent-run-context.ts
@@ -21,6 +21,13 @@ import { listProjectResourceAttachments } from "./resource-catalog.js";
 import { secretService } from "./secrets.js";
 const REPO_ONLY_CWD_SENTINEL = "/__paperclip_repo_only__";
 const LEGACY_COPILOT_SYSTEM_KIND = "rudder_copilot";
+const HOST_CATALOG_APPROVED_AGENT_STATUSES = new Set([
+  "active",
+  "paused",
+  "idle",
+  "running",
+  "error",
+]);
 
 export type AgentRunScene = "issue" | "chat" | "automation" | "review" | "heartbeat";
 
@@ -489,6 +496,13 @@ export function agentRunContextService(db: Db) {
         input.agent.agentRuntimeType,
         resolvedConfig,
         desiredSkills,
+        {
+          // Host catalog discovery is allowed only for durable agent configs
+          // that have cleared pending approval. Organization local_path rows
+          // remain excluded from unattended runtime preparation.
+          allowHostCatalogs: HOST_CATALOG_APPROVED_AGENT_STATUSES.has(input.agent.status ?? ""),
+          allowHostLocalPaths: false,
+        },
       );
     const desiredRuntimeSkills = runtimeSkillEntries.map((entry) => entry.key);
     return {

--- a/server/src/services/agents.ts
+++ b/server/src/services/agents.ts
@@ -609,6 +609,9 @@ export function agentService(db: Db) {
       const existing = await getById(id);
       if (!existing) return null;
       if (existing.status === "terminated") throw conflict("Cannot pause terminated agent");
+      if (existing.status === "pending_approval") {
+        throw conflict("Pending approval agents cannot be paused");
+      }
 
       const updated = await db
         .update(agents)

--- a/server/src/services/approvals.ts
+++ b/server/src/services/approvals.ts
@@ -42,6 +42,17 @@ export function approvalService(db: Db) {
     return existing;
   }
 
+  async function assertHireAgentTargetScope(approval: ApprovalRecord) {
+    if (approval.type !== "hire_agent") return;
+    const payload = approval.payload as Record<string, unknown>;
+    const payloadAgentId = typeof payload.agentId === "string" ? payload.agentId : null;
+    if (!payloadAgentId) return;
+    const targetAgent = await agentsSvc.getById(payloadAgentId);
+    if (!targetAgent || targetAgent.orgId !== approval.orgId) {
+      throw unprocessable("Hire approval target agent must belong to the approval organization");
+    }
+  }
+
   async function resolveApproval(
     id: string,
     targetStatus: "approved" | "rejected",
@@ -115,6 +126,11 @@ export function approvalService(db: Db) {
       decisionNote?: string | null,
       payloadOverride?: Record<string, unknown>,
     ) => {
+      const existing = await getExistingApproval(id);
+      await assertHireAgentTargetScope({
+        ...existing,
+        ...(payloadOverride ? { payload: payloadOverride } : {}),
+      });
       const { approval: updated, applied } = await resolveApproval(
         id,
         "approved",
@@ -185,6 +201,7 @@ export function approvalService(db: Db) {
     },
 
     reject: async (id: string, decidedByUserId: string, decisionNote?: string | null) => {
+      await assertHireAgentTargetScope(await getExistingApproval(id));
       const { approval: updated, applied } = await resolveApproval(
         id,
         "rejected",

--- a/server/src/services/automations.ts
+++ b/server/src/services/automations.ts
@@ -64,6 +64,7 @@ import { heartbeatService } from "./heartbeat.js";
 import { queueIssueAssignmentWakeup, type IssueAssignmentWakeupDeps } from "./issue-assignment-wakeup.js";
 import { issueService } from "./issues.js";
 import { publishLiveEvent } from "./live-events.js";
+import { isPostgresError } from "./postgres-errors.js";
 import { secretService } from "./secrets.js";
 
 type Actor = { agentId?: string | null; userId?: string | null };
@@ -1390,13 +1391,11 @@ export function automationService(db: Db, deps: AutomationServiceDeps = {}) {
             originRunId: createdRun.id,
           });
         } catch (error) {
-          const isOpenExecutionConflict =
-            !!error &&
-            typeof error === "object" &&
-            "code" in error &&
-            (error as { code?: string }).code === "23505" &&
-            "constraint" in error &&
-            (error as { constraint?: string }).constraint === "issues_open_automation_execution_uq";
+          const isOpenExecutionConflict = isPostgresError(
+            error,
+            "23505",
+            "issues_open_automation_execution_uq",
+          );
           if (!isOpenExecutionConflict || input.automation.concurrencyPolicy === "always_enqueue") {
             throw error;
           }

--- a/server/src/services/chat-agent-runs.ts
+++ b/server/src/services/chat-agent-runs.ts
@@ -5,6 +5,7 @@ import type { ChatConversation, HeartbeatRun } from "@rudderhq/shared";
 import { and, desc, eq, inArray, sql } from "drizzle-orm";
 import type { AgentRuntimeInvocationMeta } from "../agent-runtimes/index.js";
 import { publishLiveEvent } from "./live-events.js";
+import { isPostgresError } from "./postgres-errors.js";
 import { buildHeartbeatAdapterInvokePayload } from "./runtime-kernel/heartbeat.core.js";
 
 const MAX_EVENT_TEXT_CHARS = 2_000;
@@ -45,12 +46,7 @@ function serializeRun(row: typeof heartbeatRuns.$inferSelect): HeartbeatRun {
 }
 
 function isActiveChatRunConflict(error: unknown) {
-  const candidate = error as { code?: unknown; constraint?: unknown; message?: unknown };
-  return candidate.code === "23505"
-    && (
-      candidate.constraint === ACTIVE_CHAT_RUN_UNIQUE_INDEX
-      || (typeof candidate.message === "string" && candidate.message.includes(ACTIVE_CHAT_RUN_UNIQUE_INDEX))
-    );
+  return isPostgresError(error, "23505", ACTIVE_CHAT_RUN_UNIQUE_INDEX);
 }
 
 export function chatAgentRunService(db: Db) {

--- a/server/src/services/chats.helpers.ts
+++ b/server/src/services/chats.helpers.ts
@@ -9,8 +9,15 @@ import {
   issues,
   projects
 } from "@rudderhq/db";
-import { formatMessengerPreview, type ChatStreamTranscriptEntry, type ChatTranscriptSummary } from "@rudderhq/shared";
+import {
+  formatMessengerPreview,
+  updateAgentSchema,
+  updateOrganizationSchema,
+  type ChatStreamTranscriptEntry,
+  type ChatTranscriptSummary,
+} from "@rudderhq/shared";
 import { inArray, sql } from "drizzle-orm";
+import { unprocessable } from "../errors.js";
 
 type ConversationRow = typeof chatConversations.$inferSelect;
 type ConversationUserStateRow = typeof chatConversationUserStates.$inferSelect;
@@ -212,6 +219,25 @@ export function operationProposalFromPayload(payload: Record<string, unknown> | 
     summary,
     patch,
   };
+}
+
+export function validateOperationProposalPatch(
+  targetType: string,
+  patch: Record<string, unknown>,
+): Record<string, unknown> {
+  if (targetType !== "organization" && targetType !== "agent") {
+    throw unprocessable("Invalid chat operation target type");
+  }
+  const schema = targetType === "agent"
+    ? updateAgentSchema.strict()
+    : updateOrganizationSchema.strict();
+  const parsed = schema.safeParse(patch);
+  if (!parsed.success) {
+    throw unprocessable(`Invalid chat ${targetType} operation patch`, {
+      issues: parsed.error.issues,
+    });
+  }
+  return parsed.data as Record<string, unknown>;
 }
 
 export function operationProposalDecisionStatusFromPayload(payload: Record<string, unknown> | null | undefined) {

--- a/server/src/services/chats.ts
+++ b/server/src/services/chats.ts
@@ -89,6 +89,7 @@ import {
   stripChatMetadataFromPayload,
   textContains,
   truncatePreview,
+  validateOperationProposalPatch,
   visibleIncomingMessageSql,
   withOperationProposalDecisionState,
   withPersistedTranscript,
@@ -2419,10 +2420,19 @@ export function chatService(db: Db) {
       const decidedAtIso = new Date().toISOString();
 
       if (input.action === "approve") {
+        const validatedPatch = validateOperationProposalPatch(proposal.targetType, proposal.patch);
+        if (
+          proposal.targetType === "agent"
+          && ["agentRuntimeType", "agentRuntimeConfig", "runtimeConfig"].some((key) =>
+            Object.prototype.hasOwnProperty.call(validatedPatch, key)
+          )
+        ) {
+          throw unprocessable("Agent runtime changes require a full approval");
+        }
         if (proposal.targetType === "organization") {
           const updated = await organizationsSvc.update(
             proposal.targetId,
-            proposal.patch as Partial<typeof organizations.$inferInsert> & { logoAssetId?: string | null },
+            validatedPatch as Partial<typeof organizations.$inferInsert> & { logoAssetId?: string | null },
           );
           if (!updated) throw notFound("Organization not found");
           const updatedMessage = await updateMessageStructuredPayload(
@@ -2464,7 +2474,7 @@ export function chatService(db: Db) {
               source: "chat_lightweight_change",
               sourceMessageId: messageId,
               decisionNote,
-              ...proposal.patch,
+              ...validatedPatch,
             },
           });
           return { message: updatedMessage, systemMessage };
@@ -2472,7 +2482,7 @@ export function chatService(db: Db) {
 
         const updated = await agentsSvc.update(
           proposal.targetId,
-          proposal.patch as Partial<typeof agents.$inferInsert>,
+          validatedPatch as Partial<typeof agents.$inferInsert>,
         );
         if (!updated || updated.orgId !== conversation.orgId) {
           throw notFound("Agent not found");
@@ -2515,7 +2525,7 @@ export function chatService(db: Db) {
             source: "chat_lightweight_change",
             sourceMessageId: messageId,
             decisionNote,
-            ...proposal.patch,
+            ...validatedPatch,
           },
         });
         return { message: updatedMessage, systemMessage };
@@ -2566,6 +2576,10 @@ export function chatService(db: Db) {
       const messageId = safeTrim(typeof payload.chatMessageId === "string" ? payload.chatMessageId : null);
       if (!conversationId) {
         throw unprocessable("Chat approval missing chatConversationId");
+      }
+      const approvalConversation = await getConversationOrThrow(conversationId);
+      if (approvalConversation.orgId !== approval.orgId) {
+        throw unprocessable("Chat approval conversation must belong to the approval organization");
       }
 
       if (approval.type === "chat_issue_creation") {
@@ -2655,6 +2669,7 @@ export function chatService(db: Db) {
       if (!proposal) {
         throw unprocessable("Chat operation approval payload was incomplete");
       }
+      const validatedPatch = validateOperationProposalPatch(proposal.targetType, proposal.patch);
 
       if (proposal.targetType === "organization" && proposal.targetId !== approval.orgId) {
         throw unprocessable("Organization approvals can only update the same organization");
@@ -2669,7 +2684,7 @@ export function chatService(db: Db) {
       if (proposal.targetType === "organization") {
         const updated = await organizationsSvc.update(
           proposal.targetId,
-          proposal.patch as Partial<typeof organizations.$inferInsert> & { logoAssetId?: string | null },
+          validatedPatch as Partial<typeof organizations.$inferInsert> & { logoAssetId?: string | null },
         );
         if (!updated) throw notFound("Organization not found");
         await addMessage(conversationId, {
@@ -2691,14 +2706,14 @@ export function chatService(db: Db) {
           action: "organization.updated",
           entityType: "organization",
           entityId: proposal.targetId,
-          details: proposal.patch,
+          details: validatedPatch,
         });
         return updated;
       }
 
       const updated = await agentsSvc.update(
         proposal.targetId,
-        proposal.patch as Partial<typeof agents.$inferInsert>,
+        validatedPatch as Partial<typeof agents.$inferInsert>,
       );
       if (!updated) throw notFound("Agent not found");
       await addMessage(conversationId, {
@@ -2720,7 +2735,7 @@ export function chatService(db: Db) {
         action: "agent.updated",
         entityType: "agent",
         entityId: proposal.targetId,
-        details: proposal.patch,
+        details: validatedPatch,
       });
       return updated;
   }

--- a/server/src/services/chats.ts
+++ b/server/src/services/chats.ts
@@ -27,6 +27,7 @@ import { issueApprovalService } from "./issue-approvals.js";
 import { issueService } from "./issues.js";
 import { normalizeLocalLibraryPathMarkdown } from "./library-path-markdown.js";
 import { organizationService } from "./orgs.js";
+import { isPostgresError } from "./postgres-errors.js";
 
 type ConversationRow = typeof chatConversations.$inferSelect;
 type ConversationUserStateRow = typeof chatConversationUserStates.$inferSelect;
@@ -628,12 +629,7 @@ export function chatService(db: Db) {
   }
 
   function isQueuePositionConflict(error: unknown): boolean {
-    return Boolean(
-      error
-      && typeof error === "object"
-      && "code" in error
-      && (error as { code?: unknown }).code === "23505",
-    );
+    return isPostgresError(error, "23505");
   }
 
   function normalizeQueuedPayload(payload: Record<string, unknown>): ChatQueuedMessagePayload {

--- a/server/src/services/execution-workspaces.ts
+++ b/server/src/services/execution-workspaces.ts
@@ -2,6 +2,7 @@ import type { Db } from "@rudderhq/db";
 import { executionWorkspaces } from "@rudderhq/db";
 import type { RunWorkspace } from "@rudderhq/shared";
 import { and, desc, eq, inArray } from "drizzle-orm";
+import { unprocessable } from "../errors.js";
 
 type ExecutionWorkspaceRow = typeof executionWorkspaces.$inferSelect;
 
@@ -85,7 +86,17 @@ export function runWorkspaceService(db: Db) {
       return row ? toRunWorkspace(row) : null;
     },
 
-    update: async (id: string, patch: Partial<typeof executionWorkspaces.$inferInsert>) => {
+    update: async (
+      id: string,
+      patch: Partial<typeof executionWorkspaces.$inferInsert>,
+      options?: { allowRuntimeMetadata?: boolean },
+    ) => {
+      if (
+        Object.prototype.hasOwnProperty.call(patch, "metadata")
+        && options?.allowRuntimeMetadata !== true
+      ) {
+        throw unprocessable("Run workspace runtime metadata is managed internally");
+      }
       const row = await db
         .update(executionWorkspaces)
         .set({ ...patch, updatedAt: new Date() })

--- a/server/src/services/export-jobs.ts
+++ b/server/src/services/export-jobs.ts
@@ -22,6 +22,7 @@ type ExportJobRecord = OrganizationExportJob & {
   controller: AbortController;
   result: OrganizationPortabilityExportResult | null;
   cleanupTimer: NodeJS.Timeout;
+  requiresInstanceAdmin: boolean;
 };
 
 function nowIso() {
@@ -69,7 +70,11 @@ export function organizationExportJobService() {
     job.updatedAt = nowIso();
   }
 
-  function create(orgId: string, build: ExportJobBuild): OrganizationExportJob {
+  function create(
+    orgId: string,
+    build: ExportJobBuild,
+    options?: { requiresInstanceAdmin?: boolean },
+  ): OrganizationExportJob {
     const controller = new AbortController();
     const createdAt = nowIso();
     const job: ExportJobRecord = {
@@ -91,6 +96,7 @@ export function organizationExportJobService() {
       controller,
       result: null,
       cleanupTimer: setTimeout(() => undefined, 0),
+      requiresInstanceAdmin: options?.requiresInstanceAdmin === true,
     };
     jobs.set(job.id, job);
     scheduleCleanup(job);
@@ -151,6 +157,10 @@ export function organizationExportJobService() {
     return jobs.get(jobId)?.result ?? null;
   }
 
+  function requiresInstanceAdmin(jobId: string): boolean {
+    return jobs.get(jobId)?.requiresInstanceAdmin === true;
+  }
+
   function cancel(jobId: string): OrganizationExportJob | null {
     const job = jobs.get(jobId);
     if (!job) return null;
@@ -173,6 +183,7 @@ export function organizationExportJobService() {
     create,
     get,
     getResult,
+    requiresInstanceAdmin,
     cancel,
   };
 }

--- a/server/src/services/integrations/feishu/inbound-dispatcher-db.ts
+++ b/server/src/services/integrations/feishu/inbound-dispatcher-db.ts
@@ -23,6 +23,7 @@ import { cancelActiveChatGeneration, getActiveChatGeneration } from "../../chat-
 import { chatTitleGenerationService } from "../../chat-title-generation.js";
 import { chatService } from "../../chats.js";
 import { issueService } from "../../issues.js";
+import { isPostgresError } from "../../postgres-errors.js";
 import { productIntelligenceService, type ProductIntelligenceExecuteInput } from "../../product-intelligence.js";
 import { executeAdapterWithModelFallbacks } from "../../runtime-kernel/model-fallback.js";
 import { secretService } from "../../secrets.js";
@@ -36,10 +37,6 @@ import type {
 const BINDING_TOKEN_TTL_MS = 15 * 60 * 1000;
 const DEFAULT_DAILY_SESSION_ROLLOVER_HOURS = 24;
 const DAILY_SESSION_STARTED_TEXT = "New daily session started.";
-
-function isUniqueViolation(error: unknown) {
-  return (error as { code?: unknown }).code === "23505";
-}
 
 function createBindingToken() {
   return `rudder_feishu_${randomBytes(24).toString("hex")}`;
@@ -533,7 +530,7 @@ export function createFeishuInboundDispatcherDbDeps(
         });
         return true;
       } catch (error) {
-        if (isUniqueViolation(error)) return false;
+        if (isPostgresError(error, "23505")) return false;
         throw error;
       }
     },
@@ -618,7 +615,7 @@ export function createFeishuInboundDispatcherDbDeps(
           .then((rows) => rows[0]);
         if (inserted) return { ...inserted, created: true, initialTitle };
       } catch (error) {
-        if (!isUniqueViolation(error)) throw error;
+        if (!isPostgresError(error, "23505")) throw error;
       }
 
       const raced = await db

--- a/server/src/services/integrations/feishu/user-bindings.ts
+++ b/server/src/services/integrations/feishu/user-bindings.ts
@@ -1,10 +1,7 @@
 import type { Db } from "@rudderhq/db";
 import { agentIntegrationUserBindings, organizationMemberships } from "@rudderhq/db";
 import { and, eq, isNull, or } from "drizzle-orm";
-
-function isUniqueViolation(error: unknown) {
-  return (error as { code?: unknown }).code === "23505";
-}
+import { isPostgresError } from "../../postgres-errors.js";
 
 export function feishuIntegrationUserBindingService(db: Db) {
   return {
@@ -62,7 +59,7 @@ export function feishuIntegrationUserBindingService(db: Db) {
           .returning()
           .then((rows) => rows[0] ?? null);
       } catch (error) {
-        if (!isUniqueViolation(error)) throw error;
+        if (!isPostgresError(error, "23505")) throw error;
         return db
           .select()
           .from(agentIntegrationUserBindings)

--- a/server/src/services/issues.helpers.ts
+++ b/server/src/services/issues.helpers.ts
@@ -22,6 +22,7 @@ import {
 } from "@rudderhq/shared";
 import { and, asc, eq, inArray, sql } from "drizzle-orm";
 import { conflict } from "../errors.js";
+import { isPostgresError } from "./postgres-errors.js";
 
 
 export const ALL_ISSUE_STATUSES = ["backlog", "todo", "in_progress", "in_review", "blocked", "done", "cancelled"];
@@ -29,14 +30,7 @@ export const MAX_ISSUE_COMMENT_PAGE_LIMIT = 500;
 export const BOARD_ORDER_STEP = 1000;
 
 export function isUniqueConstraintConflict(error: unknown, constraintName: string) {
-  return (
-    typeof error === "object" &&
-    error !== null &&
-    "code" in error &&
-    (error as { code?: unknown }).code === "23505" &&
-    "constraint" in error &&
-    (error as { constraint?: unknown }).constraint === constraintName
-  );
+  return isPostgresError(error, "23505", constraintName);
 }
 
 export function assertTransition(from: string, to: string) {

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -162,6 +162,32 @@ export function issueService(db: Db) {
     await assertIssueUserPrincipal(orgId, userId, "Reviewer");
   }
 
+  async function assertValidProject(orgId: string, projectId: string | null | undefined) {
+    if (!projectId) return;
+    const project = await db
+      .select({ id: projects.id, orgId: projects.orgId })
+      .from(projects)
+      .where(eq(projects.id, projectId))
+      .then((rows) => rows[0] ?? null);
+    if (!project) throw notFound("Project not found");
+    if (project.orgId !== orgId) {
+      throw unprocessable("Project must belong to same organization");
+    }
+  }
+
+  async function assertValidCreatorAgent(orgId: string, agentId: string | null | undefined) {
+    if (!agentId) return;
+    const creator = await db
+      .select({ id: agents.id, orgId: agents.orgId })
+      .from(agents)
+      .where(eq(agents.id, agentId))
+      .then((rows) => rows[0] ?? null);
+    if (!creator) throw notFound("Creator agent not found");
+    if (creator.orgId !== orgId) {
+      throw unprocessable("Creator agent must belong to same organization");
+    }
+  }
+
   async function assertValidProjectWorkspace(orgId: string, projectId: string | null | undefined, projectWorkspaceId: string) {
     // Compatibility guard for legacy issue.projectWorkspaceId references.
     // Project Workspace CRUD is no longer a normal product entry point, but old
@@ -805,6 +831,8 @@ export function issueService(db: Db) {
       if (data.goalId) {
         await assertValidGoal(orgId, data.goalId);
       }
+      await assertValidProject(orgId, issueData.projectId);
+      await assertValidCreatorAgent(orgId, issueData.createdByAgentId);
       const parentIssue = await assertValidParentIssue(orgId, null, issueData.parentId);
       if (issueData.parentId && issueData.projectId === undefined && parentIssue?.projectId) {
         issueData.projectId = parentIssue.projectId;
@@ -959,6 +987,12 @@ export function issueService(db: Db) {
       }
       if (issueData.goalId) {
         await assertValidGoal(existing.orgId, issueData.goalId);
+      }
+      if (issueData.projectId) {
+        await assertValidProject(existing.orgId, issueData.projectId);
+      }
+      if (issueData.createdByAgentId) {
+        await assertValidCreatorAgent(existing.orgId, issueData.createdByAgentId);
       }
       const projectChanged = issueData.projectId !== undefined && issueData.projectId !== existing.projectId;
       if (projectChanged) {

--- a/server/src/services/knowledge-portability/organization-portability.core.ts
+++ b/server/src/services/knowledge-portability/organization-portability.core.ts
@@ -27,6 +27,7 @@ import { execFile } from "node:child_process";
 import { createHash } from "node:crypto";
 import path from "node:path";
 import { promisify } from "node:util";
+import { unprocessable } from "../../errors.js";
 import { type OrgNode } from "../../routes/org-chart-svg.js";
 import { automationService } from "../automations.js";
 import { validateCron } from "../cron.js";
@@ -102,6 +103,46 @@ export let bundledSkillsCommitPromise: Promise<string | null> | null = null;
 
 export function resolveImportMode(options?: ImportBehaviorOptions): ImportMode {
   return options?.mode ?? "board_full";
+}
+
+export function assertAgentSafeImportPolicy(
+  manifest: OrganizationPortabilityManifest,
+  include: OrganizationPortabilityInclude,
+) {
+  if (include.agents) {
+    throw unprocessable("Safe import routes do not allow importing agents.");
+  }
+
+  if (include.projects) {
+    const projectWithPolicy = manifest.projects.find(
+      (project) => project.executionWorkspacePolicy != null,
+    );
+    if (projectWithPolicy) {
+      throw unprocessable(
+        `Safe import routes do not allow project executionWorkspacePolicy (${projectWithPolicy.slug}).`,
+      );
+    }
+
+    const workspaceWithCommands = manifest.projects
+      .flatMap((project) => project.workspaces.map((workspace) => ({ project, workspace })))
+      .find(({ workspace }) => Boolean(asString(workspace.setupCommand) || asString(workspace.cleanupCommand)));
+    if (workspaceWithCommands) {
+      throw unprocessable(
+        `Safe import routes do not allow workspace setup/cleanup commands (${workspaceWithCommands.project.slug}/${workspaceWithCommands.workspace.key}).`,
+      );
+    }
+  }
+
+  if (include.issues) {
+    const issueWithRuntimeOverrides = manifest.issues.find(
+      (issue) => issue.assigneeAgentRuntimeOverrides != null || issue.executionWorkspaceSettings != null,
+    );
+    if (issueWithRuntimeOverrides) {
+      throw unprocessable(
+        `Safe import routes do not allow issue runtime overrides (${issueWithRuntimeOverrides.slug}).`,
+      );
+    }
+  }
 }
 
 export function resolveSkillConflictStrategy(mode: ImportMode, collisionStrategy: OrganizationPortabilityCollisionStrategy) {

--- a/server/src/services/knowledge-portability/organization-portability.preview.ts
+++ b/server/src/services/knowledge-portability/organization-portability.preview.ts
@@ -16,6 +16,7 @@ import { organizationService } from "../orgs.js";
 import { projectService } from "../projects.js";
 
 import {
+  assertAgentSafeImportPolicy,
   DEFAULT_COLLISION_STRATEGY,
   normalizeSkillSlug,
   resolveImportMode,
@@ -62,6 +63,9 @@ export function createOrganizationPortabilityPreviewHandlers(context: PreviewCon
     const collisionStrategy = input.collisionStrategy ?? DEFAULT_COLLISION_STRATEGY;
     if (mode === "agent_safe" && collisionStrategy === "replace") {
       throw unprocessable("Safe import routes do not allow replace collision strategy.");
+    }
+    if (mode === "agent_safe") {
+      assertAgentSafeImportPolicy(manifest, include);
     }
     const warnings = [...source.warnings];
     const errors: string[] = [];

--- a/server/src/services/knowledge-portability/organization-skills.catalog.ts
+++ b/server/src/services/knowledge-portability/organization-skills.catalog.ts
@@ -94,9 +94,31 @@ export type ProjectSkillScanTarget = {
   workspaceCwd: string;
 };
 
-export type RuntimeSkillEntryOptions = {
+export type SkillCatalogAccessOptions = {
+  /** Caller has already enforced instance-admin authority for organization host-local paths. */
+  allowHostLocalPaths?: boolean;
+  /** Caller has already established a trusted persisted host-runtime configuration. */
+  allowHostCatalogs?: boolean;
+};
+
+export type RuntimeSkillEntryOptions = SkillCatalogAccessOptions & {
   materializeMissing?: boolean;
 };
+
+export function filterRuntimeSafeOrganizationSkills<T extends Pick<OrganizationSkill, "sourceType">>(
+  skills: T[],
+  options: SkillCatalogAccessOptions = {},
+) {
+  if (options.allowHostLocalPaths === true) return skills;
+  return skills.filter((skill) => skill.sourceType !== "local_path");
+}
+
+export async function readHostSkillCatalogsWhenAllowed<T>(
+  options: SkillCatalogAccessOptions,
+  reader: () => Promise<T[]>,
+) {
+  return options.allowHostCatalogs === true ? reader() : [];
+}
 
 export type AgentWorkspaceRow = {
   id: string;

--- a/server/src/services/knowledge-portability/organization-skills.sources.ts
+++ b/server/src/services/knowledge-portability/organization-skills.sources.ts
@@ -6,6 +6,10 @@ import { promises as fs } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { unprocessable } from "../../errors.js";
+import {
+  fetchPublicHttpText,
+  type PublicHttpTextOptions,
+} from "../website-metadata.js";
 import type {
   ImportedSkill,
   LocalSkillInventoryMode,
@@ -196,24 +200,49 @@ export function parseFrontmatterMarkdown(raw: string): { frontmatter: Record<str
   };
 }
 
-export async function fetchText(url: string) {
-  const response = await fetch(url);
-  if (!response.ok) {
-    throw unprocessable(`Failed to fetch ${url}: ${response.status}`);
+export async function fetchText(url: string, options: PublicHttpTextOptions = {}) {
+  let response: Awaited<ReturnType<typeof fetchPublicHttpText>>;
+  try {
+    response = await fetchPublicHttpText(url, {
+      maxBytes: 1024 * 1024,
+      timeoutMs: 10_000,
+      ...options,
+    });
+  } catch (error) {
+    throw unprocessable(
+      error instanceof Error ? error.message : "Failed to fetch public skill source",
+    );
   }
-  return response.text();
+  if (!response.ok) {
+    throw unprocessable(`Failed to fetch public skill source: ${response.status}`);
+  }
+  return response.text;
 }
 
-export async function fetchJson<T>(url: string): Promise<T> {
-  const response = await fetch(url, {
-    headers: {
-      accept: "application/vnd.github+json",
-    },
-  });
-  if (!response.ok) {
-    throw unprocessable(`Failed to fetch ${url}: ${response.status}`);
+export async function fetchJson<T>(url: string, options: PublicHttpTextOptions = {}): Promise<T> {
+  let response: Awaited<ReturnType<typeof fetchPublicHttpText>>;
+  try {
+    response = await fetchPublicHttpText(url, {
+      maxBytes: 8 * 1024 * 1024,
+      timeoutMs: 10_000,
+      headers: {
+        accept: "application/vnd.github+json",
+      },
+      ...options,
+    });
+  } catch (error) {
+    throw unprocessable(
+      error instanceof Error ? error.message : "Failed to fetch public skill source",
+    );
   }
-  return response.json() as Promise<T>;
+  if (!response.ok) {
+    throw unprocessable(`Failed to fetch public skill source: ${response.status}`);
+  }
+  try {
+    return JSON.parse(response.text) as T;
+  } catch {
+    throw unprocessable("Public skill source returned invalid JSON");
+  }
 }
 
 export async function resolveGitHubDefaultBranch(owner: string, repo: string) {

--- a/server/src/services/knowledge-portability/organization-skills.ts
+++ b/server/src/services/knowledge-portability/organization-skills.ts
@@ -45,6 +45,7 @@ import {
   ImportedSkill,
   PackageSkillConflictStrategy,
   RuntimeSkillEntryOptions,
+  SkillCatalogAccessOptions,
   applyDesiredSelectionsToCatalog,
   arraysEqual,
   asString,
@@ -59,6 +60,7 @@ import {
   deriveCanonicalSkillKey,
   deriveSkillSourceInfo,
   enrichSkill,
+  filterRuntimeSafeOrganizationSkills,
   findMissingLocalSkillIds,
   getRequiredBundledSkillKeys,
   getSkillMeta,
@@ -80,6 +82,7 @@ import {
   parseSelectionKey,
   readAdapterSkillCatalogEntries,
   readDiscoveredSkillEntries,
+  readHostSkillCatalogsWhenAllowed,
   resolveConfiguredHomeDir,
   resolveLocalSkillFilePath,
   resolveManagedSkillsRoot,
@@ -351,16 +354,6 @@ export function organizationSkillService(db: Db) {
       const skill = toCompanySkill(row);
       let description = normalizeSkillDescription(parseFrontmatterMarkdown(skill.markdown).frontmatter.description);
 
-      if (!description) {
-        const skillDir = normalizeSkillDirectory(skill);
-        if (skillDir) {
-          const markdown = await fs.readFile(path.join(skillDir, "SKILL.md"), "utf8").catch(() => null);
-          if (markdown) {
-            description = normalizeSkillDescription(parseFrontmatterMarkdown(markdown).frontmatter.description);
-          }
-        }
-      }
-
       if (!description) continue;
 
       await db
@@ -381,7 +374,6 @@ export function organizationSkillService(db: Db) {
       await ensureBundledSkills(orgId);
       await ensureCommunityPresetSkills(orgId);
       await pruneLegacyUserHomeLocalScanSkills(orgId);
-      await pruneMissingLocalPathSkills(orgId);
       await backfillMissingSkillDescriptions(orgId);
     })();
 
@@ -528,10 +520,11 @@ export function organizationSkillService(db: Db) {
     agentRuntimeType: string,
     runtimeConfig: Record<string, unknown>,
     skills: OrganizationSkill[],
+    options: SkillCatalogAccessOptions = {},
   ): Promise<AgentSkillCatalogEntry[]> {
     const entries: AgentSkillCatalogEntry[] = [];
 
-    for (const skill of skills) {
+    for (const skill of filterRuntimeSafeOrganizationSkills(skills, options)) {
       const bundled = isBundledRudderSkillKey(skill.key);
       entries.push({
         key: skill.slug,
@@ -559,33 +552,38 @@ export function organizationSkillService(db: Db) {
       });
     }
 
-    if (agentId) {
-      const agentWorkspace = await getAgentWorkspaceRow(orgId, agentId);
-      entries.push(...await readDiscoveredSkillEntries(
+    // Agent workspace, global HOME, and adapter catalogs all require host
+    // directory enumeration and SKILL.md reads. They are opt-in only.
+    entries.push(...await readHostSkillCatalogsWhenAllowed(options, async () => {
+      const hostEntries: AgentSkillCatalogEntry[] = [];
+      if (agentId) {
+        const agentWorkspace = await getAgentWorkspaceRow(orgId, agentId);
+        hostEntries.push(...await readDiscoveredSkillEntries(
+          orgId,
+          resolveAgentSkillsDir(orgId, agentWorkspace),
+          (slug) => buildAgentSelectionKey(slug),
+          {
+            sourceClass: "agent_home",
+            originLabel: "Agent skill",
+            locationLabel: "AGENT_HOME/skills",
+          },
+        ));
+      }
+
+      const globalRoot = path.join(resolveConfiguredHomeDir(runtimeConfig), ".agents", "skills");
+      hostEntries.push(...await readDiscoveredSkillEntries(
         orgId,
-        resolveAgentSkillsDir(orgId, agentWorkspace),
-        (slug) => buildAgentSelectionKey(slug),
+        globalRoot,
+        (slug) => buildGlobalSelectionKey(slug),
         {
-          sourceClass: "agent_home",
-          originLabel: "Agent skill",
-          locationLabel: "AGENT_HOME/skills",
+          sourceClass: "global",
+          originLabel: "Global skill",
+          locationLabel: "~/.agents/skills",
         },
       ));
-    }
-
-    const globalRoot = path.join(resolveConfiguredHomeDir(runtimeConfig), ".agents", "skills");
-    entries.push(...await readDiscoveredSkillEntries(
-      orgId,
-      globalRoot,
-      (slug) => buildGlobalSelectionKey(slug),
-      {
-        sourceClass: "global",
-        originLabel: "Global skill",
-        locationLabel: "~/.agents/skills",
-      },
-    ));
-
-    entries.push(...await readAdapterSkillCatalogEntries(orgId, runtimeConfig));
+      hostEntries.push(...await readAdapterSkillCatalogEntries(orgId, runtimeConfig));
+      return hostEntries;
+    }));
 
     return entries.sort((left, right) =>
       left.key.localeCompare(right.key) || left.selectionKey.localeCompare(right.selectionKey));
@@ -640,6 +638,7 @@ export function organizationSkillService(db: Db) {
   async function buildAgentSkillSnapshot(
     agent: EnabledSkillsAgentRef,
     runtimeConfig: Record<string, unknown>,
+    options: SkillCatalogAccessOptions = {},
   ): Promise<AgentSkillSnapshot> {
     if (!agent) {
       return {
@@ -652,7 +651,7 @@ export function organizationSkillService(db: Db) {
       };
     }
 
-    const skills = await listFull(agent.orgId);
+    const skills = filterRuntimeSafeOrganizationSkills(await listFull(agent.orgId), options);
     const desiredSkills = await getEnabledSkillSelectionRefsForAgent(agent.orgId, agent, skills);
     const entries = await buildAgentSkillCatalogEntries(
       agent.orgId,
@@ -660,6 +659,7 @@ export function organizationSkillService(db: Db) {
       agent.agentRuntimeType,
       runtimeConfig,
       skills,
+      options,
     );
     const applied = applyDesiredSelectionsToCatalog(entries, desiredSkills, agent.agentRuntimeType);
     return {
@@ -720,17 +720,19 @@ export function organizationSkillService(db: Db) {
     agent: EnabledSkillsAgentRef,
     runtimeConfig: Record<string, unknown>,
     requestedDesiredSkills: string[] | undefined,
+    options: SkillCatalogAccessOptions = {},
   ): Promise<AgentSkillSelectionResolution> {
     if (!agent) {
       return { desiredSkills: [], warnings: [] };
     }
-    const skills = await listFull(agent.orgId);
+    const skills = filterRuntimeSafeOrganizationSkills(await listFull(agent.orgId), options);
     const catalogEntries = await buildAgentSkillCatalogEntries(
       agent.orgId,
       agent.id,
       agent.agentRuntimeType,
       runtimeConfig,
       skills,
+      options,
     );
     const ambiguousRefs = new Set<string>();
     const unresolvedRefs = new Set<string>();
@@ -771,9 +773,19 @@ export function organizationSkillService(db: Db) {
     selectionRefs: string[],
     options: RuntimeSkillEntryOptions = {},
   ): Promise<RudderSkillEntry[]> {
-    const skills = await listFull(orgId);
+    // Runtime preparation is server-internal and carries no user authority.
+    // Existing hostile rows must be excluded unless an upstream caller
+    // explicitly proves host-global authorization.
+    const skills = filterRuntimeSafeOrganizationSkills(await listFull(orgId), options);
     const skillByKey = new Map(skills.map((skill) => [skill.key, skill]));
-    const catalogEntries = await buildAgentSkillCatalogEntries(orgId, agentId, agentRuntimeType, runtimeConfig, skills);
+    const catalogEntries = await buildAgentSkillCatalogEntries(
+      orgId,
+      agentId,
+      agentRuntimeType,
+      runtimeConfig,
+      skills,
+      options,
+    );
     const bySelectionKey = new Map(catalogEntries.map((entry) => [entry.selectionKey, entry]));
     const desiredSet = new Set(selectionRefs);
     const activeEntries = catalogEntries.filter((entry) => entry.alwaysEnabled || desiredSet.has(entry.selectionKey));
@@ -821,6 +833,15 @@ export function organizationSkillService(db: Db) {
       .where(eq(organizationSkills.id, id))
       .then((rows) => rows[0] ?? null);
     return row ? toCompanySkill(row) : null;
+  }
+
+  async function hasLocalPathSkills(orgId: string) {
+    return db
+      .select({ id: organizationSkills.id })
+      .from(organizationSkills)
+      .where(and(eq(organizationSkills.orgId, orgId), eq(organizationSkills.sourceType, "local_path")))
+      .limit(1)
+      .then((rows) => rows.length > 0);
   }
 
   async function getByKey(orgId: string, key: string) {
@@ -1189,7 +1210,7 @@ export function organizationSkillService(db: Db) {
     orgId: string,
     options: RuntimeSkillEntryOptions = {},
   ): Promise<RudderSkillEntry[]> {
-    const skills = await listFull(orgId);
+    const skills = filterRuntimeSafeOrganizationSkills(await listFull(orgId), options);
 
     const out: RudderSkillEntry[] = [];
     for (const skill of skills) {
@@ -1457,6 +1478,7 @@ export function organizationSkillService(db: Db) {
     list,
     listFull,
     getById,
+    hasLocalPathSkills,
     getByKey,
     resolveRequestedSkillKeys: async (orgId: string, requestedReferences: string[]) => {
       const skills = await listFull(orgId);

--- a/server/src/services/organization-workspace-browser.ts
+++ b/server/src/services/organization-workspace-browser.ts
@@ -13,6 +13,7 @@ import {
   buildLibraryEntryMentionMarkdown,
 } from "@rudderhq/shared";
 import { eq } from "drizzle-orm";
+import { constants as fsConstants } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { resolveStoredOrDerivedAgentWorkspaceKey } from "../agent-workspace-key.js";
@@ -96,6 +97,132 @@ function resolveWithinRoot(rootPath: string, requestedPath: string) {
     resolvedTarget,
     normalizedPath: toPortableRelativePath(relative === "" ? "" : relative),
   };
+}
+
+async function lstatWorkspaceEntry(targetPath: string) {
+  try {
+    return await fs.lstat(targetPath);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw err;
+  }
+}
+
+function workspaceSymlinkBoundaryError() {
+  return unprocessable(
+    "Requested path must stay inside the organization Library root and cannot traverse symbolic links",
+  );
+}
+
+async function inspectWorkspacePathWithinRoot(resolvedRoot: string, resolvedTarget: string) {
+  const relativePath = path.relative(path.resolve(resolvedRoot), path.resolve(resolvedTarget));
+  if (relativePath === ".." || relativePath.startsWith(`..${path.sep}`) || path.isAbsolute(relativePath)) {
+    throw unprocessable("Requested path must stay inside the organization Library root");
+  }
+
+  const rootStat = await lstatWorkspaceEntry(resolvedRoot);
+  if (!rootStat) return null;
+  if (!rootStat.isDirectory() || rootStat.isSymbolicLink()) throw workspaceSymlinkBoundaryError();
+
+  let currentPath = path.resolve(resolvedRoot);
+  let currentStat = rootStat;
+  for (const segment of relativePath.split(path.sep).filter(Boolean)) {
+    currentPath = path.join(currentPath, segment);
+    const nextStat = await lstatWorkspaceEntry(currentPath);
+    if (!nextStat) return null;
+    if (nextStat.isSymbolicLink()) throw workspaceSymlinkBoundaryError();
+    currentStat = nextStat;
+  }
+  return currentStat;
+}
+
+async function readWorkspaceBufferWithinRoot(resolvedRoot: string, resolvedTarget: string) {
+  const stat = await inspectWorkspacePathWithinRoot(resolvedRoot, resolvedTarget);
+  if (!stat?.isFile()) return null;
+
+  let handle: Awaited<ReturnType<typeof fs.open>>;
+  try {
+    handle = await fs.open(
+      resolvedTarget,
+      fsConstants.O_RDONLY | (fsConstants.O_NOFOLLOW ?? 0),
+    );
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ELOOP") throw workspaceSymlinkBoundaryError();
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw err;
+  }
+  try {
+    const openedStat = await handle.stat();
+    if (!openedStat.isFile()) return null;
+    return await handle.readFile();
+  } finally {
+    await handle.close();
+  }
+}
+
+async function writeWorkspaceTextWithinRoot(
+  resolvedRoot: string,
+  resolvedTarget: string,
+  content: string,
+  options?: { create?: boolean },
+) {
+  const parentPath = path.dirname(resolvedTarget);
+  const parentStat = await inspectWorkspacePathWithinRoot(resolvedRoot, parentPath);
+  if (!parentStat?.isDirectory()) {
+    throw notFound("Directory not found inside the organization Library");
+  }
+  if (!options?.create) {
+    const targetStat = await inspectWorkspacePathWithinRoot(resolvedRoot, resolvedTarget);
+    if (!targetStat?.isFile()) throw notFound("File not found inside the organization Library");
+  }
+
+  let handle: Awaited<ReturnType<typeof fs.open>>;
+  try {
+    handle = await fs.open(
+      resolvedTarget,
+      fsConstants.O_WRONLY
+        | (options?.create ? fsConstants.O_CREAT | fsConstants.O_EXCL : fsConstants.O_TRUNC)
+        | (fsConstants.O_NOFOLLOW ?? 0),
+      0o600,
+    );
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ELOOP") throw workspaceSymlinkBoundaryError();
+    throw err;
+  }
+  try {
+    await handle.writeFile(content, { encoding: "utf8" });
+  } finally {
+    await handle.close();
+  }
+}
+
+async function ensureWorkspaceDirectoryPathWithinRoot(
+  resolvedRoot: string,
+  targetDirectory: string,
+) {
+  const relativePath = path.relative(path.resolve(resolvedRoot), path.resolve(targetDirectory));
+  if (relativePath === ".." || relativePath.startsWith(`..${path.sep}`) || path.isAbsolute(relativePath)) {
+    throw unprocessable("Requested path must stay inside the organization Library root");
+  }
+  const rootStat = await inspectWorkspacePathWithinRoot(resolvedRoot, resolvedRoot);
+  if (!rootStat?.isDirectory()) {
+    throw notFound("The shared Library root is not available on this machine yet.");
+  }
+
+  let currentPath = path.resolve(resolvedRoot);
+  for (const segment of relativePath.split(path.sep).filter(Boolean)) {
+    currentPath = path.join(currentPath, segment);
+    let stat = await lstatWorkspaceEntry(currentPath);
+    if (!stat) {
+      try {
+        await fs.mkdir(currentPath);
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code !== "EEXIST") throw err;
+      }
+      stat = await lstatWorkspaceEntry(currentPath);
+    }
+    if (!stat?.isDirectory() || stat.isSymbolicLink()) throw workspaceSymlinkBoundaryError();
+  }
 }
 
 function isProtectedAgentWorkspaceContainerPath(normalizedPath: string) {
@@ -208,26 +335,11 @@ async function resolveAvailableCopyTarget(
   for (let attempt = 1; attempt <= 999; attempt += 1) {
     const name = copyNameForAttempt(originalName, attempt);
     const targetPath = path.resolve(destinationDirectory, name);
-    if (!(await statWorkspaceEntry(targetPath))) {
+    if (!(await lstatWorkspaceEntry(targetPath))) {
       return { targetPath, name };
     }
   }
   throw conflict("No available copy name was found for this entry");
-}
-
-async function statWorkspaceEntry(targetPath: string) {
-  return await fs.stat(targetPath).catch((error: NodeJS.ErrnoException) => {
-    if (error.code === "ENOENT") return null;
-    throw error;
-  });
-}
-
-async function pathExistsAsDirectory(targetPath: string) {
-  return await fs.stat(targetPath).then((entry) => entry.isDirectory()).catch(() => false);
-}
-
-async function pathExistsAsFile(targetPath: string) {
-  return await fs.stat(targetPath).then((entry) => entry.isFile()).catch(() => false);
 }
 
 function hasBinaryBytes(buffer: Buffer) {
@@ -373,7 +485,7 @@ export function organizationWorkspaceBrowserService(db: Db) {
     async listFiles(orgId: string, directoryPath = ""): Promise<OrganizationWorkspaceFileList> {
       const root = await resolveWorkspaceRoot(orgId);
       const { resolvedRoot, resolvedTarget, normalizedPath } = resolveWithinRoot(root.rootPath, directoryPath);
-      const rootExists = await pathExistsAsDirectory(resolvedRoot);
+      const rootExists = (await inspectWorkspacePathWithinRoot(resolvedRoot, resolvedRoot))?.isDirectory() === true;
       if (!rootExists) {
         return {
           source: root.source,
@@ -386,12 +498,12 @@ export function organizationWorkspaceBrowserService(db: Db) {
         };
       }
 
-      if (!(await pathExistsAsDirectory(resolvedTarget))) {
+      if (!(await inspectWorkspacePathWithinRoot(resolvedRoot, resolvedTarget))?.isDirectory()) {
         throw notFound("Directory not found inside the organization Library");
       }
 
       const rawEntries = (await fs.readdir(resolvedTarget, { withFileTypes: true }))
-        .filter((entry) => !shouldHideWorkspaceEntry(entry.name));
+        .filter((entry) => !shouldHideWorkspaceEntry(entry.name) && (entry.isDirectory() || entry.isFile()));
       const unsortedEntries: OrganizationWorkspaceFileEntry[] = rawEntries.map((entry) => {
         const entryPath = toPortableRelativePath(path.relative(resolvedRoot, path.join(resolvedTarget, entry.name)));
         return {
@@ -426,7 +538,7 @@ export function organizationWorkspaceBrowserService(db: Db) {
     }): Promise<OrganizationWorkspaceFileEntry[]> {
       const root = await resolveWorkspaceRoot(orgId);
       const { resolvedRoot } = resolveWithinRoot(root.rootPath, "");
-      const rootExists = await pathExistsAsDirectory(resolvedRoot);
+      const rootExists = (await inspectWorkspacePathWithinRoot(resolvedRoot, resolvedRoot))?.isDirectory() === true;
       if (!rootExists) return [];
 
       const entries: OrganizationWorkspaceFileEntry[] = [];
@@ -481,7 +593,7 @@ export function organizationWorkspaceBrowserService(db: Db) {
     async readFile(orgId: string, filePath: string): Promise<OrganizationWorkspaceFileDetail> {
       const root = await resolveWorkspaceRoot(orgId);
       const { resolvedRoot, resolvedTarget, normalizedPath } = resolveWithinRoot(root.rootPath, filePath);
-      const rootExists = await pathExistsAsDirectory(resolvedRoot);
+      const rootExists = (await inspectWorkspacePathWithinRoot(resolvedRoot, resolvedRoot))?.isDirectory() === true;
       if (!rootExists) {
         return {
           source: root.source,
@@ -500,11 +612,8 @@ export function organizationWorkspaceBrowserService(db: Db) {
         };
       }
 
-      if (!(await pathExistsAsFile(resolvedTarget))) {
-        throw notFound("File not found inside the organization Library");
-      }
-
-      const buffer = await fs.readFile(resolvedTarget);
+      const buffer = await readWorkspaceBufferWithinRoot(resolvedRoot, resolvedTarget);
+      if (!buffer) throw notFound("File not found inside the organization Library");
       const contentType = getWorkspaceFileContentType(normalizedPath || resolvedTarget, buffer) ?? "application/octet-stream";
       const previewKind = getWorkspaceFilePreviewKind(contentType, buffer);
       const libraryEntry = await libraryEntries.getOrCreateWorkspaceFileEntry(orgId, normalizedPath);
@@ -568,15 +677,12 @@ export function organizationWorkspaceBrowserService(db: Db) {
     }> {
       const root = await resolveWorkspaceRoot(orgId);
       const { resolvedRoot, resolvedTarget, normalizedPath } = resolveWithinRoot(root.rootPath, filePath);
-      const rootExists = await pathExistsAsDirectory(resolvedRoot);
+      const rootExists = (await inspectWorkspacePathWithinRoot(resolvedRoot, resolvedRoot))?.isDirectory() === true;
       if (!rootExists) {
         throw notFound("The shared Library root is not available on this machine yet.");
       }
-      if (!(await pathExistsAsFile(resolvedTarget))) {
-        throw notFound("File not found inside the organization Library");
-      }
-
-      const buffer = await fs.readFile(resolvedTarget);
+      const buffer = await readWorkspaceBufferWithinRoot(resolvedRoot, resolvedTarget);
+      if (!buffer) throw notFound("File not found inside the organization Library");
       return {
         normalizedPath,
         originalFilename: path.basename(resolvedTarget),
@@ -592,15 +698,11 @@ export function organizationWorkspaceBrowserService(db: Db) {
     ): Promise<OrganizationWorkspaceFileDetail> {
       const root = await resolveWorkspaceRoot(orgId);
       const { resolvedRoot, resolvedTarget, normalizedPath } = resolveWithinRoot(root.rootPath, filePath);
-      const rootExists = await pathExistsAsDirectory(resolvedRoot);
+      const rootExists = (await inspectWorkspacePathWithinRoot(resolvedRoot, resolvedRoot))?.isDirectory() === true;
       if (!rootExists) {
         throw notFound("The shared Library root is not available on this machine yet.");
       }
-      if (!(await pathExistsAsFile(resolvedTarget))) {
-        throw notFound("File not found inside the organization Library");
-      }
-
-      await fs.writeFile(resolvedTarget, content, "utf8");
+      await writeWorkspaceTextWithinRoot(resolvedRoot, resolvedTarget, content);
       const libraryEntry = await libraryEntries.getOrCreateWorkspaceFileEntry(orgId, normalizedPath);
 
       return {
@@ -627,7 +729,7 @@ export function organizationWorkspaceBrowserService(db: Db) {
     ): Promise<OrganizationWorkspaceFileDetail> {
       const root = await resolveWorkspaceRoot(orgId);
       const { resolvedRoot, resolvedTarget, normalizedPath } = resolveWithinRoot(root.rootPath, filePath);
-      const rootExists = await pathExistsAsDirectory(resolvedRoot);
+      const rootExists = (await inspectWorkspacePathWithinRoot(resolvedRoot, resolvedRoot))?.isDirectory() === true;
       if (!rootExists) {
         throw notFound("The shared Library root is not available on this machine yet.");
       }
@@ -635,12 +737,12 @@ export function organizationWorkspaceBrowserService(db: Db) {
         throw unprocessable("File path is required");
       }
       assertCanCreateWorkspaceEntry(normalizedPath);
-      if (await statWorkspaceEntry(resolvedTarget)) {
+      if (await inspectWorkspacePathWithinRoot(resolvedRoot, resolvedTarget)) {
         throw conflict("A file or folder already exists at that path");
       }
 
-      await fs.mkdir(path.dirname(resolvedTarget), { recursive: true });
-      await fs.writeFile(resolvedTarget, content, { encoding: "utf8", flag: "wx" });
+      await ensureWorkspaceDirectoryPathWithinRoot(resolvedRoot, path.dirname(resolvedTarget));
+      await writeWorkspaceTextWithinRoot(resolvedRoot, resolvedTarget, content, { create: true });
       const libraryEntry = await libraryEntries.getOrCreateWorkspaceFileEntry(orgId, normalizedPath);
 
       return {
@@ -666,7 +768,7 @@ export function organizationWorkspaceBrowserService(db: Db) {
     ): Promise<OrganizationWorkspaceEntryMutationResult> {
       const root = await resolveWorkspaceRoot(orgId);
       const { resolvedRoot, resolvedTarget, normalizedPath } = resolveWithinRoot(root.rootPath, directoryPath);
-      const rootExists = await pathExistsAsDirectory(resolvedRoot);
+      const rootExists = (await inspectWorkspacePathWithinRoot(resolvedRoot, resolvedRoot))?.isDirectory() === true;
       if (!rootExists) {
         throw notFound("The shared Library root is not available on this machine yet.");
       }
@@ -674,10 +776,14 @@ export function organizationWorkspaceBrowserService(db: Db) {
         throw unprocessable("Directory path is required");
       }
       assertCanCreateWorkspaceEntry(normalizedPath);
-      if (await statWorkspaceEntry(resolvedTarget)) {
+      if (await inspectWorkspacePathWithinRoot(resolvedRoot, resolvedTarget)) {
         throw conflict("A file or folder already exists at that path");
       }
 
+      const parentStat = await inspectWorkspacePathWithinRoot(resolvedRoot, path.dirname(resolvedTarget));
+      if (!parentStat?.isDirectory()) {
+        throw notFound("Directory not found inside the organization Library");
+      }
       await fs.mkdir(resolvedTarget, { recursive: false });
       return {
         path: normalizedPath,
@@ -692,13 +798,13 @@ export function organizationWorkspaceBrowserService(db: Db) {
     ): Promise<OrganizationWorkspaceEntryMutationResult> {
       const root = await resolveWorkspaceRoot(orgId);
       const { resolvedRoot, resolvedTarget, normalizedPath } = resolveWithinRoot(root.rootPath, entryPath);
-      const rootExists = await pathExistsAsDirectory(resolvedRoot);
+      const rootExists = (await inspectWorkspacePathWithinRoot(resolvedRoot, resolvedRoot))?.isDirectory() === true;
       if (!rootExists) {
         throw notFound("The shared Library root is not available on this machine yet.");
       }
       assertMutableWorkspaceEntry(normalizedPath);
 
-      const stat = await statWorkspaceEntry(resolvedTarget);
+      const stat = await inspectWorkspacePathWithinRoot(resolvedRoot, resolvedTarget);
       if (!stat) {
         throw notFound("Entry not found inside the organization Library");
       }
@@ -720,7 +826,7 @@ export function organizationWorkspaceBrowserService(db: Db) {
           isDirectory: stat.isDirectory(),
         };
       }
-      if (await statWorkspaceEntry(nextTarget)) {
+      if (await inspectWorkspacePathWithinRoot(resolvedRoot, nextTarget)) {
         throw conflict("An entry with that name already exists");
       }
 
@@ -747,7 +853,7 @@ export function organizationWorkspaceBrowserService(db: Db) {
         resolvedTarget: resolvedDestinationDirectory,
         normalizedPath: normalizedDestinationDirectory,
       } = resolveWithinRoot(root.rootPath, destinationDirectoryPath);
-      const rootExists = await pathExistsAsDirectory(resolvedRoot);
+      const rootExists = (await inspectWorkspacePathWithinRoot(resolvedRoot, resolvedRoot))?.isDirectory() === true;
       if (!rootExists) {
         throw notFound("The shared Library root is not available on this machine yet.");
       }
@@ -756,11 +862,11 @@ export function organizationWorkspaceBrowserService(db: Db) {
         throw unprocessable("Entries cannot be moved into the protected agent area");
       }
 
-      const stat = await statWorkspaceEntry(resolvedTarget);
+      const stat = await inspectWorkspacePathWithinRoot(resolvedRoot, resolvedTarget);
       if (!stat) {
         throw notFound("Entry not found inside the organization Library");
       }
-      if (!(await pathExistsAsDirectory(resolvedDestinationDirectory))) {
+      if (!(await inspectWorkspacePathWithinRoot(resolvedRoot, resolvedDestinationDirectory))?.isDirectory()) {
         throw notFound("Destination directory not found inside the organization Library");
       }
       if (stat.isDirectory()) {
@@ -784,7 +890,7 @@ export function organizationWorkspaceBrowserService(db: Db) {
           isDirectory: stat.isDirectory(),
         };
       }
-      if (await statWorkspaceEntry(nextTarget)) {
+      if (await inspectWorkspacePathWithinRoot(resolvedRoot, nextTarget)) {
         throw conflict("An entry with that name already exists in the destination directory");
       }
 
@@ -812,7 +918,7 @@ export function organizationWorkspaceBrowserService(db: Db) {
         resolvedTarget: resolvedDestinationDirectory,
         normalizedPath: normalizedDestinationDirectory,
       } = resolveWithinRoot(root.rootPath, destinationInput === "." ? "" : destinationInput);
-      const rootExists = await pathExistsAsDirectory(resolvedRoot);
+      const rootExists = (await inspectWorkspacePathWithinRoot(resolvedRoot, resolvedRoot))?.isDirectory() === true;
       if (!rootExists) {
         throw notFound("The shared Library root is not available on this machine yet.");
       }
@@ -821,11 +927,11 @@ export function organizationWorkspaceBrowserService(db: Db) {
         throw unprocessable("Entries cannot be copied into the protected agent area");
       }
 
-      const stat = await statWorkspaceEntry(resolvedTarget);
+      const stat = await inspectWorkspacePathWithinRoot(resolvedRoot, resolvedTarget);
       if (!stat) {
         throw notFound("Entry not found inside the organization Library");
       }
-      if (!(await pathExistsAsDirectory(resolvedDestinationDirectory))) {
+      if (!(await inspectWorkspacePathWithinRoot(resolvedRoot, resolvedDestinationDirectory))?.isDirectory()) {
         throw notFound("Destination directory not found inside the organization Library");
       }
       if (stat.isDirectory()) {
@@ -865,13 +971,13 @@ export function organizationWorkspaceBrowserService(db: Db) {
     async deleteEntry(orgId: string, entryPath: string): Promise<OrganizationWorkspaceEntryMutationResult> {
       const root = await resolveWorkspaceRoot(orgId);
       const { resolvedRoot, resolvedTarget, normalizedPath } = resolveWithinRoot(root.rootPath, entryPath);
-      const rootExists = await pathExistsAsDirectory(resolvedRoot);
+      const rootExists = (await inspectWorkspacePathWithinRoot(resolvedRoot, resolvedRoot))?.isDirectory() === true;
       if (!rootExists) {
         throw notFound("The shared Library root is not available on this machine yet.");
       }
       assertMutableWorkspaceEntry(normalizedPath);
 
-      const stat = await statWorkspaceEntry(resolvedTarget);
+      const stat = await inspectWorkspacePathWithinRoot(resolvedRoot, resolvedTarget);
       if (!stat) {
         throw notFound("Entry not found inside the organization Library");
       }
@@ -889,7 +995,7 @@ export function organizationWorkspaceBrowserService(db: Db) {
 
     async deleteLegacyHeartbeatInstructions(orgId: string): Promise<OrganizationLegacyHeartbeatInstructionDeleteResult> {
       const root = await resolveWorkspaceRoot(orgId);
-      const rootExists = await pathExistsAsDirectory(root.rootPath);
+      const rootExists = (await inspectWorkspacePathWithinRoot(root.rootPath, root.rootPath))?.isDirectory() === true;
       if (!rootExists) {
         throw notFound("The shared Library root is not available on this machine yet.");
       }
@@ -913,7 +1019,7 @@ export function organizationWorkspaceBrowserService(db: Db) {
         const normalizedPath = toPortableRelativePath(path.join("agents", workspaceKey, "instructions", "HEARTBEAT.md"));
         if (!isLegacyAgentHeartbeatInstructionPath(normalizedPath)) continue;
         const heartbeatPath = path.join(root.rootPath, normalizedPath);
-        if (!(await pathExistsAsFile(heartbeatPath))) continue;
+        if (!(await inspectWorkspacePathWithinRoot(root.rootPath, heartbeatPath))?.isFile()) continue;
 
         await fs.rm(heartbeatPath, { force: false });
         const libraryEntry = await libraryEntries.markWorkspaceFileEntryDeleted(orgId, normalizedPath);

--- a/server/src/services/orgs.ts
+++ b/server/src/services/orgs.ts
@@ -52,6 +52,7 @@ import { and, count, eq, gte, inArray, lt, sql } from "drizzle-orm";
 import { notFound, unprocessable } from "../errors.js";
 import { ensureOrganizationWorkspaceLayout, removeOrganizationStorage } from "../home-paths.js";
 import { logger } from "../middleware/logger.js";
+import { isPostgresError } from "./postgres-errors.js";
 
 export function organizationService(db: Db) {
   const ISSUE_PREFIX_FALLBACK = "CMP";
@@ -155,16 +156,7 @@ export function organizationService(db: Db) {
   }
 
   function isUniqueConstraintConflict(error: unknown, constraintName: string) {
-    const constraint = typeof error === "object" && error !== null && "constraint" in error
-      ? (error as { constraint?: string }).constraint
-      : typeof error === "object" && error !== null && "constraint_name" in error
-        ? (error as { constraint_name?: string }).constraint_name
-        : undefined;
-    return typeof error === "object"
-      && error !== null
-      && "code" in error
-      && (error as { code?: string }).code === "23505"
-      && constraint === constraintName;
+    return isPostgresError(error, "23505", constraintName);
   }
 
   async function createCompanyWithUniqueKeys(

--- a/server/src/services/plugin-host-services.ts
+++ b/server/src/services/plugin-host-services.ts
@@ -11,11 +11,6 @@ import type {
 } from "@rudderhq/plugin-sdk";
 import { and, desc, eq, like } from "drizzle-orm";
 import { randomUUID } from "node:crypto";
-import { lookup as dnsLookup } from "node:dns/promises";
-import type { RequestOptions as HttpRequestOptions, IncomingMessage } from "node:http";
-import { request as httpRequest } from "node:http";
-import { request as httpsRequest } from "node:https";
-import { isIP } from "node:net";
 import { logger } from "../middleware/logger.js";
 import { logActivity } from "./activity-log.js";
 import { activityService } from "./activity.js";
@@ -32,238 +27,207 @@ import { pluginRegistryService } from "./plugin-registry.js";
 import { createPluginSecretsHandler } from "./plugin-secrets-handler.js";
 import { pluginStateStore } from "./plugin-state-store.js";
 import { projectService } from "./projects.js";
+import {
+  fetchPublicHttpUrlOnce,
+  type WebsiteMetadataOptions,
+} from "./website-metadata.js";
 
 // ---------------------------------------------------------------------------
-// SSRF protection for plugin HTTP fetch
+// SSRF and resource controls for plugin HTTP fetch
 // ---------------------------------------------------------------------------
 
-/** Maximum time (ms) a plugin fetch request may take before being aborted. */
 const PLUGIN_FETCH_TIMEOUT_MS = 30_000;
+const PLUGIN_FETCH_MAX_REDIRECTS = 5;
+const DEFAULT_PLUGIN_FETCH_REQUEST_BYTES = 1024 * 1024;
+const HARD_MAX_PLUGIN_FETCH_REQUEST_BYTES = 8 * 1024 * 1024;
+const DEFAULT_PLUGIN_FETCH_RESPONSE_BYTES = 8 * 1024 * 1024;
+const HARD_MAX_PLUGIN_FETCH_RESPONSE_BYTES = 32 * 1024 * 1024;
 
-/** Maximum time (ms) to wait for a DNS lookup before aborting. */
-const DNS_LOOKUP_TIMEOUT_MS = 5_000;
+export type PluginHttpFetchOptions = {
+  timeoutMs?: number;
+  maxRedirects?: number;
+  maxRequestBytes?: number;
+  maxResponseBytes?: number;
+  publicHttpOptions?: WebsiteMetadataOptions;
+};
 
-/** Only these protocols are allowed for plugin HTTP requests. */
-const ALLOWED_PROTOCOLS = new Set(["http:", "https:"]);
-
-/**
- * Check if an IP address is in a private/reserved range (RFC 1918, loopback,
- * link-local, etc.) that plugins should never be able to reach.
- *
- * Handles IPv4-mapped IPv6 addresses (e.g. ::ffff:127.0.0.1) which Node's
- * dns.lookup may return depending on OS configuration.
- */
-function isPrivateIP(ip: string): boolean {
-  const lower = ip.toLowerCase();
-
-  // Unwrap IPv4-mapped IPv6 addresses (::ffff:x.x.x.x) and re-check as IPv4
-  const v4MappedMatch = lower.match(/^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/);
-  if (v4MappedMatch && v4MappedMatch[1]) return isPrivateIP(v4MappedMatch[1]);
-
-  // IPv4 patterns
-  if (ip.startsWith("10.")) return true;
-  if (ip.startsWith("172.")) {
-    const second = parseInt(ip.split(".")[1]!, 10);
-    if (second >= 16 && second <= 31) return true;
-  }
-  if (ip.startsWith("192.168.")) return true;
-  if (ip.startsWith("127.")) return true;                   // loopback
-  if (ip.startsWith("169.254.")) return true;               // link-local
-  if (ip === "0.0.0.0") return true;
-
-  // IPv6 patterns
-  if (lower === "::1") return true;                          // loopback
-  if (lower.startsWith("fc") || lower.startsWith("fd")) return true; // ULA
-  if (lower.startsWith("fe80")) return true;                 // link-local
-  if (lower === "::") return true;
-
-  return false;
+function boundedPluginFetchInteger(value: unknown, fallback: number, min: number, max: number) {
+  const parsed = typeof value === "number" ? value : Number.parseInt(String(value ?? ""), 10);
+  if (!Number.isFinite(parsed)) return fallback;
+  return Math.min(Math.max(Math.floor(parsed), min), max);
 }
 
-/**
- * Validate a URL for plugin fetch: protocol whitelist + private IP blocking.
- *
- * SSRF Prevention Strategy:
- * 1. Parse and validate the URL syntax
- * 2. Enforce protocol whitelist (http/https only)
- * 3. Resolve the hostname to IP(s) via DNS
- * 4. Validate that ALL resolved IPs are non-private
- * 5. Pin the first safe IP into the URL so fetch() does not re-resolve DNS
- *
- * This prevents DNS rebinding attacks where an attacker controls DNS to
- * resolve to a safe IP during validation, then to a private IP when fetch() runs.
- *
- * @returns Request-routing metadata used to connect directly to the resolved IP
- *          while preserving the original hostname for HTTP Host and TLS SNI.
- */
-interface ValidatedFetchTarget {
-  parsedUrl: URL;
-  resolvedAddress: string;
-  hostHeader: string;
-  tlsServername?: string;
-  useTls: boolean;
+function pluginRequestBody(body: RequestInit["body"]) {
+  if (body === undefined || body === null) return undefined;
+  return typeof body === "string" ? body : String(body);
 }
 
-async function validateAndResolveFetchUrl(urlString: string): Promise<ValidatedFetchTarget> {
-  let parsed: URL;
-  try {
-    parsed = new URL(urlString);
-  } catch {
-    throw new Error(`Invalid URL: ${urlString}`);
-  }
+function pluginFetchHeaders(response: Response) {
+  return Object.fromEntries(response.headers.entries());
+}
 
-  if (!ALLOWED_PROTOCOLS.has(parsed.protocol)) {
-    throw new Error(
-      `Disallowed protocol "${parsed.protocol}" — only http: and https: are permitted`,
-    );
-  }
+async function cancelPluginFetchResponse(response: Response, reason?: unknown) {
+  await response.body?.cancel(reason).catch(() => undefined);
+}
 
-  // Resolve the hostname to an IP and check for private ranges.
-  // We pin the resolved IP into the URL to eliminate the TOCTOU window
-  // between DNS resolution here and the second resolution fetch() would do.
-  const originalHostname = parsed.hostname.replace(/^\[|\]$/g, ""); // strip IPv6 brackets
-  const hostHeader = parsed.host; // includes port if non-default
-
-  // Race the DNS lookup against a timeout to prevent indefinite hangs
-  // when DNS is misconfigured or unresponsive.
-  const dnsPromise = dnsLookup(originalHostname, { all: true });
-  const timeoutPromise = new Promise<never>((_, reject) => {
-    setTimeout(
-      () => reject(new Error(`DNS lookup timed out after ${DNS_LOOKUP_TIMEOUT_MS}ms for ${originalHostname}`)),
-      DNS_LOOKUP_TIMEOUT_MS,
-    );
+async function racePluginFetchSignal<T>(operation: Promise<T>, signal: AbortSignal): Promise<T> {
+  if (signal.aborted) throw signal.reason ?? new Error("Plugin HTTP request aborted");
+  let rejectOnAbort: ((reason?: unknown) => void) | null = null;
+  const abortPromise = new Promise<never>((_resolve, reject) => {
+    rejectOnAbort = reject;
   });
-
+  const onAbort = () => rejectOnAbort?.(signal.reason ?? new Error("Plugin HTTP request aborted"));
+  signal.addEventListener("abort", onAbort, { once: true });
   try {
-    const results = await Promise.race([dnsPromise, timeoutPromise]);
-    if (results.length === 0) {
-      throw new Error(`DNS resolution returned no results for ${originalHostname}`);
-    }
-
-    // Filter to only non-private IPs instead of rejecting the entire request
-    // when some IPs are private. This handles multi-homed hosts that resolve
-    // to both private and public addresses.
-    const safeResults = results.filter((entry) => !isPrivateIP(entry.address));
-    if (safeResults.length === 0) {
-      throw new Error(
-        `All resolved IPs for ${originalHostname} are in private/reserved ranges`,
-      );
-    }
-
-    const resolved = safeResults[0]!;
-    return {
-      parsedUrl: parsed,
-      resolvedAddress: resolved.address,
-      hostHeader,
-      tlsServername: parsed.protocol === "https:" && isIP(originalHostname) === 0
-        ? originalHostname
-        : undefined,
-      useTls: parsed.protocol === "https:",
-    };
-  } catch (err) {
-    // Re-throw our own errors; wrap DNS failures
-    if (err instanceof Error && (
-      err.message.startsWith("All resolved IPs") ||
-      err.message.startsWith("DNS resolution returned") ||
-      err.message.startsWith("DNS lookup timed out")
-    )) throw err;
-    throw new Error(`DNS resolution failed for ${originalHostname}: ${(err as Error).message}`);
+    return await Promise.race([operation, abortPromise]);
+  } finally {
+    signal.removeEventListener("abort", onAbort);
   }
 }
 
-function buildPinnedRequestOptions(
-  target: ValidatedFetchTarget,
-  init?: RequestInit,
-): { options: HttpRequestOptions & { servername?: string }; body: string | undefined } {
-  const headers = new Headers(init?.headers);
-  const method = init?.method ?? "GET";
-  const body = init?.body === undefined || init?.body === null
-    ? undefined
-    : typeof init.body === "string"
-      ? init.body
-      : String(init.body);
-
-  headers.set("Host", target.hostHeader);
-  if (body !== undefined && !headers.has("content-length") && !headers.has("transfer-encoding")) {
-    headers.set("content-length", String(Buffer.byteLength(body)));
+async function readBoundedPluginFetchBody(response: Response, maxBytes: number) {
+  const declaredLength = Number(response.headers.get("content-length"));
+  if (Number.isFinite(declaredLength) && declaredLength > maxBytes) {
+    await cancelPluginFetchResponse(response, new Error("Plugin HTTP response exceeds size limit"));
+    throw new Error(`Plugin HTTP response body exceeded ${maxBytes} bytes`);
   }
+  if (!response.body) return "";
 
-  const pathname = `${target.parsedUrl.pathname}${target.parsedUrl.search}`;
-  const auth = target.parsedUrl.username || target.parsedUrl.password
-    ? `${decodeURIComponent(target.parsedUrl.username)}:${decodeURIComponent(target.parsedUrl.password)}`
-    : undefined;
-
-  return {
-    options: {
-      protocol: target.parsedUrl.protocol,
-      host: target.resolvedAddress,
-      port: target.parsedUrl.port
-        ? Number(target.parsedUrl.port)
-        : target.useTls
-          ? 443
-          : 80,
-      path: pathname,
-      method,
-      headers: Object.fromEntries(headers.entries()),
-      auth,
-      servername: target.tlsServername,
-    },
-    body,
-  };
-}
-
-async function executePinnedHttpRequest(
-  target: ValidatedFetchTarget,
-  init: RequestInit | undefined,
-  signal: AbortSignal,
-): Promise<{ status: number; statusText: string; headers: Record<string, string>; body: string }> {
-  const { options, body } = buildPinnedRequestOptions(target, init);
-
-  const response = await new Promise<IncomingMessage>((resolve, reject) => {
-    const requestFn = target.useTls ? httpsRequest : httpRequest;
-    const req = requestFn({ ...options, signal }, resolve);
-
-    req.on("error", reject);
-
-    if (body !== undefined) {
-      req.write(body);
-    }
-    req.end();
-  });
-
-  const MAX_RESPONSE_BODY_BYTES = 200 * 1024 * 1024; // 200 MB
+  const reader = response.body.getReader();
   const chunks: Buffer[] = [];
   let totalBytes = 0;
-  await new Promise<void>((resolve, reject) => {
-    response.on("data", (chunk: Buffer | string) => {
-      const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
-      totalBytes += buf.length;
-      if (totalBytes > MAX_RESPONSE_BODY_BYTES) {
+  try {
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      if (!value) continue;
+      totalBytes += value.byteLength;
+      if (totalBytes > maxBytes) {
         chunks.length = 0;
-        response.destroy(new Error(`Response body exceeded ${MAX_RESPONSE_BODY_BYTES} bytes`));
-        return;
+        await reader.cancel(new Error("Plugin HTTP response exceeds size limit"));
+        throw new Error(`Plugin HTTP response body exceeded ${maxBytes} bytes`);
       }
-      chunks.push(buf);
-    });
-    response.on("end", resolve);
-    response.on("error", reject);
-  });
-
-  const headers: Record<string, string> = {};
-  for (const [key, value] of Object.entries(response.headers)) {
-    if (Array.isArray(value)) {
-      headers[key] = value.join(", ");
-    } else if (value !== undefined) {
-      headers[key] = value;
+      chunks.push(Buffer.from(value));
     }
+    return Buffer.concat(chunks).toString("utf8");
+  } catch (error) {
+    chunks.length = 0;
+    throw error;
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+function stripCrossOriginSensitiveHeaders(headers: Headers) {
+  for (const name of ["authorization", "cookie", "proxy-authorization"]) {
+    headers.delete(name);
+  }
+}
+
+export async function fetchPluginHttp(
+  params: { url: string; init?: RequestInit },
+  options: PluginHttpFetchOptions = {},
+): Promise<{ status: number; statusText: string; headers: Record<string, string>; body: string }> {
+  const maxRequestBytes = boundedPluginFetchInteger(
+    options.maxRequestBytes ?? process.env.RUDDER_PLUGIN_HTTP_MAX_REQUEST_BYTES,
+    DEFAULT_PLUGIN_FETCH_REQUEST_BYTES,
+    1,
+    HARD_MAX_PLUGIN_FETCH_REQUEST_BYTES,
+  );
+  const maxResponseBytes = boundedPluginFetchInteger(
+    options.maxResponseBytes ?? process.env.RUDDER_PLUGIN_HTTP_MAX_RESPONSE_BYTES,
+    DEFAULT_PLUGIN_FETCH_RESPONSE_BYTES,
+    1,
+    HARD_MAX_PLUGIN_FETCH_RESPONSE_BYTES,
+  );
+  const maxRedirects = boundedPluginFetchInteger(
+    options.maxRedirects,
+    PLUGIN_FETCH_MAX_REDIRECTS,
+    0,
+    10,
+  );
+  const timeoutMs = boundedPluginFetchInteger(
+    options.timeoutMs,
+    PLUGIN_FETCH_TIMEOUT_MS,
+    1,
+    PLUGIN_FETCH_TIMEOUT_MS,
+  );
+  let requestBody = pluginRequestBody(params.init?.body);
+  if (requestBody !== undefined && Buffer.byteLength(requestBody) > maxRequestBytes) {
+    throw new Error(`Plugin HTTP request body exceeded ${maxRequestBytes} bytes`);
   }
 
-  return {
-    status: response.statusCode ?? 500,
-    statusText: response.statusMessage ?? "",
-    headers,
-    body: Buffer.concat(chunks).toString("utf8"),
-  };
+  const timeoutSignal = AbortSignal.timeout(timeoutMs);
+  const signal = params.init?.signal
+    ? AbortSignal.any([params.init.signal, timeoutSignal])
+    : timeoutSignal;
+  let currentUrl = new URL(params.url);
+  let method = params.init?.method ?? "GET";
+  let headers = new Headers(params.init?.headers);
+
+  for (let redirectCount = 0; redirectCount <= maxRedirects; redirectCount += 1) {
+    if (requestBody !== undefined && !headers.has("content-length") && !headers.has("transfer-encoding")) {
+      headers.set("content-length", String(Buffer.byteLength(requestBody)));
+    }
+    const fetched = await racePluginFetchSignal(
+      fetchPublicHttpUrlOnce(
+        currentUrl,
+        options.publicHttpOptions,
+        {
+          method,
+          headers,
+          body: requestBody,
+          signal,
+          redirect: "manual",
+        },
+      ),
+      signal,
+    );
+    const { response } = fetched;
+    if (response.status >= 300 && response.status < 400) {
+      const location = response.headers.get("location");
+      await cancelPluginFetchResponse(response);
+      if (!location) {
+        return {
+          status: response.status,
+          statusText: response.statusText,
+          headers: pluginFetchHeaders(response),
+          body: "",
+        };
+      }
+      if (redirectCount === maxRedirects) {
+        throw new Error("Plugin HTTP redirect limit exceeded");
+      }
+
+      const nextUrl = new URL(location, fetched.url);
+      if (nextUrl.origin !== fetched.url.origin) {
+        headers = new Headers(headers);
+        stripCrossOriginSensitiveHeaders(headers);
+      }
+      if (response.status === 303 || ((response.status === 301 || response.status === 302) && method === "POST")) {
+        method = "GET";
+        requestBody = undefined;
+        headers.delete("content-length");
+        headers.delete("content-type");
+        headers.delete("transfer-encoding");
+      }
+      currentUrl = nextUrl;
+      continue;
+    }
+
+    const body = await racePluginFetchSignal(
+      readBoundedPluginFetchBody(response, maxResponseBytes),
+      signal,
+    );
+    return {
+      status: response.status,
+      statusText: response.statusText,
+      headers: pluginFetchHeaders(response),
+      body,
+    };
+  }
+
+  throw new Error("Plugin HTTP redirect limit exceeded");
 }
 
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
@@ -571,19 +535,10 @@ export function buildHostServices(
 
     http: {
       async fetch(params) {
-        // SSRF protection: validate protocol whitelist + block private IPs.
-        // Resolve once, then connect directly to that IP to prevent DNS rebinding.
-        const target = await validateAndResolveFetchUrl(params.url);
-
-        const controller = new AbortController();
-        const timeout = setTimeout(() => controller.abort(), PLUGIN_FETCH_TIMEOUT_MS);
-
-        try {
-          const init = params.init as RequestInit | undefined;
-          return await executePinnedHttpRequest(target, init, controller.signal);
-        } finally {
-          clearTimeout(timeout);
-        }
+        return fetchPluginHttp({
+          url: params.url,
+          init: params.init as RequestInit | undefined,
+        });
       },
     },
 

--- a/server/src/services/plugin-registry.ts
+++ b/server/src/services/plugin-registry.ts
@@ -22,6 +22,7 @@ import type {
 } from "@rudderhq/shared";
 import { and, asc, eq, ne, sql } from "drizzle-orm";
 import { conflict, notFound } from "../errors.js";
+import { isPostgresError } from "./postgres-errors.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -32,10 +33,7 @@ import { conflict, notFound } from "../errors.js";
  * `plugins_plugin_key_idx` unique index.
  */
 function isPluginKeyConflict(error: unknown): boolean {
-  if (typeof error !== "object" || error === null) return false;
-  const err = error as { code?: string; constraint?: string; constraint_name?: string };
-  const constraint = err.constraint ?? err.constraint_name;
-  return err.code === "23505" && constraint === "plugins_plugin_key_idx";
+  return isPostgresError(error, "23505", "plugins_plugin_key_idx");
 }
 
 // ---------------------------------------------------------------------------

--- a/server/src/services/postgres-errors.ts
+++ b/server/src/services/postgres-errors.ts
@@ -1,0 +1,46 @@
+const MAX_ERROR_CAUSE_DEPTH = 8;
+
+type ErrorRecord = Record<string, unknown>;
+
+function isErrorRecord(value: unknown): value is ErrorRecord {
+  return typeof value === "object" && value !== null;
+}
+
+/**
+ * Matches PostgreSQL errors whether a driver exposes them directly or an ORM
+ * wraps them in one or more standard `cause` properties.
+ */
+export function isPostgresError(
+  error: unknown,
+  code: string,
+  constraintName?: string,
+) {
+  let current = error;
+  const seen = new Set<object>();
+
+  for (let depth = 0; depth < MAX_ERROR_CAUSE_DEPTH; depth += 1) {
+    if (!isErrorRecord(current) || seen.has(current)) return false;
+    seen.add(current);
+
+    const hasExplicitConstraint = "constraint" in current || "constraint_name" in current;
+    if (
+      current.code === code
+      && (
+        constraintName === undefined
+        || current.constraint === constraintName
+        || current.constraint_name === constraintName
+        || (
+          !hasExplicitConstraint
+          && typeof current.message === "string"
+          && current.message.includes(constraintName)
+        )
+      )
+    ) {
+      return true;
+    }
+
+    current = current.cause;
+  }
+
+  return false;
+}

--- a/server/src/services/resource-catalog.ts
+++ b/server/src/services/resource-catalog.ts
@@ -14,7 +14,7 @@ import type {
   UpdateProjectResourceAttachmentRequest,
 } from "@rudderhq/shared";
 import { and, asc, desc, eq, inArray, ne } from "drizzle-orm";
-import { badRequest, conflict } from "../errors.js";
+import { badRequest, conflict, unprocessable } from "../errors.js";
 
 function toOrganizationResource(row: typeof organizationResources.$inferSelect): OrganizationResource {
   return {
@@ -145,6 +145,26 @@ async function listOrganizationResourceMap(db: Db, orgId: string, resourceIds: s
   return new Map(rows.map((row) => [row.id, toOrganizationResource(row)]));
 }
 
+async function assertResourcesBelongToOrganization(
+  dbOrTx: Db | any,
+  orgId: string,
+  attachments: ProjectResourceAttachmentInput[],
+) {
+  const resourceIds = [...new Set(attachments.map((attachment) => attachment.resourceId))];
+  if (resourceIds.length === 0) return;
+
+  const resources = await dbOrTx
+    .select({ id: organizationResources.id })
+    .from(organizationResources)
+    .where(and(eq(organizationResources.orgId, orgId), inArray(organizationResources.id, resourceIds)))
+    .then((rows: Array<{ id: string }>) => rows);
+  if (resources.length !== resourceIds.length) {
+    // Keep missing and cross-organization resources indistinguishable so this
+    // endpoint cannot be used to probe resource UUIDs in another organization.
+    throw unprocessable("One or more project resources are invalid for this organization.");
+  }
+}
+
 export async function listProjectResourceAttachments(
   db: Db,
   orgId: string,
@@ -216,6 +236,11 @@ export async function replaceProjectResourceAttachments(
     newResources?: CreateProjectInlineResourceInput[];
   },
 ): Promise<ProjectResourceAttachment[]> {
+  // Validate before creating inline resources or deleting existing attachments.
+  // This makes replacement atomic even when this helper is used without an
+  // explicit surrounding transaction.
+  await assertResourcesBelongToOrganization(dbOrTx, input.orgId, input.attachments);
+
   const createdResourceIds: string[] = [];
 
   for (const inlineResource of input.newResources ?? []) {

--- a/server/src/services/runtime-kernel/heartbeat.execute.ts
+++ b/server/src/services/runtime-kernel/heartbeat.execute.ts
@@ -333,21 +333,25 @@ export function createHeartbeatExecuteHandlers(context: any) {
     let persistedExecutionWorkspace = null;
     try {
       persistedExecutionWorkspace = shouldReuseExisting && existingExecutionWorkspace
-        ? await executionWorkspacesSvc.update(existingExecutionWorkspace.id, {
-            cwd: executionWorkspace.cwd,
-            repoUrl: executionWorkspace.repoUrl,
-            baseRef: executionWorkspace.repoRef,
-            branchName: executionWorkspace.branchName,
-            providerType: executionWorkspace.strategy === "git_worktree" ? "git_worktree" : "local_fs",
-            providerRef: executionWorkspace.worktreePath,
-            status: "active",
-            lastUsedAt: new Date(),
-            metadata: {
-              ...(existingExecutionWorkspace.metadata ?? {}),
-              source: executionWorkspace.source,
-              createdByRuntime: executionWorkspace.created,
+        ? await executionWorkspacesSvc.update(
+            existingExecutionWorkspace.id,
+            {
+              cwd: executionWorkspace.cwd,
+              repoUrl: executionWorkspace.repoUrl,
+              baseRef: executionWorkspace.repoRef,
+              branchName: executionWorkspace.branchName,
+              providerType: executionWorkspace.strategy === "git_worktree" ? "git_worktree" : "local_fs",
+              providerRef: executionWorkspace.worktreePath,
+              status: "active",
+              lastUsedAt: new Date(),
+              metadata: {
+                ...(existingExecutionWorkspace.metadata ?? {}),
+                source: executionWorkspace.source,
+                createdByRuntime: executionWorkspace.created,
+              },
             },
-          })
+            { allowRuntimeMetadata: true },
+          )
         : resolvedProjectId
           ? await executionWorkspacesSvc.create({
               orgId: agent.orgId,
@@ -385,6 +389,7 @@ export function createHeartbeatExecuteHandlers(context: any) {
           await cleanupExecutionWorkspaceArtifacts({
             workspace: {
               id: existingExecutionWorkspace?.id ?? `transient-${run.id}`,
+              orgId: agent.orgId,
               cwd: executionWorkspace.cwd,
               providerType: executionWorkspace.strategy === "git_worktree" ? "git_worktree" : "local_fs",
               providerRef: executionWorkspace.worktreePath,

--- a/server/src/services/website-metadata.ts
+++ b/server/src/services/website-metadata.ts
@@ -3,9 +3,17 @@ import { JSDOM } from "jsdom";
 import { createHash } from "node:crypto";
 import { lookup } from "node:dns/promises";
 import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import { request as httpRequest, type IncomingMessage, type RequestOptions } from "node:http";
+import { request as httpsRequest, type RequestOptions as HttpsRequestOptions } from "node:https";
 import { isIP } from "node:net";
 import path from "node:path";
+import { Readable } from "node:stream";
 import { resolveRudderInstanceRoot } from "../home-paths.js";
+import {
+  isNonPublicIpAddress,
+  isPrivateHostname,
+  isPublicDnsHostname,
+} from "../network/public-address.js";
 
 export interface WebsiteMetadata {
   url: string;
@@ -16,6 +24,12 @@ export interface WebsiteMetadata {
 export interface WebsiteMetadataOptions {
   allowPrivateHosts?: boolean;
   fetchImpl?: (url: string, init?: RequestInit) => Promise<Response>;
+  /** Test-only transport hook that still exercises production DNS validation. */
+  pinnedFetchImpl?: (
+    url: URL,
+    init: RequestInit,
+    addresses: ReadonlyArray<{ address: string; family: 4 | 6 }>,
+  ) => Promise<Response>;
 }
 
 const MAX_HTML_BYTES = 256 * 1024;
@@ -31,72 +45,10 @@ const IMAGE_CONTENT_TYPES = new Set([
   "image/jpeg",
   "image/jpg",
   "image/png",
-  "image/svg+xml",
   "image/vnd.microsoft.icon",
   "image/webp",
   "image/x-icon",
 ]);
-
-function isBenchmarkNetworkIpAddress(value: string) {
-  const normalized = value.replace(/^\[|\]$/gu, "").toLowerCase();
-  const ipv4Mapped = normalized.match(/^::ffff:(\d{1,3}(?:\.\d{1,3}){3})$/u);
-  if (ipv4Mapped) return isBenchmarkNetworkIpAddress(ipv4Mapped[1]);
-
-  const parts = normalized.split(".");
-  if (parts.length !== 4) return false;
-  const octets = parts.map((part) => Number(part));
-  if (octets.some((octet) => !Number.isInteger(octet) || octet < 0 || octet > 255)) return false;
-  const [a, b] = octets;
-  return a === 198 && (b === 18 || b === 19);
-}
-
-function isPrivateIpAddress(value: string) {
-  const normalized = value.replace(/^\[|\]$/gu, "").toLowerCase();
-  const ipv4Mapped = normalized.match(/^::ffff:(\d{1,3}(?:\.\d{1,3}){3})$/u);
-  if (ipv4Mapped) return isPrivateIpAddress(ipv4Mapped[1]);
-  if (normalized === "::1" || normalized.startsWith("fe80:") || normalized.startsWith("fc") || normalized.startsWith("fd")) return true;
-
-  const parts = normalized.split(".");
-  if (parts.length !== 4) return false;
-  const octets = parts.map((part) => Number(part));
-  if (octets.some((octet) => !Number.isInteger(octet) || octet < 0 || octet > 255)) return false;
-  const [a, b] = octets;
-  if (a === 10 || a === 127 || a === 0) return true;
-  if (a === 100 && b >= 64 && b <= 127) return true;
-  if (a === 169 && b === 254) return true;
-  if (a === 172 && b >= 16 && b <= 31) return true;
-  if (a === 192 && b === 0) return true;
-  if (a === 192 && b === 168) return true;
-  if (isBenchmarkNetworkIpAddress(normalized)) return true;
-  return false;
-}
-
-function isBlockedResolvedIpAddress(value: string) {
-  return isPrivateIpAddress(value) && !isBenchmarkNetworkIpAddress(value);
-}
-
-function isPrivateHostname(hostname: string) {
-  const normalized = hostname.replace(/^\[|\]$/gu, "").toLowerCase();
-  if (normalized === "localhost" || normalized.endsWith(".localhost")) return true;
-  if (isIP(normalized)) return isPrivateIpAddress(normalized);
-  return false;
-}
-
-function isPublicDnsHostname(hostname: string) {
-  const normalized = hostname.replace(/^\[|\]$/gu, "").toLowerCase();
-  if (normalized === "localhost" || normalized.endsWith(".localhost")) return false;
-  if (
-    normalized.endsWith(".local") ||
-    normalized.endsWith(".lan") ||
-    normalized.endsWith(".home") ||
-    normalized.endsWith(".internal") ||
-    normalized.endsWith(".corp") ||
-    normalized.endsWith(".intranet")
-  ) return false;
-  if (!normalized.includes(".")) return false;
-  if (isIP(normalized)) return false;
-  return true;
-}
 
 export function parsePublicHttpUrl(value: string, options: WebsiteMetadataOptions = {}) {
   const parsed = new URL(value);
@@ -114,48 +66,167 @@ function resolveWebsiteIconCacheDir() {
   return path.resolve(resolveRudderInstanceRoot(), "data", "website-icons");
 }
 
-async function assertPublicResolvedHost(url: URL, options: WebsiteMetadataOptions) {
-  if (options.allowPrivateHosts || options.fetchImpl || isIP(url.hostname.replace(/^\[|\]$/gu, ""))) return;
-  const addresses = await lookup(url.hostname, { all: true, verbatim: true });
-  const allowBenchmarkNetworkResolution = isPublicDnsHostname(url.hostname);
-  if (addresses.some((address) => isPrivateIpAddress(address.address) && (!allowBenchmarkNetworkResolution || !isBenchmarkNetworkIpAddress(address.address)))) {
+export type PublicHttpResolvedAddress = { address: string; family: 4 | 6 };
+
+async function resolvePublicConnectionAddresses(
+  url: URL,
+  options: WebsiteMetadataOptions,
+): Promise<PublicHttpResolvedAddress[] | null> {
+  if (options.allowPrivateHosts || options.fetchImpl) return null;
+
+  const hostname = url.hostname.replace(/^\[|\]$/gu, "");
+  const literalFamily = isIP(hostname);
+  const addresses = literalFamily
+    ? [{ address: hostname, family: literalFamily as 4 | 6 }]
+    : await lookup(hostname, { all: true, verbatim: true });
+  if (
+    addresses.length === 0
+    || addresses.some((address) => isNonPublicIpAddress(address.address))
+  ) {
     throw new Error("Private network URLs cannot be inspected");
   }
+  return addresses.map((address) => ({
+    address: address.address,
+    family: address.family as 4 | 6,
+  }));
 }
 
-interface FetchResult {
+function pinnedRequestBody(init: RequestInit) {
+  if (init.body === undefined || init.body === null) return undefined;
+  return typeof init.body === "string" ? init.body : String(init.body);
+}
+
+function requestHeaders(init: RequestInit, url: URL, body: string | undefined) {
+  const headers = new Headers(init.headers);
+  headers.set("host", url.host);
+  headers.set("accept-encoding", "identity");
+  headers.set("connection", "close");
+  if (body !== undefined && !headers.has("content-length") && !headers.has("transfer-encoding")) {
+    headers.set("content-length", String(Buffer.byteLength(body)));
+  }
+  return Object.fromEntries(headers.entries());
+}
+
+function requestPinnedAddress(
+  url: URL,
+  init: RequestInit,
+  address: PublicHttpResolvedAddress,
+): Promise<Response> {
+  return new Promise<Response>((resolve, reject) => {
+    const body = pinnedRequestBody(init);
+    const commonOptions: RequestOptions = {
+      hostname: address.address,
+      family: address.family,
+      port: url.port || undefined,
+      path: `${url.pathname}${url.search}`,
+      method: init.method ?? "GET",
+      headers: requestHeaders(init, url, body),
+      signal: init.signal ?? undefined,
+      agent: false,
+    };
+    const handleResponse = (incoming: IncomingMessage) => {
+      const headers = new Headers();
+      for (let index = 0; index < incoming.rawHeaders.length; index += 2) {
+        headers.append(incoming.rawHeaders[index]!, incoming.rawHeaders[index + 1]!);
+      }
+      const status = incoming.statusCode ?? 500;
+      const responseHasBody = init.method !== "HEAD" && ![101, 204, 205, 304].includes(status);
+      const body = responseHasBody
+        ? Readable.toWeb(incoming) as unknown as ReadableStream<Uint8Array>
+        : null;
+      resolve(new Response(body, {
+        status,
+        statusText: incoming.statusMessage,
+        headers,
+      }));
+    };
+    const request = url.protocol === "https:"
+      ? httpsRequest({
+          ...commonOptions,
+          servername: isIP(url.hostname.replace(/^\[|\]$/gu, "")) ? undefined : url.hostname,
+        } satisfies HttpsRequestOptions, handleResponse)
+      : httpRequest(commonOptions, handleResponse);
+    request.once("error", reject);
+    request.end(body);
+  });
+}
+
+async function fetchPinnedPublicUrl(
+  url: URL,
+  init: RequestInit,
+  addresses: PublicHttpResolvedAddress[],
+): Promise<Response> {
+  let lastError: unknown = null;
+  for (const address of addresses) {
+    try {
+      return await requestPinnedAddress(url, init, address);
+    } catch (error) {
+      lastError = error;
+      if (init.signal?.aborted) throw error;
+    }
+  }
+  throw lastError instanceof Error ? lastError : new Error("Website metadata connection failed");
+}
+
+export interface PublicHttpFetchResult {
   response: Response;
   url: URL;
 }
 
-async function fetchWithTimeout(url: URL, options: WebsiteMetadataOptions, init?: RequestInit): Promise<FetchResult> {
+/**
+ * Fetch one HTTP(S) URL after rejecting every non-public DNS answer and pinning
+ * the connection to the validated address set. Redirects are deliberately
+ * returned to the caller so each hop can be authorized independently.
+ */
+export async function fetchPublicHttpUrlOnce(
+  url: URL,
+  options: WebsiteMetadataOptions = {},
+  init: RequestInit = {},
+): Promise<PublicHttpFetchResult> {
+  const currentUrl = parsePublicHttpUrl(url.href, options);
+  const addresses = await resolvePublicConnectionAddresses(currentUrl, options);
+  const requestInit: RequestInit = {
+    ...init,
+    redirect: "manual",
+  };
+  const response = options.fetchImpl
+    ? await options.fetchImpl(currentUrl.href, requestInit)
+    : addresses && options.pinnedFetchImpl
+      ? await options.pinnedFetchImpl(currentUrl, requestInit, addresses)
+      : addresses
+        ? await fetchPinnedPublicUrl(currentUrl, requestInit, addresses)
+        : await fetch(currentUrl.href, requestInit);
+  return { response, url: currentUrl };
+}
+
+async function fetchWithTimeout(
+  url: URL,
+  options: WebsiteMetadataOptions,
+  init?: RequestInit,
+): Promise<PublicHttpFetchResult> {
   let currentUrl = parsePublicHttpUrl(url.href, options);
-  const fetchImpl = options.fetchImpl ?? fetch;
 
   for (let redirectCount = 0; redirectCount <= MAX_REDIRECTS; redirectCount += 1) {
-    await assertPublicResolvedHost(currentUrl, options);
+    const requestInit: RequestInit = {
+      redirect: "manual",
+      ...init,
+      signal: init?.signal
+        ? AbortSignal.any([init.signal, AbortSignal.timeout(FETCH_TIMEOUT_MS)])
+        : AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      headers: {
+        accept: "text/html,application/xhtml+xml,image/avif,image/webp,image/png,image/*,*/*;q=0.8",
+        "user-agent": "RudderWebsiteMetadata/1.0",
+        ...(init?.headers ?? {}),
+      },
+    };
+    const fetched = await fetchPublicHttpUrlOnce(currentUrl, options, requestInit);
+    const { response } = fetched;
 
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
-    try {
-      const response = await fetchImpl(currentUrl.href, {
-        redirect: "manual",
-        ...init,
-        signal: controller.signal,
-        headers: {
-          accept: "text/html,application/xhtml+xml,image/avif,image/webp,image/png,image/svg+xml,image/*,*/*;q=0.8",
-          "user-agent": "RudderWebsiteMetadata/1.0",
-          ...(init?.headers ?? {}),
-        },
-      });
-
-      if (response.status < 300 || response.status >= 400) return { response, url: currentUrl };
-      const location = response.headers.get("location");
-      if (!location) return { response, url: currentUrl };
-      currentUrl = parsePublicHttpUrl(new URL(location, currentUrl).href, options);
-    } finally {
-      clearTimeout(timeout);
-    }
+    if (response.status < 300 || response.status >= 400) return fetched;
+    const location = response.headers.get("location");
+    if (!location) return fetched;
+    await response.body?.cancel().catch(() => undefined);
+    currentUrl = parsePublicHttpUrl(new URL(location, currentUrl).href, options);
   }
 
   throw new Error("Website metadata redirect limit exceeded");
@@ -188,6 +259,7 @@ async function readLimitedBuffer(response: Response, maxBytes: number, options: 
           await reader.cancel();
           break;
         }
+        await reader.cancel();
         throw new Error("Response exceeds metadata size limit");
       }
       chunks.push(Buffer.from(value));
@@ -196,6 +268,110 @@ async function readLimitedBuffer(response: Response, maxBytes: number, options: 
     reader.releaseLock();
   }
   return Buffer.concat(chunks);
+}
+
+export interface PublicHttpTextOptions extends WebsiteMetadataOptions {
+  timeoutMs?: number;
+  maxRedirects?: number;
+  maxBytes?: number;
+  headers?: HeadersInit;
+  userAgent?: string;
+}
+
+export interface PublicHttpTextResult {
+  ok: boolean;
+  status: number;
+  text: string;
+  url: URL;
+}
+
+/**
+ * Fetch bounded public text while validating and pinning every redirect hop.
+ * This is shared by features that accept administrator- or tenant-supplied
+ * URLs and must never reach loopback, metadata, or private network services.
+ */
+export async function fetchPublicHttpText(
+  value: string | URL,
+  options: PublicHttpTextOptions = {},
+): Promise<PublicHttpTextResult> {
+  const timeoutMs = Math.max(1, Math.min(30_000, Math.floor(options.timeoutMs ?? 10_000)));
+  const maxRedirects = Math.max(0, Math.min(10, Math.floor(options.maxRedirects ?? 5)));
+  const maxBytes = Math.max(1, Math.min(16 * 1024 * 1024, Math.floor(options.maxBytes ?? 1024 * 1024)));
+  const signal = AbortSignal.timeout(timeoutMs);
+  const headers = new Headers(options.headers);
+  if (!headers.has("accept")) {
+    headers.set("accept", "text/markdown,text/plain,application/json;q=0.9,*/*;q=0.1");
+  }
+  headers.set("user-agent", options.userAgent ?? "RudderPublicTextFetcher/1.0");
+
+  const performFetch = async () => {
+    let currentUrl = parsePublicHttpUrl(value instanceof URL ? value.href : value, options);
+    for (let redirectCount = 0; redirectCount <= maxRedirects; redirectCount += 1) {
+      const fetched = await fetchPublicHttpUrlOnce(
+        currentUrl,
+        options,
+        {
+          method: "GET",
+          redirect: "manual",
+          signal,
+          headers,
+        },
+      );
+      const { response } = fetched;
+      if (response.status >= 300 && response.status < 400) {
+        const location = response.headers.get("location");
+        if (!location) {
+          await response.body?.cancel().catch(() => undefined);
+          return { ok: false, status: response.status, text: "", url: fetched.url };
+        }
+        await response.body?.cancel().catch(() => undefined);
+        if (redirectCount === maxRedirects) {
+          throw new Error("Public HTTP redirect limit exceeded");
+        }
+        currentUrl = parsePublicHttpUrl(new URL(location, fetched.url).href, options);
+        continue;
+      }
+
+      if (!response.ok) {
+        await response.body?.cancel().catch(() => undefined);
+        return { ok: false, status: response.status, text: "", url: fetched.url };
+      }
+      const declaredLength = Number(response.headers.get("content-length"));
+      if (Number.isFinite(declaredLength) && declaredLength > maxBytes) {
+        await response.body?.cancel().catch(() => undefined);
+        throw new Error("Response exceeds public text size limit");
+      }
+      let body: Buffer;
+      try {
+        body = await readLimitedBuffer(response, maxBytes);
+      } catch (error) {
+        if (error instanceof Error && error.message === "Response exceeds metadata size limit") {
+          throw new Error("Response exceeds public text size limit");
+        }
+        throw error;
+      }
+      return {
+        ok: true,
+        status: response.status,
+        text: body.toString("utf8"),
+        url: fetched.url,
+      };
+    }
+    throw new Error("Public HTTP redirect limit exceeded");
+  };
+
+  let rejectOnTimeout: ((reason?: unknown) => void) | null = null;
+  const timeoutPromise = new Promise<never>((_resolve, reject) => {
+    rejectOnTimeout = reject;
+  });
+  const onTimeout = () => rejectOnTimeout?.(signal.reason ?? new Error("Public HTTP request timed out"));
+  if (signal.aborted) onTimeout();
+  else signal.addEventListener("abort", onTimeout, { once: true });
+  try {
+    return await Promise.race([performFetch(), timeoutPromise]);
+  } finally {
+    signal.removeEventListener("abort", onTimeout);
+  }
 }
 
 function contentTypeBase(value: string | null) {
@@ -309,7 +485,7 @@ async function resolveWebsiteMetadataUncached(value: string, options: WebsiteMet
     return { url: pageUrl.href, siteName: knownIcon.siteName, iconUrl: knownIcon.iconDataUrl };
   }
 
-  let pageResult: FetchResult;
+  let pageResult: PublicHttpFetchResult;
   try {
     pageResult = await fetchWithTimeout(pageUrl, options);
   } catch (error) {

--- a/server/src/services/work-products.ts
+++ b/server/src/services/work-products.ts
@@ -1,9 +1,117 @@
 import type { Db } from "@rudderhq/db";
-import { issueWorkProducts } from "@rudderhq/db";
+import {
+  executionWorkspaces,
+  heartbeatRuns,
+  issueWorkProducts,
+  projects,
+  workspaceRuntimeServices,
+} from "@rudderhq/db";
 import type { IssueWorkProduct } from "@rudderhq/shared";
 import { and, desc, eq } from "drizzle-orm";
+import { unprocessable } from "../errors.js";
 
 type IssueWorkProductRow = typeof issueWorkProducts.$inferSelect;
+type IssueWorkProductMutableData = Omit<
+  typeof issueWorkProducts.$inferInsert,
+  "id" | "orgId" | "issueId" | "createdAt" | "updatedAt"
+>;
+type IssueWorkProductInput = IssueWorkProductMutableData & {
+  /** Public API alias for the legacy database column executionWorkspaceId. */
+  runWorkspaceId?: string | null;
+};
+type IssueWorkProductPatch = Partial<IssueWorkProductInput>;
+
+const INVALID_REFERENCE_MESSAGE = "One or more work product references are invalid for this organization";
+
+function normalizeRunWorkspaceReference(
+  input: IssueWorkProductInput | IssueWorkProductPatch,
+): Partial<IssueWorkProductMutableData> {
+  const source = input as Record<string, unknown>;
+  const hasRunWorkspaceId = Object.prototype.hasOwnProperty.call(source, "runWorkspaceId");
+  const hasExecutionWorkspaceId = Object.prototype.hasOwnProperty.call(source, "executionWorkspaceId");
+  if (
+    hasRunWorkspaceId
+    && hasExecutionWorkspaceId
+    && (source.runWorkspaceId ?? null) !== (source.executionWorkspaceId ?? null)
+  ) {
+    throw unprocessable(INVALID_REFERENCE_MESSAGE);
+  }
+
+  const normalized = { ...source };
+  if (hasRunWorkspaceId) {
+    normalized.executionWorkspaceId = source.runWorkspaceId ?? null;
+  }
+  delete normalized.runWorkspaceId;
+  // Owner and audit columns are immutable even if an internal caller passes a
+  // wider object than the public validator permits.
+  delete normalized.id;
+  delete normalized.orgId;
+  delete normalized.issueId;
+  delete normalized.createdAt;
+  delete normalized.updatedAt;
+  return normalized as Partial<IssueWorkProductMutableData>;
+}
+
+async function assertReferencesBelongToOrganization(
+  dbOrTx: Db | any,
+  orgId: string,
+  references: Pick<
+    IssueWorkProductRow,
+    "projectId" | "executionWorkspaceId" | "runtimeServiceId" | "createdByRunId"
+  >,
+) {
+  const checks: Array<Promise<boolean>> = [];
+  if (references.projectId) {
+    checks.push(
+      dbOrTx
+        .select({ id: projects.id })
+        .from(projects)
+        .where(and(eq(projects.id, references.projectId), eq(projects.orgId, orgId)))
+        .then((rows: Array<{ id: string }>) => rows.length > 0),
+    );
+  }
+  if (references.executionWorkspaceId) {
+    checks.push(
+      dbOrTx
+        .select({ id: executionWorkspaces.id })
+        .from(executionWorkspaces)
+        .where(
+          and(
+            eq(executionWorkspaces.id, references.executionWorkspaceId),
+            eq(executionWorkspaces.orgId, orgId),
+          ),
+        )
+        .then((rows: Array<{ id: string }>) => rows.length > 0),
+    );
+  }
+  if (references.runtimeServiceId) {
+    checks.push(
+      dbOrTx
+        .select({ id: workspaceRuntimeServices.id })
+        .from(workspaceRuntimeServices)
+        .where(
+          and(
+            eq(workspaceRuntimeServices.id, references.runtimeServiceId),
+            eq(workspaceRuntimeServices.orgId, orgId),
+          ),
+        )
+        .then((rows: Array<{ id: string }>) => rows.length > 0),
+    );
+  }
+  if (references.createdByRunId) {
+    checks.push(
+      dbOrTx
+        .select({ id: heartbeatRuns.id })
+        .from(heartbeatRuns)
+        .where(and(eq(heartbeatRuns.id, references.createdByRunId), eq(heartbeatRuns.orgId, orgId)))
+        .then((rows: Array<{ id: string }>) => rows.length > 0),
+    );
+  }
+
+  if ((await Promise.all(checks)).some((valid) => !valid)) {
+    throw unprocessable(INVALID_REFERENCE_MESSAGE);
+  }
+}
 
 function toIssueWorkProduct(row: IssueWorkProductRow): IssueWorkProduct {
   return {
@@ -51,9 +159,16 @@ export function workProductService(db: Db) {
       return row ? toIssueWorkProduct(row) : null;
     },
 
-    createForIssue: async (issueId: string, orgId: string, data: Omit<typeof issueWorkProducts.$inferInsert, "issueId" | "orgId">) => {
+    createForIssue: async (issueId: string, orgId: string, data: IssueWorkProductInput) => {
+      const normalizedData = normalizeRunWorkspaceReference(data) as IssueWorkProductMutableData;
       const row = await db.transaction(async (tx) => {
-        if (data.isPrimary) {
+        await assertReferencesBelongToOrganization(tx, orgId, {
+          projectId: normalizedData.projectId ?? null,
+          executionWorkspaceId: normalizedData.executionWorkspaceId ?? null,
+          runtimeServiceId: normalizedData.runtimeServiceId ?? null,
+          createdByRunId: normalizedData.createdByRunId ?? null,
+        });
+        if (normalizedData.isPrimary) {
           await tx
             .update(issueWorkProducts)
             .set({ isPrimary: false, updatedAt: new Date() })
@@ -61,14 +176,14 @@ export function workProductService(db: Db) {
               and(
                 eq(issueWorkProducts.orgId, orgId),
                 eq(issueWorkProducts.issueId, issueId),
-                eq(issueWorkProducts.type, data.type),
+                eq(issueWorkProducts.type, normalizedData.type),
               ),
             );
         }
         return await tx
           .insert(issueWorkProducts)
           .values({
-            ...data,
+            ...normalizedData,
             orgId,
             issueId,
           })
@@ -78,7 +193,8 @@ export function workProductService(db: Db) {
       return row ? toIssueWorkProduct(row) : null;
     },
 
-    update: async (id: string, patch: Partial<typeof issueWorkProducts.$inferInsert>) => {
+    update: async (id: string, patch: IssueWorkProductPatch) => {
+      const normalizedPatch = normalizeRunWorkspaceReference(patch);
       const row = await db.transaction(async (tx) => {
         const existing = await tx
           .select()
@@ -87,7 +203,15 @@ export function workProductService(db: Db) {
           .then((rows) => rows[0] ?? null);
         if (!existing) return null;
 
-        if (patch.isPrimary === true) {
+        const next = { ...existing, ...normalizedPatch };
+        await assertReferencesBelongToOrganization(tx, existing.orgId, {
+          projectId: next.projectId ?? null,
+          executionWorkspaceId: next.executionWorkspaceId ?? null,
+          runtimeServiceId: next.runtimeServiceId ?? null,
+          createdByRunId: next.createdByRunId ?? null,
+        });
+
+        if (normalizedPatch.isPrimary === true) {
           await tx
             .update(issueWorkProducts)
             .set({ isPrimary: false, updatedAt: new Date() })
@@ -102,7 +226,7 @@ export function workProductService(db: Db) {
 
         return await tx
           .update(issueWorkProducts)
-          .set({ ...patch, updatedAt: new Date() })
+          .set({ ...normalizedPatch, updatedAt: new Date() })
           .where(eq(issueWorkProducts.id, id))
           .returning()
           .then((rows) => rows[0] ?? null);

--- a/server/src/services/workspace-runtime.lifecycle.ts
+++ b/server/src/services/workspace-runtime.lifecycle.ts
@@ -1,8 +1,111 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { asString, parseObject } from "../agent-runtimes/utils.js";
+import {
+  resolveManagedRunWorkspacesRoot,
+  resolveOrganizationWorkspaceRoot,
+} from "../home-paths.js";
 import type { WorkspaceOperationRecorder } from "./workspace-operations.js";
 import { buildExecutionWorkspaceCleanupEnv, directoryExists, ExecutionWorkspaceAgentRef, ExecutionWorkspaceInput, ExecutionWorkspaceIssueRef, gitErrorIncludes, provisionExecutionWorktree, RealizedExecutionWorkspace, recordGitOperation, recordWorkspaceCommandOperation, renderWorkspaceTemplate, resolveConfiguredPath, resolveGitRepoRootForWorkspaceCleanup, runGit, sanitizeBranchName } from "./workspace-runtime.helpers.js";
+
+function isPathWithin(ancestorPath: string, candidatePath: string, allowEqual: boolean) {
+  const relative = path.relative(ancestorPath, candidatePath);
+  if (relative === "") return allowEqual;
+  return !relative.startsWith("..") && !path.isAbsolute(relative);
+}
+
+async function lstatOrNull(targetPath: string) {
+  try {
+    return await fs.lstat(targetPath);
+  } catch (error) {
+    if (typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT") {
+      return null;
+    }
+    throw error;
+  }
+}
+
+async function resolveManagedLocalWorkspaceCleanupTarget(input: {
+  orgId: string;
+  workspacePath: string;
+}): Promise<{ targetPath: string | null; refusalReason: string | null }> {
+  const managedRoot = path.resolve(resolveManagedRunWorkspacesRoot(input.orgId));
+  const targetPath = path.resolve(input.workspacePath);
+  if (!isPathWithin(managedRoot, targetPath, false)) {
+    return {
+      targetPath: null,
+      refusalReason: `path is not a child of the managed runtime workspace root "${managedRoot}"`,
+    };
+  }
+
+  const organizationWorkspaceRoot = path.resolve(resolveOrganizationWorkspaceRoot(input.orgId));
+  if (isPathWithin(targetPath, organizationWorkspaceRoot, true)) {
+    return {
+      targetPath: null,
+      refusalReason: "path is or contains the organization workspace root",
+    };
+  }
+
+  const managedRootStat = await lstatOrNull(managedRoot);
+  if (!managedRootStat) {
+    return { targetPath: null, refusalReason: null };
+  }
+  if (managedRootStat.isSymbolicLink() || !managedRootStat.isDirectory()) {
+    return {
+      targetPath: null,
+      refusalReason: "managed runtime workspace root is not a real directory",
+    };
+  }
+
+  const relativeSegments = path.relative(managedRoot, targetPath).split(path.sep).filter(Boolean);
+  let currentPath = managedRoot;
+  for (const [index, segment] of relativeSegments.entries()) {
+    currentPath = path.join(currentPath, segment);
+    const stat = await lstatOrNull(currentPath);
+    if (!stat) {
+      return { targetPath: null, refusalReason: null };
+    }
+    if (stat.isSymbolicLink()) {
+      return {
+        targetPath: null,
+        refusalReason: `path contains symbolic link "${currentPath}"`,
+      };
+    }
+    const isTarget = index === relativeSegments.length - 1;
+    if (!stat.isDirectory()) {
+      return {
+        targetPath: null,
+        refusalReason: isTarget
+          ? "managed runtime workspace target is not a directory"
+          : `path ancestor "${currentPath}" is not a directory`,
+      };
+    }
+  }
+
+  const [realManagedRoot, realTargetPath] = await Promise.all([
+    fs.realpath(managedRoot),
+    fs.realpath(targetPath),
+  ]);
+  if (!isPathWithin(realManagedRoot, realTargetPath, false)) {
+    return {
+      targetPath: null,
+      refusalReason: "resolved path escapes the managed runtime workspace root",
+    };
+  }
+
+  const realOrganizationWorkspaceRoot = await fs.realpath(organizationWorkspaceRoot).catch(() => null);
+  if (
+    realOrganizationWorkspaceRoot
+    && isPathWithin(realTargetPath, realOrganizationWorkspaceRoot, true)
+  ) {
+    return {
+      targetPath: null,
+      refusalReason: "resolved path is or contains the organization workspace root",
+    };
+  }
+
+  return { targetPath: realTargetPath, refusalReason: null };
+}
 
 export async function realizeExecutionWorkspace(input: {
   base: ExecutionWorkspaceInput;
@@ -151,6 +254,7 @@ export async function realizeExecutionWorkspace(input: {
 export async function cleanupExecutionWorkspaceArtifacts(input: {
   workspace: {
     id: string;
+    orgId?: string | null;
     cwd: string | null;
     providerType: string;
     providerRef: string | null;
@@ -268,8 +372,18 @@ export async function cleanupExecutionWorkspaceArtifacts(input: {
       : false;
     if (containsProjectWorkspace) {
       warnings.push(`Refusing to remove path "${workspacePath}" because it contains the project workspace.`);
+    } else if (!input.workspace.orgId) {
+      warnings.push(`Refusing to remove path "${workspacePath}" because its organization is unknown.`);
     } else {
-      await fs.rm(resolvedWorkspacePath, { recursive: true, force: true });
+      const safeCleanupTarget = await resolveManagedLocalWorkspaceCleanupTarget({
+        orgId: input.workspace.orgId,
+        workspacePath: resolvedWorkspacePath,
+      });
+      if (safeCleanupTarget.refusalReason) {
+        warnings.push(`Refusing to remove path "${workspacePath}" because ${safeCleanupTarget.refusalReason}.`);
+      } else if (safeCleanupTarget.targetPath) {
+        await fs.rm(safeCleanupTarget.targetPath, { recursive: true, force: true });
+      }
       if (input.recorder) {
         await input.recorder.recordOperation({
           phase: "workspace_teardown",
@@ -277,12 +391,14 @@ export async function cleanupExecutionWorkspaceArtifacts(input: {
           metadata: {
             workspaceId: input.workspace.id,
             workspacePath: resolvedWorkspacePath,
-            cleanupAction: "remove_local_fs",
+            cleanupAction: safeCleanupTarget.targetPath ? "remove_local_fs" : "skip_remove_local_fs",
           },
           run: async () => ({
             status: "succeeded",
             exitCode: 0,
-            system: `Removed local workspace directory ${resolvedWorkspacePath}\n`,
+            system: safeCleanupTarget.targetPath
+              ? `Removed local workspace directory ${resolvedWorkspacePath}\n`
+              : `Skipped removing local workspace directory ${resolvedWorkspacePath}\n`,
           }),
         });
       }
@@ -299,4 +415,3 @@ export async function cleanupExecutionWorkspaceArtifacts(input: {
     warnings,
   };
 }
-

--- a/ui/package.json
+++ b/ui/package.json
@@ -45,12 +45,12 @@
     "codemirror": "^6.0.2",
     "lexical": "0.35.0",
     "lucide-react": "^0.574.0",
-    "mermaid": "^11.13.0",
+    "mermaid": "^11.15.0",
     "radix-ui": "^1.4.3",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-markdown": "^10.1.0",
-    "react-router-dom": "^7.13.2",
+    "react-router-dom": "7.15.1",
     "remark-gfm": "^4.0.1",
     "tailwind-merge": "^3.5.0"
   },
@@ -63,6 +63,6 @@
     "tailwindcss": "^4.2.2",
     "typescript": "^5.9.3",
     "vite": "^6.4.1",
-    "vitest": "^3.2.4"
+    "vitest": "^3.2.7"
   }
 }

--- a/ui/src/components/CommentThread.test.tsx
+++ b/ui/src/components/CommentThread.test.tsx
@@ -6,6 +6,7 @@ import { createRoot } from "react-dom/client";
 import { renderToStaticMarkup } from "react-dom/server";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { formatDateTime } from "../lib/utils";
 import {
   CommentThread,
   commentIdFromIssueCommentHash,
@@ -1394,6 +1395,8 @@ describe("CommentThread", () => {
   it("shows recent activity timestamps as relative labels while preserving exact titles", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-05-07T01:12:00.000Z"));
+    const commentCreatedAt = new Date("2026-05-07T00:36:00.000Z");
+    const runCreatedAt = new Date("2026-05-07T00:12:00.000Z");
 
     const html = renderToStaticMarkup(
       <MemoryRouter>
@@ -1406,8 +1409,8 @@ describe("CommentThread", () => {
               authorUserId: "user-1",
               authorAgentId: null,
               body: "Fresh update.",
-              createdAt: new Date("2026-05-07T00:36:00.000Z"),
-              updatedAt: new Date("2026-05-07T00:36:00.000Z"),
+              createdAt: commentCreatedAt,
+              updatedAt: commentCreatedAt,
             },
           ]}
           linkedRuns={[
@@ -1415,8 +1418,8 @@ describe("CommentThread", () => {
               runId: "55555555-5555-4555-8555-555555555555",
               status: "succeeded",
               agentId: "22222222-2222-4222-8222-222222222222",
-              createdAt: new Date("2026-05-07T00:12:00.000Z"),
-              startedAt: new Date("2026-05-07T00:12:00.000Z"),
+              createdAt: runCreatedAt,
+              startedAt: runCreatedAt,
             },
           ]}
           onAdd={async () => undefined}
@@ -1426,10 +1429,10 @@ describe("CommentThread", () => {
 
     expect(html).toContain(">36m ago</time>");
     expect(html).toContain(">1h ago</time>");
-    expect(html).toMatch(/title="May 7, 2026, \d{2}:36"/);
-    expect(html).toMatch(/title="May 7, 2026, \d{2}:12"/);
-    expect(html).not.toContain(">May 7, 2026, 00:36</a>");
-    expect(html).not.toContain(">May 7, 2026, 00:12</time>");
+    expect(html).toContain(`title="${formatDateTime(commentCreatedAt)}"`);
+    expect(html).toContain(`title="${formatDateTime(runCreatedAt)}"`);
+    expect(html).not.toContain(`>${formatDateTime(commentCreatedAt)}</a>`);
+    expect(html).not.toContain(`>${formatDateTime(runCreatedAt)}</time>`);
   });
 
   it("collapses inactive linked run details by default", () => {

--- a/ui/src/pages/Chat.attachment-preview.test.tsx
+++ b/ui/src/pages/Chat.attachment-preview.test.tsx
@@ -2144,6 +2144,7 @@ describe("Chat Side Panel link handling", () => {
     sidePanel = container.querySelector<HTMLElement>("[data-testid='chat-side-panel']");
     expect(sidePanel?.textContent).toContain("Start browsing");
     expect(sidePanel?.querySelector("[data-testid='chat-side-panel-browser-view']")).not.toBeNull();
+    expect(sidePanel?.querySelector("[data-testid='chat-side-panel-browser-webview']")).toBeNull();
     expect(sidePanel?.className).toContain("motion-chat-side-panel");
     expect(sidePanel?.className).toContain("transition-[width,opacity,transform]");
     expect(container.querySelector('[data-testid="chat-side-panel-trigger"]')).toBeNull();
@@ -2164,6 +2165,8 @@ describe("Chat Side Panel link handling", () => {
     const webview = sidePanel?.querySelector<HTMLElement>("[data-testid='chat-side-panel-browser-webview']");
     expect(webview).not.toBeNull();
     expect(webview?.getAttribute("src")).toBe("http://localhost:3100/api/health");
+    expect(webview?.getAttribute("partition")).toBe("persist:rudder-browser");
+    expect(webview?.getAttribute("allowpopups")).toBeNull();
     expect(Array.from(sidePanel!.querySelectorAll<HTMLElement>("[data-testid='chat-side-panel-tab']")).at(0)?.textContent).toContain("localhost");
 
     const newBrowserTabButton = sidePanel!.querySelector<HTMLButtonElement>('button[aria-label="Open new browser tab"]');

--- a/ui/src/pages/Chat.side-panel.tsx
+++ b/ui/src/pages/Chat.side-panel.tsx
@@ -75,6 +75,7 @@ const CHAT_SIDE_PANEL_TEXT_DOCUMENT_FILE_EXTENSIONS = new Set([
   ".text",
 ]);
 const CHAT_SIDE_PANEL_BROWSER_BLANK_URL = "about:blank";
+const CHAT_SIDE_PANEL_BROWSER_PARTITION = "persist:rudder-browser";
 
 type BrowserWebviewElement = HTMLElement & {
   canGoBack?: () => boolean;
@@ -145,10 +146,23 @@ function chatSidePanelBrowserLabel(url: string) {
 function normalizeChatSidePanelBrowserUrl(value: string) {
   const trimmed = value.trim();
   if (!trimmed) return CHAT_SIDE_PANEL_BROWSER_BLANK_URL;
-  if (/^(about|data|file|https?):/i.test(trimmed)) return trimmed;
+  if (/^https?:/i.test(trimmed)) {
+    try {
+      const parsed = new URL(trimmed);
+      if (parsed.hostname && !parsed.username && !parsed.password) return parsed.href;
+    } catch {
+      // Treat malformed and unsupported addresses as search terms below.
+    }
+  }
   if (/\s/.test(trimmed)) return `https://www.google.com/search?q=${encodeURIComponent(trimmed)}`;
   if (/^(localhost|\d{1,3}(?:\.\d{1,3}){3})(:\d+)?(\/.*)?$/i.test(trimmed)) {
     return `http://${trimmed}`;
+  }
+  if (/^(?:[a-z\d](?:[a-z\d-]*[a-z\d])?\.)+[a-z\d-]{2,}(?::\d+)?(?:[/?#].*)?$/i.test(trimmed)) {
+    return `https://${trimmed}`;
+  }
+  if (/^[a-z][a-z\d+.-]*:/i.test(trimmed)) {
+    return `https://www.google.com/search?q=${encodeURIComponent(trimmed)}`;
   }
   if (trimmed.includes(".")) {
     return `https://${trimmed}`;
@@ -1140,9 +1154,9 @@ function ChatSidePanelBrowserView({
         ) : createElement("webview", {
           ref: handleWebviewRef,
           src: currentUrl,
+          partition: CHAT_SIDE_PANEL_BROWSER_PARTITION,
           className: "min-h-[52vh] flex-1 bg-[color:var(--surface-panel)]",
           "data-testid": "chat-side-panel-browser-webview",
-          allowpopups: "true",
         })}
       </div>
     </div>


### PR DESCRIPTION
## Summary

This security hardening pass closes host-execution, approval, tenant-isolation, SSRF, content-serving, desktop, plugin, and release-pipeline trust-boundary gaps.

- Gate host-global runtime configuration, environment tests, local skills, external instructions, filesystem cleanup, Claude login, and intelligence profiles behind instance-admin authority.
- Prevent pending-agent lifecycle and hire-validation paths from bypassing approval or spawning caller-selected OpenCode/Pi/Claude commands.
- Enforce organization ownership across approvals, chats, issues, projects, resources, work products, plugin operations, and portability jobs.
- Add DNS-pinned, redirect-aware public-network transports for website metadata, invite probes, skill imports, and plugin HTTP.
- Harden plugin webhooks, active-content delivery, Electron navigation/IPC/permissions, Host/Origin checks, WebSockets, CI/release inputs, Docker staging, and dependency versions.

## Notable fixes

- **Approval bypass:** a `pending_approval` agent can no longer be paused and resumed into `idle`, or receive an API key before approval.
- **Pre-approval RCE:** agent hires pure-validate OpenCode/Pi model identifiers and defer command discovery until the hire is trusted.
- **Host-command RCE:** `claude-login`, runtime environment tests, intelligence profiles, config rollback, and host runtime selection require instance-admin authority before secret resolution, filesystem access, or process launch.
- **Filesystem boundaries:** external instruction roots, local skill catalogs, organization workspace browsing, and local workspace cleanup reject symlink/containment escapes and untrusted host paths.
- **SSRF:** outbound requests re-resolve and pin every hop, reject private/special IPv4, IPv6, mapped, and NAT64 addresses, strip sensitive cross-origin headers, and enforce redirect/body/time limits.
- **Tenant isolation:** cross-organization references are rejected for work products, projects, issues, chats, activity, approvals, portability jobs, and plugin capabilities.
- **Plugin boundaries:** lifecycle/config/log/job/dashboard/bridge operations are admin-scoped; webhook ingress has bounded bodies, bounded rate-limit state, header allowlists, and non-reflective errors.
- **Content/desktop:** SVG and other active content is attachment-sandboxed, raster previews are allowlisted, Electron webviews/navigation/permissions are restricted, and IDE launching no longer uses a shell.
- **Database error handling:** PostgreSQL error classification now safely follows Drizzle's wrapped `cause` chain while honoring explicit constraint names.
- **Import authorization:** executable-entity and replace imports stay on the privileged board-full route; the E2E expectations now reflect its existing `update/updated` organization semantics.

## Validation

- [GitHub Actions run 1087](https://github.com/Undertone0809/rudder/actions/runs/29096722590): **Windows, macOS, and Ubuntu all passed**.
  - macOS and Ubuntu completed the full unit-test suites, including embedded-PostgreSQL integration coverage.
  - All three runners passed typecheck, Product Logic registry checks, CLI start tests where configured, and production builds.
- `pnpm -r typecheck`: all **21 workspace projects** passed.
- `pnpm build`: full monorepo build passed; CLI and server were rebuilt after the final production changes.
- Security-focused changed tests: **35 files, 516/516 tests passed**.
- Final approval/host-execution regression set: **63/63 passed**.
- Final CI-fix regression set: **7 files, 71/71 passed**.
- CLI start tests: **85/85 passed**.
- Desktop navigation/IDE hardening tests: **29/29 passed**.
- `pnpm lint`: **1,845 files passed**.
- `pnpm product-logic:check`: **66 contracts valid**; no `doc/product/**` files changed.
- All 9 workflow YAML files parsed; release-input validation tests: **14/14 passed**.
- pnpm 9 frozen offline install passed; pnpm 11 frozen lock/minimum-release-age policy passed for **1,505 entries**.
- High-confidence added-line secret scan and `git diff --check` passed.
- Production dependency audit improved from **3 critical / 42 high** to **0 critical / 0 high / 2 moderate / 2 low**.

## Environment notes

- The local container runs as root, which embedded PostgreSQL refuses; the non-root macOS and Ubuntu GitHub runners now provide the full database-backed verification and are green.
- Chromium's process-singleton socket is blocked by the local sandbox, so Electron executable smoke could not run locally; the desktop build and focused security tests passed.
- Docker CLI is unavailable in the local container, so a live container boot was not performed. Docker staging and closure behavior were reviewed and the release workflows build successfully.
- The local sandbox blocks the Pi source-manifest Unix IPC probe; the built CLI was verified directly with **69/69** strict tool schemas.

## Residual dependency advisories

No critical or high production advisories remain. The four residual reports are transitive/tooling constraints:

- Moderate: `@opentelemetry/core` via `@langfuse/otel` ([GHSA-8988-4f7v-96qf](https://github.com/advisories/GHSA-8988-4f7v-96qf)).
- Moderate: legacy `esbuild@0.18.20` via `better-auth > drizzle-kit > @esbuild-kit` ([GHSA-67mh-4wv8-2f99](https://github.com/advisories/GHSA-67mh-4wv8-2f99)).
- Low: `esbuild@0.27.4` in the transitive Vitest/tsx chain ([GHSA-g7r4-m6w7-qqqr](https://github.com/advisories/GHSA-g7r4-m6w7-qqqr)).
- Low: the audit reports the local workspace package name `cli@0.4.4` with an empty dependency path ([GHSA-6cpc-mj5c-m9rq](https://github.com/advisories/GHSA-6cpc-mj5c-m9rq)).

This remains a draft because the security patch is intentionally broad and should receive focused owner review before merge.