### PR TITLE
docs: require explicit deployment authorization

### DIFF
--- a/.github/workflows/docs-production.yml
+++ b/.github/workflows/docs-production.yml
@@ -11,6 +11,10 @@ on:
         description: "Optional docs release tag, for example docs/v2026.05.27"
         required: false
         default: ""
+      confirm_domain:
+        description: "Enter only after explicit operator approval; type docs.rudderhq.dev"
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -37,6 +41,11 @@ jobs:
     timeout-minutes: 30
     if: github.repository == 'Undertone0809/rudder'
     steps:
+      - name: Confirm production target
+        env:
+          CONFIRM_DOMAIN: ${{ inputs.confirm_domain }}
+        run: test "$CONFIRM_DOMAIN" = "$DOCS_PRODUCTION_DOMAIN"
+
       - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.source_ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,11 @@ on:
         required: true
         type: boolean
         default: true
+      confirm_stable:
+        description: "For a real publish, enter PUBLISH STABLE only after explicit operator approval"
+        required: false
+        default: ""
+        type: string
 
 permissions:
   actions: write
@@ -203,6 +208,11 @@ jobs:
     outputs:
       version: ${{ steps.publish.outputs.version }}
     steps:
+      - name: Confirm stable publish authorization
+        env:
+          CONFIRM_STABLE: ${{ inputs.confirm_stable }}
+        run: test "$CONFIRM_STABLE" = "PUBLISH STABLE"
+
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -190,6 +190,35 @@ Do not stop at a happy-path fixture when the behavior depends on data volume, da
 Include at least one representative edge case or production-shaped failure mode whenever that is where the implementation is likely to break.
 If a corner case is too expensive or impossible to cover in E2E, document why and add the closest lower-level regression test instead.
 
+## 5.1 Release And Deployment Authorization
+
+Implementation authority is not release authority. Treat local implementation,
+feature-branch push/PR, merge to `main`, shared staging, stable publication, and
+production deployment as separate transitions.
+
+- `start`, `continue`, `proceed`, `implement`, `finish`, or approval of a plan
+  authorizes implementation and verification only. The default stopping point
+  is Review Ready: validated changes, a pushed feature branch, a PR when
+  appropriate, review evidence, and a release-risk summary.
+- Automatic branch previews are review surfaces only. Do not promote them or
+  assign shared aliases without explicit authorization.
+- Merging or pushing to `main` can publish canaries and update docs staging.
+  Do not land changes on `main` without explicit permission to merge or release
+  those automatic effects.
+- Production docs, stable npm/GitHub/Desktop releases, and any other production
+  publish require a fresh, target-specific confirmation at the deployment gate.
+  A plan that mentions deployment, a request to start, or staging approval does
+  not satisfy that gate.
+- Never choose `dry_run: false`, enter `confirm_domain` or `confirm_stable`,
+  supply a production tag, invoke a deployment hook, or run an equivalent
+  production command on the user's behalf unless the user explicitly approved
+  that exact release. Workflow inputs are safeguards, not substitutes for human
+  authorization.
+- Before asking for production approval, report the exact commit/tag and target,
+  completed checks, unresolved or unrelated failing checks, migration or data
+  impact, and rollback point. After approval, release only that reviewed source
+  and verify the public surface.
+
 ## 6. Database Change Workflow
 
 When changing data model:

--- a/doc/engineering/RELEASING.md
+++ b/doc/engineering/RELEASING.md
@@ -57,15 +57,38 @@ external release blocker for docs-site publishing. Do not silently count a
 failed docs workflow as handled; either escalate the credential/account issue to
 the Vercel owner or explicitly scope docs-site publishing out of that release.
 
+## Authorization Gates
+
+Release preparation and release execution are separate operations:
+
+1. **Review Ready** — identify the exact source SHA, complete verification,
+   prepare release notes/screenshots, push the feature branch, and open the PR.
+2. **Landing/Staging Gate** — obtain explicit permission before merging to
+   `main` when that merge publishes a canary or updates docs staging.
+3. **Production Gate** — report the exact source ref, version/tag, production
+   targets, successful and failing checks, and rollback point; then stop and wait
+   for an operator to explicitly approve the production release.
+
+Instructions such as `start`, `continue`, `proceed`, `implement`, or approval of
+a plan do not satisfy the production gate. A staging approval is not production
+approval. Agents and automation must not set `dry_run: false`, enter workflow
+confirmation strings, or synthesize a release tag as evidence of approval. The
+operator's explicit authorization must exist before those values are supplied.
+
+Even when an initial request or plan includes production deployment, always
+pause at the production gate after presenting the reviewed source, target,
+checks, known failures, and rollback point. Only the operator's latest explicit
+approval for that described release authorizes proceeding.
+
 ## Docs Site Releases
 
 The public docs site uses separate staging and production channels:
 
-- `staging.doc.rudder.zeeland.studio` follows the latest `main` docs commit.
+- `staging.docs.rudderhq.dev` follows the latest `main` docs commit.
   [`.github/workflows/docs-staging.yml`](../.github/workflows/docs-staging.yml)
   runs automatically on `main` pushes that touch the docs tree or docs deployment
   workflow.
-- `doc.rudder.zeeland.studio` is production. It does not auto-follow `main`.
+- `docs.rudderhq.dev` is production. It does not auto-follow `main`.
   Publish it manually with
   [`.github/workflows/docs-production.yml`](../.github/workflows/docs-production.yml)
   from the Actions tab.
