### PR TITLE
perf(release): cut redundant release validation

### DIFF
--- a/.agents/skills/maintainer/release-maintainer/SKILL.md
+++ b/.agents/skills/maintainer/release-maintainer/SKILL.md
@@ -32,7 +32,10 @@ cannot be safely inferred.
   `npx @rudderhq/cli@latest <command>` are the same CLI surface when they resolve
   to the same CLI version. The `npx` form is the first-run or explicit dist-tag
   form.
-- Canaries publish from `main` automatically and use npm dist-tag `canary`.
+- Canaries publish from `main` automatically after the exact commit's `CI`
+  workflow succeeds, and use npm dist-tag `canary`. The release workflow must
+  consume that CI result instead of repeating the full operating-system test
+  matrix.
 - Canary git tags use `canary/vX.Y.Z-canary.N`. The matching GitHub Release
   display title should be clean `vX.Y.Z-canary.N`, not the full tag name, and
   it should be marked prerelease.
@@ -41,6 +44,10 @@ cannot be safely inferred.
   explicitly dispatch `desktop-release.yml`, or the maintainer must do it.
 - Stables are manually promoted from an explicitly chosen source ref and use
   npm dist-tag `latest`.
+- Stable preflight must fail closed unless `npm-stable` has required reviewers,
+  `main` is protected, and GitHub Actions is allowed to create pull requests.
+  Do not bypass these checks or treat the confirmation string as a substitute
+  for the repository safeguards.
 - Stable tags point at the original source commit, not at a generated release
   commit.
 - After a stable `vX.Y.Z` is published and verified, older canary GitHub
@@ -83,6 +90,20 @@ cannot be safely inferred.
   local shell can publish or repair npm state.
 - Release-maintenance commits that should not publish another canary must
   include `[skip release]`, then be verified as skipped in `release.yml`.
+- Run `./scripts/release.sh <canary|stable> --preflight` before dependency
+  installation or build work. A stale base, existing tag/npm version, or
+  missing stable notes should fail in this fast gate, not after CI or packaging.
+- Canary and stable publication share one non-cancelling `release-publish`
+  concurrency group. Never bypass it by starting a second publish path while
+  npm or Desktop orchestration is still active. GitHub concurrency is not a
+  FIFO queue and retains only one pending job; if a queued manual stable is
+  superseded by another pending run, report it and rerun that same locked
+  stable SHA after the active publish finishes.
+- After a stable publish, the workflow should open the next-patch base pull
+  request automatically. Verify that PR exists (or that `main` was already
+  advanced) and that its explicitly dispatched CI succeeds before calling the
+  version handoff complete; merging remains a reviewed maintainer action and
+  does not happen automatically.
 - If a normal `main` push is already running while you make release-maintenance
   changes, watch it to completion. It may publish the next canary, and that
   canary still needs npm, tag, Desktop, and Release-title verification. After
@@ -111,6 +132,7 @@ Start by reading only the context needed for the user's request:
 - `.github/workflows/npm-dist-tag.yml` when repairing `latest` or `canary`
   dist-tags through GitHub Actions.
 - `scripts/release.sh`, `scripts/release-package-map.mjs`,
+  `scripts/prepare-next-release.mjs`,
   `scripts/create-github-release.sh`, `scripts/promote-npm-dist-tag.mjs`,
   `scripts/wait-for-desktop-release-assets.mjs`, and
   `scripts/rollback-latest.sh` when you need exact command behavior.
@@ -134,7 +156,9 @@ git log --oneline --decorate --graph -8
 git tag --list 'v*' --sort=-version:refname | head -10
 node scripts/release-package-map.mjs list
 ./scripts/release.sh stable --print-version
+./scripts/release.sh stable --preflight
 ./scripts/release.sh canary --print-version
+./scripts/release.sh canary --preflight
 ```
 
 When the task depends on remote truth, also check:
@@ -148,6 +172,9 @@ gh release list --repo Undertone0809/rudder --limit 20
 git ls-remote --tags origin 'refs/tags/canary/v*'
 npm view @rudderhq/cli dist-tags --json
 npm view @rudderhq/cli versions --json
+gh api repos/Undertone0809/rudder/environments/npm-stable
+gh api repos/Undertone0809/rudder/actions/permissions/workflow
+gh api repos/Undertone0809/rudder/branches/main/protection
 ```
 
 If the worktree has unrelated dirty files, explicitly say you will ignore them
@@ -243,8 +270,10 @@ NODE
 
 Canary releases should normally be automatic.
 
-1. Confirm the change is merged to `main`.
-2. Watch the `Release` workflow canary job. If the triggering commit is a
+1. Confirm the change is merged to `main` and its exact `CI` workflow succeeds.
+2. Watch the `Release` workflow started by that successful CI run. Confirm its
+   preflight source SHA matches the CI head SHA; do not accept a release run
+   that re-resolves a moving branch. If the triggering commit is a
    release-maintenance commit with `[skip release]`, verify the run is skipped
    before assuming no canary was produced. For pre-stable public canaries, the
    canary job is not complete until it has dispatched the Desktop release,
@@ -376,6 +405,7 @@ Prefer the GitHub Actions workflow over local stable publishing.
 ```bash
 node scripts/release-package-map.mjs list
 ./scripts/release.sh stable --print-version
+./scripts/release.sh stable --preflight
 ```
 
 3. Confirm `releases/vX.Y.Z.md` exists on the source ref and uses exactly this
@@ -397,8 +427,11 @@ node scripts/release-package-map.mjs list
    update drill below before real stable publish. If the drill cannot run on
    the local platform, name the missing platform and treat stable readiness as
    not fully proven.
-7. Run the `Release` workflow with `dry_run: true`, using the locked SHA as
-   `source_ref`.
+7. Confirm the locked SHA already has a successful `CI` run, then run the
+   `Release` workflow with `dry_run: true`, using that SHA as `source_ref`.
+   The workflow reuses the exact CI result and runs only the fast release
+   preflight plus publish-payload preview; it must not repeat the full test
+   matrix.
 8. If dry-run passes, rerun with `dry_run: false`, again using the same locked
    SHA as `source_ref`.
 9. Wait for or request `npm-stable` approval.
@@ -417,6 +450,12 @@ rudder start --no-open
 ```
 
 The second command is only expected to work after the persistent CLI exists.
+
+13. Confirm the workflow opened `automation/release-vX.Y.(Z+1)` as a pull
+    request and dispatched the trusted `main`-branch CI workflow with its
+    immutable head SHA, or reported that `main` already has a newer base.
+    Review and merge that PR before expecting the next automatic canary line
+    to publish.
 
 If the workflow fails after npm publish, do not rerun the whole stable workflow
 without first classifying the partial state. Stable npm versions are immutable;
@@ -515,7 +554,14 @@ known risk is the in-app update path itself.
 
 ### Version Bump
 
-Use this before the next stable line.
+After stable, first use the workflow-created next-patch pull request. The
+workflow runs the equivalent of:
+
+```bash
+node scripts/prepare-next-release.mjs --stable-version X.Y.Z --repo Undertone0809/rudder
+```
+
+If automation could not create the PR, recover manually:
 
 ```bash
 node scripts/release-package-map.mjs set-version X.Y.Z

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,12 +6,17 @@ on:
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      source_sha:
+        description: "Optional immutable source SHA to verify with the trusted main-branch CI workflow"
+        required: false
+        type: string
 
 permissions:
   contents: read
 
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.ref }}
+  group: ci-${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && inputs.source_sha || github.ref }}
   cancel-in-progress: true
 
 defaults:
@@ -27,6 +32,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.source_sha || github.sha }}
 
       - name: Architecture audit tests
         run: node --test scripts/architecture-audit.test.mjs scripts/architecture-boundaries.test.mjs
@@ -86,6 +92,8 @@ jobs:
       ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.source_sha || github.sha }}
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -61,7 +61,14 @@ jobs:
           corepack prepare pnpm@9.15.4 --activate
 
       - name: Install dependencies
-        run: pnpm install --no-frozen-lockfile
+        run: pnpm install --frozen-lockfile
+
+      - name: Cache PostgreSQL runtime payload
+        if: matrix.platform != 'linux'
+        uses: actions/cache@v5
+        with:
+          path: ~/.rudder/runtime-payloads/postgres-18.4
+          key: postgres-runtime-18.4-${{ runner.os }}-${{ matrix.arch }}-${{ hashFiles('desktop/scripts/prepare-postgres-runtime.mjs') }}
 
       - name: Prepare PostgreSQL 18.4 runtime payload
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,9 @@
 name: Release
 
 on:
