### PR TITLE
docs: add Rudder Discord community links

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,9 @@ pnpm desktop:verify
 
 ## Community
 
-[LINUX DO](https://linux.do/)
+Join the [Rudder Discord](https://discord.gg/ZcfWwPVkUz) for setup help, build logs, product feedback, and a Build Review every two weeks. Use [GitHub Issues](https://github.com/Undertone0809/rudder/issues) for reproducible bugs and concrete code changes.
+
+You can also find Rudder on [LINUX DO](https://linux.do/).
 
 ## License
 

--- a/doc/engineering/public-docs/ui-label-allowlist.json
+++ b/doc/engineering/public-docs/ui-label-allowlist.json
@@ -23,6 +23,7 @@
     "Create agent",
     "Cursor (local)",
     "Dashboard",
+    "Discord",
     "Email support",
     "Feishu",
     "Feishu CN",

--- a/docs/contact.mdx
+++ b/docs/contact.mdx
@@ -18,10 +18,14 @@ Rudder is developed in public. Use the channel that matches the request.
 ## Questions and setup help
 
 Search the documentation and existing GitHub Issues first. If the answer is
-still unclear, open a focused Issue with the Rudder version, operating system,
-install method, and the step that failed.
+still unclear, ask in Discord with the Rudder version, operating system,
+install method, and the step that failed. Open a GitHub Issue once a bug is
+reproducible or a product change is concrete.
 
 <CardGroup cols={2}>
+  <Card title="Rudder Discord" icon="discord" href="https://discord.gg/ZcfWwPVkUz">
+    Get setup help, share a build log, leave early feedback, or join a Build Review.
+  </Card>
   <Card title="GitHub repository" icon="external-link" href="https://github.com/Undertone0809/rudder">
     Read the source, Issues, releases, and contribution history.
   </Card>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -33,6 +33,10 @@
   "navbar": {
     "links": [
       {
+        "label": "Discord",
+        "href": "https://discord.gg/ZcfWwPVkUz"
+      },
+      {
         "label": "GitHub",
         "href": "https://github.com/Undertone0809/rudder"
       }
@@ -181,6 +185,7 @@
   },
   "footer": {
     "socials": {
+      "discord": "https://discord.gg/ZcfWwPVkUz",
       "github": "https://github.com/Undertone0809/rudder"
     },
     "links": [
@@ -225,6 +230,10 @@
       {
         "header": "Project",
         "items": [
+          {
+            "label": "Discord",
+            "href": "https://discord.gg/ZcfWwPVkUz"
+          },
           {
             "label": "Contact",
             "href": "/contact"

--- a/docs/zh/contact.mdx
+++ b/docs/zh/contact.mdx
@@ -17,10 +17,14 @@ Rudder 采用公开方式开发。请根据请求内容选择渠道。
 
 ## 使用问题与安装帮助
 
-先搜索文档和已有 GitHub Issue。如果仍找不到答案，可以提交一条主题明确的
-Issue，并附上 Rudder 版本、操作系统、安装方式和失败步骤。
+先搜索文档和已有 GitHub Issue。如果仍找不到答案，可以在 `Discord` 提问，并附上
+Rudder 版本、操作系统、安装方式和失败步骤。当问题可以稳定复现，或产品改动已经
+足够具体时，再提交 GitHub Issue。
 
 <CardGroup cols={2}>
+  <Card title="Rudder Discord" icon="discord" href="https://discord.gg/ZcfWwPVkUz">
+    获取安装帮助、发布运行记录、提交早期反馈，或参加构建评审活动。
+  </Card>
   <Card title="GitHub 仓库" icon="external-link" href="https://github.com/Undertone0809/rudder">
     查看源码、Issue、版本发布和贡献记录。
   </Card>


### PR DESCRIPTION
## Summary
- add the permanent Rudder Discord invite to the README Community section
- add Discord to the docs navbar and footer
- route English and Chinese setup questions, build logs, and early feedback through Discord

## Verification
- docs.json parses as JSON
- pnpm docs:integrity
- pnpm docs:validate
- targeted Chinese UI label allowlist test
- public Discord invite API resolves to guild 1529148109748306051, never expires, and returns the Rudder icon

## Existing worktree failures
- pnpm lint: existing import-order issue in ui/src/pages/Chat.side-panel.tsx
- pnpm -r typecheck and pnpm build: existing missing ListChecks symbol in ui/src/pages/Chat.tsx
- pnpm test:run: existing UI and heartbeat/server failures from unrelated in-progress changes