@@ -127,14 +150,21 @@ Inputs:
   - commit SHA, branch, or tag
 - `dry_run`
   - preview only when true
+- `confirm_stable`
+  - leave empty for dry runs
+  - after explicit production authorization, enter `PUBLISH STABLE` for the
+    real stable release
 
 Before running stable:
 
 1. pick the canary commit or tag you trust
 2. confirm the committed public package version is the stable version you want to ship
 3. create or update `releases/vX.Y.Z.md` on that source ref
-4. run the stable workflow from that source ref
-5. after stable is published, merge a separate version-bump commit before
+4. run the workflow with `dry_run: true`
+5. present the exact source ref, version, checks, targets, and rollback point;
+   obtain explicit production approval
+6. run the workflow with `dry_run: false` and `confirm_stable: PUBLISH STABLE`
+7. after stable is published, merge a separate version-bump commit before
    expecting later canaries to be detectable as updates for stable users
 
 Example:

--- a/docs/README.md
+++ b/docs/README.md
@@ -46,6 +46,19 @@ staging channel uses `staging.docs.rudderhq.dev` only. Staging pages are
 still expected to emit production canonical URLs so preview traffic does not
 compete with the canonical docs host in search indexes.
 
+### Production authorization gate
+
+Preparing or approving docs content does not authorize publishing it. Before a
+production docs release, report the exact source ref and proposed tag, confirm
+`pnpm docs:validate` and staging health, disclose known failing checks, and name
+the rollback ref. Then stop and obtain explicit authorization to deploy
+`docs.rudderhq.dev`.
+
+Do not infer production authorization from `start`, `continue`, `proceed`, a
+previously approved plan, permission to merge, or a staging approval. Automation
+must not enter the production confirmation input until an operator explicitly
+approves that exact release.
+
 ## Public Edge Protection
 
 The production Vercel project can receive high-volume generic crawler probes for

--- a/scripts/postprocess-docs-export.test.mjs
+++ b/scripts/postprocess-docs-export.test.mjs
@@ -154,3 +154,19 @@ test("staging and production workflows postprocess exported docs", () => {
     );
   }
 });
+
+test("docs production requires explicit target confirmation before deployment", () => {
+  const source = fs.readFileSync(
+    path.join(REPO_ROOT, ".github/workflows", "docs-production.yml"),
+    "utf8",
+  );
+  const confirmationIndex = source.indexOf("Confirm production target");
+  const deployIndex = source.indexOf("Deploy to Vercel production");
+
+  assert.match(source, /confirm_domain:/);
+  assert.match(source, /explicit operator approval/);
+  assert.match(source, /CONFIRM_DOMAIN: \$\{\{ inputs\.confirm_domain \}\}/);
+  assert.match(source, /test "\$CONFIRM_DOMAIN" = "\$DOCS_PRODUCTION_DOMAIN"/);
+  assert.doesNotMatch(source, /test "\$\{\{ inputs\.confirm_domain \}\}"/);
+  assert.ok(confirmationIndex > -1 && confirmationIndex < deployIndex);
+});

--- a/scripts/release-canary-cleanup.test.mjs
+++ b/scripts/release-canary-cleanup.test.mjs
@@ -72,4 +72,25 @@ describe("obsolete canary cleanup", () => {
     expect(workflow).toContain("node scripts/cleanup-obsolete-canaries.mjs");
     expect(workflow).toContain('--stable-version "${{ steps.publish.outputs.version }}"');
   });
+
+  it("requires an explicit stable-publish confirmation before the real release job", () => {
+    const workflow = readFileSync(path.join(repoRoot, ".github", "workflows", "release.yml"), "utf8");
+    const stableJobStart = workflow.indexOf("\n  stable:\n");
+    const stableJobEnd = workflow.indexOf("\n  public-install-smoke:\n", stableJobStart);
+    const stableJob = workflow.slice(stableJobStart, stableJobEnd);
+    const canaryJob = workflow.slice(
+      workflow.indexOf("\n  canary:\n"),
+      stableJobStart,
+    );
+    const confirmationIndex = stableJob.indexOf("Confirm stable publish authorization");
+    const publishIndex = stableJob.indexOf("- name: Publish stable");
+
+    expect(workflow).toContain("confirm_stable:");
+    expect(stableJob).toContain('CONFIRM_STABLE: ${{ inputs.confirm_stable }}');
+    expect(stableJob).toContain('test "$CONFIRM_STABLE" = "PUBLISH STABLE"');
+    expect(stableJob).not.toContain('test "${{ inputs.confirm_stable }}"');
+    expect(canaryJob).not.toContain("Confirm stable publish authorization");
+    expect(confirmationIndex).toBeGreaterThan(-1);
+    expect(confirmationIndex).toBeLessThan(publishIndex);
+  });
 });


### PR DESCRIPTION
## Summary
- define separate implementation, landing, staging, and production authorization gates
- require safe explicit confirmation for stable and docs production workflows
- preserve automatic canary and dry-run behavior
- add regression tests and update release documentation

## Validation
- targeted release workflow tests
- node docs workflow tests
- pnpm docs:validate
- workflow YAML parse
- git diff --check

Review Ready only. This PR has not been merged or deployed.