### PR TITLE
fix: restore main architecture ratchet

### DIFF
--- a/server/src/routes/chats.generated-attachments.ts
+++ b/server/src/routes/chats.generated-attachments.ts
@@ -1,0 +1,201 @@
+import {
+  parseCodexInlineVisualDirectives,
+  parseRudderInlineVisualPlacements,
+  type ChatAttachment,
+  type ChatConversation,
+  type ChatInlineVisualMapping,
+  type ChatMessage,
+  type RudderInlineVisualMapping,
+} from "@rudderhq/shared";
+import { MAX_ATTACHMENT_BYTES } from "../attachment-types.js";
+import { logger } from "../middleware/logger.js";
+import {
+  ChatAssistantStreamError,
+  type ChatAssistantResult,
+  type ChatGeneratedAttachment,
+} from "../services/chat-assistant.js";
+import type { chatService } from "../services/chats.js";
+import type { StorageService } from "../storage/types.js";
+
+type GeneratedAttachmentChatService = Pick<
+  ReturnType<typeof chatService>,
+  "createAttachment" | "removeAttachment" | "updateMessageInternalInlineVisuals"
+>;
+
+export async function attachGeneratedChatFiles(input: {
+  assistantReply: ChatAssistantResult;
+  generatedAttachments: ChatGeneratedAttachment[] | undefined;
+  message: ChatMessage;
+  conversation: ChatConversation;
+  replyingAgentId: string | null;
+  storage: StorageService;
+  chats: GeneratedAttachmentChatService;
+}) {
+  const finalDirectives = parseCodexInlineVisualDirectives(input.assistantReply.body).directives;
+  const finalPlacements = parseRudderInlineVisualPlacements(input.assistantReply.body).placements;
+  const inlineVisuals = (input.assistantReply.inlineVisuals ?? []).filter((visual) =>
+    finalDirectives.some((directive) =>
+      directive.index === visual.directiveIndex && directive.file === visual.file
+    )
+  );
+  const inlineVisualsV1 = (input.assistantReply.inlineVisualsV1 ?? []).filter((visual) =>
+    finalPlacements.some((placement) => placement.slot === visual.slot)
+  );
+  const generatedFiles = (input.generatedAttachments ?? []).filter((generated) =>
+    (generated.source !== "codex_inline_visual" && generated.source !== "rudder_inline_visual")
+    || (generated.source === "codex_inline_visual" && inlineVisuals.some((visual) =>
+      visual.status === "captured"
+      && visual.directiveIndex === generated.directiveIndex
+      && visual.file === generated.directiveFile
+    ))
+    || (generated.source === "rudder_inline_visual" && inlineVisualsV1.some((visual) =>
+      visual.status === "captured"
+      && visual.slot === generated.slot
+      && visual.file === generated.originalFilename
+    ))
+  );
+  if (generatedFiles.length === 0 && inlineVisuals.length === 0 && inlineVisualsV1.length === 0) {
+    return input.message;
+  }
+  const attachments: ChatAttachment[] = [];
+  const attachmentByVisualIndex = new Map<number, ChatAttachment>();
+  const attachmentByVisualSlot = new Map<number, ChatAttachment>();
+  const createdAttachmentRecords: Array<{ attachmentId: string; orgId: string; objectKey: string }> = [];
+  try {
+    for (const generated of generatedFiles) {
+      if (generated.body.length > MAX_ATTACHMENT_BYTES) {
+        throw new ChatAssistantStreamError(
+          `Generated attachment exceeds ${MAX_ATTACHMENT_BYTES} bytes`,
+          input.assistantReply.body,
+          generatedFiles,
+          { partialBodyUserVisible: true },
+        );
+      }
+      const stored = await input.storage.putFile({
+        orgId: input.conversation.orgId,
+        namespace: `chats/${input.conversation.id}/generated`,
+        originalFilename: generated.originalFilename,
+        contentType: generated.contentType,
+        body: generated.body,
+      });
+      let attachment;
+      try {
+        attachment = await input.chats.createAttachment({
+          orgId: input.conversation.orgId,
+          conversationId: input.conversation.id,
+          messageId: input.message.id,
+          provider: stored.provider,
+          objectKey: stored.objectKey,
+          contentType: stored.contentType,
+          byteSize: stored.byteSize,
+          sha256: stored.sha256,
+          originalFilename: stored.originalFilename,
+          createdByAgentId: input.replyingAgentId,
+          createdByUserId: null,
+        });
+      } catch (error) {
+        await input.storage.deleteObject(input.conversation.orgId, stored.objectKey).catch((cleanupError) => {
+          logger.warn({ err: cleanupError, objectKey: stored.objectKey }, "failed to clean up generated chat object");
+        });
+        throw error;
+      }
+      createdAttachmentRecords.push({
+        attachmentId: attachment.id,
+        orgId: input.conversation.orgId,
+        objectKey: stored.objectKey,
+      });
+      const typedAttachment = attachment as ChatAttachment;
+      const publicAttachment = generated.source === "codex_inline_visual" || generated.source === "rudder_inline_visual"
+        ? (({ provider: _provider, objectKey: _objectKey, ...safe }) => safe)(typedAttachment)
+        : typedAttachment;
+      attachments.push(publicAttachment as ChatAttachment);
+      if (generated.source === "codex_inline_visual") {
+        attachmentByVisualIndex.set(generated.directiveIndex, publicAttachment as ChatAttachment);
+      } else if (generated.source === "rudder_inline_visual") {
+        attachmentByVisualSlot.set(generated.slot, publicAttachment as ChatAttachment);
+      }
+    }
+    let structuredPayload = input.message.structuredPayload ?? null;
+    let persistedLegacyMappings: ChatInlineVisualMapping[] = [];
+    let persistedRudderMappings: RudderInlineVisualMapping[] = [];
+    if (inlineVisuals.length > 0) {
+      persistedLegacyMappings = inlineVisuals.map((visual) => {
+        if (visual.status === "captured") {
+          const attachment = attachmentByVisualIndex.get(visual.directiveIndex);
+          if (attachment) {
+            return {
+              directiveIndex: visual.directiveIndex,
+              file: visual.file,
+              status: "ready" as const,
+              attachmentId: attachment.id,
+            };
+          }
+        }
+        return {
+          directiveIndex: visual.directiveIndex,
+          file: visual.file,
+          status: "unavailable" as const,
+          reason: visual.status === "unavailable" ? visual.reason : "capture_failed",
+        };
+      });
+      structuredPayload = { ...(structuredPayload ?? {}), inlineVisuals: persistedLegacyMappings };
+    }
+    if (inlineVisualsV1.length > 0) {
+      persistedRudderMappings = inlineVisualsV1.map((visual) => {
+        if (visual.status === "captured") {
+          const attachment = attachmentByVisualSlot.get(visual.slot);
+          if (attachment) {
+            return {
+              version: 1 as const,
+              slot: visual.slot,
+              file: visual.file,
+              status: "ready" as const,
+              attachmentId: attachment.id,
+              contentType: "text/html" as const,
+              byteSize: attachment.byteSize,
+              sha256: attachment.sha256,
+            };
+          }
+        }
+        return {
+          version: 1 as const,
+          slot: visual.slot,
+          file: visual.file,
+          status: "unavailable" as const,
+          reason: visual.status === "unavailable" ? visual.reason : "capture_failed",
+        };
+      });
+      structuredPayload = { ...(structuredPayload ?? {}), inlineVisualsV1: persistedRudderMappings };
+    }
+    if (persistedLegacyMappings.length > 0 || persistedRudderMappings.length > 0) {
+      const internallyUpdated = await input.chats.updateMessageInternalInlineVisuals(
+        input.conversation.id,
+        input.message.id,
+        {
+          ...(persistedLegacyMappings.length > 0 ? { inlineVisuals: persistedLegacyMappings } : {}),
+          ...(persistedRudderMappings.length > 0 ? { inlineVisualsV1: persistedRudderMappings } : {}),
+        },
+      );
+      if (!internallyUpdated) throw new Error("Failed to persist trusted inline visual mapping");
+      structuredPayload = internallyUpdated.structuredPayload ?? structuredPayload;
+    }
+    return {
+      ...input.message,
+      structuredPayload,
+      attachments: [...(input.message.attachments ?? []), ...attachments],
+    } as ChatMessage;
+  } catch (error) {
+    for (const created of createdAttachmentRecords.reverse()) {
+      const removed = await input.chats.removeAttachment(created.attachmentId).catch((cleanupError) => {
+        logger.warn({ err: cleanupError, attachmentId: created.attachmentId }, "failed to remove generated chat attachment");
+        return null;
+      });
+      if (removed?.assetDeleted) {
+        await input.storage.deleteObject(created.orgId, created.objectKey).catch((cleanupError) => {
+          logger.warn({ err: cleanupError, objectKey: created.objectKey }, "failed to remove generated chat object");
+        });
+      }
+    }
+    throw error;
+  }
+}

