### PR TITLE
fix(docs): use supported Discord card icon

### DIFF
--- a/docs/contact.mdx
+++ b/docs/contact.mdx
@@ -23,7 +23,7 @@ install method, and the step that failed. Open a GitHub Issue once a bug is
 reproducible or a product change is concrete.
 
 <CardGroup cols={2}>
-  <Card title="Rudder Discord" icon="discord" href="https://discord.gg/ZcfWwPVkUz">
+  <Card title="Rudder Discord" icon="messages-square" href="https://discord.gg/ZcfWwPVkUz">
     Get setup help, share a build log, leave early feedback, or join a Build Review.
   </Card>
   <Card title="GitHub repository" icon="external-link" href="https://github.com/Undertone0809/rudder">

--- a/docs/zh/contact.mdx
+++ b/docs/zh/contact.mdx
@@ -22,7 +22,7 @@ Rudder 版本、操作系统、安装方式和失败步骤。当问题可以稳�
 足够具体时，再提交 GitHub Issue。
 
 <CardGroup cols={2}>
-  <Card title="Rudder Discord" icon="discord" href="https://discord.gg/ZcfWwPVkUz">
+  <Card title="Rudder Discord" icon="messages-square" href="https://discord.gg/ZcfWwPVkUz">
     获取安装帮助、发布运行记录、提交早期反馈，或参加构建评审活动。
   </Card>
   <Card title="GitHub 仓库" icon="external-link" href="https://github.com/Undertone0809/rudder">

--- a/scripts/docs-alignment-reviews.json
+++ b/scripts/docs-alignment-reviews.json
@@ -63,6 +63,7 @@
     {"reminder":"gdpval-harness: reviewer should compare English and Chinese counterparts","fingerprint":"776fc041708cf5a61dcde022c6511ab7a8a23146f5b601fef1e9f767c92fd312","classification":"fixed","reviewed_revision":"93df830ef-working-tree-review-2026-07-21"},
     {"reminder":"about: reviewer should compare English and Chinese counterparts","fingerprint":"f9e86f129053ae312a0cd33658537b048bd5863349983b317b6905cea12e131c","classification":"false-positive","reviewed_revision":"c5236c074-working-tree-review-2026-07-21"},
     {"reminder":"contact: reviewer should compare English and Chinese counterparts","fingerprint":"63652200cfad6b5ee68b9e78ec0a8f5ee45c47ad299f553a9ff3fd7178b119a9","classification":"false-positive","reviewed_revision":"2bb37f919-integration-review-2026-07-21"},
+    {"reminder":"contact: reviewer should compare English and Chinese counterparts","fingerprint":"68ea9f0d1530b21e9b29492f43f4452022443cc389552454f5c52d895b0d733c","classification":"false-positive","reviewed_revision":"ae3284612-discord-icon-review-2026-07-22"},
     {"reminder":"releases: reviewer should compare English and Chinese counterparts","fingerprint":"b187be58055d0835f910059a6ff05166b58019d97818a63bb5b6969b660d1aa4","classification":"false-positive","reviewed_revision":"c5236c074-working-tree-review-2026-07-21"}
   ],
   "allowed_classifications": ["fixed", "intentional", "false-positive"]


### PR DESCRIPTION
## What changed

- replaces the unsupported `discord` Lucide card icon with `messages-square` on the English and Chinese Contact pages
- records the reviewed bilingual Contact fingerprint

## Why

The initial Discord docs staging deployment rendered the pages correctly, but the public-health gate failed because Mintlify resolved `discord` to a Lucide CDN URL that returned HTTP 403. The supported icon passes the same public-health check and is already live in the verified production docs release.

## Verification

- `node scripts/docs-content-map.mjs integrity`
- targeted Contact alignment check: no unclassified Contact reminder
- `PUPPETEER_SKIP_DOWNLOAD=1 npx -y mint@4.2.637 validate`
- staging workflow: https://github.com/Undertone0809/rudder/actions/runs/29852347853
- production workflow: https://github.com/Undertone0809/rudder/actions/runs/29852619064

The remaining 14 alignment reminders on `main` predate this fix and are intentionally not classified here.