-  push:
-    branches:
-      - main
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
   workflow_dispatch:
     inputs:
       source_ref:
@@ -22,75 +22,91 @@ on:
         type: string
 
 permissions:
-  actions: write
-  contents: write
-  id-token: write
-
-concurrency:
-  group: release-${{ github.event_name }}-${{ github.ref }}-${{ github.event_name == 'workflow_dispatch' && inputs.source_ref || 'push' }}
-  cancel-in-progress: false
+  contents: read
 
 jobs:
-  verify:
-    name: Verify ${{ matrix.os }}
-    if: (github.event_name == 'push' && github.repository == 'Undertone0809/rudder' && !contains(github.event.head_commit.message, '[skip release]')) || github.event_name == 'workflow_dispatch'
-    runs-on: ${{ matrix.os }}
-    timeout-minutes: 60
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: ubuntu-latest
-            test: full
-          - os: macos-latest
-            test: full
-          - os: windows-latest
-            test: cli-start
-    env:
-      CI: true
-      ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
-    defaults:
-      run:
-        shell: bash
+  preflight:
+    name: Release preflight
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event == 'push' &&
+       github.event.workflow_run.head_branch == 'main' &&
+       github.event.workflow_run.repository.full_name == github.repository &&
+       !contains(github.event.workflow_run.head_commit.message, '[skip release]'))
+    permissions:
+      actions: read
+      contents: read
+    runs-on: ubuntu-latest
+    outputs:
+      source_sha: ${{ steps.source.outputs.sha }}
+      version: ${{ steps.release-preflight.outputs.version }}
     steps:
+      - name: Confirm stable publish authorization
+        if: github.event_name == 'workflow_dispatch' && !inputs.dry_run
+        env:
+          CONFIRM_STABLE: ${{ inputs.confirm_stable }}
+        run: test "$CONFIRM_STABLE" = "PUBLISH STABLE"
+
+      - name: Require release repository safeguards
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          RELEASE_SAFEGUARDS_CONFIGURED: ${{ vars.RELEASE_SAFEGUARDS_CONFIGURED }}
+        run: |
+          if [ "$RELEASE_SAFEGUARDS_CONFIGURED" != "true" ]; then
+            echo "Configure npm-stable reviewers, main protection, and Actions PR creation, then set RELEASE_SAFEGUARDS_CONFIGURED=true." >&2
+            exit 1
+          fi
+
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.source_ref || github.sha }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.source_ref || github.event.workflow_run.head_sha }}
 
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 24
+      - name: Resolve immutable release source
+        id: source
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
-      - name: Enable pnpm
-        run: |
-          corepack enable
-          corepack prepare pnpm@9.15.4 --activate
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Typecheck
-        run: pnpm -r typecheck
-
-      - name: Unit tests
-        if: matrix.test == 'full'
-        run: pnpm test:run --maxWorkers=1
-
-      - name: CLI start tests
-        if: matrix.test == 'cli-start'
-        run: pnpm -s exec vitest run cli/src/__tests__/start.test.ts
-
-      - name: Build
+      - name: Require successful CI for exact source
+        if: github.event_name == 'workflow_dispatch'
         env:
-          RUDDER_ALLOW_LEGACY_EMBEDDED_POSTGRES: "1"
-          RUDDER_SKIP_POSTGRES_RUNTIME_AUTO_PREPARE: "1"
-        run: pnpm build
+          GH_TOKEN: ${{ github.token }}
+          SOURCE_SHA: ${{ steps.source.outputs.sha }}
+        run: |
+          count="$(gh api -X GET "repos/$GITHUB_REPOSITORY/actions/workflows/ci.yml/runs" \
+            -f head_sha="$SOURCE_SHA" \
+            -f status=success \
+            -f per_page=100 \
+            --jq '.workflow_runs | length')"
+          if [ "$count" -lt 1 ]; then
+            echo "No successful CI workflow found for exact source $SOURCE_SHA." >&2
+            exit 1
+          fi
+
+      - name: Release preflight
+        id: release-preflight
+        run: |
+          if [ "$GITHUB_EVENT_NAME" = "workflow_run" ]; then
+            git checkout -B main "${{ steps.source.outputs.sha }}"
+            version="$(./scripts/release.sh canary --preflight)"
+          else
+            version="$(./scripts/release.sh stable --preflight)"
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Release source: ${{ steps.source.outputs.sha }}"
+          echo "Release version: $version"
 
   canary:
     name: Publish npm canary
-    needs: verify
-    if: github.event_name == 'push' && github.repository == 'Undertone0809/rudder' && !contains(github.event.head_commit.message, '[skip release]')
+    needs: preflight
+    if: github.event_name == 'workflow_run'
+    permissions:
+      actions: write
+      contents: write
+      id-token: write
+    concurrency:
+      group: release-publish
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     environment: npm-canary
     env:
@@ -103,6 +119,14 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          ref: ${{ needs.preflight.outputs.source_sha }}
+
+      - name: Pin canary source to main
+        run: git checkout -B main "${{ needs.preflight.outputs.source_sha }}"
+
+      - name: Locked canary preflight
+        id: locked-preflight
+        run: echo "version=$(./scripts/release.sh canary --preflight)" >> "$GITHUB_OUTPUT"
 
       - uses: actions/setup-node@v6
         with:
@@ -117,22 +141,21 @@ jobs:
           npm --version
 
       - name: Install dependencies
-        run: pnpm install --no-frozen-lockfile
+        run: pnpm install --frozen-lockfile
 
       - name: Configure git identity
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git checkout -B main "$GITHUB_SHA"
 
       - name: Publish canary
         id: publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          version="$(./scripts/release.sh canary --print-version)"
+          version="${{ steps.locked-preflight.outputs.version }}"
           echo "version=${version}" >> "$GITHUB_OUTPUT"
-          ./scripts/release.sh canary --skip-verify
+          ./scripts/release.sh canary --skip-verify --expected-version "$version"
           git push origin "refs/tags/canary/v${version}"
 
       - name: Start desktop release build
@@ -140,7 +163,10 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           tag="canary/v${{ steps.publish.outputs.version }}"
-          gh workflow run desktop-release.yml --ref "$tag" -f release_tag="$tag"
+          gh workflow run desktop-release.yml \
+            --ref main \
+            -f release_tag="$tag" \
+            -f source_ref="$tag"
 
       - name: Wait for desktop release assets
         env:
@@ -164,8 +190,10 @@ jobs:
 
   stable-dry-run:
     name: Preview stable release
-    needs: verify
+    needs: preflight
     if: github.event_name == 'workflow_dispatch' && inputs.dry_run
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     env:
       ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
@@ -175,7 +203,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          ref: ${{ inputs.source_ref }}
+          ref: ${{ needs.preflight.outputs.source_sha }}
 
       - uses: actions/setup-node@v6
         with:
@@ -190,15 +218,22 @@ jobs:
           npm --version
 
       - name: Install dependencies
-        run: pnpm install --no-frozen-lockfile
+        run: pnpm install --frozen-lockfile
 
       - name: Preview stable publish
         run: ./scripts/release.sh stable --dry-run --skip-verify
 
   stable:
     name: Publish stable release
-    needs: verify
+    needs: preflight
     if: github.event_name == 'workflow_dispatch' && !inputs.dry_run && github.repository == 'Undertone0809/rudder'
+    permissions:
+      actions: write
+      contents: write
+      id-token: write
+    concurrency:
+      group: release-publish
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     environment: npm-stable
     env:
@@ -216,7 +251,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          ref: ${{ inputs.source_ref }}
+          ref: ${{ needs.preflight.outputs.source_sha }}
 
       - uses: actions/setup-node@v6
         with:
@@ -231,7 +266,7 @@ jobs:
           npm --version
 
       - name: Install dependencies
-        run: pnpm install --no-frozen-lockfile
+        run: pnpm install --frozen-lockfile
 
       - name: Configure git identity
         run: |
@@ -244,16 +279,21 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           GH_TOKEN: ${{ github.token }}
         run: |
-          version="$(./scripts/release.sh stable --print-version)"
+          version="${{ needs.preflight.outputs.version }}"
           echo "version=${version}" >> "$GITHUB_OUTPUT"
