### PR TITLE
fix: keep dev server running when Library is blocked

### DIFF
--- a/server/src/__tests__/home-paths.test.ts
+++ b/server/src/__tests__/home-paths.test.ts
@@ -366,6 +366,84 @@ describe("home paths", () => {
     await expect(fs.stat(layout.root)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
+  it("keeps startup reconciliation available when macOS blocks the organization workspace map", async () => {
+    const rudderHome = await makeTempDir("rudder-home-paths-reconcile-permission-");
+    const workspaceHome = await makeTempDir("rudder-user-workspaces-reconcile-permission-");
+    cleanupDirs.add(rudderHome);
+    cleanupDirs.add(workspaceHome);
+    process.env.RUDDER_HOME = rudderHome;
+    process.env.RUDDER_INSTANCE_ID = "test-instance";
+    process.env.RUDDER_ORGANIZATION_WORKSPACE_HOME = workspaceHome;
+
+    const org = {
+      id: orgId,
+      name: "Permission Blocked Org",
+      urlKey: "permission-blocked-org",
+    };
+    const layout = await ensureOrganizationWorkspaceLayout(org);
+    const mapPath = resolveOrganizationWorkspaceMapPath();
+    const originalReadFile = fs.readFile;
+    const permissionError = Object.assign(new Error("operation not permitted"), {
+      code: "EPERM",
+      path: mapPath,
+    });
+    fs.readFile = vi.fn(async (targetPath, options) => {
+      if (path.resolve(String(targetPath)) === mapPath) throw permissionError;
+      return originalReadFile.call(fs, targetPath, options as never);
+    }) as typeof fs.readFile;
+
+    try {
+      const result = await reconcileOrganizationStorageRoots([org]);
+
+      expect(result.workspacePermissionFailures).toEqual([
+        expect.objectContaining({
+          orgId,
+          code: "EPERM",
+          message: expect.stringMatching(/grant Rudder permission to access Documents/i),
+        }),
+      ]);
+      expect(result.workspaceAvailableOrganizationIds).toEqual([]);
+      await expect(fs.stat(layout.root)).resolves.toBeDefined();
+    } finally {
+      fs.readFile = originalReadFile;
+    }
+  });
+
+  it("explains how to repair a blocked organization workspace map", async () => {
+    const rudderHome = await makeTempDir("rudder-home-paths-map-permission-");
+    const workspaceHome = await makeTempDir("rudder-user-workspaces-map-permission-");
+    cleanupDirs.add(rudderHome);
+    cleanupDirs.add(workspaceHome);
+    process.env.RUDDER_HOME = rudderHome;
+    process.env.RUDDER_INSTANCE_ID = "test-instance";
+    process.env.RUDDER_ORGANIZATION_WORKSPACE_HOME = workspaceHome;
+
+    const org = {
+      id: orgId,
+      name: "Permission Blocked Org",
+      urlKey: "permission-blocked-org",
+    };
+    await ensureOrganizationWorkspaceLayout(org);
+    const mapPath = resolveOrganizationWorkspaceMapPath();
+    const originalReadFile = fs.readFile;
+    const permissionError = Object.assign(new Error("operation not permitted"), {
+      code: "EPERM",
+      path: mapPath,
+    });
+    fs.readFile = vi.fn(async (targetPath, options) => {
+      if (path.resolve(String(targetPath)) === mapPath) throw permissionError;
+      return originalReadFile.call(fs, targetPath, options as never);
+    }) as typeof fs.readFile;
+
+    try {
+      await expect(ensureOrganizationWorkspaceLayout(org)).rejects.toThrow(
+        /could not read the organization workspace mapping.*EPERM.*grant Rudder permission to access Documents/i,
+      );
+    } finally {
+      fs.readFile = originalReadFile;
+    }
+  });
+
   it("reclaims an existing friendly folder when the mapping file is missing", async () => {
     const rudderHome = await makeTempDir("rudder-home-paths-reclaim-friendly-");
     const workspaceHome = await makeTempDir("rudder-user-workspaces-reclaim-friendly-");
@@ -754,6 +832,7 @@ describe("home paths", () => {
       }),
     ]);
     expect(result.pruned.removedOrganizationDirNames).toEqual(["orphan-org"]);
+    expect(result.workspaceAvailableOrganizationIds).toEqual([uuidOrgId]);
     await expect(fs.stat(legacyRoot)).rejects.toMatchObject({ code: "ENOENT" });
     await expect(fs.readFile(path.join(canonicalRoot, "workspaces", "projects", "plan.md"), "utf8"))
       .resolves.toBe("# Plan\n");

--- a/server/src/home-paths.ts
+++ b/server/src/home-paths.ts
@@ -59,6 +59,12 @@ type OrganizationWorkspaceMapFileState = {
   exists: boolean;
 };
 
+type OrganizationWorkspacePermissionFailure = {
+  orgId: string;
+  code: string | null;
+  message: string;
+};
+
 function expandHomePrefix(value: string): string {
   if (value === "~") return os.homedir();
   if (value.startsWith("~/")) return path.resolve(os.homedir(), value.slice(2));
@@ -546,13 +552,40 @@ export async function reconcileOrganizationStorageRoots(
 ): Promise<{
   migrations: Array<Awaited<ReturnType<typeof migrateOrganizationStorageRoot>>>;
   pruned: Awaited<ReturnType<typeof pruneOrphanedOrganizationStorage>>;
+  workspaceAvailableOrganizationIds: string[];
+  workspacePermissionFailures: OrganizationWorkspacePermissionFailure[];
 }> {
   const liveOrgIds = liveOrganizations.map((org) => typeof org === "string" ? org : org.id);
   assertUniqueOrganizationStorageKeys(liveOrgIds);
   const migrations = await Promise.all(liveOrgIds.map((orgId) => migrateOrganizationStorageRoot(orgId)));
-  await Promise.all(liveOrganizations.map((org) => typeof org === "string" ? null : ensureOrganizationWorkspaceLayout(org)));
+  const workspaceAvailability = await Promise.all(liveOrganizations.map(async (org): Promise<{
+    orgId: string;
+    permissionFailure: OrganizationWorkspacePermissionFailure | null;
+  }> => {
+    if (typeof org === "string") return { orgId: org, permissionFailure: null };
+    try {
+      await ensureOrganizationWorkspaceLayout(org);
+      return { orgId: org.id, permissionFailure: null };
+    } catch (error) {
+      if (!isPermissionError(error)) throw error;
+      return {
+        orgId: org.id,
+        permissionFailure: {
+          orgId: org.id,
+          code: errorCode(error),
+          message: organizationWorkspacePermissionFailureMessage(error, org.id),
+        },
+      };
+    }
+  }));
+  const workspacePermissionFailures = workspaceAvailability.flatMap((result) =>
+    result.permissionFailure ? [result.permissionFailure] : []
+  );
+  const workspaceAvailableOrganizationIds = workspaceAvailability.flatMap((result) =>
+    result.permissionFailure ? [] : [result.orgId]
+  );
   const pruned = await pruneOrphanedOrganizationStorage(liveOrgIds);
-  return { migrations, pruned };
+  return { migrations, pruned, workspaceAvailableOrganizationIds, workspacePermissionFailures };
 }
 
 export async function ensureProjectLibraryLayout(input: {
@@ -679,6 +712,17 @@ async function readOrganizationWorkspaceMapFileState(): Promise<OrganizationWork
     };
   } catch (error) {
     if (errorCode(error) === "ENOENT") return { exists: false, map: { version: 1, organizations: [] } };
+    if (isPermissionError(error)) {
+      const code = errorCode(error);
+      const permissionError = new Error([
+        `Rudder could not read the organization workspace mapping${code ? ` (${code})` : ""}.`,
+        `Mapping: ${mapPath}.`,
+        "This usually means the operating system blocked access to the Documents workspace location.",
+        "Grant Rudder permission to access Documents or choose a writable folder with RUDDER_ORGANIZATION_WORKSPACE_HOME.",
+      ].join(" "), { cause: error });
+      if (code) Object.assign(permissionError, { code });
+      throw permissionError;
+    }
     throw error;
   }
 }
@@ -826,6 +870,17 @@ function errorCode(error: unknown): string | null {
 function isPermissionError(error: unknown): boolean {
   const code = errorCode(error);
   return code !== null && WORKSPACE_PERMISSION_ERROR_CODES.has(code);
+}
+
+function organizationWorkspacePermissionFailureMessage(error: unknown, orgId: string): string {
+  const existingMessage = error instanceof Error ? error.message : "";
+  if (/Grant Rudder permission to access Documents/i.test(existingMessage)) return existingMessage;
+  return formatOrganizationWorkspacePermissionMessage({
+    operation: "access",
+    code: errorCode(error),
+    legacyRootPath: resolveLegacyOrganizationWorkspaceRoot(orgId),
+    canonicalRootPath: resolveOrganizationWorkspaceHomeDir(),
+  });
 }
 
 function formatOrganizationWorkspacePermissionMessage(input: {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -790,13 +790,21 @@ async function startServerRuntime(
     name: row.name,
     urlKey: row.urlKey,
   }));
-  const liveOrganizationIds = liveOrganizationRows.map((row) => row.id);
   const organizationStorageReconciliation = await reconcileOrganizationStorageRoots(liveOrganizations);
   const organizationStorageMigrations = organizationStorageReconciliation.migrations;
+  const workspaceAvailableOrganizationIds = organizationStorageReconciliation.workspaceAvailableOrganizationIds;
   const migratedOrganizationStorage = organizationStorageMigrations.filter((result) => result.migrated);
   const skippedOrganizationStorageMigrations = organizationStorageMigrations.filter((result) =>
     result.skippedBecauseTargetExists
   );
+  if (organizationStorageReconciliation.workspacePermissionFailures.length > 0) {
+    logger.warn(
+      {
+        workspacePermissionFailures: organizationStorageReconciliation.workspacePermissionFailures,
+      },
+      "organization Library workspaces are unavailable until filesystem permissions are repaired",
+    );
+  }
   if (migratedOrganizationStorage.length > 0) {
     logger.info(
       {
@@ -835,7 +843,10 @@ async function startServerRuntime(
       "reconciled local organization storage on startup",
     );
   }
-  const workspaceBackupArtifactReconciliation = await reconcileWorkspaceBackupArtifactStorage(db, liveOrganizationIds);
+  const workspaceBackupArtifactReconciliation = await reconcileWorkspaceBackupArtifactStorage(
+    db,
+    workspaceAvailableOrganizationIds,
+  );
   if (workspaceBackupArtifactReconciliation.migrated.length > 0) {
     logger.info(
       {
@@ -859,7 +870,7 @@ async function startServerRuntime(
     );
   }
   const workspaceBackupRepairService = workspaceBackupService(db);
-  for (const orgId of liveOrganizationIds) {
+  for (const orgId of workspaceAvailableOrganizationIds) {
     try {
       const recovery = await workspaceBackupRepairService.recoverSparseWorkspaceFromLatestBackup(orgId);
       if (!recovery.recovered) continue;


### PR DESCRIPTION
## Summary
- treat Documents workspace permission errors as a degraded Library state instead of aborting server startup
- skip backup migration and sparse repair for unavailable organization workspaces
- surface actionable permission guidance and add regression coverage

## Verification
- focused home-path and workspace-backup tests: 58 passed
- pnpm lint
- pnpm -r typecheck
- pnpm build
- pnpm product-logic:check
- isolated black-box startup: health 200, no fallback workspace, backup artifact and metadata unchanged

## Known unrelated failures
- full pnpm test:run currently reports 25 failures across 9 files in the existing dirty workspace; none involve these three changed files