--- a/server/src/routes/chats.ts
+++ b/server/src/routes/chats.ts
@@ -9,8 +9,6 @@ import {
   createChatQueuedMessageSchema,
   createSideChatSchema,
   forkChatConversationSchema,
-  parseCodexInlineVisualDirectives,
-  parseRudderInlineVisualPlacements,
   steerChatQueuedMessageSchema,
   updateChatConversationSchema,
   updateChatQueuedMessageSchema,
@@ -18,10 +16,8 @@ import {
   type ChatContextLink,
   type ChatControlDisposition,
   type ChatConversation,
-  type ChatInlineVisualMapping,
   type ChatMessage,
   type ChatQueueRequestActor,
-  type RudderInlineVisualMapping,
 } from "@rudderhq/shared";
 import { Router, type Request, type Response } from "express";
 import multer from "multer";
@@ -85,6 +81,7 @@ import {
   type ChatBackgroundTimer,
 } from "./chat-background-runtime.js";
 import { wakeIssueAssigneeAfterChatConversion } from "./chat-issue-assignment-wakeup.js";
+import { attachGeneratedChatFiles } from "./chats.generated-attachments.js";
 import {
   isMultipartRequest,
   paginateChatMessages,
@@ -648,179 +645,16 @@ export function chatRoutes(
   ) {
     const createdMessages: ChatMessage[] = [];
     const { chatTurnId, turnVariant } = turnContext;
-    const attachGeneratedFiles = async (message: ChatMessage, generatedAttachments: ChatGeneratedAttachment[] | undefined) => {
-      const finalDirectives = parseCodexInlineVisualDirectives(assistantReply.body).directives;
-      const finalPlacements = parseRudderInlineVisualPlacements(assistantReply.body).placements;
-      const inlineVisuals = (assistantReply.inlineVisuals ?? []).filter((visual) =>
-        finalDirectives.some((directive) =>
-          directive.index === visual.directiveIndex && directive.file === visual.file
-        )
-      );
-      const inlineVisualsV1 = (assistantReply.inlineVisualsV1 ?? []).filter((visual) =>
-        finalPlacements.some((placement) => placement.slot === visual.slot)
-      );
-      const generatedFiles = (generatedAttachments ?? []).filter((generated) =>
-        (generated.source !== "codex_inline_visual" && generated.source !== "rudder_inline_visual")
-        || (generated.source === "codex_inline_visual" && inlineVisuals.some((visual) =>
-          visual.status === "captured"
-          && visual.directiveIndex === generated.directiveIndex
-          && visual.file === generated.directiveFile
-        ))
-        || (generated.source === "rudder_inline_visual" && inlineVisualsV1.some((visual) =>
-          visual.status === "captured"
-          && visual.slot === generated.slot
-          && visual.file === generated.originalFilename
-        ))
-      );
-      if (generatedFiles.length === 0 && inlineVisuals.length === 0 && inlineVisualsV1.length === 0) return message;
-      const attachments: ChatAttachment[] = [];
-      const attachmentByVisualIndex = new Map<number, ChatAttachment>();
-      const attachmentByVisualSlot = new Map<number, ChatAttachment>();
-      const createdAttachmentRecords: Array<{ attachmentId: string; orgId: string; objectKey: string }> = [];
-      try {
-        for (const generated of generatedFiles) {
-          if (generated.body.length > MAX_ATTACHMENT_BYTES) {
-            throw new ChatAssistantStreamError(
-              `Generated attachment exceeds ${MAX_ATTACHMENT_BYTES} bytes`,
-              assistantReply.body,
-              generatedFiles,
-              { partialBodyUserVisible: true },
-            );
-          }
-          const stored = await storage.putFile({
-            orgId: conversation.orgId,
-            namespace: `chats/${conversation.id}/generated`,
-            originalFilename: generated.originalFilename,
-            contentType: generated.contentType,
-            body: generated.body,
-          });
-          let attachment;
-          try {
-            attachment = await svc.createAttachment({
-              orgId: conversation.orgId,
-              conversationId: conversation.id,
-              messageId: message.id,
-              provider: stored.provider,
-              objectKey: stored.objectKey,
-              contentType: stored.contentType,
-              byteSize: stored.byteSize,
-              sha256: stored.sha256,
-              originalFilename: stored.originalFilename,
-              createdByAgentId: replyingAgentId,
-              createdByUserId: null,
-            });
-          } catch (error) {
-            await storage.deleteObject(conversation.orgId, stored.objectKey).catch((cleanupError) => {
-              logger.warn({ err: cleanupError, objectKey: stored.objectKey }, "failed to clean up generated chat object");
-            });
-            throw error;
-          }
-          createdAttachmentRecords.push({
-            attachmentId: attachment.id,
-            orgId: conversation.orgId,
-            objectKey: stored.objectKey,
-          });
-          const typedAttachment = attachment as ChatAttachment;
-          const publicAttachment = generated.source === "codex_inline_visual" || generated.source === "rudder_inline_visual"
-            ? (({ provider: _provider, objectKey: _objectKey, ...safe }) => safe)(typedAttachment)
-            : typedAttachment;
-          attachments.push(publicAttachment as ChatAttachment);
-          if (generated.source === "codex_inline_visual") {
-            attachmentByVisualIndex.set(generated.directiveIndex, publicAttachment as ChatAttachment);
-          } else if (generated.source === "rudder_inline_visual") {
-            attachmentByVisualSlot.set(generated.slot, publicAttachment as ChatAttachment);
-          }
-        }
-      let structuredPayload = message.structuredPayload ?? null;
-      let persistedLegacyMappings: ChatInlineVisualMapping[] = [];
-      let persistedRudderMappings: RudderInlineVisualMapping[] = [];
-      if (inlineVisuals.length > 0) {
-        persistedLegacyMappings = inlineVisuals.map((visual) => {
-          if (visual.status === "captured") {
-            const attachment = attachmentByVisualIndex.get(visual.directiveIndex);
-            if (attachment) {
-              return {
-                directiveIndex: visual.directiveIndex,
-                file: visual.file,
-                status: "ready" as const,
-                attachmentId: attachment.id,
-              };
-            }
-          }
-          return {
-            directiveIndex: visual.directiveIndex,
-            file: visual.file,
-            status: "unavailable" as const,
-            reason: visual.status === "unavailable" ? visual.reason : "capture_failed",
-          };
-        });
-        structuredPayload = {
-          ...(structuredPayload ?? {}),
-          inlineVisuals: persistedLegacyMappings,
-        };
-      }
-      if (inlineVisualsV1.length > 0) {
-        persistedRudderMappings = inlineVisualsV1.map((visual) => {
-          if (visual.status === "captured") {
-            const attachment = attachmentByVisualSlot.get(visual.slot);
-            if (attachment) {
-              return {
-                version: 1 as const,
-                slot: visual.slot,
-                file: visual.file,
-                status: "ready" as const,
-                attachmentId: attachment.id,
-                contentType: "text/html" as const,
-                byteSize: attachment.byteSize,
-                sha256: attachment.sha256,
-              };
-            }
-          }
-          return {
-            version: 1 as const,
-            slot: visual.slot,
-            file: visual.file,
-            status: "unavailable" as const,
-            reason: visual.status === "unavailable" ? visual.reason : "capture_failed",
-          };
-        });
-        structuredPayload = {
-          ...(structuredPayload ?? {}),
-          inlineVisualsV1: persistedRudderMappings,
-        };
-      }
-        if (persistedLegacyMappings.length > 0 || persistedRudderMappings.length > 0) {
-          const internallyUpdated = await svc.updateMessageInternalInlineVisuals(
-            conversation.id,
-            message.id,
-            {
-              ...(persistedLegacyMappings.length > 0 ? { inlineVisuals: persistedLegacyMappings } : {}),
-              ...(persistedRudderMappings.length > 0 ? { inlineVisualsV1: persistedRudderMappings } : {}),
-            },
-          );
-          if (!internallyUpdated) throw new Error("Failed to persist trusted inline visual mapping");
-          structuredPayload = internallyUpdated.structuredPayload ?? structuredPayload;
-        }
-        return {
-          ...message,
-          structuredPayload,
-          attachments: [...(message.attachments ?? []), ...attachments],
-        } as ChatMessage;
-      } catch (error) {
-        for (const created of createdAttachmentRecords.reverse()) {
-          const removed = await svc.removeAttachment(created.attachmentId).catch((cleanupError) => {
-            logger.warn({ err: cleanupError, attachmentId: created.attachmentId }, "failed to remove generated chat attachment");
-            return null;
-          });
-          if (removed?.assetDeleted) {
-            await storage.deleteObject(created.orgId, created.objectKey).catch((cleanupError) => {
-              logger.warn({ err: cleanupError, objectKey: created.objectKey }, "failed to remove generated chat object");
-            });
-          }
-        }
-        throw error;
-      }
-    };
+    const attachGeneratedFiles = (message: ChatMessage, generatedAttachments: ChatGeneratedAttachment[] | undefined) =>
+      attachGeneratedChatFiles({
+        assistantReply,
+        generatedAttachments,
+        message,
+        conversation,
+        replyingAgentId,
+        storage,
+        chats: svc,
+      });
     const saveAssistantMessage = async (input: {
       kind: "message" | "ask_user" | "issue_proposal" | "operation_proposal";
       body: string;

--- a/server/src/services/chat-assistant.helpers.ts
+++ b/server/src/services/chat-assistant.helpers.ts
@@ -15,16 +15,12 @@ import type {
 } from "@rudderhq/shared";
 import {
   MAX_CODEX_INLINE_VISUALS,
-  MAX_RUDDER_INLINE_VISUAL_FRAGMENT_BYTES,
   chatAskUserRequestFromStructuredPayload,
   chatAutomationCreateFromStructuredPayload,
   chatIssueProposalFromStructuredPayload,
   parseCodexInlineVisualDirectives,
-  parseRudderInlineVisualEnvelopes,
   redactRudderInlineVisualSources,
-  replaceRudderInlineVisualSources,
   sanitizeChatStructuredPayload,
-  stripRudderInlineVisualPlacements,
 } from "@rudderhq/shared";
 import { createWriteStream } from "node:fs";
 import fs from "node:fs/promises";
@@ -35,6 +31,16 @@ import type { AgentRuntimeInvocationMeta, AgentRuntimeLoadedSkillMeta } from "..
 import type { AgentRuntimeExecutionContext, AgentRuntimeExecutionResult } from "../agent-runtimes/types.js";
 import type { StorageService } from "../storage/types.js";
 import { type AgentRunContextAgent } from "./agent-run-context.js";
+import {
+  buildChatInlineVisualPromptSection
+} from "./chat-assistant.inline-visuals.js";
+
+export {
+  buildChatInlineVisualPromptSection,
+  chatAssistantErrorForLog,
+  extractRudderInlineVisualArtifacts,
+  redactChatInlineVisualDiagnosticText
+} from "./chat-assistant.inline-visuals.js";
 
 export const CHAT_UNSUPPORTED_ADAPTER_TYPES = new Set<AgentRuntimeType>();
 export const CHAT_RESULT_SENTINEL_PREFIX = "__RUDDER_RESULT_";
@@ -241,58 +247,6 @@ export function buildMissingResultSentinelRepairPrompt(input: {
 export function safeTrim(value: string | null | undefined) {
   const trimmed = value?.trim();
   return trimmed ? trimmed : null;
-}
-
-export function chatAssistantErrorForLog(error: unknown) {
-  if (!(error instanceof Error)) {
-    return {
-      name: "Error",
-      message: redactChatInlineVisualDiagnosticText(
-        String(error),
-        "Chat runtime failed while handling private presentation data",
-      ),
-    };
-  }
-  const candidate = error as Error & {
-    errorCode?: unknown;
-    retryable?: unknown;
-    failurePhase?: unknown;
-    action?: unknown;
-  };
-  const message = redactChatInlineVisualDiagnosticText(
-    error.message,
-    "Chat runtime failed while handling private presentation data",
-  );
-  const stack = error.stack
-    ? redactChatInlineVisualDiagnosticText(error.stack, message)
-    : undefined;
-  return {
-    name: redactChatInlineVisualDiagnosticText(error.name, "Error"),
-    message,
-    stack,
-    ...(typeof candidate.errorCode === "string"
-      ? { errorCode: redactChatInlineVisualDiagnosticText(candidate.errorCode, "chat_runtime_exception") }
-      : {}),
-    ...(typeof candidate.retryable === "boolean" ? { retryable: candidate.retryable } : {}),
-    ...(typeof candidate.failurePhase === "string"
-      ? { failurePhase: redactChatInlineVisualDiagnosticText(candidate.failurePhase, "runtime") }
-      : {}),
-    ...(typeof candidate.action === "string"
-      ? { action: redactChatInlineVisualDiagnosticText(candidate.action, "retry") }
-      : {}),
-  };
-}
-
-export function redactChatInlineVisualDiagnosticText(
-  value: string | null | undefined,
-  fallback: string,
-) {
-  const source = value?.trim();
-  if (!source) return fallback;
-  const sourceWithoutEnvelopes = redactRudderInlineVisualSources(source);
-  if (/<div\b[^>]*\bid\s*=\s*["']widget["']/i.test(sourceWithoutEnvelopes)) return fallback;
-  const redacted = stripRudderInlineVisualPlacements(sourceWithoutEnvelopes).trim();
-  return redacted || fallback;
 }
 
 export function asString(value: unknown): string {
@@ -587,21 +541,6 @@ export function buildAutomationRunInputPromptSection(messages: ChatMessage[]) {
     lines.push("- For this automation-run input, mayCreateAutomation: false.");
   }
   return lines.join("\n");
-}
-
-export function buildChatInlineVisualPromptSection() {
-  return [
-    "Resolved Rudder built-in skill projection: visualize (Chat v1). This common prompt projection is authoritative even when the runtime has no native skill directory or skill-sync API.",
-    "Rudder Chat supports runtime-neutral, message-owned inline visuals. Use this only when an interactive or structured visual materially improves the answer.",
-    "Wrap each complete scriptless HTML fragment in this exact v1 envelope:",
-    ":::rudder-inline-visual:v1",
-    '<div id="widget">...</div>',
-    ":::rudder-inline-visual:end",
-    "The opening and closing markers must each be on their own line. The fragment must have exactly one <div id=\"widget\"> root, use inline CSS only, contain no JavaScript, event handlers, network requests, external resources, fonts, URLs, or forms, and remain useful without interaction.",
-    "Emit at most three fragments. Each fragment must be at most 64 KiB UTF-8, all fragments together at most 128 KiB, and the complete final reply at most 256 KiB.",
-    "Do not emit an iframe, file path, attachment id, or provider-specific directive. Do not emit Rudder's canonical placement syntax; Rudder replaces each valid envelope with that internal placement after capture.",
-    "If the runtime cannot produce this envelope, return an equivalent Markdown or fenced HTML explanation instead of inventing another embedding protocol.",
-  ].join("\n");
 }
 
 export function buildBaseSystemPromptSections(runtimeSource: ResolvedChatRuntimeSource, resultSentinel: string) {
@@ -913,94 +852,6 @@ export function extractCodexInlineVisualArtifacts(result: AgentRuntimeExecutionR
       : 0
   );
   return { attachments, inlineVisuals };
-}
-
-function rudderInlineVisualFragmentIssue(fragment: string) {
-  if (!/<div\b[^>]*\bid\s*=\s*["']widget["'][^>]*>/i.test(fragment)) return "missing_widget";
-  if (/<\/?(?:html|head|body|base|script|iframe|frame|object|embed|form|input|button|select|textarea|a|img|image|video|audio|source|link|meta)\b/i.test(fragment)) {
-    return "unsafe_fragment";
-  }
-  if (/\s(?:on[a-z]+|href|src|srcset|action|formaction|poster|data|xlink:href)\s*=/i.test(fragment)) {
-    return "unsafe_fragment";
-  }
-  if (/<style\b[^>]*>[\s\S]*?(?:@import|@font-face|url\s*\(|expression\s*\(|javascript:)[\s\S]*?<\/style>/i.test(fragment)) {
-    return "unsafe_fragment";
-  }
-  return null;
-}
-
-export function extractRudderInlineVisualArtifacts(
-  body: string,
-  options: { reservedSlots?: number } = {},
-): {
-  body: string;
-  attachments: ChatGeneratedAttachment[];
-  inlineVisualsV1: ChatInlineVisualV1Result[];
-} {
-  const parsed = parseRudderInlineVisualEnvelopes(body);
-  const reservedSlots = Math.max(0, Math.min(MAX_CODEX_INLINE_VISUALS, options.reservedSlots ?? 0));
-  const attachments: ChatGeneratedAttachment[] = [];
-  const inlineVisualsV1: ChatInlineVisualV1Result[] = [];
-  const replacements: Array<{ start: number; end: number; replacement: string }> = [];
-
-  for (const envelope of parsed.envelopes) {
-    const slot = envelope.slot + reservedSlots;
-    if (slot >= MAX_CODEX_INLINE_VISUALS) {
-      replacements.push({ start: envelope.start, end: envelope.end, replacement: "" });
-      continue;
-    }
-    const file = `inline-visual-${slot + 1}.html`;
-    const fragmentIssue = rudderInlineVisualFragmentIssue(envelope.fragment);
-    replacements.push({
-      start: envelope.start,
-      end: envelope.end,
-      replacement: `::rudder-inline-vis{slot="${slot}"}`,
-    });
-    if (fragmentIssue) {
-      inlineVisualsV1.push({ version: 1, slot, file, status: "unavailable", reason: fragmentIssue });
-      continue;
-    }
-    const fragmentBody = Buffer.from(envelope.fragment, "utf8");
-    if (fragmentBody.length !== envelope.byteSize || fragmentBody.length > MAX_RUDDER_INLINE_VISUAL_FRAGMENT_BYTES) {
-      inlineVisualsV1.push({ version: 1, slot, file, status: "unavailable", reason: "fragment_size_limit" });
-      continue;
-    }
-    inlineVisualsV1.push({ version: 1, slot, file, status: "captured", byteSize: fragmentBody.length });
-    attachments.push({
-      source: "rudder_inline_visual",
-      originalFilename: file,
-      contentType: "text/html",
-      body: fragmentBody,
-      slot,
-    });
-  }
-
-  for (const visualIssue of parsed.issues) {
-    const slot = visualIssue.slot === null ? null : visualIssue.slot + reservedSlots;
-    if (slot === null || slot >= MAX_CODEX_INLINE_VISUALS) {
-      replacements.push({ start: visualIssue.start, end: visualIssue.end, replacement: "" });
-      continue;
-    }
-    const file = `inline-visual-${slot + 1}.html`;
-    replacements.push({
-      start: visualIssue.start,
-      end: visualIssue.end,
-      replacement: `::rudder-inline-vis{slot="${slot}"}`,
-    });
-    inlineVisualsV1.push({ version: 1, slot, file, status: "unavailable", reason: visualIssue.code });
-  }
-
-  inlineVisualsV1.sort((a, b) => a.slot - b.slot);
-  attachments.sort((a, b) =>
-    a.source === "rudder_inline_visual" && b.source === "rudder_inline_visual"
-      ? a.slot - b.slot
-      : 0
-  );
-  return {
-    body: replaceRudderInlineVisualSources(body, replacements),
-    attachments,
-    inlineVisualsV1,
-  };
 }
 
 export function isImageAttachment(attachment: Pick<ChatMessage["attachments"][number], "contentType">) {

--- a/server/src/services/chat-assistant.inline-visuals.ts
+++ b/server/src/services/chat-assistant.inline-visuals.ts
@@ -1,0 +1,167 @@
+import {
+  MAX_CODEX_INLINE_VISUALS,
+  MAX_RUDDER_INLINE_VISUAL_FRAGMENT_BYTES,
+  parseRudderInlineVisualEnvelopes,
+  redactRudderInlineVisualSources,
+  replaceRudderInlineVisualSources,
+  stripRudderInlineVisualPlacements,
+} from "@rudderhq/shared";
+import type {
+  ChatGeneratedAttachment,
+  ChatInlineVisualV1Result,
+} from "./chat-assistant.helpers.js";
+
+export function chatAssistantErrorForLog(error: unknown) {
+  if (!(error instanceof Error)) {
+    return {
+      name: "Error",
+      message: redactChatInlineVisualDiagnosticText(
+        String(error),
+        "Chat runtime failed while handling private presentation data",
+      ),
+    };
+  }
+  const candidate = error as Error & {
+    errorCode?: unknown;
+    retryable?: unknown;
+    failurePhase?: unknown;
+    action?: unknown;
+  };
+  const message = redactChatInlineVisualDiagnosticText(
+    error.message,
+    "Chat runtime failed while handling private presentation data",
+  );
+  const stack = error.stack
+    ? redactChatInlineVisualDiagnosticText(error.stack, message)
+    : undefined;
+  return {
+    name: redactChatInlineVisualDiagnosticText(error.name, "Error"),
+    message,
+    stack,
+    ...(typeof candidate.errorCode === "string"
+      ? { errorCode: redactChatInlineVisualDiagnosticText(candidate.errorCode, "chat_runtime_exception") }
+      : {}),
+    ...(typeof candidate.retryable === "boolean" ? { retryable: candidate.retryable } : {}),
+    ...(typeof candidate.failurePhase === "string"
+      ? { failurePhase: redactChatInlineVisualDiagnosticText(candidate.failurePhase, "runtime") }
+      : {}),
+    ...(typeof candidate.action === "string"
+      ? { action: redactChatInlineVisualDiagnosticText(candidate.action, "retry") }
+      : {}),
+  };
+}
+
+export function redactChatInlineVisualDiagnosticText(
+  value: string | null | undefined,
+  fallback: string,
+) {
+  const source = value?.trim();
+  if (!source) return fallback;
+  const sourceWithoutEnvelopes = redactRudderInlineVisualSources(source);
+  if (/<div\b[^>]*\bid\s*=\s*["']widget["']/i.test(sourceWithoutEnvelopes)) return fallback;
+  const redacted = stripRudderInlineVisualPlacements(sourceWithoutEnvelopes).trim();
+  return redacted || fallback;
+}
+
+export function buildChatInlineVisualPromptSection() {
+  return [
+    "Resolved Rudder built-in skill projection: visualize (Chat v1). This common prompt projection is authoritative even when the runtime has no native skill directory or skill-sync API.",
+    "Rudder Chat supports runtime-neutral, message-owned inline visuals. Use this only when an interactive or structured visual materially improves the answer.",
+    "Wrap each complete scriptless HTML fragment in this exact v1 envelope:",
+    ":::rudder-inline-visual:v1",
+    '<div id="widget">...</div>',
+    ":::rudder-inline-visual:end",
+    "The opening and closing markers must each be on their own line. The fragment must have exactly one <div id=\"widget\"> root, use inline CSS only, contain no JavaScript, event handlers, network requests, external resources, fonts, URLs, or forms, and remain useful without interaction.",
+    "Emit at most three fragments. Each fragment must be at most 64 KiB UTF-8, all fragments together at most 128 KiB, and the complete final reply at most 256 KiB.",
+    "Do not emit an iframe, file path, attachment id, or provider-specific directive. Do not emit Rudder's canonical placement syntax; Rudder replaces each valid envelope with that internal placement after capture.",
+    "If the runtime cannot produce this envelope, return an equivalent Markdown or fenced HTML explanation instead of inventing another embedding protocol.",
+  ].join("\n");
+}
+
+function rudderInlineVisualFragmentIssue(fragment: string) {
+  if (!/<div\b[^>]*\bid\s*=\s*["']widget["'][^>]*>/i.test(fragment)) return "missing_widget";
+  if (/<\/?(?:html|head|body|base|script|iframe|frame|object|embed|form|input|button|select|textarea|a|img|image|video|audio|source|link|meta)\b/i.test(fragment)) {
+    return "unsafe_fragment";
+  }
+  if (/\s(?:on[a-z]+|href|src|srcset|action|formaction|poster|data|xlink:href)\s*=/i.test(fragment)) {
+    return "unsafe_fragment";
+  }
+  if (/<style\b[^>]*>[\s\S]*?(?:@import|@font-face|url\s*\(|expression\s*\(|javascript:)[\s\S]*?<\/style>/i.test(fragment)) {
+    return "unsafe_fragment";
+  }
+  return null;
+}
+
+export function extractRudderInlineVisualArtifacts(
+  body: string,
+  options: { reservedSlots?: number } = {},
+): {
+  body: string;
+  attachments: ChatGeneratedAttachment[];
+  inlineVisualsV1: ChatInlineVisualV1Result[];
+} {
+  const parsed = parseRudderInlineVisualEnvelopes(body);
+  const reservedSlots = Math.max(0, Math.min(MAX_CODEX_INLINE_VISUALS, options.reservedSlots ?? 0));
+  const attachments: ChatGeneratedAttachment[] = [];
+  const inlineVisualsV1: ChatInlineVisualV1Result[] = [];
+  const replacements: Array<{ start: number; end: number; replacement: string }> = [];
+
+  for (const envelope of parsed.envelopes) {
+    const slot = envelope.slot + reservedSlots;
+    if (slot >= MAX_CODEX_INLINE_VISUALS) {
+      replacements.push({ start: envelope.start, end: envelope.end, replacement: "" });
+      continue;
+    }
+    const file = `inline-visual-${slot + 1}.html`;
+    const fragmentIssue = rudderInlineVisualFragmentIssue(envelope.fragment);
+    replacements.push({
+      start: envelope.start,
+      end: envelope.end,
+      replacement: `::rudder-inline-vis{slot="${slot}"}`,
+    });
+    if (fragmentIssue) {
+      inlineVisualsV1.push({ version: 1, slot, file, status: "unavailable", reason: fragmentIssue });
+      continue;
+    }
+    const fragmentBody = Buffer.from(envelope.fragment, "utf8");
+    if (fragmentBody.length !== envelope.byteSize || fragmentBody.length > MAX_RUDDER_INLINE_VISUAL_FRAGMENT_BYTES) {
+      inlineVisualsV1.push({ version: 1, slot, file, status: "unavailable", reason: "fragment_size_limit" });
+      continue;
+    }
+    inlineVisualsV1.push({ version: 1, slot, file, status: "captured", byteSize: fragmentBody.length });
+    attachments.push({
+      source: "rudder_inline_visual",
+      originalFilename: file,
+      contentType: "text/html",
+      body: fragmentBody,
+      slot,
+    });
+  }
+
+  for (const visualIssue of parsed.issues) {
+    const slot = visualIssue.slot === null ? null : visualIssue.slot + reservedSlots;
+    if (slot === null || slot >= MAX_CODEX_INLINE_VISUALS) {
+      replacements.push({ start: visualIssue.start, end: visualIssue.end, replacement: "" });
+      continue;
+    }
+    const file = `inline-visual-${slot + 1}.html`;
+    replacements.push({
+      start: visualIssue.start,
+      end: visualIssue.end,
+      replacement: `::rudder-inline-vis{slot="${slot}"}`,
+    });
+    inlineVisualsV1.push({ version: 1, slot, file, status: "unavailable", reason: visualIssue.code });
+  }
+
+  inlineVisualsV1.sort((a, b) => a.slot - b.slot);
+  attachments.sort((a, b) =>
+    a.source === "rudder_inline_visual" && b.source === "rudder_inline_visual"
+      ? a.slot - b.slot
+      : 0
+  );
+  return {
+    body: replaceRudderInlineVisualSources(body, replacements),
+    attachments,
+    inlineVisualsV1,
+  };
+}

--- a/server/src/services/chats.inline-visual-persistence.ts
+++ b/server/src/services/chats.inline-visual-persistence.ts
@@ -1,0 +1,273 @@
+import type { Db } from "@rudderhq/db";
+import { assets, chatAttachments, chatConversations, chatMessages } from "@rudderhq/db";
+import {
+  chatInlineVisualMappingsFromStructuredPayload,
+  parseCodexInlineVisualDirectives,
+  parseRudderInlineVisualPlacements,
+  rudderInlineVisualMappingsFromStructuredPayload,
+  sanitizeChatStructuredPayload,
+  type ChatInlineVisualMapping,
+  type RudderInlineVisualMapping,
+} from "@rudderhq/shared";
+import { and, desc, eq, inArray, isNull, sql } from "drizzle-orm";
+import { randomUUID } from "node:crypto";
+import type { MessageHydrationRow } from "./chats.types.js";
+
+type ChatTransaction = Parameters<Parameters<Db["transaction"]>[0]>[0];
+type ChatMessageRow = typeof chatMessages.$inferSelect;
+
+export async function listRecentUserChatMessages(db: Db, conversationId: string, limit: number) {
+  const ecmascriptTrimWhitespace = "\u0009\u000A\u000B\u000C\u000D\u0020\u00A0\u1680\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200A\u2028\u2029\u202F\u205F\u3000\uFEFF";
+  const boundedLimit = Math.min(5, Math.max(1, Math.trunc(limit)));
+  const conversationOrgIds = db
+    .select({ orgId: chatConversations.orgId })
+    .from(chatConversations)
+    .where(eq(chatConversations.id, conversationId));
+  const rows = await db
+    .select({
+      id: chatMessages.id,
+      role: chatMessages.role,
+      kind: chatMessages.kind,
+      body: chatMessages.body,
+      createdAt: chatMessages.createdAt,
+    })
+    .from(chatMessages)
+    .where(and(
+      eq(chatMessages.conversationId, conversationId),
+      inArray(chatMessages.orgId, conversationOrgIds),
+      isNull(chatMessages.supersededAt),
+      eq(chatMessages.role, "user"),
+      eq(chatMessages.kind, "message"),
+      sql<boolean>`btrim(${chatMessages.body}, ${ecmascriptTrimWhitespace}) <> ''`,
+    ))
+    .orderBy(desc(chatMessages.createdAt), desc(chatMessages.id))
+    .limit(boundedLimit);
+  return rows.reverse();
+}
+
+export async function copyForkInlineVisualMessages(input: {
+  tx: ChatTransaction;
+  messages: ChatMessageRow[];
+  sourceConversationId: string;
+  targetConversationId: string;
+  orgId: string;
+}) {
+  for (const message of input.messages) {
+    const copiedMessageId = randomUUID();
+    const visualMappings = chatInlineVisualMappingsFromStructuredPayload(message.structuredPayload);
+    const visualMappingsV1 = rudderInlineVisualMappingsFromStructuredPayload(message.structuredPayload);
+    const readyAttachmentIds = [...visualMappings, ...visualMappingsV1]
+      .filter((mapping) => mapping.status === "ready")
+      .map((mapping) => mapping.attachmentId);
+    const copiedAttachmentIdBySourceId = new Map<string, string>();
+    const pendingVisualAttachments: Array<{
+      id: string;
+      orgId: string;
+      conversationId: string;
+      messageId: string;
+      assetId: string;
+    }> = [];
+    if (readyAttachmentIds.length > 0) {
+      const sourceVisualAttachments = await input.tx
+        .select({
+          id: chatAttachments.id,
+          assetId: chatAttachments.assetId,
+          contentType: assets.contentType,
+          byteSize: assets.byteSize,
+          sha256: assets.sha256,
+          originalFilename: assets.originalFilename,
+          createdByAgentId: assets.createdByAgentId,
+          createdByUserId: assets.createdByUserId,
+        })
+        .from(chatAttachments)
+        .innerJoin(assets, eq(chatAttachments.assetId, assets.id))
+        .where(and(
+          eq(chatAttachments.conversationId, input.sourceConversationId),
+          eq(chatAttachments.messageId, message.id),
+          inArray(chatAttachments.id, readyAttachmentIds),
+        ));
+      const safeVisualAttachments = sourceVisualAttachments.filter((attachment) => {
+        if (
+          attachment.contentType !== "text/html"
+          || !attachment.createdByAgentId
+          || attachment.createdByUserId
+        ) return false;
+        return visualMappings.some((mapping) =>
+          mapping.status === "ready"
+          && mapping.attachmentId === attachment.id
+          && mapping.file === attachment.originalFilename
+        ) || visualMappingsV1.some((mapping) =>
+          mapping.status === "ready"
+          && mapping.attachmentId === attachment.id
+          && mapping.file === attachment.originalFilename
+          && mapping.contentType === attachment.contentType
+          && mapping.byteSize === attachment.byteSize
+          && mapping.sha256 === attachment.sha256.toLowerCase()
+        );
+      });
+      pendingVisualAttachments.push(...safeVisualAttachments.map((attachment) => {
+        const copiedAttachmentId = randomUUID();
+        copiedAttachmentIdBySourceId.set(attachment.id, copiedAttachmentId);
+        return {
+          id: copiedAttachmentId,
+          orgId: input.orgId,
+          conversationId: input.targetConversationId,
+          messageId: copiedMessageId,
+          assetId: attachment.assetId,
+        };
+      }));
+    }
+    const copiedVisualMappings = visualMappings.map((mapping) => {
+      if (mapping.status === "unavailable") return mapping;
+      const copiedAttachmentId = copiedAttachmentIdBySourceId.get(mapping.attachmentId);
+      return copiedAttachmentId
+        ? { ...mapping, attachmentId: copiedAttachmentId }
+        : {
+          directiveIndex: mapping.directiveIndex,
+          file: mapping.file,
+          status: "unavailable" as const,
+          reason: "fork_source_missing",
+        };
+    });
+    const copiedVisualMappingsV1 = visualMappingsV1.map((mapping) => {
+      if (mapping.status === "unavailable") return mapping;
+      const copiedAttachmentId = copiedAttachmentIdBySourceId.get(mapping.attachmentId);
+      return copiedAttachmentId
+        ? { ...mapping, attachmentId: copiedAttachmentId }
+        : {
+          version: 1 as const,
+          slot: mapping.slot,
+          file: mapping.file,
+          status: "unavailable" as const,
+          reason: "fork_source_missing",
+        };
+    });
+    const copiedStructuredPayload = {
+      ...(copiedVisualMappings.length > 0 ? { inlineVisuals: copiedVisualMappings } : {}),
+      ...(copiedVisualMappingsV1.length > 0 ? { inlineVisualsV1: copiedVisualMappingsV1 } : {}),
+    };
+    await input.tx.insert(chatMessages).values({
+      id: copiedMessageId,
+      orgId: input.orgId,
+      conversationId: input.targetConversationId,
+      role: message.role,
+      kind: message.kind,
+      status: message.status === "streaming" ? "interrupted" : message.status,
+      body: message.body,
+      structuredPayload: Object.keys(copiedStructuredPayload).length > 0 ? copiedStructuredPayload : null,
+      approvalId: null,
+      runId: null,
+      replyingAgentId: message.replyingAgentId,
+      chatTurnId: null,
+      turnVariant: 0,
+      createdAt: message.createdAt,
+      updatedAt: message.updatedAt,
+    });
+    if (pendingVisualAttachments.length > 0) {
+      await input.tx.insert(chatAttachments).values(pendingVisualAttachments);
+    }
+  }
+}
+
+export async function updateTrustedInlineVisualMappings<THydrated>(input: {
+  db: Db;
+  hydrateMessages: (rows: MessageHydrationRow[]) => Promise<THydrated[]>;
+  conversationId: string;
+  messageId: string;
+  inlineVisuals?: ChatInlineVisualMapping[];
+  inlineVisualsV1?: RudderInlineVisualMapping[];
+}) {
+  const existing = await input.db
+    .select()
+    .from(chatMessages)
+    .where(and(
+      eq(chatMessages.conversationId, input.conversationId),
+      eq(chatMessages.id, input.messageId),
+    ))
+    .then((rows) => rows[0] ?? null);
+  if (!existing || existing.role !== "assistant" || existing.status !== "completed") return null;
+
+  const legacyDirectives = parseCodexInlineVisualDirectives(existing.body).directives;
+  const rudderPlacements = parseRudderInlineVisualPlacements(existing.body).placements;
+  const requestedLegacy = chatInlineVisualMappingsFromStructuredPayload({ inlineVisuals: input.inlineVisuals ?? [] })
+    .filter((mapping) => legacyDirectives.some((directive) =>
+      directive.index === mapping.directiveIndex && directive.file === mapping.file
+    ));
+  const requestedRudder = rudderInlineVisualMappingsFromStructuredPayload({ inlineVisualsV1: input.inlineVisualsV1 ?? [] })
+    .filter((mapping) => rudderPlacements.some((placement) => placement.slot === mapping.slot));
+  const readyAttachmentIds = [...requestedLegacy, ...requestedRudder]
+    .filter((mapping) => mapping.status === "ready")
+    .map((mapping) => mapping.attachmentId);
+  const attachmentRows = readyAttachmentIds.length === 0 ? [] : await input.db
+    .select({
+      id: chatAttachments.id,
+      contentType: assets.contentType,
+      byteSize: assets.byteSize,
+      sha256: assets.sha256,
+      originalFilename: assets.originalFilename,
+      createdByAgentId: assets.createdByAgentId,
+      createdByUserId: assets.createdByUserId,
+    })
+    .from(chatAttachments)
+    .innerJoin(assets, eq(chatAttachments.assetId, assets.id))
+    .where(and(
+      eq(chatAttachments.orgId, existing.orgId),
+      eq(chatAttachments.conversationId, input.conversationId),
+      eq(chatAttachments.messageId, input.messageId),
+      inArray(chatAttachments.id, readyAttachmentIds),
+    ));
+  const inlineVisuals = requestedLegacy.map((mapping): ChatInlineVisualMapping => {
+    if (mapping.status === "unavailable") return mapping;
+    const attachment = attachmentRows.find((row) =>
+      row.id === mapping.attachmentId
+      && row.contentType === "text/html"
+      && row.originalFilename === mapping.file
+      && row.createdByAgentId === existing.replyingAgentId
+      && !row.createdByUserId
+      && row.byteSize > 0
+      && row.byteSize <= 2 * 1024 * 1024
+    );
+    return attachment ? mapping : {
+      directiveIndex: mapping.directiveIndex,
+      file: mapping.file,
+      status: "unavailable",
+      reason: "ownership_mismatch",
+    };
+  });
+  const inlineVisualsV1 = requestedRudder.map((mapping): RudderInlineVisualMapping => {
+    if (mapping.status === "unavailable") return mapping;
+    const attachment = attachmentRows.find((row) =>
+      row.id === mapping.attachmentId
+      && row.contentType === mapping.contentType
+      && row.originalFilename === mapping.file
+      && row.byteSize === mapping.byteSize
+      && row.sha256.toLowerCase() === mapping.sha256
+      && row.createdByAgentId === existing.replyingAgentId
+      && !row.createdByUserId
+    );
+    return attachment ? mapping : {
+      version: 1,
+      slot: mapping.slot,
+      file: mapping.file,
+      status: "unavailable",
+      reason: "ownership_mismatch",
+    };
+  });
+  const base = sanitizeChatStructuredPayload(existing.structuredPayload) ?? {};
+  const next = {
+    ...base,
+    ...(inlineVisuals.length > 0 ? { inlineVisuals } : {}),
+    ...(inlineVisualsV1.length > 0 ? { inlineVisualsV1 } : {}),
+  };
+  const [updated] = await input.db
+    .update(chatMessages)
+    .set({ structuredPayload: next, updatedAt: new Date() })
+    .where(and(
+      eq(chatMessages.orgId, existing.orgId),
+      eq(chatMessages.conversationId, input.conversationId),
+      eq(chatMessages.id, input.messageId),
+    ))
+    .returning();
+  const [hydrated] = await input.hydrateMessages([updated]);
+  return hydrated ?? null;
+}

--- a/server/src/services/chats.ts
+++ b/server/src/services/chats.ts
@@ -18,7 +18,7 @@ import {
   messengerCustomGroups,
   organizations
 } from "@rudderhq/db";
-import { chatInlineVisualMappingsFromStructuredPayload, MESSENGER_FORK_GROUP_DEFAULT_ICON, parseCodexInlineVisualDirectives, parseRudderInlineVisualPlacements, rudderInlineVisualMappingsFromStructuredPayload, sanitizeChatStructuredPayload, type ChatControlDisposition, type ChatInlineVisualMapping, type ChatProviderControlDisposition, type ChatQueuedMessage, type ChatQueuedMessagePayload, type ChatQueuedMessageStatus, type ChatQueueRequestActor, type ChatStreamTranscriptEntry, type RudderInlineVisualMapping } from "@rudderhq/shared";
+import { MESSENGER_FORK_GROUP_DEFAULT_ICON, sanitizeChatStructuredPayload, type ChatControlDisposition, type ChatInlineVisualMapping, type ChatProviderControlDisposition, type ChatQueuedMessage, type ChatQueuedMessagePayload, type ChatQueuedMessageStatus, type ChatQueueRequestActor, type ChatStreamTranscriptEntry, type RudderInlineVisualMapping } from "@rudderhq/shared";
 import { and, asc, desc, eq, gt, gte, inArray, isNotNull, isNull, lt, or, sql } from "drizzle-orm";
 import { randomUUID } from "node:crypto";
 import { conflict, notFound, unprocessable } from "../errors.js";
@@ -57,6 +57,11 @@ import {
   withOperationProposalDecisionState,
   withPersistedTranscript,
 } from "./chats.helpers.js";
+import {
+  copyForkInlineVisualMessages,
+  listRecentUserChatMessages,
+  updateTrustedInlineVisualMappings,
+} from "./chats.inline-visual-persistence.js";
 import type { ChatServerQueueClaim, ConversationSourceMetadata, ConversationSummaryCursor, MessageHydrationRow } from "./chats.types.js";
 import { issueApprovalService } from "./issue-approvals.js";
 import { issueService } from "./issues.js";
@@ -3171,126 +3176,13 @@ export function chatService(db: Db) {
       const forkMessages = input.sourceMessageId
         ? messagesToCopy.slice(0, messagesToCopy.findIndex((message) => message.id === input.sourceMessageId) + 1)
         : messagesToCopy;
-      if (forkMessages.length > 0) {
-        for (const message of forkMessages) {
-          const copiedMessageId = randomUUID();
-          const visualMappings = chatInlineVisualMappingsFromStructuredPayload(message.structuredPayload);
-          const visualMappingsV1 = rudderInlineVisualMappingsFromStructuredPayload(message.structuredPayload);
-          const readyAttachmentIds = [
-            ...visualMappings,
-            ...visualMappingsV1,
-          ].filter((mapping) => mapping.status === "ready").map((mapping) => mapping.attachmentId);
-          const copiedAttachmentIdBySourceId = new Map<string, string>();
-          const pendingVisualAttachments: Array<{
-            id: string;
-            orgId: string;
-            conversationId: string;
-            messageId: string;
-            assetId: string;
-          }> = [];
-          if (readyAttachmentIds.length > 0) {
-            const sourceVisualAttachments = await tx
-              .select({
-                id: chatAttachments.id,
-                assetId: chatAttachments.assetId,
-                contentType: assets.contentType,
-                byteSize: assets.byteSize,
-                sha256: assets.sha256,
-                originalFilename: assets.originalFilename,
-                createdByAgentId: assets.createdByAgentId,
-                createdByUserId: assets.createdByUserId,
-              })
-              .from(chatAttachments)
-              .innerJoin(assets, eq(chatAttachments.assetId, assets.id))
-              .where(and(
-                eq(chatAttachments.conversationId, source.id),
-                eq(chatAttachments.messageId, message.id),
-                inArray(chatAttachments.id, readyAttachmentIds),
-              ));
-            const safeVisualAttachments = sourceVisualAttachments.filter((attachment) => {
-              if (
-                attachment.contentType !== "text/html"
-                || !attachment.createdByAgentId
-                || attachment.createdByUserId
-              ) return false;
-              return visualMappings.some((mapping) =>
-                mapping.status === "ready"
-                && mapping.attachmentId === attachment.id
-                && mapping.file === attachment.originalFilename
-              ) || visualMappingsV1.some((mapping) =>
-                mapping.status === "ready"
-                && mapping.attachmentId === attachment.id
-                && mapping.file === attachment.originalFilename
-                && mapping.contentType === attachment.contentType
-                && mapping.byteSize === attachment.byteSize
-                && mapping.sha256 === attachment.sha256.toLowerCase()
-              );
-            });
-            if (safeVisualAttachments.length > 0) {
-              pendingVisualAttachments.push(...safeVisualAttachments.map((attachment) => {
-                const copiedAttachmentId = randomUUID();
-                copiedAttachmentIdBySourceId.set(attachment.id, copiedAttachmentId);
-                return {
-                  id: copiedAttachmentId,
-                  orgId: input.orgId,
-                  conversationId: child.id,
-                  messageId: copiedMessageId,
-                  assetId: attachment.assetId,
-                };
-              }));
-            }
-          }
-          const copiedVisualMappings = visualMappings.map((mapping) => {
-            if (mapping.status === "unavailable") return mapping;
-            const copiedAttachmentId = copiedAttachmentIdBySourceId.get(mapping.attachmentId);
-            return copiedAttachmentId
-              ? { ...mapping, attachmentId: copiedAttachmentId }
-              : {
-                directiveIndex: mapping.directiveIndex,
-                file: mapping.file,
-                status: "unavailable" as const,
-                reason: "fork_source_missing",
-              };
-          });
-          const copiedVisualMappingsV1 = visualMappingsV1.map((mapping) => {
-            if (mapping.status === "unavailable") return mapping;
-            const copiedAttachmentId = copiedAttachmentIdBySourceId.get(mapping.attachmentId);
-            return copiedAttachmentId
-              ? { ...mapping, attachmentId: copiedAttachmentId }
-              : {
-                version: 1 as const,
-                slot: mapping.slot,
-                file: mapping.file,
-                status: "unavailable" as const,
-                reason: "fork_source_missing",
-              };
-          });
-          const copiedStructuredPayload = {
-            ...(copiedVisualMappings.length > 0 ? { inlineVisuals: copiedVisualMappings } : {}),
-            ...(copiedVisualMappingsV1.length > 0 ? { inlineVisualsV1: copiedVisualMappingsV1 } : {}),
-          };
-          await tx.insert(chatMessages).values({
-            id: copiedMessageId,
-            orgId: input.orgId,
-            conversationId: child.id,
-            role: message.role,
-            kind: message.kind,
-            status: message.status === "streaming" ? "interrupted" : message.status,
-            body: message.body,
-            structuredPayload: Object.keys(copiedStructuredPayload).length > 0 ? copiedStructuredPayload : null,
-            approvalId: null,
-            runId: null,
-            replyingAgentId: message.replyingAgentId,
-            chatTurnId: null,
-            turnVariant: 0,
-            createdAt: message.createdAt,
-            updatedAt: message.updatedAt,
-          });
-          if (pendingVisualAttachments.length > 0) {
-            await tx.insert(chatAttachments).values(pendingVisualAttachments);
-          }
-        }
-      }
+      await copyForkInlineVisualMessages({
+        tx,
+        messages: forkMessages,
+        sourceConversationId: source.id,
+        targetConversationId: child.id,
+        orgId: input.orgId,
+      });
 
       const [systemEvent] = await tx
         .insert(chatMessages)
@@ -3559,32 +3451,7 @@ export function chatService(db: Db) {
   }
 
   async function listRecentUserMessages(conversationId: string, limit: number) {
-      const ecmascriptTrimWhitespace = "\u0009\u000A\u000B\u000C\u000D\u0020\u00A0\u1680\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200A\u2028\u2029\u202F\u205F\u3000\uFEFF";
-      const boundedLimit = Math.min(5, Math.max(1, Math.trunc(limit)));
-      const conversationOrgIds = db
-        .select({ orgId: chatConversations.orgId })
-        .from(chatConversations)
-        .where(eq(chatConversations.id, conversationId));
-      const rows = await db
-        .select({
-          id: chatMessages.id,
-          role: chatMessages.role,
-          kind: chatMessages.kind,
-          body: chatMessages.body,
-          createdAt: chatMessages.createdAt,
-        })
-        .from(chatMessages)
-        .where(and(
-          eq(chatMessages.conversationId, conversationId),
-          inArray(chatMessages.orgId, conversationOrgIds),
-          isNull(chatMessages.supersededAt),
-          eq(chatMessages.role, "user"),
-          eq(chatMessages.kind, "message"),
-          sql<boolean>`btrim(${chatMessages.body}, ${ecmascriptTrimWhitespace}) <> ''`,
-        ))
-        .orderBy(desc(chatMessages.createdAt), desc(chatMessages.id))
-        .limit(boundedLimit);
-      return rows.reverse();
+      return listRecentUserChatMessages(db, conversationId, limit);
   }
 
   async function listMessages(conversationId: string, options: { includeTranscript?: boolean } = {}) {
@@ -3905,96 +3772,13 @@ export function chatService(db: Db) {
       inlineVisualsV1?: RudderInlineVisualMapping[];
     },
   ) {
-    const existing = await db
-      .select()
-      .from(chatMessages)
-      .where(and(eq(chatMessages.conversationId, conversationId), eq(chatMessages.id, messageId)))
-      .then((rows) => rows[0] ?? null);
-    if (!existing || existing.role !== "assistant" || existing.status !== "completed") return null;
-
-    const legacyDirectives = parseCodexInlineVisualDirectives(existing.body).directives;
-    const rudderPlacements = parseRudderInlineVisualPlacements(existing.body).placements;
-    const requestedLegacy = chatInlineVisualMappingsFromStructuredPayload({ inlineVisuals: input.inlineVisuals ?? [] })
-      .filter((mapping) => legacyDirectives.some((directive) =>
-        directive.index === mapping.directiveIndex && directive.file === mapping.file
-      ));
-    const requestedRudder = rudderInlineVisualMappingsFromStructuredPayload({ inlineVisualsV1: input.inlineVisualsV1 ?? [] })
-      .filter((mapping) => rudderPlacements.some((placement) => placement.slot === mapping.slot));
-    const readyAttachmentIds = [...requestedLegacy, ...requestedRudder]
-      .filter((mapping) => mapping.status === "ready")
-      .map((mapping) => mapping.attachmentId);
-    const attachmentRows = readyAttachmentIds.length === 0 ? [] : await db
-      .select({
-        id: chatAttachments.id,
-        contentType: assets.contentType,
-        byteSize: assets.byteSize,
-        sha256: assets.sha256,
-        originalFilename: assets.originalFilename,
-        createdByAgentId: assets.createdByAgentId,
-        createdByUserId: assets.createdByUserId,
-      })
-      .from(chatAttachments)
-      .innerJoin(assets, eq(chatAttachments.assetId, assets.id))
-      .where(and(
-        eq(chatAttachments.orgId, existing.orgId),
-        eq(chatAttachments.conversationId, conversationId),
-        eq(chatAttachments.messageId, messageId),
-        inArray(chatAttachments.id, readyAttachmentIds),
-      ));
-    const inlineVisuals = requestedLegacy.map((mapping): ChatInlineVisualMapping => {
-      if (mapping.status === "unavailable") return mapping;
-      const attachment = attachmentRows.find((row) =>
-        row.id === mapping.attachmentId
-        && row.contentType === "text/html"
-        && row.originalFilename === mapping.file
-        && row.createdByAgentId === existing.replyingAgentId
-        && !row.createdByUserId
-        && row.byteSize > 0
-        && row.byteSize <= 2 * 1024 * 1024
-      );
-      return attachment ? mapping : {
-        directiveIndex: mapping.directiveIndex,
-        file: mapping.file,
-        status: "unavailable",
-        reason: "ownership_mismatch",
-      };
+    return updateTrustedInlineVisualMappings({
+      db,
+      hydrateMessages,
+      conversationId,
+      messageId,
+      ...input,
     });
-    const inlineVisualsV1 = requestedRudder.map((mapping): RudderInlineVisualMapping => {
-      if (mapping.status === "unavailable") return mapping;
-      const attachment = attachmentRows.find((row) =>
-        row.id === mapping.attachmentId
-        && row.contentType === mapping.contentType
-        && row.originalFilename === mapping.file
-        && row.byteSize === mapping.byteSize
-        && row.sha256.toLowerCase() === mapping.sha256
-        && row.createdByAgentId === existing.replyingAgentId
-        && !row.createdByUserId
-      );
-      return attachment ? mapping : {
-        version: 1,
-        slot: mapping.slot,
-        file: mapping.file,
-        status: "unavailable",
-        reason: "ownership_mismatch",
-      };
-    });
-    const base = sanitizeChatStructuredPayload(existing.structuredPayload) ?? {};
-    const next = {
-      ...base,
-      ...(inlineVisuals.length > 0 ? { inlineVisuals } : {}),
-      ...(inlineVisualsV1.length > 0 ? { inlineVisualsV1 } : {}),
-    };
-    const [updated] = await db
-      .update(chatMessages)
-      .set({ structuredPayload: next, updatedAt: new Date() })
-      .where(and(
-        eq(chatMessages.orgId, existing.orgId),
-        eq(chatMessages.conversationId, conversationId),
-        eq(chatMessages.id, messageId),
-      ))
-      .returning();
-    const [hydrated] = await hydrateMessages([updated]);
-    return hydrated ?? null;
   }
 
   async function markInterruptedStreamingMessages(conversationId: string) {

--- a/ui/src/pages/Chat.messages.tsx
+++ b/ui/src/pages/Chat.messages.tsx
@@ -2241,14 +2241,7 @@ export function ChatMessageItem({
 
   const isUser = message.role === "user";
   const statusLabel = !isUser ? assistantStateLabel(message.status) : null;
-  const inlineVisualAttachmentIds = new Set(
-    [
-      ...chatInlineVisualMappingsFromStructuredPayload(message.structuredPayload),
-      ...rudderInlineVisualMappingsFromStructuredPayload(message.structuredPayload),
-    ]
-      .filter((mapping) => mapping.status === "ready")
-      .map((mapping) => mapping.attachmentId),
-  );
+  const inlineVisualAttachmentIds = new Set([...chatInlineVisualMappingsFromStructuredPayload(message.structuredPayload), ...rudderInlineVisualMappingsFromStructuredPayload(message.structuredPayload)].filter((mapping) => mapping.status === "ready").map((mapping) => mapping.attachmentId));
   const visibleMessageAttachments = message.attachments.filter(
     (attachment) => !inlineVisualAttachmentIds.has(attachment.id),
   );

--- a/ui/src/pages/Chat.plan-mode-controls.tsx
+++ b/ui/src/pages/Chat.plan-mode-controls.tsx
@@ -1,0 +1,42 @@
+import { cn } from "@/lib/utils";
+import { ListChecks, X } from "lucide-react";
+import { PLAN_MODE_HELP_TEXT } from "./Chat.parts";
+
+export function ChatPlanModeMenuToggle({
+  active,
+  onChange,
+}: {
+  active: boolean;
+  onChange: (active: boolean) => void;
+}) {
+  return (
+    <button type="button" role="switch" aria-checked={active} aria-label="Plan mode" data-testid="chat-plan-mode-toggle" title={PLAN_MODE_HELP_TEXT} className={cn(
+      "flex w-full cursor-pointer items-center justify-between gap-2 rounded-[var(--radius-md)] px-3 py-2.5 text-left text-sm outline-hidden transition-colors focus:bg-accent focus:text-accent-foreground focus-visible:ring-2 focus-visible:ring-ring/40",
+      active && "bg-[color:color-mix(in_oklab,var(--accent-soft)_72%,transparent)] text-foreground focus:bg-[color:color-mix(in_oklab,var(--accent-soft)_88%,transparent)]",
+    )} onClick={(event) => { event.preventDefault(); onChange(!active); }} >
+      <div className="flex min-w-0 items-center">
+        <ListChecks className="mr-2 h-4 w-4 shrink-0 text-muted-foreground" />
+        <div className="font-medium text-foreground">Plan mode</div> </div>
+      <span aria-hidden="true" data-testid="chat-plan-mode-track" className={cn(
+        "relative mt-0.5 inline-flex h-6 w-11 shrink-0 items-center rounded-full border transition-[background-color,border-color,box-shadow,opacity]",
+        active ? "border-[color:color-mix(in_oklab,var(--accent-base)_72%,white)] bg-[color:var(--accent-base)] text-primary-foreground shadow-[0_0_0_1px_color-mix(in_oklab,var(--accent-base)_22%,transparent),0_8px_22px_color-mix(in_oklab,var(--accent-base)_20%,transparent)]" : "border-[color:color-mix(in_oklab,var(--border-soft)_82%,transparent)] bg-[color:color-mix(in_oklab,var(--surface-inset)_92%,transparent)] text-muted-foreground",
+      )} >
+        <span data-testid="chat-plan-mode-thumb" className={cn(
+          "inline-block h-5 w-5 rounded-full border border-[color:color-mix(in_oklab,var(--border-soft)_80%,transparent)] bg-[color:var(--surface-elevated)] shadow-[0_4px_12px_rgb(0_0_0/0.18)] transition-transform",
+          active ? "translate-x-5" : "translate-x-0.5",
+        )} /> </span>
+    </button>
+  );
+}
+
+export function ChatPlanModeChip({ onDisable }: { onDisable: () => void }) {
+  return (
+    <button type="button" className="group/plan inline-flex max-w-[10rem] min-w-0 items-center gap-1.5 rounded-[var(--radius-md)] bg-[color:color-mix(in_oklab,var(--accent-soft)_78%,var(--surface-elevated))] px-2.5 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-[color:color-mix(in_oklab,var(--accent-soft)_92%,var(--surface-elevated))] hover:text-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring/40" aria-label="Turn off plan mode" title={PLAN_MODE_HELP_TEXT} onClick={onDisable} >
+      <span className="inline-flex h-4 w-4 shrink-0 items-center justify-center">
+        <ListChecks data-testid="chat-plan-mode-icon" className="h-3.5 w-3.5 group-hover/plan:hidden" aria-hidden="true" />
+        <span data-testid="chat-plan-mode-dismiss-icon" className="hidden h-4 w-4 items-center justify-center rounded-full bg-[color:color-mix(in_oklab,var(--ink-muted)_78%,transparent)] text-[color:var(--surface-elevated)] group-hover/plan:inline-flex">
+          <X className="h-3 w-3" strokeWidth={2.6} aria-hidden="true" /> </span> </span>
+      <span className="min-w-0 truncate">Plan</span>
+    </button>
+  );
+}

--- a/ui/src/pages/Chat.timeline.ts
+++ b/ui/src/pages/Chat.timeline.ts
@@ -1,0 +1,26 @@
+import {
+  activeChatStreamTimelineInsertionIndex,
+  type ActiveChatStreamTimelineState,
+} from "@/lib/chat-stream-state";
+import type { ChatMessage } from "@rudderhq/shared";
+
+export type ChatTimelineRow =
+  | { kind: "message"; message: ChatMessage; messageIndex: number }
+  | { kind: "active_stream" };
+
+export function buildChatTimelineRows(
+  messages: ChatMessage[],
+  activeStream: ActiveChatStreamTimelineState | null,
+  showActiveStreamDraft: boolean,
+) {
+  const rows: ChatTimelineRow[] = messages.map((message, messageIndex) => ({
+    kind: "message",
+    message,
+    messageIndex,
+  }));
+  if (!showActiveStreamDraft || !activeStream) return rows;
+  rows.splice(activeChatStreamTimelineInsertionIndex(messages, activeStream), 0, {
+    kind: "active_stream",
+  });
+  return rows;
+}

--- a/ui/src/pages/Chat.tsx
+++ b/ui/src/pages/Chat.tsx
@@ -74,7 +74,6 @@ import {
   type PendingChatStopRecovery,
 } from "@/lib/chat-stop-recovery";
 import {
-  activeChatStreamTimelineInsertionIndex,
   readChatScopedFlag,
   readChatScopedState,
   shouldShowMessageDuringActiveEdit,
@@ -124,7 +123,6 @@ import {
   FolderInput,
   FolderPlus,
   GitFork,
-  ListChecks,
   Loader2,
   Mail,
   MailOpen,
@@ -146,17 +144,16 @@ import { Fragment, useCallback, useEffect, useLayoutEffect, useMemo, useRef, use
 import { createPortal } from "react-dom";
 import { PendingAttachmentPreview } from "./Chat.attachments";
 import { AskUserPanel, AssistantDraftItem, ChatMessageItem, ChatMessagesLoadingState, LazyStreamTranscriptItem, OptimisticUserDraftItem, StreamTranscriptItem, chatIssueApprovalPayloadWithProposalOverride, type ChatTurnBranchControls } from "./Chat.messages";
-import { ASK_USER_ANSWER_PREFIX, ApprovalAction, ChatBranchPreview, ChatEmptyStatePromptOptions, ChatEmptyStatePromptStarters, ChatEmptyStateRecentConversations, EmptyStatePromptGroup, EmptyStatePromptSuggestion, INTERRUPTED_CHAT_CONTINUATION_PROMPT, NO_CHAT_AGENT_LABEL, NO_PROJECT_ID, PLAN_MODE_HELP_TEXT, applyChatPromptToDraft, approvalNeedsAction, askUserAnswerFromMessage, askUserRequestFromMessage, buildChatProposalRejectFeedbackPrompt, buildChatProposalRevisionPrompt, buildDraftChatContextLinks, buildMessengerChatThreadSummary, canRefreshAssistantChatMessage, canRefreshDisplayedAssistantChatMessage, chatEmptyStateHeading, chatPromptGroupForExactTrigger, chatPromptQueryKey, chatPromptSuggestionsForDraft, chatSidePanelTargetFromHref, composerMenuPositionForAnchor, computeDisplayedChatMessages, conversationDisplayTitle, draftIssueContextLabel, findLatestUnansweredAskUserMessage, findRetrySourceUserMessage, formatChatPrimaryIssueBreadcrumb, isAskUserMessageAnswered, isChatAgentSelectionLocked, isChatProjectSelectionLocked, isUserVisibleIncomingChatMessage, issueProposalFromMessage, materializePendingAttachment, mergeChatConversationsForStatus, mergeChatMessages, operationProposalFromMessage, operationProposalStatusFromMessage, parseAskUserAnswerMessage, pendingAttachmentKey, projectContextId, projectDisplayName, rememberChatProjectId, rememberChatProjectIdForAgent, resolveDefaultDraftChatProjectId, resolveDraftIssueContext, scrollChatMessagesToBottom, shouldAttachApprovalFeedbackSystemMessage, shouldAttachIssueCreatedSystemMessage, shouldHandlePlainChatLinkClick, withOptimisticOutgoingMessage, withOptimisticPlanMode } from "./Chat.parts";
+import { ASK_USER_ANSWER_PREFIX, ApprovalAction, ChatBranchPreview, ChatEmptyStatePromptOptions, ChatEmptyStatePromptStarters, ChatEmptyStateRecentConversations, EmptyStatePromptGroup, EmptyStatePromptSuggestion, INTERRUPTED_CHAT_CONTINUATION_PROMPT, NO_CHAT_AGENT_LABEL, NO_PROJECT_ID, applyChatPromptToDraft, approvalNeedsAction, askUserAnswerFromMessage, askUserRequestFromMessage, buildChatProposalRejectFeedbackPrompt, buildChatProposalRevisionPrompt, buildDraftChatContextLinks, buildMessengerChatThreadSummary, canRefreshAssistantChatMessage, canRefreshDisplayedAssistantChatMessage, chatEmptyStateHeading, chatPromptGroupForExactTrigger, chatPromptQueryKey, chatPromptSuggestionsForDraft, chatSidePanelTargetFromHref, composerMenuPositionForAnchor, computeDisplayedChatMessages, conversationDisplayTitle, draftIssueContextLabel, findLatestUnansweredAskUserMessage, findRetrySourceUserMessage, formatChatPrimaryIssueBreadcrumb, isAskUserMessageAnswered, isChatAgentSelectionLocked, isChatProjectSelectionLocked, isUserVisibleIncomingChatMessage, issueProposalFromMessage, materializePendingAttachment, mergeChatConversationsForStatus, mergeChatMessages, operationProposalFromMessage, operationProposalStatusFromMessage, parseAskUserAnswerMessage, pendingAttachmentKey, projectContextId, projectDisplayName, rememberChatProjectId, rememberChatProjectIdForAgent, resolveDefaultDraftChatProjectId, resolveDraftIssueContext, scrollChatMessagesToBottom, shouldAttachApprovalFeedbackSystemMessage, shouldAttachIssueCreatedSystemMessage, shouldHandlePlainChatLinkClick, withOptimisticOutgoingMessage, withOptimisticPlanMode } from "./Chat.parts";
+import { ChatPlanModeChip, ChatPlanModeMenuToggle } from "./Chat.plan-mode-controls";
 import { ChatScrollMap, countScrollMapUserMessages } from "./Chat.scroll-map";
+import { buildChatTimelineRows } from "./Chat.timeline";
 import { ChatWorkManifest, ChatWorkManifestToggle, hasChatWorkManifestContent } from "./Chat.work-manifest";
 import { CHAT_ISSUE_MENTION_LIMIT, CHAT_LIST_PREVIEW_LIMIT, CHAT_SCROLL_MAP_USER_MESSAGE_THRESHOLD, CHAT_STEER_RETRY_DELAYS_MS, EMPTY_CHAT_BODY_SHA256, EMPTY_STATE_PROMPT_PAGE_TRANSITION_MS, RECENT_PROJECT_CONVERSATION_INITIAL_LIMIT, RECENT_PROJECT_CONVERSATION_LOAD_INCREMENT, activeGenerationIdFromSnapshot, applyChatStreamProgressEvent, chatMessageJumpTargetFromHref, chatReferenceMarkdown, clipboardAttachmentPayloadKey, createQueuedComposerMessage, findChatMessageElement, isExternalBoundConversation, revealChatMessageElement, sideChatTargetFromMessage, useChatDraftQueries, type PendingChatSteerRetry, type SendButtonMode } from "./Chat.workspace-helpers";
 export * from "./Chat.attachments";
 export * from "./Chat.messages";
 export * from "./Chat.parts";
 export { applyChatStreamProgressEvent } from "./Chat.workspace-helpers";
-type ChatTimelineRow =
-  | { kind: "message"; message: ChatMessage; messageIndex: number }
-  | { kind: "active_stream" };
 export function Chat() { const { selectedOrganizationId } = useOrganization(); return selectedOrganizationId ? <ChatWorkspace key={selectedOrganizationId} /> : <div className="text-sm text-muted-foreground">Select a organization first.</div>; }
 function ChatWorkspace() { const { conversationId } = useParams<{ conversationId?: string }>(); const location = useLocation(); const navigate = useNavigate(); const [searchParams] = useSearchParams(); const queryClient = useQueryClient(); const { selectedOrganization, selectedOrganizationId } = useOrganization(); const { viewedOrganizationId } = useViewedOrganization(); const { t } = useI18n(); const { setBreadcrumbs } = useBreadcrumbs(); const { pushToast } = useToast(); const { confirm } = useDialog();
   const { openImagePreview } = useImagePreview(); const {
@@ -1433,18 +1430,10 @@ function ChatWorkspace() { const { conversationId } = useParams<{ conversationId
     activeStream && (
       activeEditCutoffMs !== null
       || !activeStream.userMessageId || !rawMessages.some((message) => message.id === activeStream.userMessageId) ), );
-  const chatTimelineRows = useMemo(() => {
-    const rows: ChatTimelineRow[] = visibleMessages.map((message, messageIndex) => ({
-      kind: "message",
-      message,
-      messageIndex,
-    }));
-    if (!showActiveStreamDraft || !activeStream) return rows;
-    rows.splice(activeChatStreamTimelineInsertionIndex(visibleMessages, activeStream), 0, {
-      kind: "active_stream",
-    });
-    return rows;
-  }, [activeStream, showActiveStreamDraft, visibleMessages]);
+  const chatTimelineRows = useMemo(
+    () => buildChatTimelineRows(visibleMessages, activeStream, showActiveStreamDraft),
+    [activeStream, showActiveStreamDraft, visibleMessages],
+  );
   useEffect(() => {
     if (agentSelectionLocked) {
       setAgentMenuOpen(false); } }, [agentSelectionLocked]);
@@ -2366,30 +2355,9 @@ function ChatWorkspace() { const { conversationId } = useParams<{ conversationId
                 }} >
                 <Paperclip className="mr-2 h-4 w-4" />
                 Add files </DropdownMenuItem>
-              <button type="button" role="switch" aria-checked={activePlanMode} aria-label="Plan mode" data-testid="chat-plan-mode-toggle" title={PLAN_MODE_HELP_TEXT} className={cn(
-                  "flex w-full cursor-pointer items-center justify-between gap-2 rounded-[var(--radius-md)] px-3 py-2.5 text-left text-sm outline-hidden transition-colors focus:bg-accent focus:text-accent-foreground focus-visible:ring-2 focus-visible:ring-ring/40",
-                  activePlanMode && "bg-[color:color-mix(in_oklab,var(--accent-soft)_72%,transparent)] text-foreground focus:bg-[color:color-mix(in_oklab,var(--accent-soft)_88%,transparent)]",
-                )} onClick={(event) => { event.preventDefault(); applyPlanMode(!activePlanMode);
-                }} >
-                <div className="flex min-w-0 items-center">
-                  <ListChecks className="mr-2 h-4 w-4 shrink-0 text-muted-foreground" />
-                  <div className="font-medium text-foreground">Plan mode</div> </div>
-                <span aria-hidden="true" data-testid="chat-plan-mode-track" className={cn(
-                    "relative mt-0.5 inline-flex h-6 w-11 shrink-0 items-center rounded-full border transition-[background-color,border-color,box-shadow,opacity]",
-                    activePlanMode ? "border-[color:color-mix(in_oklab,var(--accent-base)_72%,white)] bg-[color:var(--accent-base)] text-primary-foreground shadow-[0_0_0_1px_color-mix(in_oklab,var(--accent-base)_22%,transparent),0_8px_22px_color-mix(in_oklab,var(--accent-base)_20%,transparent)]" : "border-[color:color-mix(in_oklab,var(--border-soft)_82%,transparent)] bg-[color:color-mix(in_oklab,var(--surface-inset)_92%,transparent)] text-muted-foreground",
-                  )} >
-                  <span data-testid="chat-plan-mode-thumb" className={cn(
-                      "inline-block h-5 w-5 rounded-full border border-[color:color-mix(in_oklab,var(--border-soft)_80%,transparent)] bg-[color:var(--surface-elevated)] shadow-[0_4px_12px_rgb(0_0_0/0.18)] transition-transform",
-                      activePlanMode ? "translate-x-5" : "translate-x-0.5",
-                    )} /> </span> </button>
+              <ChatPlanModeMenuToggle active={activePlanMode} onChange={applyPlanMode} />
               </DropdownMenuContent> </DropdownMenu>
-          {activePlanMode ? (
-            <button type="button" className="group/plan inline-flex max-w-[10rem] min-w-0 items-center gap-1.5 rounded-[var(--radius-md)] bg-[color:color-mix(in_oklab,var(--accent-soft)_78%,var(--surface-elevated))] px-2.5 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-[color:color-mix(in_oklab,var(--accent-soft)_92%,var(--surface-elevated))] hover:text-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring/40" aria-label="Turn off plan mode" title={PLAN_MODE_HELP_TEXT} onClick={() => applyPlanMode(false)} >
-              <span className="inline-flex h-4 w-4 shrink-0 items-center justify-center">
-                <ListChecks data-testid="chat-plan-mode-icon" className="h-3.5 w-3.5 group-hover/plan:hidden" aria-hidden="true" />
-                <span data-testid="chat-plan-mode-dismiss-icon" className="hidden h-4 w-4 items-center justify-center rounded-full bg-[color:color-mix(in_oklab,var(--ink-muted)_78%,transparent)] text-[color:var(--surface-elevated)] group-hover/plan:inline-flex">
-                  <X className="h-3 w-3" strokeWidth={2.6} aria-hidden="true" /> </span> </span>
-              <span className="min-w-0 truncate">Plan</span> </button> ) : null}
+          {activePlanMode ? <ChatPlanModeChip onDisable={() => applyPlanMode(false)} /> : null}
           {showProjectSelector ? (
             <div className="group/project relative inline-flex max-w-[min(100%,15rem)] min-w-0">
               <button type="button" data-testid="chat-project-selector" aria-label={`Project context: ${projectPillLabel}`} aria-expanded={projectSelectionLocked ? false : projectMenuOpen} disabled={projectSelectionLocked} title={projectSelectionLocked ? "Project context is locked after conversation starts." : undefined} className={cn(


### PR DESCRIPTION
## Summary
- extract chat route attachment handling into a focused helper
- extract assistant inline visual and fork persistence helpers
- extract Chat plan controls and timeline building to restore architecture line-count ratchets

## Verification
- architecture comparison: no regressions; debt governance valid
- architecture tests: 18/18
- related Chat tests: 330/330 in independent verification
- pnpm lint
- pnpm -r typecheck
- pnpm product-logic:check
- pnpm build
- reviewer and independent verifier: no blocking findings

## Existing test/E2E noise
Full-suite execution reached existing order/environment failures and ended with worker IPC closure. Each observed unit failure passed when rerun in isolation. Independent real-environment E2E started API/UI with embedded PostgreSQL; relevant inline-visual/work-manifest paths passed, while unrelated main-baseline cases failed on stale initialMessage contracts and environment timing.