-          ./scripts/release.sh stable --skip-verify
+          ./scripts/release.sh stable --skip-verify --expected-version "$version"
           git push origin "refs/tags/v${version}"
           PUBLISH_REMOTE=origin ./scripts/create-github-release.sh "${version}"
 
       - name: Start desktop release build
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh workflow run desktop-release.yml --ref "v${{ steps.publish.outputs.version }}" -f release_tag="v${{ steps.publish.outputs.version }}"
+        run: |
+          tag="v${{ steps.publish.outputs.version }}"
+          gh workflow run desktop-release.yml \
+            --ref main \
+            -f release_tag="$tag" \
+            -f source_ref="$tag"
 
       - name: Wait for desktop release assets
         env:
@@ -275,12 +315,59 @@ jobs:
             --remote origin \
             --stable-version "${{ steps.publish.outputs.version }}"
 
+  next-release-base:
+    name: Propose next release base
+    needs:
+      - preflight
+      - stable
+    if: needs.stable.result == 'success'
+    permissions:
+      actions: write
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.preflight.outputs.source_sha }}
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Create next patch version pull request
+        id: next-release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          node scripts/prepare-next-release.mjs \
+            --stable-version "${{ needs.stable.outputs.version }}" \
+            --repo "$GITHUB_REPOSITORY"
+
+      - name: Start CI for next release base
+        if: steps.next-release.outputs.action == 'created' || steps.next-release.outputs.action == 'existing'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh workflow run ci.yml \
+            --ref main \
+            -f source_sha="${{ steps.next-release.outputs.head_sha }}"
+          {
+            echo "### Next release base"
+            echo "PR: ${{ steps.next-release.outputs.pull_request_url }}"
+            echo "Trusted CI dispatched for ${{ steps.next-release.outputs.head_sha }}."
+          } >> "$GITHUB_STEP_SUMMARY"
+
   public-install-smoke:
     name: Public install smoke
     needs:
       - canary
       - stable
     if: always() && (needs.canary.result == 'success' || needs.stable.result == 'success')
+    permissions:
+      contents: read
     uses: ./.github/workflows/public-install-smoke.yml
     with:
       package_spec: "@rudderhq/cli@${{ needs.canary.outputs.version || needs.stable.outputs.version }}"

--- a/doc/engineering/PUBLISHING.md
+++ b/doc/engineering/PUBLISHING.md
@@ -80,6 +80,13 @@ fail with instructions to commit an explicit base bump first, for example
 `X.Y.Z` remains newer than `X.Y.Z-canary.N`, so post-stable canaries must move
 to the next base to be visible as updates to stable users.
 
+`scripts/release.sh <channel> --preflight` performs these version, existing-tag,
+existing-npm-version, and stable-notes checks without installing dependencies
+or building the workspace. GitHub release automation runs it before expensive
+work. After a stable succeeds, `scripts/prepare-next-release.mjs` creates an
+idempotent next-patch pull request from current `main`; it never pushes the bump
+directly to protected `main`.
+
 ## Version formats
 
 Rudder uses committed semver:

--- a/doc/engineering/RELEASE-AUTOMATION-SETUP.md
+++ b/doc/engineering/RELEASE-AUTOMATION-SETUP.md
@@ -13,16 +13,27 @@ Repo-side files that depend on this setup:
 - `.github/workflows/desktop-release.yml`
 - `.github/CODEOWNERS`
 
-The `Release` workflow needs `actions: write` because it dispatches
-`desktop-release.yml` after publishing npm and pushing the release tag. A tag
-push performed with `GITHUB_TOKEN` will not, by itself, trigger a second
-workflow run.
+The `Release` workflow needs `actions: write` because it inspects exact-source
+CI runs and dispatches `desktop-release.yml` after publishing npm and pushing
+the release tag. It needs `pull-requests: write` to propose the next patch base
+after stable. A tag push performed with `GITHUB_TOKEN` will not, by itself,
+trigger a second workflow run.
+
+In repository `Settings` -> `Actions` -> `General` -> `Workflow permissions`,
+enable **Allow GitHub Actions to create and approve pull requests**. The release
+preflight requires an operator attestation that this and the other safeguards
+below are configured; the workflow does not silently skip the next-version
+handoff.
 
 Note:
 
-- the release workflows intentionally use `pnpm install --no-frozen-lockfile`
-- this matches the repo's current policy where `pnpm-lock.yaml` is refreshed by GitHub automation after manifest changes land on `main`
-- the publish jobs then restore `pnpm-lock.yaml` before running `scripts/release.sh`, so the release script still sees a clean worktree
+- release and Desktop jobs use `pnpm install --frozen-lockfile` because the
+  exact source commit must already have passed CI dependency resolution
+- canary publishing begins from the successful `CI` workflow-run SHA; manual
+  stable dispatches query CI for the exact immutable source before installing
+  dependencies
+- release-specific preflight rejects stale versions and missing notes before
+  package installation or build work
 
 ## 1. Merge the Repo Changes First
 
@@ -153,12 +164,12 @@ Reasoning:
 
 ## 6. Configure `npm-stable`
 
-Recommended settings for `npm-stable`:
+Required settings for `npm-stable`:
 
 - environment name: `npm-stable`
-- required reviewers: at least one maintainer other than the person triggering the workflow when possible
+- required reviewers: at least one maintainer other than the person triggering the workflow
 - prevent self-review: enabled
-- admin bypass: disabled if your team can tolerate it
+- admin bypass: disabled
 - wait timer: optional
 - deployment branches and tags:
   - selected branches only
@@ -168,12 +179,14 @@ Reasoning:
 
 - stable publishes should require an explicit human approval gate
 - the workflow is manual, but the environment should still be the real control point
+- the safeguards attestation must not be set while the environment has no
+  required-reviewer protection rule
 
 ## 7. Protect `main`
 
 Open the branch protection settings for `main`.
 
-Recommended rules:
+Required rules for release automation:
 
 1. require pull requests before merging
 2. require status checks to pass before merging
@@ -181,7 +194,17 @@ Recommended rules:
 4. dismiss stale approvals when new commits are pushed
 5. restrict who can push directly to `main`
 
-At minimum, make sure workflow and release script changes cannot land without review.
+At minimum, make sure workflow and release script changes cannot land without
+review. The stable preflight stops before executing source-ref release code
+unless all safeguards have been attested.
+
+After required reviewers, `main` protection, and Actions pull-request creation
+are all configured and manually verified, create the repository Actions
+variable `RELEASE_SAFEGUARDS_CONFIGURED` with value `true`. Manual stable
+preflight fails closed while this variable is missing. The variable is an
+operator attestation because the workflow's scoped `GITHUB_TOKEN` cannot read
+repository-administration settings; do not set it before checking all three
+controls.
 
 ## 8. Enforce CODEOWNERS Review
 
@@ -236,8 +259,9 @@ This keeps LLM spending intentional and avoids a high-value token sitting in Act
 After setup:
 
 1. merge a harmless commit to `main`
-2. open the `Release` workflow run triggered by that push
-3. confirm it passes verification
+2. confirm the exact push passes the `CI` workflow
+3. open the `Release` workflow run triggered by that successful CI run and
+   confirm its preflight reports the same source SHA
 4. confirm publish succeeds under the `npm-canary` environment
 5. confirm npm now shows a new `canary` release
 6. confirm a git tag named `canary/v0.1.0-canary.N` was pushed
@@ -269,6 +293,8 @@ After at least one good canary exists:
 10. confirm the GitHub Release was created
 11. confirm `.github/workflows/desktop-release.yml` runs for `v0.1.0`
 12. confirm the GitHub Release contains macOS, Windows, Linux, and `SHASUMS256.txt` assets
+13. confirm the workflow opens the next-patch version pull request and
+    dispatches its CI, or reports that `main` already advanced
 
 Start-path check:
 

--- a/doc/engineering/RELEASING.md
+++ b/doc/engineering/RELEASING.md
@@ -4,7 +4,7 @@ Maintainer runbook for shipping Rudder across npm, GitHub, and the website-facin
 
 The release model is now commit-driven:
 
-1. Every push to `main` publishes a canary automatically, except explicit release-infra maintenance commits marked `[skip release]`.
+1. Every successful `CI` run for a `main` push publishes a canary automatically, except explicit release-infra maintenance commits marked `[skip release]`.
 2. Stable releases are manually promoted from a chosen tested commit or canary tag.
 3. Stable release notes live in `releases/vX.Y.Z.md`.
 4. Stable releases get user-facing GitHub Releases; canaries may get prerelease GitHub Releases for Desktop portable assets.
@@ -27,9 +27,9 @@ Important constraints:
 - stable source commits must have one committed public package version
 - all public packages must share that same stable semver before release
 - canary publishes derive the next prerelease from the committed stable version
-- after publishing stable `X.Y.Z`, the next canary requires an explicit commit
-  that bumps the public package version to the next stable base, for example
-  `X.Y.Z -> X.Y.(Z+1)`
+- after publishing stable `X.Y.Z`, the workflow opens a pull request that bumps
+  the public package version to the next stable base, for example
+  `X.Y.Z -> X.Y.(Z+1)`; a maintainer still reviews and merges that commit
 - `./scripts/release.sh canary --print-version` fails if the committed canary
   base already exists as stable npm package `X.Y.Z` or remote git tag `vX.Y.Z`
 
@@ -75,6 +75,11 @@ approval. Agents and automation must not set `dry_run: false`, enter workflow
 confirmation strings, or synthesize a release tag as evidence of approval. The
 operator's explicit authorization must exist before those values are supplied.
 
+The workflow also fails closed unless `npm-stable` has required reviewers,
+`main` is protected, and GitHub Actions is allowed to create the post-stable
+version pull request. These repository settings are part of the release gate,
+not optional documentation.
+
 Even when an initial request or plan includes production deployment, always
 pause at the production gate after presenting the reviewed source, target,
 checks, known failures, and rollback point. Only the operator's latest explicit
@@ -113,11 +118,12 @@ Canaries cover verification, npm, a traceability tag, and Desktop portable asset
 
 ### Canary
 
-Every push to `main` runs the canary path inside [`.github/workflows/release.yml`](../.github/workflows/release.yml), unless the head commit message contains `[skip release]`.
+Every successful `CI` workflow for a `main` push starts the canary path inside [`.github/workflows/release.yml`](../.github/workflows/release.yml), unless the head commit message contains `[skip release]`.
 
 It:
 
-- verifies the pushed commit
+- reuses the successful CI result for the exact pushed commit
+- runs a fast version/tag/npm preflight before installing dependencies
 - derives the next canary prerelease from the committed semver
 - publishes under npm dist-tag `canary`
 - while no stable npm version exists yet, also points npm dist-tag `latest` at
@@ -129,6 +135,12 @@ It:
 The release workflow dispatches the Desktop workflow explicitly after pushing the
 canary tag. Do not rely on a tag push made by `GITHUB_TOKEN` to trigger another
 workflow.
+
+Canary and stable publication use the same non-cancelling concurrency group, so
+their npm/Desktop orchestration cannot run at the same time. GitHub retains at
+most one pending job per group rather than a FIFO queue. If a pending manual
+stable is superseded by a newer pending run, rerun the same locked stable SHA
+after the active publication finishes; do not silently retarget it.
 
 Users install canaries with:
 
@@ -160,12 +172,13 @@ Before running stable:
 1. pick the canary commit or tag you trust
 2. confirm the committed public package version is the stable version you want to ship
 3. create or update `releases/vX.Y.Z.md` on that source ref
-4. run the workflow with `dry_run: true`
-5. present the exact source ref, version, checks, targets, and rollback point;
+4. confirm that exact source commit has a successful `CI` run
+5. run the workflow with `dry_run: true`
+6. present the exact source ref, version, checks, targets, and rollback point;
    obtain explicit production approval
-6. run the workflow with `dry_run: false` and `confirm_stable: PUBLISH STABLE`
-7. after stable is published, merge a separate version-bump commit before
-   expecting later canaries to be detectable as updates for stable users
+7. run the workflow with `dry_run: false` and `confirm_stable: PUBLISH STABLE`
+8. after stable is published, review and merge the automatically opened
+   next-patch version pull request before expecting later canaries
 
 Example:
 
@@ -175,7 +188,9 @@ Example:
 
 The workflow:
 
-- re-verifies the exact source ref
+- resolves the source ref to an immutable SHA and requires successful CI for
+  that exact commit
+- runs release-specific version/tag/npm preflight before dependency install
 - publishes the committed `X.Y.Z` under npm dist-tag `latest`
 - creates git tag `vX.Y.Z`
 - creates or updates the GitHub Release from `releases/vX.Y.Z.md`
@@ -184,6 +199,9 @@ The workflow:
   the released stable version or older, while preserving the current npm
   `@rudderhq/cli@canary` target if the next-base canary has not been published
   yet
+- opens an idempotent `automation/release-vX.Y.(Z+1)` pull request for the next
+  canary/stable base and dispatches the trusted `main`-branch CI workflow with
+  its immutable head SHA, unless `main` already advanced
 - records the announcement channel, and publishes docs production when website
   content is part of the release scope
 

--- a/doc/plans/2026-07-22-release-pipeline-latency.md
+++ b/doc/plans/2026-07-22-release-pipeline-latency.md
@@ -1,0 +1,124 @@
+---
+title: Release Pipeline Latency And Version Handoff
+date: 2026-07-22
+kind: fix-plan
+status: completed
+area: deployment
+entities:
+  - release_automation
+  - npm_publishing
+  - desktop_release
+  - version_handoff
+issue:
+related_plans:
+  - 2026-03-17-release-automation-and-versioning.md
+  - 2026-04-24-release-desktop-npm-distribution.md
+supersedes: []
+related_code:
+  - .agents/skills/maintainer/release-maintainer/SKILL.md
+  - .github/workflows/ci.yml
+  - .github/workflows/release.yml
+  - .github/workflows/desktop-release.yml
+  - scripts/release.sh
+  - scripts/release-lib.sh
+commit_refs:
+  - "perf(release): cut redundant release validation"
+updated_at: 2026-07-22
+---
+
+# Release Pipeline Latency And Version Handoff
+
+## Problem
+
+Release automation repeats the full operating-system test matrix even when CI
+already verified the exact source commit. A stale committed base version is
+therefore discovered only after roughly twenty minutes of duplicated checks.
+Stable and canary dispatches also use different concurrency groups, so they can
+publish npm packages and build Desktop releases at the same time.
+
+After a stable release, the repository remains on the just-published version
+until a maintainer manually prepares the next patch version. During this gap,
+every main-branch canary is guaranteed to fail.
+
+## Scope
+
+1. Start automatic canaries only after the main-branch CI workflow succeeds.
+2. For manual stable requests, resolve the source to an immutable commit and
+   require a successful CI run for that exact commit before release work.
+3. Run version and authorization preflight before dependency installation or
+   package builds.
+4. Serialize npm/Desktop release orchestration across canary and stable jobs.
+5. After a stable publish, create an idempotent pull request that advances all
+   public packages to the next patch base.
+6. Cache the prepared PostgreSQL 18.4 Desktop runtime payload on macOS and
+   Windows runners.
+7. Update the repository release skill and release documentation so the
+   version handoff is part of the normal completion contract.
+8. Keep source-ref preflight and dry-run jobs read-only, and fail closed until
+   repository reviewers, branch protection, and Actions pull-request creation
+   have been configured and attested.
+
+Cross-run npm tarball promotion is intentionally excluded. npm publication is
+not transactional, so promoting a dry-run artifact needs a separate candidate
+manifest, digest verification, retention policy, and partial-publish recovery
+design before it can safely replace the current build path.
+
+Resumable partial npm publication is also deferred to that candidate design.
+The current per-package publish is not transactional; adding a skip-existing
+mode without verifying package digests/provenance could attach a release tag to
+the wrong immutable payload.
+
+## Safety Constraints
+
+- This change must not trigger a canary or stable publication during local
+  verification.
+- A real stable publish still requires the exact `PUBLISH STABLE` confirmation.
+- CI reuse is valid only for the exact immutable source commit and a successful
+  `CI` workflow conclusion.
+- The post-stable version change is proposed through a pull request, never
+  pushed directly to protected `main`.
+- Failure to open the follow-up pull request must be visible, but must not
+  pretend an already-published stable release was rolled back.
+
+## Regression Coverage
+
+- Static workflow contract tests for the CI handoff, early preflight,
+  cross-channel concurrency, and Desktop runtime cache.
+- Unit tests for next-patch planning and idempotent version-bump behavior.
+- Existing canary guard tests continue to prove stale stable bases fail before
+  canary derivation.
+- Black-box checks run the new version-handoff helper in temporary git
+  repositories without contacting production services.
+
+## Validation
+
+- targeted release-script tests
+- workflow YAML parse and action linting when available
+- `pnpm lint`
+- `pnpm -r typecheck`
+- `pnpm test:run`
+- `pnpm build`
+- independent release review and black-box verification
+
+## Rollback
+
+Revert the workflow and helper commit. No schema, migration, or persisted user
+data is involved. Existing stable tags and npm versions remain immutable.
+
+## Validation Results
+
+- Passed: release workflow and script regression suite (22 focused tests).
+- Passed: `actionlint v1.7.12` for CI, Release, and Desktop Release workflows.
+- Passed: `bash -n scripts/release.sh` and
+  `node --check scripts/prepare-next-release.mjs`.
+- Passed: `pnpm -r typecheck`.
+- Passed: `pnpm build`.
+- Passed: `pnpm product-logic:check` and `pnpm product-logic:test`.
+- Passed: `pnpm lint:changed`.
+- Known repository baseline: `pnpm lint` reports the pre-existing import order
+  in `ui/src/pages/Chat.workspace-helpers.test.tsx`, outside this change.
+- Full serial tests: 559 files passed; only
+  `server/src/__tests__/heartbeat-run-concurrency.test.ts` failed two timing
+  waits. The focused release suite passes independently.
+- Independent release review and black-box verification found no remaining
+  blocking P0/P1 issues.

--- a/scripts/docs-alignment-reviews.json
+++ b/scripts/docs-alignment-reviews.json
@@ -63,7 +63,7 @@
     {"reminder":"gdpval-harness: reviewer should compare English and Chinese counterparts","fingerprint":"776fc041708cf5a61dcde022c6511ab7a8a23146f5b601fef1e9f767c92fd312","classification":"fixed","reviewed_revision":"93df830ef-working-tree-review-2026-07-21"},
     {"reminder":"about: reviewer should compare English and Chinese counterparts","fingerprint":"f9e86f129053ae312a0cd33658537b048bd5863349983b317b6905cea12e131c","classification":"false-positive","reviewed_revision":"c5236c074-working-tree-review-2026-07-21"},
     {"reminder":"contact: reviewer should compare English and Chinese counterparts","fingerprint":"68ea9f0d1530b21e9b29492f43f4452022443cc389552454f5c52d895b0d733c","classification":"false-positive","reviewed_revision":"ae3284612-discord-icon-review-2026-07-22"},
-    {"reminder":"releases: reviewer should compare English and Chinese counterparts","fingerprint":"de0a3752201a55145e8e5b03735b7cf80aa51545a033a142bdaf2bcc31354f43","classification":"false-positive","reviewed_revision":"v0.5.1-release-review-2026-07-22"}
+    {"reminder":"releases: reviewer should compare English and Chinese counterparts","fingerprint":"6bc7c9c5dab8a4d7212fe60c11567debadffa6a285aeddefa802c4f38665499c","classification":"false-positive","reviewed_revision":"release-pipeline-review-2026-07-22"}
   ],
   "allowed_classifications": ["fixed", "intentional", "false-positive"]
 }

--- a/scripts/prepare-next-release.mjs
+++ b/scripts/prepare-next-release.mjs
@@ -1,0 +1,277 @@
+#!/usr/bin/env node
+
+import { execFileSync, spawnSync } from "node:child_process";
+import { appendFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptPath = fileURLToPath(import.meta.url);
+const repoRoot = resolve(dirname(scriptPath), "..");
+
+function parseStableVersion(version) {
+  const match = String(version ?? "").match(/^(\d+)\.(\d+)\.(\d+)$/);
+  if (!match) {
+    throw new Error(`expected a stable semver like 0.5.1, found: ${version || "<empty>"}`);
+  }
+  return match.slice(1).map(Number);
+}
+
+export function nextPatchVersion(version) {
+  const [major, minor, patch] = parseStableVersion(version);
+  return `${major}.${minor}.${patch + 1}`;
+}
+
+export function compareStableVersions(left, right) {
+  const leftParts = parseStableVersion(left);
+  const rightParts = parseStableVersion(right);
+  for (let index = 0; index < leftParts.length; index += 1) {
+    if (leftParts[index] > rightParts[index]) return 1;
+    if (leftParts[index] < rightParts[index]) return -1;
+  }
+  return 0;
+}
+
+export function decideVersionHandoff(currentVersion, stableVersion) {
+  const comparison = compareStableVersions(currentVersion, stableVersion);
+  const nextVersion = nextPatchVersion(stableVersion);
+  if (comparison < 0) {
+    throw new Error(
+      `main version ${currentVersion} is behind published stable ${stableVersion}; `
+      + "merge or reconcile the stable source before preparing another release line",
+    );
+  }
+  if (comparison > 0) {
+    return {
+      action: "skip",
+      nextVersion,
+      reason: `main already advanced to ${currentVersion}`,
+    };
+  }
+  return { action: "create", nextVersion };
+}
+
+function run(command, args, { capture = false, env = {} } = {}) {
+  const output = execFileSync(command, args, {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: { ...process.env, ...env },
+    stdio: capture ? ["ignore", "pipe", "pipe"] : "inherit",
+  });
+  return capture ? output.trim() : "";
+}
+
+function parseArgs(argv) {
+  const options = {
+    base: "main",
+    dryRun: false,
+    remote: "origin",
+    repository: process.env.GITHUB_REPOSITORY ?? "",
+    stableVersion: "",
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--dry-run") {
+      options.dryRun = true;
+      continue;
+    }
+    const key = {
+      "--base": "base",
+      "--remote": "remote",
+      "--repo": "repository",
+      "--stable-version": "stableVersion",
+    }[arg];
+    if (!key || !argv[index + 1]) {
+      throw new Error(`unexpected or incomplete argument: ${arg}`);
+    }
+    options[key] = argv[index + 1];
+    index += 1;
+  }
+
+  parseStableVersion(options.stableVersion);
+  if (!options.repository && !options.dryRun) {
+    throw new Error("--repo or GITHUB_REPOSITORY is required when creating the pull request");
+  }
+  return options;
+}
+
+function readWorkspaceVersion() {
+  const rows = run("node", ["scripts/release-package-map.mjs", "list"], { capture: true })
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => line.split("\t"));
+  if (rows.length === 0) throw new Error("no public packages found on main");
+
+  const versions = [...new Set(rows.map(([, , version]) => version))];
+  if (versions.length !== 1) {
+    throw new Error(`public package versions on main do not match: ${versions.join(", ")}`);
+  }
+  parseStableVersion(versions[0]);
+  return versions[0];
+}
+
+function findOpenPullRequest(repository, branch) {
+  const result = run("gh", [
+    "pr", "list",
+    "--repo", repository,
+    "--head", branch,
+    "--state", "open",
+    "--json", "url,baseRefName,headRefName,headRefOid",
+  ], { capture: true });
+  const pullRequests = JSON.parse(result || "[]");
+  return pullRequests[0] ?? null;
+}
+
+function readWorkspaceVersionAtRevision(revision) {
+  const packageDirs = run("node", ["scripts/release-package-map.mjs", "list"], { capture: true })
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => line.split("\t")[0]);
+  const versions = [...new Set(packageDirs.map((packageDir) => {
+    const manifest = JSON.parse(run("git", ["show", `${revision}:${packageDir}/package.json`], { capture: true }));
+    return manifest.version;
+  }))];
+  if (versions.length !== 1) {
+    throw new Error(`existing next-release branch has mismatched public package versions: ${versions.join(", ")}`);
+  }
+  return versions[0];
+}
+
+function validateExistingPullRequest(pullRequest, options, branch, nextVersion) {
+  if (pullRequest.baseRefName !== options.base || pullRequest.headRefName !== branch) {
+    throw new Error(`existing pull request ${pullRequest.url} does not target ${options.base} from ${branch}`);
+  }
+
+  const remoteRef = `refs/remotes/${options.remote}/${branch}`;
+  run("git", [
+    "fetch",
+    options.remote,
+    `+refs/heads/${branch}:${remoteRef}`,
+  ]);
+  const remoteOid = run("git", ["rev-parse", remoteRef], { capture: true });
+  if (remoteOid !== pullRequest.headRefOid) {
+    throw new Error(`existing pull request ${pullRequest.url} head does not match ${options.remote}/${branch}`);
+  }
+
+  const ancestry = spawnSync(
+    "git",
+    ["merge-base", "--is-ancestor", `${options.remote}/${options.base}`, remoteOid],
+    { cwd: repoRoot, stdio: "ignore" },
+  );
+  if (ancestry.status !== 0) {
+    throw new Error(`existing pull request ${pullRequest.url} is not based on current ${options.remote}/${options.base}`);
+  }
+
+  const branchVersion = readWorkspaceVersionAtRevision(remoteOid);
+  if (branchVersion !== nextVersion) {
+    throw new Error(
+      `existing pull request ${pullRequest.url} has version ${branchVersion}, expected ${nextVersion}`,
+    );
+  }
+}
+
+function writeActionOutput(name, value) {
+  if (!process.env.GITHUB_OUTPUT) return;
+  appendFileSync(process.env.GITHUB_OUTPUT, `${name}=${value}\n`);
+}
+
+function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const status = run("git", ["status", "--porcelain"], { capture: true });
+  if (status) throw new Error("working tree must be clean before preparing the next release base");
+  const originalBranch = run("git", ["branch", "--show-current"], { capture: true });
+  const originalCheckout = originalBranch || run("git", ["rev-parse", "HEAD"], { capture: true });
+  const restoreOriginalCheckout = () => run("git", ["checkout", originalCheckout]);
+  let shouldRestoreCheckout = true;
+
+  try {
+    run("git", [
+      "fetch",
+      options.remote,
+      "--prune",
+      `+refs/heads/${options.base}:refs/remotes/${options.remote}/${options.base}`,
+    ]);
+    run("git", ["checkout", "--detach", `${options.remote}/${options.base}`]);
+
+    const currentVersion = readWorkspaceVersion();
+    const decision = decideVersionHandoff(currentVersion, options.stableVersion);
+    if (decision.action === "skip") {
+      writeActionOutput("action", "skip");
+      console.log(`Next release base not needed: ${decision.reason}.`);
+      return;
+    }
+
+    const branch = `automation/release-v${decision.nextVersion}`;
+    writeActionOutput("branch", branch);
+    writeActionOutput("version", decision.nextVersion);
+    if (!options.dryRun) {
+      const existingPullRequest = findOpenPullRequest(options.repository, branch);
+      if (existingPullRequest) {
+        validateExistingPullRequest(existingPullRequest, options, branch, decision.nextVersion);
+        writeActionOutput("action", "existing");
+        writeActionOutput("head_sha", existingPullRequest.headRefOid);
+        writeActionOutput("pull_request_url", existingPullRequest.url);
+        console.log(`Next release base pull request already exists: ${existingPullRequest.url}`);
+        return;
+      }
+    }
+
+    if (options.dryRun) {
+      writeActionOutput("action", "dry-run");
+      console.log(
+        `Would create ${branch} from ${options.remote}/${options.base}, bump `
+        + `${currentVersion} -> ${decision.nextVersion}, and open a pull request.`,
+      );
+      return;
+    }
+
+    run("git", ["checkout", "-B", branch, `${options.remote}/${options.base}`]);
+    shouldRestoreCheckout = false;
+    run("node", ["scripts/release-package-map.mjs", "set-version", decision.nextVersion]);
+    run("git", ["add", "-u"]);
+    run("git", ["commit", "-m", `chore(release): start v${decision.nextVersion}`]);
+
+    const remoteBranch = run(
+      "git",
+      ["ls-remote", "--heads", options.remote, `refs/heads/${branch}`],
+      { capture: true },
+    );
+    const pushArgs = [options.remote, `HEAD:refs/heads/${branch}`];
+    if (remoteBranch) {
+      const remoteOid = remoteBranch.split(/\s+/)[0];
+      pushArgs.unshift(`--force-with-lease=refs/heads/${branch}:${remoteOid}`);
+    }
+    run("git", ["push", ...pushArgs]);
+
+    const pullRequestUrl = run("gh", [
+      "pr", "create",
+      "--repo", options.repository,
+      "--base", options.base,
+      "--head", branch,
+      "--title", `chore(release): start v${decision.nextVersion}`,
+      "--body",
+      [
+        `Automated follow-up to stable v${options.stableVersion}.`,
+        "",
+        `Advances the committed public package base to ${decision.nextVersion} so subsequent main-branch canaries can publish without reusing an already released stable version.`,
+        "",
+        "This pull request does not publish a release.",
+      ].join("\n"),
+    ], { capture: true });
+    writeActionOutput("action", "created");
+    writeActionOutput("head_sha", run("git", ["rev-parse", "HEAD"], { capture: true }));
+    writeActionOutput("pull_request_url", pullRequestUrl);
+    console.log(`Created next release base pull request: ${pullRequestUrl}`);
+  } finally {
+    if (shouldRestoreCheckout) restoreOriginalCheckout();
+  }
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === scriptPath) {
+  try {
+    main();
+  } catch (error) {
+    console.error(`Error: ${error instanceof Error ? error.message : error}`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/release-canary-guard.test.mjs
+++ b/scripts/release-canary-guard.test.mjs
@@ -77,6 +77,17 @@ function runPrintVersion(repo, env = {}) {
   });
 }
 
+function runPreflight(repo, channel, env = {}) {
+  return spawnSync("./scripts/release.sh", [channel, "--preflight"], {
+    cwd: repo,
+    env: {
+      ...process.env,
+      ...env,
+    },
+    encoding: "utf8",
+  });
+}
+
 function runWaitForNpmPackageVersions(repo, packageInfo, env = {}) {
   return spawnSync("bash", [
     "-c",
@@ -147,6 +158,41 @@ describe("release canary base guard", () => {
     expect(result.stderr).toContain("npm package @rudderhq/cli@0.2.2 exists");
     expect(result.stderr).toContain("0.2.2 -> 0.2.3");
   }, 15000);
+});
+
+describe("release fast preflight", () => {
+  it("rejects a version that drifted after the release lock was acquired", () => {
+    const { repo } = createReleaseRepo();
+
+    const result = spawnSync("./scripts/release.sh", [
+      "stable",
+      "--preflight",
+      "--expected-version",
+      "0.2.3",
+    ], { cwd: repo, env: process.env, encoding: "utf8" });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("Expected 0.2.3 but resolved 0.2.2");
+    expect(result.stdout).not.toContain("Building workspace artifacts");
+  });
+
+  it("rejects an already published stable before dependency installation or build", () => {
+    const { repo } = createReleaseRepo();
+    mkdirSync(join(repo, "releases"), { recursive: true });
+    writeFileSync(join(repo, "releases", "v0.2.2.md"), "# v0.2.2\n");
+    exec("git", ["add", "releases/v0.2.2.md"], { cwd: repo });
+    exec("git", ["commit", "-m", "notes"], { cwd: repo });
+    exec("git", ["push", "origin", "main"], { cwd: repo });
+    exec("git", ["tag", "v0.2.2"], { cwd: repo });
+    exec("git", ["push", "origin", "v0.2.2"], { cwd: repo });
+    exec("git", ["tag", "-d", "v0.2.2"], { cwd: repo });
+
+    const result = runPreflight(repo, "stable");
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("git tag v0.2.2 already exists");
+    expect(result.stdout).not.toContain("Building workspace artifacts");
+  });
 });
 
 describe("npm publish verification", () => {

--- a/scripts/release-next-version.test.mjs
+++ b/scripts/release-next-version.test.mjs
@@ -1,0 +1,179 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { chmodSync, cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  compareStableVersions,
+  decideVersionHandoff,
+  nextPatchVersion,
+} from "./prepare-next-release.mjs";
+
+const scriptsDir = dirname(fileURLToPath(import.meta.url));
+const tempRoots = [];
+
+function exec(command, args, cwd) {
+  return execFileSync(command, args, { cwd, encoding: "utf8" });
+}
+
+function createReleaseRepo() {
+  const root = mkdtempSync(join(tmpdir(), "rudder-next-release-test-"));
+  tempRoots.push(root);
+  const repo = join(root, "repo");
+  const remote = join(root, "remote.git");
+  mkdirSync(join(repo, "scripts"), { recursive: true });
+  mkdirSync(join(repo, "cli"), { recursive: true });
+  cpSync(join(scriptsDir, "prepare-next-release.mjs"), join(repo, "scripts", "prepare-next-release.mjs"));
+  cpSync(join(scriptsDir, "release-package-map.mjs"), join(repo, "scripts", "release-package-map.mjs"));
+  writeFileSync(join(repo, "cli", "package.json"), `${JSON.stringify({
+    name: "@rudderhq/cli",
+    version: "0.5.1",
+  }, null, 2)}\n`);
+
+  exec("git", ["init", "--bare", remote], root);
+  exec("git", ["init"], repo);
+  exec("git", ["checkout", "-b", "main"], repo);
+  exec("git", ["config", "user.name", "Release Test"], repo);
+  exec("git", ["config", "user.email", "release-test@example.com"], repo);
+  exec("git", ["add", "."], repo);
+  exec("git", ["commit", "-m", "fixture"], repo);
+  exec("git", ["remote", "add", "origin", remote], repo);
+  exec("git", ["push", "-u", "origin", "main"], repo);
+  return repo;
+}
+
+afterEach(() => {
+  for (const root of tempRoots.splice(0)) {
+    rmSync(root, { force: true, recursive: true });
+  }
+});
+
+describe("next release version handoff", () => {
+  it("increments only the patch component", () => {
+    expect(nextPatchVersion("0.5.1")).toBe("0.5.2");
+    expect(nextPatchVersion("12.34.99")).toBe("12.34.100");
+    expect(() => nextPatchVersion("0.5.1-canary.0")).toThrow("stable semver");
+  });
+
+  it("compares stable semvers numerically", () => {
+    expect(compareStableVersions("0.10.0", "0.9.99")).toBe(1);
+    expect(compareStableVersions("1.0.0", "1.0.0")).toBe(0);
+    expect(compareStableVersions("1.0.9", "1.1.0")).toBe(-1);
+  });
+
+  it("creates a handoff only while main is still on the published stable base", () => {
+    expect(decideVersionHandoff("0.5.1", "0.5.1")).toEqual({
+      action: "create",
+      nextVersion: "0.5.2",
+    });
+    expect(decideVersionHandoff("0.5.2", "0.5.1")).toEqual({
+      action: "skip",
+      nextVersion: "0.5.2",
+      reason: "main already advanced to 0.5.2",
+    });
+  });
+
+  it("rejects a main branch behind the version that was published", () => {
+    expect(() => decideVersionHandoff("0.5.0", "0.5.1")).toThrow(
+      "main version 0.5.0 is behind published stable 0.5.1",
+    );
+  });
+
+  it("plans the next-base pull request without mutating a real temporary repository", () => {
+    const repo = createReleaseRepo();
+    const before = exec("git", ["rev-parse", "HEAD"], repo).trim();
+    const beforeBranch = exec("git", ["branch", "--show-current"], repo).trim();
+    const outputFile = join(repo, "..", "github-output.txt");
+    writeFileSync(outputFile, "");
+
+    const result = spawnSync("node", [
+      "scripts/prepare-next-release.mjs",
+      "--stable-version", "0.5.1",
+      "--repo", "example/rudder",
+      "--dry-run",
+    ], {
+      cwd: repo,
+      encoding: "utf8",
+      env: { ...process.env, GITHUB_OUTPUT: outputFile },
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain("bump 0.5.1 -> 0.5.2");
+    expect(result.stdout).toContain("automation/release-v0.5.2");
+    expect(exec("git", ["rev-parse", "HEAD"], repo).trim()).toBe(before);
+    expect(exec("git", ["branch", "--show-current"], repo).trim()).toBe(beforeBranch);
+    expect(exec("git", ["status", "--porcelain"], repo)).toBe("");
+    expect(readFileSync(outputFile, "utf8")).toContain("action=dry-run");
+    expect(readFileSync(outputFile, "utf8")).toContain("branch=automation/release-v0.5.2");
+  });
+
+  it("restores the original branch when a dry-run plan fails", () => {
+    const repo = createReleaseRepo();
+    const before = exec("git", ["rev-parse", "HEAD"], repo).trim();
+    const beforeBranch = exec("git", ["branch", "--show-current"], repo).trim();
+
+    const result = spawnSync("node", [
+      "scripts/prepare-next-release.mjs",
+      "--stable-version", "0.5.2",
+      "--repo", "example/rudder",
+      "--dry-run",
+    ], { cwd: repo, encoding: "utf8" });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("main version 0.5.1 is behind published stable 0.5.2");
+    expect(exec("git", ["rev-parse", "HEAD"], repo).trim()).toBe(before);
+    expect(exec("git", ["branch", "--show-current"], repo).trim()).toBe(beforeBranch);
+    expect(exec("git", ["status", "--porcelain"], repo)).toBe("");
+  });
+
+  it("reuses only an existing next-version pull request with a valid remote head", () => {
+    const repo = createReleaseRepo();
+    const branch = "automation/release-v0.5.2";
+    exec("git", ["checkout", "-b", branch], repo);
+    exec("node", ["scripts/release-package-map.mjs", "set-version", "0.5.2"], repo);
+    exec("git", ["add", "-u"], repo);
+    exec("git", ["commit", "-m", "next version"], repo);
+    exec("git", ["push", "origin", branch], repo);
+    const headOid = exec("git", ["rev-parse", "HEAD"], repo).trim();
+    exec("git", ["checkout", "main"], repo);
+
+    const mockBin = join(repo, "..", "bin");
+    mkdirSync(mockBin, { recursive: true });
+    const ghPath = join(mockBin, "gh");
+    writeFileSync(ghPath, [
+      "#!/usr/bin/env node",
+      `console.log(${JSON.stringify(JSON.stringify([{
+        baseRefName: "main",
+        headRefName: branch,
+        headRefOid: headOid,
+        url: "https://example.test/pull/1",
+      }]))});`,
+      "",
+    ].join("\n"));
+    chmodSync(ghPath, 0o755);
+    const outputFile = join(repo, "..", "github-output-existing.txt");
+    writeFileSync(outputFile, "");
+
+    const result = spawnSync("node", [
+      "scripts/prepare-next-release.mjs",
+      "--stable-version", "0.5.1",
+      "--repo", "example/rudder",
+    ], {
+      cwd: repo,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        GITHUB_OUTPUT: outputFile,
+        PATH: `${mockBin}:${process.env.PATH}`,
+      },
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain("pull request already exists");
+    expect(exec("git", ["branch", "--show-current"], repo).trim()).toBe("main");
+    expect(readFileSync(outputFile, "utf8")).toContain("action=existing");
+    expect(readFileSync(outputFile, "utf8")).toContain(`head_sha=${headOid}`);
+  });
+});

--- a/scripts/release-workflow-contract.test.mjs
+++ b/scripts/release-workflow-contract.test.mjs
@@ -1,0 +1,74 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const releaseWorkflow = readFileSync(join(repoRoot, ".github/workflows/release.yml"), "utf8");
+const ciWorkflow = readFileSync(join(repoRoot, ".github/workflows/ci.yml"), "utf8");
+const desktopWorkflow = readFileSync(join(repoRoot, ".github/workflows/desktop-release.yml"), "utf8");
+const releaseScript = readFileSync(join(repoRoot, "scripts/release.sh"), "utf8");
+
+describe("release workflow latency contracts", () => {
+  it("starts canaries from successful CI instead of repeating the verification matrix", () => {
+    expect(releaseWorkflow).toContain("workflow_run:");
+    expect(releaseWorkflow).toMatch(/workflows:\s*\[?\"?CI\"?/);
+    expect(releaseWorkflow).toContain("types: [completed]");
+    expect(releaseWorkflow).not.toMatch(/^  verify:/m);
+    expect(releaseWorkflow).not.toContain("Unit tests");
+    expect(releaseWorkflow).not.toContain("matrix.os");
+  });
+
+  it("resolves an immutable source and runs release preflight before installation", () => {
+    expect(releaseWorkflow).toMatch(/^  preflight:/m);
+    expect(releaseWorkflow).toContain("source_sha:");
+    expect(releaseWorkflow).toContain("Require successful CI for exact source");
+    expect(releaseWorkflow).toContain("./scripts/release.sh canary --preflight");
+    expect(releaseWorkflow).toContain("./scripts/release.sh stable --preflight");
+    expect(releaseWorkflow).toContain("Locked canary preflight");
+    expect(releaseWorkflow).toContain('--expected-version "$version"');
+
+    const preflightIndex = releaseWorkflow.indexOf("Release preflight");
+    const installIndex = releaseWorkflow.indexOf("Install dependencies");
+    expect(preflightIndex).toBeGreaterThan(-1);
+    expect(installIndex).toBeGreaterThan(preflightIndex);
+  });
+
+  it("keeps dry-run code read-only and fails closed when repository safeguards are missing", () => {
+    const workflowPermissions = releaseWorkflow.slice(
+      releaseWorkflow.indexOf("permissions:"),
+      releaseWorkflow.indexOf("jobs:"),
+    );
+    expect(workflowPermissions).toContain("contents: read");
+    expect(workflowPermissions).not.toContain("id-token: write");
+    expect(releaseWorkflow).toContain("Require release repository safeguards");
+    expect(releaseWorkflow).toContain("RELEASE_SAFEGUARDS_CONFIGURED");
+  });
+
+  it("serializes canary and stable publication and proposes the next patch base", () => {
+    expect(releaseWorkflow.match(/group: release-publish/g)).toHaveLength(2);
+    expect(releaseWorkflow).toMatch(/^  next-release-base:/m);
+    expect(releaseWorkflow).toContain("node scripts/prepare-next-release.mjs");
+    expect(releaseWorkflow).toContain("Start CI for next release base");
+    expect(releaseWorkflow).toContain('-f source_sha="${{ steps.next-release.outputs.head_sha }}"');
+    expect(ciWorkflow).toContain("source_sha:");
+    expect(ciWorkflow).toContain("inputs.source_sha || github.sha");
+    expect(releaseWorkflow).toContain("pull-requests: write");
+    expect(releaseWorkflow).not.toContain("continue-on-error: true");
+  });
+
+  it("caches prepared Desktop PostgreSQL payloads on non-Linux runners", () => {
+    expect(desktopWorkflow).toContain("Cache PostgreSQL runtime payload");
+    expect(desktopWorkflow).toContain("actions/cache@");
+    expect(desktopWorkflow).toContain("postgres-runtime-18.4-");
+    expect(desktopWorkflow).toContain("hashFiles('desktop/scripts/prepare-postgres-runtime.mjs')");
+    expect(desktopWorkflow).toContain("matrix.platform != 'linux'");
+    expect(releaseWorkflow).toContain("--ref main");
+    expect(releaseWorkflow).toContain('-f source_ref="$tag"');
+  });
+
+  it("does not rebuild after the local verification gate already built the workspace", () => {
+    expect(releaseScript).toContain("workspace_built=true");
+    expect(releaseScript).toContain("Reusing workspace build from verification gate");
+  });
+});

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -19,6 +19,8 @@ channel=""
 dry_run=false
 skip_verify=false
 print_version_only=false
+preflight_only=false
+expected_version=""
 tag_name=""
 
 cleanup_on_exit=false
@@ -26,7 +28,7 @@ cleanup_on_exit=false
 usage() {
   cat <<'EOF'
 Usage:
-  ./scripts/release.sh <canary|stable> [--dry-run] [--skip-verify] [--print-version]
+  ./scripts/release.sh <canary|stable> [--dry-run] [--skip-verify] [--print-version] [--preflight] [--expected-version X.Y.Z]
 
 Examples:
   ./scripts/release.sh canary
@@ -34,6 +36,7 @@ Examples:
   ./scripts/release.sh stable
   ./scripts/release.sh stable --dry-run
   ./scripts/release.sh stable --print-version
+  ./scripts/release.sh stable --preflight
 
 Notes:
   - Stable releases publish the committed workspace semver under npm dist-tag
@@ -42,6 +45,10 @@ Notes:
     semver, publish under npm dist-tag "canary", and create git tag
     canary/v<version>-canary.N.
   - Stable release notes must already exist at releases/v<version>.md.
+  - --preflight checks the committed version, release notes, git tags, and npm
+    versions without installing dependencies, building, or publishing.
+  - --expected-version fails if a previously locked release version drifted
+    before the publish command acquired its release lock.
   - Canary publish payloads are version-rewritten temporarily and restored on
     exit. Stable releases publish the committed version directly.
 EOF
@@ -100,6 +107,12 @@ while [ $# -gt 0 ]; do
     --dry-run) dry_run=true ;;
     --skip-verify) skip_verify=true ;;
     --print-version) print_version_only=true ;;
+    --preflight) preflight_only=true ;;
+    --expected-version)
+      [ $# -ge 2 ] || release_fail "--expected-version requires a version."
+      expected_version="$2"
+      shift
+      ;;
     -h|--help)
       usage
       exit 0
@@ -166,6 +179,10 @@ else
   tag_name="$(stable_tag_name "$TARGET_STABLE_VERSION")"
 fi
 
+if [ -n "$expected_version" ] && [ "$TARGET_PUBLISH_VERSION" != "$expected_version" ]; then
+  release_fail "release version drifted after it was locked. Expected $expected_version but resolved $TARGET_PUBLISH_VERSION. Run preflight again under the release lock."
+fi
+
 if [ "$print_version_only" = true ]; then
   printf '%s\n' "$TARGET_PUBLISH_VERSION"
   exit 0
@@ -174,7 +191,6 @@ fi
 NOTES_FILE="$(release_notes_file "$TARGET_STABLE_VERSION")"
 
 require_clean_worktree
-require_npm_publish_auth "$dry_run"
 
 if [ "$channel" = "stable" ] && [ ! -f "$NOTES_FILE" ]; then
   release_fail "stable release notes file is required at $NOTES_FILE before publishing stable."
@@ -194,6 +210,13 @@ while IFS= read -r package_name; do
     release_fail "npm version ${package_name}@${TARGET_PUBLISH_VERSION} already exists."
   fi
 done <<< "$(printf '%s\n' "${PUBLIC_PACKAGE_NAMES[@]}")"
+
+if [ "$preflight_only" = true ]; then
+  printf '%s\n' "$TARGET_PUBLISH_VERSION"
+  exit 0
+fi
+
+require_npm_publish_auth "$dry_run"
 
 release_info ""
 release_info "==> Release plan"
@@ -216,6 +239,7 @@ if [ "$channel" = "stable" ]; then
 fi
 
 set_cleanup_trap
+workspace_built=false
 
 if [ "$skip_verify" = false ]; then
   release_info ""
@@ -224,6 +248,7 @@ if [ "$skip_verify" = false ]; then
   pnpm -r typecheck
   pnpm test:run
   pnpm build
+  workspace_built=true
 else
   release_info ""
   release_info "==> Step 1/7: Verification gate skipped (--skip-verify)"
@@ -232,7 +257,11 @@ fi
 release_info ""
 release_info "==> Step 2/7: Building workspace artifacts..."
 cd "$REPO_ROOT"
-pnpm build
+if [ "$workspace_built" = true ]; then
+  release_info "  ✓ Reusing workspace build from verification gate"
+else
+  pnpm build
+fi
 bash "$REPO_ROOT/scripts/prepare-server-ui-dist.sh"
 [ -d "$BUNDLED_SKILLS_DIR" ] || release_fail "bundled skills directory is missing: $BUNDLED_SKILLS_DIR"
 for pkg_dir in "${PUBLISH_SKILLS_PACKAGE_DIRS[@]}"; do


### PR DESCRIPTION
## Summary

- start automatic canaries only after exact-main CI succeeds, and require exact-SHA CI for manual stable releases
- fail fast on stale or drifted versions before install/build; serialize Canary and Stable publication
- cache Desktop PostgreSQL payloads and avoid duplicate local builds
- automatically propose the next patch base after Stable, then validate it with the trusted main CI workflow
- update release-maintainer guidance and release automation documentation

## Expected impact

- removes roughly 16–20 minutes of repeated release verification from the normal path
- catches an already-published base before dependency install/build
- can save roughly 8m40 on Windows Desktop packaging when the PostgreSQL runtime cache hits

## Verification

- 4 focused release test files / 22 tests passed
- actionlint v1.7.12 passed for CI, Release, and Desktop Release workflows
- bash and Node syntax checks passed
- pnpm -r typecheck passed
- pnpm build passed
- product logic checks passed
- independent review and black-box verification found no P0/P1 findings

Full repository lint retains one unrelated pre-existing import-order failure in ui/src/pages/Chat.workspace-helpers.test.tsx. Full serial tests pass 559/560 files; two timing waits in server/src/__tests__/heartbeat-run-concurrency.test.ts remain unrelated.

## Required repository setup before Stable

Stable now fails closed until an admin configures the npm-stable reviewer gate, main branch protection, and Actions pull-request creation, then sets RELEASE_SAFEGUARDS_CONFIGURED=true. This PR does not change those repository settings and does not trigger a release.

## Follow-ups

Transactional/resumable partial npm publication remains a separate design because it requires artifact digest, provenance, retention, and recovery guarantees.