### PR TITLE
fix: harden long chat transcripts and raise default concurrency

### DIFF
--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -27,7 +27,7 @@ export const AGENT_STATUSES = [
 ] as const;
 export type AgentStatus = (typeof AGENT_STATUSES)[number];
 
-export const AGENT_RUN_CONCURRENCY_DEFAULT = 3;
+export const AGENT_RUN_CONCURRENCY_DEFAULT = 8;
 export const AGENT_RUN_CONCURRENCY_MIN = 1;
 export const AGENT_RUN_CONCURRENCY_MAX = 10;
 

--- a/server/src/__tests__/chat-routes.test.ts
+++ b/server/src/__tests__/chat-routes.test.ts
@@ -3,8 +3,9 @@ import http from "node:http";
 import type { AddressInfo } from "node:net";
 import request from "supertest";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { unprocessable } from "../errors.js";
+import { conflict, unprocessable } from "../errors.js";
 import { errorHandler } from "../middleware/index.js";
+import { createChatBackgroundRuntime, type ChatBackgroundRuntime } from "../routes/chat-background-runtime.js";
 import { chatRoutes } from "../routes/chats.js";
 import { claimChatGeneration, clearActiveChatGenerationsForTest, createChatRuntimeControlCoordinator, getActiveChatGeneration, hasActiveChatGeneration } from "../services/chat-generation-locks.js";
 import { CHAT_TITLE_PROMPT_TOKEN_LIMIT, countChatTitlePromptTokens } from "../services/title-generation.js";
@@ -337,14 +338,17 @@ function createMessage(id: string, role: "user" | "assistant" | "system", kind: 
   };
 }
 
-function createApp(actor: Record<string, unknown> = {
-  type: "board",
-  userId: "user-1",
-  orgIds: ["organization-1"],
-  source: "session",
-  isInstanceAdmin: false,
-  runId: null,
-}) {
+function createApp(
+  actor: Record<string, unknown> = {
+    type: "board",
+    userId: "user-1",
+    orgIds: ["organization-1"],
+    source: "session",
+    isInstanceAdmin: false,
+    runId: null,
+  },
+  backgroundRuntime?: ChatBackgroundRuntime,
+) {
   const app = express();
   app.use(express.json());
   app.use((req, _res, next) => {
@@ -353,7 +357,7 @@ function createApp(actor: Record<string, unknown> = {
   });
   app.use(
     "/api",
-    chatRoutes({} as any, mockStorage as any),
+    chatRoutes({} as any, mockStorage as any, backgroundRuntime),
   );
   app.use(errorHandler);
   return app;
@@ -2095,6 +2099,158 @@ describe("chat routes", () => {
     expect(res.status).toBe(200);
     expect(mockChatService.getMessageTranscript).toHaveBeenCalledWith("chat-1", "message-1");
     expect(res.body.transcript).toHaveLength(1);
+  });
+
+  it("persists server-owned queued continuation transcripts incrementally in the generation ledger", async () => {
+    const priorQueueWorkerFlag = process.env.RUDDER_CHAT_QUEUE_WORKER_TEST;
+    process.env.RUDDER_CHAT_QUEUE_WORKER_TEST = "true";
+    const backgroundRuntime = createChatBackgroundRuntime();
+    const conversation = createConversation();
+    const userMessage = createMessage("message-user-queued", "user", "message", "Continue in background");
+    const transcriptEntries = [
+      {
+        kind: "thinking" as const,
+        ts: "2026-07-23T08:00:00.000Z",
+        text: "Inspecting the queued continuation",
+      },
+      {
+        kind: "tool_call" as const,
+        ts: "2026-07-23T08:00:01.000Z",
+        name: "read_file",
+        input: { path: "/tmp/queued" },
+      },
+    ];
+    const queuedItem = {
+      id: "queued-1",
+      orgId: conversation.orgId,
+      conversationId: conversation.id,
+      position: 1,
+      status: "dequeue_claimed",
+      version: 2,
+      clientMutationId: "queued-client-1",
+      payload: { body: "Continue in background" },
+      deliveryIntent: "queue",
+      deliveryDisposition: null,
+      controlActionId: null,
+      expectedGenerationId: null,
+      activeGenerationId: "generation-1",
+      attemptEpoch: 1,
+      providerClientMessageId: null,
+      providerThreadId: null,
+      providerTurnId: null,
+      providerEvidence: null,
+      continuationGenerationId: "generation-1",
+      continuationMessageId: userMessage.id,
+      deliveryLeaseToken: "lease-1",
+      deliveryLeaseEpoch: 1,
+      deliveryLeaseOwner: "worker-1",
+      deliveryLeaseExpiresAt: new Date("2026-07-23T08:02:00.000Z"),
+      reconciliationReason: "server_claimed",
+      deliveryAttempts: 1,
+      lastAttemptAt: new Date("2026-07-23T08:00:00.000Z"),
+      lastDeliveryReason: null,
+      requestActor: {
+        type: "board",
+        source: "session",
+        userId: "user-1",
+        orgIds: [conversation.orgId],
+        isInstanceAdmin: false,
+      },
+      sourceMessageId: userMessage.id,
+      deliveredMessageId: userMessage.id,
+      cancelledAt: null,
+      steeredAt: null,
+      dequeuedAt: new Date("2026-07-23T08:00:00.000Z"),
+      createdAt: new Date("2026-07-23T08:00:00.000Z"),
+      updatedAt: new Date("2026-07-23T08:00:00.000Z"),
+    };
+
+    mockChatService.getById.mockResolvedValue(conversation);
+    mockChatService.getMessage.mockResolvedValue(userMessage);
+    mockChatService.listMessages.mockResolvedValue([userMessage]);
+    mockChatService.claimNextServerQueuedMessage
+      .mockResolvedValueOnce({
+        item: queuedItem,
+        generationId: "generation-1",
+        userMessageId: userMessage.id,
+        leaseToken: "lease-1",
+        leaseEpoch: 1,
+      })
+      .mockResolvedValue(null);
+    mockChatService.getLatestGeneration.mockResolvedValue({
+      id: "generation-1",
+      attemptEpoch: 1,
+      controlOwnerToken: "lease-1",
+    });
+    mockChatService.completeServerQueuedMessageDelivery.mockResolvedValue(queuedItem);
+    let transcriptAdmissionCount = 0;
+    mockChatService.generationProtocol.appendVisibleEventAndProject.mockImplementation(async (input) => {
+      if (input.eventKind === "transcript") {
+        transcriptAdmissionCount += 1;
+        if (transcriptAdmissionCount === 2) {
+          throw conflict("Chat-visible output admission is closed for this generation");
+        }
+      }
+      if (input.eventKind === "runtime_output") {
+        throw conflict("Chat-visible output admission is closed for this generation");
+      }
+      return {
+        event: {
+          id: `generation-event-${transcriptAdmissionCount}`,
+          generationSeq: transcriptAdmissionCount,
+          payload: { ...(input.payload ?? {}), bodyHash: input.bodyHash },
+        },
+        generation: { id: input.generationId },
+        message: { id: input.messageId ?? "message-assistant" },
+      };
+    });
+    mockChatAssistantService.streamChatAssistantReply.mockImplementation(async (input) => {
+      const attempt = await input.controlCoordinator?.beginAttempt({
+        attemptIndex: 0,
+        runtimeType: "codex_local",
+        model: "gpt-primary",
+        isFallback: false,
+      });
+      await input.onTranscriptEntry?.(transcriptEntries[0]);
+      await input.onTranscriptEntry?.(transcriptEntries[1]);
+      await attempt?.complete();
+      return {
+        outcome: "completed",
+        partialBody: "Queued reply",
+        replyingAgentId: "agent-1",
+        reply: {
+          kind: "message",
+          body: "Queued reply",
+          structuredPayload: null,
+          replyingAgentId: "agent-1",
+        },
+      };
+    });
+
+    try {
+      createApp(undefined, backgroundRuntime);
+      await waitUntil(() => {
+        expect(mockChatService.completeServerQueuedMessageDelivery).toHaveBeenCalled();
+      }, 3_000);
+
+      const visibleProjectionCalls =
+        mockChatService.generationProtocol.appendVisibleEventAndProject.mock.calls;
+      const transcriptCalls = visibleProjectionCalls.filter(([input]) => input.eventKind === "transcript");
+      expect(transcriptCalls).toHaveLength(2);
+      expect(transcriptCalls.map(([input]) => input.payload.entry)).toEqual(transcriptEntries);
+      expect(transcriptCalls.every(([input]) => !Object.hasOwn(input, "transcript"))).toBe(true);
+      expect(visibleProjectionCalls.find(([input]) => input.eventKind === "runtime_output")?.[0])
+        .toMatchObject({ messageId: "message-assistant" });
+      expect(mockChatService.completeServerQueuedMessageDelivery).toHaveBeenCalledWith(
+        expect.objectContaining({ status: "stopped" }),
+      );
+      expect(mockChatService.updateMessage.mock.calls.at(-1)?.[2]).toMatchObject({ status: "stopped" });
+      expect(mockChatService.updateMessage.mock.calls.at(-1)?.[2]).not.toHaveProperty("transcript");
+    } finally {
+      if (priorQueueWorkerFlag === undefined) delete process.env.RUDDER_CHAT_QUEUE_WORKER_TEST;
+      else process.env.RUDDER_CHAT_QUEUE_WORKER_TEST = priorQueueWorkerFlag;
+      await backgroundRuntime.close();
+    }
   });
 
   it("does not return a lazy chat transcript without conversation access", async () => {
@@ -4175,9 +4331,11 @@ describe("chat routes", () => {
         body: "",
         replyingAgentId: "agent-1",
         runId: "chat-run-stream-1",
-        transcript: expect.any(Array),
       }),
     );
+    const transcriptProjectionCall = mockChatService.generationProtocol.appendVisibleEventAndProject.mock.calls
+      .find(([input]) => input.eventKind === "transcript");
+    expect(transcriptProjectionCall?.[0]).not.toHaveProperty("transcript");
     expect(mockChatService.updateMessage).toHaveBeenLastCalledWith(
       "chat-1",
       "message-assistant",
@@ -4187,12 +4345,9 @@ describe("chat routes", () => {
         body: "Streaming reply",
         replyingAgentId: "agent-1",
         runId: "chat-run-stream-1",
-        transcript: [
-          expect.objectContaining({ kind: "thinking", text: "Inspecting current request" }),
-          expect.objectContaining({ kind: "tool_call", name: "read_file" }),
-        ],
       }),
     );
+    expect(mockChatService.updateMessage.mock.calls.at(-1)?.[2]).not.toHaveProperty("transcript");
     expect(mockChatAgentRuns.linkAssistantMessage).toHaveBeenCalledWith("chat-run-stream-1", "chat-1", "message-assistant");
   });
 
@@ -4258,9 +4413,9 @@ describe("chat routes", () => {
             runId: null,
           },
         },
-        transcript: [expect.objectContaining({ kind: "assistant", text: "I will inspect the issue first." })],
       }),
     );
+    expect(mockChatService.updateMessage.mock.calls.at(-1)?.[2]).not.toHaveProperty("transcript");
   });
 
   it("does not publish inline-visual backing HTML from a failed stream", async () => {
@@ -4695,7 +4850,6 @@ describe("chat routes", () => {
         kind: "message",
         status: "stopped",
         replyingAgentId: "agent-1",
-        transcript: [],
       }),
     );
   });
@@ -4886,9 +5040,9 @@ describe("chat routes", () => {
       expect.objectContaining({
         status: "stopped",
         body: "Before stop",
-        transcript: [beforeStopTranscript],
       }),
     );
+    expect(mockChatService.updateMessage.mock.calls.at(-1)?.[2]).not.toHaveProperty("transcript");
   });
 
   it("never persists output when Stop closes ledger admission first", async () => {
@@ -4999,9 +5153,9 @@ describe("chat routes", () => {
       expect.objectContaining({
         body: "Visible prefix",
         status: "stopped",
-        transcript: [visibleTranscript],
       }),
     );
+    expect(mockChatService.updateMessage.mock.calls.at(-1)?.[2]).not.toHaveProperty("transcript");
   });
 
   it("converges Stop after final output admission without interrupting the completed turn", async () => {

--- a/server/src/__tests__/company-portability.test.ts
+++ b/server/src/__tests__/company-portability.test.ts
@@ -169,6 +169,7 @@ describe("organization portability", () => {
         runtimeConfig: {
           heartbeat: {
             intervalSec: 3600,
+            maxConcurrentRuns: 3,
           },
         },
         budgetMonthlyCents: 0,
@@ -447,6 +448,8 @@ describe("organization portability", () => {
     expect(extension).not.toContain("PATH:");
     expect(extension).not.toContain("requireBoardApprovalForNewAgents: true");
     expect(extension).not.toContain("budgetMonthlyCents: 0");
+    expect(extension).toContain("maxConcurrentRuns: 3");
+    expect(extension).toContain("maxConcurrentRuns: 8");
     expect(extension).toContain("permissions:");
     expect(extension).toContain("canCreateAgents: false");
     expect(exported.warnings).toContain("Agent claudecoder command /Users/dotta/.local/bin/claude was omitted from export because it is system-dependent.");
@@ -2014,9 +2017,84 @@ describe("organization portability", () => {
       runtimeConfig: {
         heartbeat: {
           enabled: false,
+          maxConcurrentRuns: 3,
         },
       },
     });
+    const createdCmo = agentSvc.create.mock.calls.find(([, input]) => input.name === "CMO");
+    expect(createdCmo?.[1]).toMatchObject({
+      runtimeConfig: {
+        heartbeat: {
+          enabled: false,
+          maxConcurrentRuns: 8,
+        },
+      },
+    });
+  });
+
+  it("preserves the legacy concurrency default when rudder/v1 packages omit it", async () => {
+    const portability = organizationPortabilityService({} as any);
+
+    companySvc.create.mockResolvedValue({
+      id: "organization-imported",
+      name: "Imported Rudder",
+    });
+    agentSvc.create.mockImplementation(async (_companyId: string, input: Record<string, unknown>) => ({
+      id: `agent-${String(input.name).toLowerCase()}`,
+      name: input.name,
+      agentRuntimeConfig: input.agentRuntimeConfig,
+      runtimeConfig: input.runtimeConfig,
+    }));
+
+    const exported = await portability.exportBundle("organization-1", {
+      include: {
+        organization: true,
+        agents: true,
+        projects: false,
+        issues: false,
+      },
+    });
+    const legacyExtension = asTextFile(exported.files[".rudder.yaml"])
+      .split("\n")
+      .filter((line) => !line.includes("maxConcurrentRuns:"))
+      .join("\n");
+
+    agentSvc.list.mockResolvedValue([]);
+
+    await portability.importBundle({
+      source: {
+        type: "inline",
+        rootPath: exported.rootPath,
+        files: {
+          ...exported.files,
+          ".rudder.yaml": legacyExtension,
+        },
+      },
+      include: {
+        organization: true,
+        agents: true,
+        projects: false,
+        issues: false,
+      },
+      target: {
+        mode: "new_organization",
+        newOrganizationName: "Imported Rudder",
+      },
+      agents: "all",
+      collisionStrategy: "rename",
+    }, "user-1");
+
+    expect(agentSvc.create).toHaveBeenCalledTimes(2);
+    for (const [, input] of agentSvc.create.mock.calls) {
+      expect(input).toMatchObject({
+        runtimeConfig: {
+          heartbeat: {
+            enabled: false,
+            maxConcurrentRuns: 3,
+          },
+        },
+      });
+    }
   });
 
   it("imports only selected files and leaves unchecked organization metadata alone", async () => {
@@ -2092,6 +2170,7 @@ describe("organization portability", () => {
       runtimeConfig: {
         heartbeat: {
           enabled: false,
+          maxConcurrentRuns: 8,
         },
       },
     }));

--- a/server/src/__tests__/heartbeat-run-concurrency.test.ts
+++ b/server/src/__tests__/heartbeat-run-concurrency.test.ts
@@ -194,11 +194,19 @@ describe("heartbeat run concurrency", () => {
     dataDir = started.dataDir;
   }, 20_000);
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    await db
+      .update(heartbeatRuns)
+      .set({
+        status: "cancelled",
+        finishedAt: new Date(),
+        updatedAt: new Date(),
+      })
+      .where(eq(heartbeatRuns.status, "queued"));
     vi.clearAllMocks();
     mockBudgetService.getInvocationBlock.mockResolvedValue(null);
     mockRuntimeAdapter.reset();
-  });
+  }, 15_000);
 
   async function countPostgresLockWaiters() {
     const rows = await db.execute(sql<{ count: number }>`
@@ -1117,32 +1125,48 @@ describe("heartbeat run concurrency", () => {
     expect(mockRuntimeAdapter.calls.map((call) => call.taskKey)).toEqual(["serial:1"]);
   });
 
-  it("defaults agents without an explicit value to three concurrent runs", async () => {
+  it("defaults agents without an explicit value to eight concurrent runs", async () => {
     const { orgId, agentId } = await seedAgentFixture();
     const createdAt = new Date("2026-04-27T01:00:00.000Z");
-    await seedQueuedRun({ orgId, agentId, taskKey: "task:1", createdAt });
-    await seedQueuedRun({ orgId, agentId, taskKey: "task:2", createdAt: new Date(createdAt.getTime() + 1_000) });
-    await seedQueuedRun({ orgId, agentId, taskKey: "task:3", createdAt: new Date(createdAt.getTime() + 2_000) });
-    await seedQueuedRun({ orgId, agentId, taskKey: "task:4", createdAt: new Date(createdAt.getTime() + 3_000) });
+    for (let index = 0; index < 9; index += 1) {
+      await seedQueuedRun({
+        orgId,
+        agentId,
+        taskKey: `task:${index + 1}`,
+        createdAt: new Date(createdAt.getTime() + index * 1_000),
+      });
+    }
 
     const heartbeat = heartbeatService(db);
     await heartbeat.resumeQueuedRuns();
 
-    await waitForCondition(async () => {
-      const statuses = await listRunStatuses(agentId);
-      return (
-        mockRuntimeAdapter.calls.length === 3
-        && statuses.filter((run) => run.status === "running").length === 3
-      );
-    });
+    await waitForCondition(
+      async () => {
+        const statuses = await listRunStatuses(agentId);
+        return (
+          mockRuntimeAdapter.calls.length === 8
+          && statuses.filter((run) => run.status === "running").length === 8
+        );
+      },
+      10_000,
+    );
 
     const statuses = await listRunStatuses(agentId);
-    expect(statuses.filter((run) => run.status === "running")).toHaveLength(3);
+    expect(statuses.filter((run) => run.status === "running")).toHaveLength(8);
     expect(statuses.filter((run) => run.status === "queued")).toHaveLength(1);
     expect(new Set(mockRuntimeAdapter.calls.map((call) => call.taskKey))).toEqual(
-      new Set(["task:1", "task:2", "task:3"]),
+      new Set([
+        "task:1",
+        "task:2",
+        "task:3",
+        "task:4",
+        "task:5",
+        "task:6",
+        "task:7",
+        "task:8",
+      ]),
     );
-  });
+  }, 15_000);
 
   it("clamps invalid and oversized concurrency values to the supported range", async () => {
     const low = await seedAgentFixture(0);
@@ -1191,7 +1215,7 @@ describe("heartbeat run concurrency", () => {
     statuses = await listRunStatuses(high.agentId);
     expect(statuses.filter((run) => run.status === "running")).toHaveLength(10);
     expect(statuses.filter((run) => run.status === "queued")).toHaveLength(1);
-  });
+  }, 15_000);
 
   it("coalesces repeated wakeups for the same issue into one active execution run", async () => {
     const { orgId, agentId } = await seedAgentFixture(3);

--- a/server/src/__tests__/messenger-service.test.ts
+++ b/server/src/__tests__/messenger-service.test.ts
@@ -3563,6 +3563,100 @@ describe("messengerService and issue follows", () => {
     expect(transcript?.transcript).toHaveLength(2);
   });
 
+  it("hydrates generation-ledger transcripts without embedding them in chat messages", async () => {
+    const orgId = randomUUID();
+    const conversationId = randomUUID();
+    const generationId = randomUUID();
+
+    await db.insert(organizations).values({
+      id: orgId,
+      name: "Generation Ledger Transcript Org",
+      urlKey: deriveOrganizationUrlKey("Generation Ledger Transcript Org"),
+      issuePrefix: `E${orgId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(chatConversations).values({
+      id: conversationId,
+      orgId,
+      title: "Generation ledger transcript",
+      issueCreationMode: "manual_approval",
+      planMode: false,
+    });
+    await db.insert(chatGenerations).values({
+      id: generationId,
+      orgId,
+      conversationId,
+      status: "stopped",
+      acceptedThroughSeq: 2,
+    });
+    const assistantMessage = await chatSvc.addMessage(conversationId, {
+      orgId,
+      role: "assistant",
+      kind: "message",
+      status: "completed",
+      body: "Final reply",
+    });
+    const entries = [
+      {
+        kind: "thinking",
+        ts: "2026-07-23T08:00:00.000Z",
+        text: "Inspecting production evidence",
+      },
+      {
+        kind: "tool_call",
+        ts: "2026-07-23T08:00:30.000Z",
+        name: "read_file",
+        input: { path: "/tmp/example" },
+      },
+      {
+        kind: "result",
+        ts: "2026-07-23T08:01:00.000Z",
+        text: "Done",
+        inputTokens: 1,
+        outputTokens: 1,
+        cachedTokens: 0,
+        costUsd: 0,
+        subtype: "success",
+        isError: false,
+        errors: [],
+      },
+    ] satisfies Array<Record<string, unknown>>;
+    await db.insert(chatGenerationEvents).values([
+      ...entries.map((entry, index) => ({
+        orgId,
+        generationId,
+        generationSeq: index + 1,
+        attemptEpoch: 1,
+        eventKind: "transcript" as const,
+        payload: { entry },
+        assistantMessageId: assistantMessage.id,
+      })),
+      {
+        orgId,
+        generationId,
+        generationSeq: entries.length + 1,
+        attemptEpoch: 1,
+        eventKind: "runtime_output" as const,
+        payload: { body: "Final reply" },
+        assistantMessageId: assistantMessage.id,
+      },
+    ]);
+
+    const messages = await chatSvc.listMessages(conversationId);
+    const [lightweight] = await chatSvc.listMessages(conversationId, { includeTranscript: false });
+    const transcript = await chatSvc.getMessageTranscript(conversationId, assistantMessage.id);
+    const hydrated = messages.find((message) => message.id === assistantMessage.id);
+
+    expect(lightweight?.transcript).toBeUndefined();
+    expect(lightweight?.transcriptSummary).toEqual({
+      entryCount: 2,
+      startedAt: "2026-07-23T08:00:00.000Z",
+      endedAt: "2026-07-23T08:00:30.000Z",
+    });
+    expect(hydrated?.transcript).toEqual(entries.slice(0, 2));
+    expect(transcript?.transcript).toEqual(entries.slice(0, 2));
+  });
+
   it("lists only the latest five eligible user messages for title generation", async () => {
     const orgId = randomUUID();
     const conversationId = randomUUID();
@@ -3691,7 +3785,9 @@ describe("messengerService and issue follows", () => {
       id: generationId,
       orgId,
       conversationId,
-      status: "completed",
+      status: "stop_requested",
+      terminalReason: "steer_fallback",
+      acceptedThroughSeq: 1,
     });
     const assistantMessage = await chatSvc.addMessage(conversationId, {
       orgId,
@@ -3699,23 +3795,48 @@ describe("messengerService and issue follows", () => {
       kind: "message",
       status: "completed",
       body: "Final reply",
-      transcript: [
-        {
-          kind: "thinking",
-          ts: "2026-07-21T08:00:00.000Z",
-          text: "Reasoning around native Steer",
+    });
+    await db.insert(chatGenerationEvents).values([
+      {
+        orgId,
+        generationId,
+        generationSeq: 1,
+        attemptEpoch: 1,
+        eventKind: "transcript",
+        payload: {
+          entry: {
+            kind: "thinking",
+            ts: "2026-07-21T08:00:00.000Z",
+            text: "Reasoning around native Steer",
+          },
         },
-      ],
-    });
-    await db.insert(chatGenerationEvents).values({
-      orgId,
-      generationId,
-      generationSeq: 1,
-      attemptEpoch: 1,
-      eventKind: "runtime_output",
-      payload: { body: "Final reply" },
-      assistantMessageId: assistantMessage.id,
-    });
+        assistantMessageId: assistantMessage.id,
+      },
+      {
+        orgId,
+        generationId,
+        generationSeq: 2,
+        attemptEpoch: 1,
+        eventKind: "transcript",
+        payload: {
+          entry: {
+            kind: "thinking",
+            ts: "2026-07-21T08:00:01.000Z",
+            text: "Reasoning after the Steer cutoff",
+          },
+        },
+        assistantMessageId: assistantMessage.id,
+      },
+      {
+        orgId,
+        generationId,
+        generationSeq: 3,
+        attemptEpoch: 1,
+        eventKind: "runtime_output",
+        payload: { body: "Final reply" },
+        assistantMessageId: assistantMessage.id,
+      },
+    ]);
     await chatSvc.addMessage(conversationId, {
       orgId,
       role: "user",
@@ -3740,6 +3861,7 @@ describe("messengerService and issue follows", () => {
     expect(hydratedAssistant?.transcript).toEqual([
       expect.objectContaining({ kind: "thinking", text: "Reasoning around native Steer" }),
     ]);
+    expect(JSON.stringify(hydratedAssistant?.transcript)).not.toContain("Reasoning after the Steer cutoff");
   });
 
   it("does not mark a chat unread until an incoming message has visible content", async () => {

--- a/server/src/routes/chats.stream-routes.ts
+++ b/server/src/routes/chats.stream-routes.ts
@@ -409,6 +409,8 @@ export function registerChatStreamRoutes(ctx: ChatStreamRouteContext) {
               replyingAgentId,
               assistantProgressMessageId,
               activeChatRunId,
+              undefined,
+              false,
             );
             lastProjectionError = undefined;
             break;
@@ -584,7 +586,6 @@ export function registerChatStreamRoutes(ctx: ChatStreamRouteContext) {
                     runId: activeChatRunId,
                     bodyHash: hashChatGenerationBody(projectedBody),
                     body: projectedBody,
-                    transcript: [...transcript],
                     replyingAgentId: chatReplyingAgentId(assistantInput.conversation),
                     chatTurnId: turnContextForPartial!.chatTurnId,
                     turnVariant: turnContextForPartial!.turnVariant,
@@ -620,7 +621,6 @@ export function registerChatStreamRoutes(ctx: ChatStreamRouteContext) {
                   1,
                   activeControl?.attemptEpoch ?? generation?.attemptEpoch ?? 1,
                 );
-                const projectedTranscript = [...transcript, entry];
                 let committed;
                 try {
                   committed = await svc.generationProtocol.appendVisibleEventAndProject({
@@ -634,7 +634,6 @@ export function registerChatStreamRoutes(ctx: ChatStreamRouteContext) {
                     runId: activeChatRunId,
                     bodyHash: hashChatGenerationBody(admittedAssistantBody),
                     body: admittedAssistantBody,
-                    transcript: projectedTranscript,
                     replyingAgentId: chatReplyingAgentId(assistantInput.conversation),
                     chatTurnId: turnContextForPartial!.chatTurnId,
                     turnVariant: turnContextForPartial!.turnVariant,
@@ -690,7 +689,6 @@ export function registerChatStreamRoutes(ctx: ChatStreamRouteContext) {
                   runId: activeChatRunId,
                   bodyHash: hashChatGenerationBody(streamed.reply.body),
                   body: streamed.reply.body,
-                  transcript: [...transcript],
                   replyingAgentId: streamed.replyingAgentId,
                   chatTurnId: turnContextForPartial!.chatTurnId,
                   turnVariant: turnContextForPartial!.turnVariant,
@@ -723,6 +721,7 @@ export function registerChatStreamRoutes(ctx: ChatStreamRouteContext) {
               streamed.replyingAgentId,
               assistantProgressMessageId,
               activeChatRunId,
+              false,
             );
             await linkChatRunMessages(assistantInput.conversation, activeChatRunId, createdMessages);
             generationTerminalStatus = "completed";
@@ -787,6 +786,7 @@ export function registerChatStreamRoutes(ctx: ChatStreamRouteContext) {
         assistantProgressMessageId,
         activeChatRunId,
         failurePayload,
+        false,
       ).catch(() => null);
       await linkChatRunMessages(
         assistantConversationForPartial ?? (conversation as ChatConversation),

--- a/server/src/routes/chats.ts
+++ b/server/src/routes/chats.ts
@@ -642,6 +642,7 @@ export function chatRoutes(
     replyingAgentId = assistantReply.replyingAgentId ?? chatReplyingAgentId(conversation),
     existingMessageId?: string | null,
     runId?: string | null,
+    persistTranscript = true,
   ) {
     const createdMessages: ChatMessage[] = [];
     const { chatTurnId, turnVariant } = turnContext;
@@ -667,7 +668,7 @@ export function chatRoutes(
           status: "completed",
           body: input.body,
           structuredPayload: input.structuredPayload ?? null,
-          transcript,
+          ...(persistTranscript ? { transcript } : {}),
           approvalId: input.approvalId ?? null,
           runId: runId ?? undefined,
           replyingAgentId,
@@ -680,7 +681,7 @@ export function chatRoutes(
         kind: input.kind,
         body: input.body,
         structuredPayload: input.structuredPayload ?? null,
-        transcript,
+        ...(persistTranscript ? { transcript } : {}),
         approvalId: input.approvalId ?? null,
         runId: runId ?? null,
         replyingAgentId,
@@ -1006,6 +1007,7 @@ export function chatRoutes(
     existingMessageId?: string | null,
     runId?: string | null,
     structuredPayload?: Record<string, unknown> | null,
+    persistTranscript = true,
   ) {
     const trimmed = body.trim();
     const fallbackBody = status === "stopped"
@@ -1021,7 +1023,7 @@ export function chatRoutes(
         status,
         body: durableBody,
         structuredPayload: structuredPayload ?? null,
-        transcript,
+        ...(persistTranscript ? { transcript } : {}),
         runId: runId ?? undefined,
         replyingAgentId,
       });
@@ -1034,7 +1036,7 @@ export function chatRoutes(
       status,
       body: durableBody,
       structuredPayload: structuredPayload ?? null,
-      transcript,
+      ...(persistTranscript ? { transcript } : {}),
       runId: runId ?? null,
       replyingAgentId,
       chatTurnId,
@@ -1267,12 +1269,39 @@ export function chatRoutes(
     let activeChatRunId: string | null = null;
     const transcript: TranscriptEntry[] = [];
     let partialBody = "";
+    let assistantProjectionMessageId: string | null = null;
+    let activeAttemptEpoch = Math.max(
+      1,
+      getActiveChatGeneration(conversation.id)?.attemptEpoch ?? 1,
+    );
     try {
       const userMessage = await svc.getMessage(conversation.id, claim.userMessageId) as ChatMessage | null;
       if (!userMessage) throw new Error("Queued chat continuation user message is missing");
       const turnContext = turnContextFromUserMessage(userMessage);
       const assistantInput = await loadAssistantInput(conversation, actor);
       assistantConversation = assistantInput.conversation;
+      const persistStoppedQueuedMessage = async (replyingAgentId: string | null) => {
+        const frozen = await svc.generationProtocol.getFrozenVisibleProjection({
+          orgId: conversation.orgId,
+          conversationId: conversation.id,
+          generationId: claim.generationId,
+        }).catch(() => null);
+        const frozenAtCutoff = frozen && frozen.generation.acceptedThroughSeq !== null
+          ? frozen
+          : null;
+        return persistPartialAssistantMessage(
+          assistantConversation,
+          frozenAtCutoff?.projection.body ?? partialBody,
+          "stopped",
+          turnContext,
+          frozenAtCutoff?.projection.transcript ?? transcript,
+          replyingAgentId,
+          assistantProjectionMessageId,
+          activeChatRunId,
+          undefined,
+          false,
+        );
+      };
       const streamed = await assistantSvc.streamChatAssistantReply({
         ...assistantInput,
         userMessageId: userMessage.id,
@@ -1285,6 +1314,7 @@ export function chatRoutes(
           claim.generationId,
           {
             onAttemptStarted: async ({ generationId, attemptEpoch, ownerToken, attempt }) => {
+              activeAttemptEpoch = attemptEpoch;
               await svc.beginGenerationControlAttempt({
                 orgId: conversation.orgId,
                 conversationId: conversation.id,
@@ -1323,23 +1353,35 @@ export function chatRoutes(
           if (!abortController.signal.aborted) partialBody = `${partialBody}${delta}`;
         },
         onTranscriptEntry: async (entry: TranscriptEntry) => {
-          if (!abortController.signal.aborted) transcript.push(entry);
+          if (abortController.signal.aborted) return;
+          transcript.push(entry);
+          try {
+            const projection = await svc.generationProtocol.appendVisibleEventAndProject({
+              orgId: conversation.orgId,
+              conversationId: conversation.id,
+              generationId: claim.generationId,
+              expectedAttemptEpoch: activeAttemptEpoch,
+              eventKind: "transcript",
+              payload: { entry },
+              messageId: assistantProjectionMessageId,
+              runId: activeChatRunId,
+              bodyHash: hashChatGenerationBody(partialBody),
+              body: partialBody,
+              chatTurnId: turnContext.chatTurnId,
+              turnVariant: turnContext.turnVariant,
+            });
+            assistantProjectionMessageId = projection.message.id;
+          } catch (error) {
+            if (chatVisibleOutputAdmissionClosed(error)) return;
+            throw error;
+          }
         },
       });
       partialBody = streamed.partialBody || partialBody;
       if (abortController.signal.aborted || streamed.outcome === "stopped") {
         terminalStatus = "stopped";
         terminalReason = "operator_stop";
-        const stoppedMessage = await persistPartialAssistantMessage(
-          assistantConversation,
-          "",
-          "stopped",
-          turnContext,
-          transcript,
-          streamed.replyingAgentId,
-          null,
-          activeChatRunId,
-        );
+        const stoppedMessage = await persistStoppedQueuedMessage(streamed.replyingAgentId);
         const stoppedMessages = stoppedMessage ? [stoppedMessage] : [];
         await linkChatRunMessages(assistantConversation, activeChatRunId, stoppedMessages);
         if (stoppedMessages.length > 0) {
@@ -1352,15 +1394,11 @@ export function chatRoutes(
       } else {
         let completionMessageId: string | null = null;
         try {
-          const attemptEpoch = Math.max(
-            1,
-            getActiveChatGeneration(conversation.id)?.attemptEpoch ?? 1,
-          );
           const completion = await svc.generationProtocol.appendVisibleEventAndProject({
             orgId: conversation.orgId,
             conversationId: conversation.id,
             generationId: claim.generationId,
-            expectedAttemptEpoch: attemptEpoch,
+            expectedAttemptEpoch: activeAttemptEpoch,
             eventKind: "runtime_output",
             payload: {
               resultKind: streamed.reply.kind,
@@ -1368,10 +1406,10 @@ export function chatRoutes(
             },
             bodyOffset: 0,
             bodyLength: streamed.reply.body.length,
+            messageId: assistantProjectionMessageId,
             runId: activeChatRunId,
             bodyHash: hashChatGenerationBody(streamed.reply.body),
             body: streamed.reply.body,
-            transcript,
             replyingAgentId: streamed.replyingAgentId,
             chatTurnId: turnContext.chatTurnId,
             turnVariant: turnContext.turnVariant,
@@ -1381,16 +1419,7 @@ export function chatRoutes(
           if (!chatVisibleOutputAdmissionClosed(error)) throw error;
           terminalStatus = "stopped";
           terminalReason = "operator_stop";
-          const stoppedMessage = await persistPartialAssistantMessage(
-            assistantConversation,
-            "",
-            "stopped",
-            turnContext,
-            transcript,
-            streamed.replyingAgentId,
-            null,
-            activeChatRunId,
-          );
+          const stoppedMessage = await persistStoppedQueuedMessage(streamed.replyingAgentId);
           const stoppedMessages = stoppedMessage ? [stoppedMessage] : [];
           await linkChatRunMessages(assistantConversation, activeChatRunId, stoppedMessages);
           if (stoppedMessages.length > 0) {
@@ -1412,6 +1441,7 @@ export function chatRoutes(
           streamed.replyingAgentId,
           completionMessageId,
           activeChatRunId,
+          false,
         );
         await linkChatRunMessages(assistantConversation, activeChatRunId, createdMessages);
         await logChatMessagesAdded(assistantConversation, createdMessages, {
@@ -1444,9 +1474,10 @@ export function chatRoutes(
           null,
           transcript,
           chatReplyingAgentId(assistantConversation),
-          null,
+          assistantProjectionMessageId,
           activeChatRunId,
           failurePayload,
+          false,
         ).catch(() => null);
         const failedMessages = failedMessage ? [failedMessage] : [];
         await linkChatRunMessages(assistantConversation, activeChatRunId, failedMessages).catch(() => undefined);

--- a/server/src/services/chat-generation-protocol.test.ts
+++ b/server/src/services/chat-generation-protocol.test.ts
@@ -162,6 +162,41 @@ describe("chatGenerationProtocolService", () => {
     return generation;
   }
 
+  it("keeps streaming transcript evidence in the generation ledger instead of the message payload", async () => {
+    const generation = await seedGeneration();
+    const entry = {
+      kind: "stdout" as const,
+      ts: "2026-07-23T08:00:00.000Z",
+      text: `one transcript ledger entry ${"x".repeat(512)}`,
+    };
+
+    const projection = await protocol.appendVisibleEventAndProject({
+      orgId: generation.orgId,
+      conversationId: generation.conversationId,
+      generationId: generation.id,
+      expectedAttemptEpoch: generation.attemptEpoch,
+      eventKind: "transcript",
+      payload: { entry },
+      bodyHash: hashChatGenerationBody(""),
+      body: "",
+      chatTurnId: randomUUID(),
+      turnVariant: 0,
+    });
+
+    const [persistedMessage] = await db
+      .select()
+      .from(chatMessages)
+      .where(eq(chatMessages.id, projection.message.id));
+    const [persistedEvent] = await db
+      .select()
+      .from(chatGenerationEvents)
+      .where(eq(chatGenerationEvents.id, projection.event.id));
+
+    expect(persistedMessage?.structuredPayload).toBeNull();
+    expect(persistedEvent?.payload).toEqual(expect.objectContaining({ entry }));
+    expect(JSON.stringify(persistedEvent?.payload).length).toBeLessThan(1_024);
+  });
+
   it("serializes visible events and applies an idempotent Stop cutoff", async () => {
     const generation = await seedGeneration();
     const bodies = ["First", "First second"];
@@ -335,7 +370,6 @@ describe("chatGenerationProtocolService", () => {
       bodyLength: finalBody.length,
       bodyHash: hashChatGenerationBody(finalBody),
       body: finalBody,
-      transcript: [],
       chatTurnId: randomUUID(),
       turnVariant: 0,
     });
@@ -398,7 +432,6 @@ describe("chatGenerationProtocolService", () => {
       messageId: completion.message.id,
       bodyHash: hashChatGenerationBody(`${finalBody} late`),
       body: `${finalBody} late`,
-      transcript: [],
       chatTurnId: completion.message.chatTurnId!,
       turnVariant: completion.message.turnVariant,
     })).rejects.toMatchObject({
@@ -432,7 +465,6 @@ describe("chatGenerationProtocolService", () => {
       payload: { resultKind: "message", body: finalBody },
       bodyHash: hashChatGenerationBody(finalBody),
       body: finalBody,
-      transcript: [],
       chatTurnId: randomUUID(),
       turnVariant: 0,
     });
@@ -544,7 +576,6 @@ describe("chatGenerationProtocolService", () => {
       bodyLength: 14,
       bodyHash: hashChatGenerationBody("Visible prefix"),
       body: "Visible prefix",
-      transcript: [],
       chatTurnId,
       turnVariant: 0,
     });
@@ -560,7 +591,6 @@ describe("chatGenerationProtocolService", () => {
       bodyLength: 12,
       bodyHash: hashChatGenerationBody("Visible prefix hidden tail"),
       body: "Visible prefix hidden tail",
-      transcript: [],
       chatTurnId,
       turnVariant: 0,
     });
@@ -593,7 +623,6 @@ describe("chatGenerationProtocolService", () => {
       messageId: first.message.id,
       bodyHash: hashChatGenerationBody("Completed too late"),
       body: "Completed too late",
-      transcript: [],
       chatTurnId,
       turnVariant: 0,
     })).rejects.toMatchObject({

--- a/server/src/services/chat-generation-protocol.ts
+++ b/server/src/services/chat-generation-protocol.ts
@@ -25,7 +25,7 @@ import {
   type AppendEventFields,
   type ChatGenerationProtocolTransaction,
 } from "./chat-generation-protocol.helpers.js";
-import { withPersistedTranscript } from "./chats.helpers.js";
+import { stripChatMetadataFromPayload } from "./chats.helpers.js";
 import { normalizeLocalLibraryPathMarkdown } from "./library-path-markdown.js";
 
 export { hashChatGenerationBody } from "./chat-generation-protocol.helpers.js";
@@ -218,7 +218,7 @@ async function freezeAssistantMessageProjection(
     .set({
       status: "stopped",
       body: durableBody,
-      structuredPayload: withPersistedTranscript(existing.structuredPayload, projection.transcript),
+      structuredPayload: stripChatMetadataFromPayload(existing.structuredPayload),
       ...(projection.runId ? { runId: projection.runId } : {}),
       updatedAt: new Date(),
     })
@@ -341,7 +341,6 @@ export function chatGenerationProtocolService(db: Db) {
     bodyHash: string;
     messageId?: string | null;
     body: string;
-    transcript: ChatStreamTranscriptEntry[];
     replyingAgentId?: string | null;
     chatTurnId: string;
     turnVariant: number;
@@ -383,7 +382,7 @@ export function chatGenerationProtocolService(db: Db) {
       if (input.messageId && !existing) {
         throw conflict("Visible generation message projection no longer exists");
       }
-      const structuredPayload = withPersistedTranscript(existing?.structuredPayload ?? null, input.transcript);
+      const structuredPayload = stripChatMetadataFromPayload(existing?.structuredPayload ?? null);
       const [message] = existing
         ? await tx
           .update(chatMessages)

--- a/server/src/services/chats.ts
+++ b/server/src/services/chats.ts
@@ -17,7 +17,7 @@ import {
   organizations
 } from "@rudderhq/db";
 import { sanitizeChatStructuredPayload, type ChatControlDisposition, type ChatInlineVisualMapping, type ChatProviderControlDisposition, type ChatQueuedMessage, type ChatQueuedMessagePayload, type ChatQueuedMessageStatus, type ChatQueueRequestActor, type ChatStreamTranscriptEntry, type RudderInlineVisualMapping } from "@rudderhq/shared";
-import { and, asc, desc, eq, gt, gte, inArray, isNotNull, isNull, lt, or, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gt, gte, inArray, isNotNull, isNull, lt, lte, or, sql } from "drizzle-orm";
 import { randomUUID } from "node:crypto";
 import { conflict, notFound, unprocessable } from "../errors.js";
 import { logActivity } from "./activity-log.js";
@@ -2761,10 +2761,17 @@ export function chatService(db: Db) {
           .select({
             assistantMessageId: chatGenerationEvents.assistantMessageId,
             generationId: chatGenerationEvents.generationId,
+            generationCreatedAt: chatGenerations.createdAt,
+            eventRecordedAt: chatGenerationEvents.recordedAt,
           })
           .from(chatGenerationEvents)
+          .innerJoin(chatGenerations, eq(chatGenerations.id, chatGenerationEvents.generationId))
           .where(inArray(chatGenerationEvents.assistantMessageId, assistantMessageIds))
-          .orderBy(desc(chatGenerationEvents.generationSeq))
+          .orderBy(
+            desc(chatGenerations.createdAt),
+            desc(chatGenerationEvents.recordedAt),
+            desc(chatGenerationEvents.generationSeq),
+          )
         : Promise.resolve([]),
       nativeSteerMessageIds.length > 0
         ? db
@@ -2836,6 +2843,91 @@ export function chatService(db: Db) {
         const generationId = generationIdByAssistantMessageId.get(messageId);
         return Boolean(generationId && nativeSteerTargetGenerationIds.has(generationId));
       });
+    const assistantGenerationIds = [
+      ...new Set(generationIdByAssistantMessageId.values()),
+    ];
+    const assistantGenerationPairs = [...generationIdByAssistantMessageId].map(
+      ([assistantMessageId, generationId]) => ({ assistantMessageId, generationId }),
+    );
+    const selectedGenerationEventCondition = assistantGenerationPairs.length > 0
+      ? or(...assistantGenerationPairs.map(({ assistantMessageId, generationId }) => and(
+        eq(chatGenerationEvents.assistantMessageId, assistantMessageId),
+        eq(chatGenerationEvents.generationId, generationId),
+      )))
+      : undefined;
+    const generationIdsNeedingFullTranscript = includeTranscript
+      ? assistantGenerationIds
+      : [...nativeSteerTargetGenerationIds].filter((generationId) =>
+        assistantGenerationIds.includes(generationId));
+    const assistantMessageIdsNeedingFullTranscript = assistantGenerationPairs
+      .filter(({ generationId }) => generationIdsNeedingFullTranscript.includes(generationId))
+      .map(({ assistantMessageId }) => assistantMessageId);
+    const transcriptByAssistantMessageId = new Map<string, ChatStreamTranscriptEntry[]>();
+    if (generationIdsNeedingFullTranscript.length > 0) {
+      const transcriptEventRows = await db
+        .select({
+          assistantMessageId: chatGenerationEvents.assistantMessageId,
+          payload: chatGenerationEvents.payload,
+        })
+        .from(chatGenerationEvents)
+        .innerJoin(chatGenerations, eq(chatGenerations.id, chatGenerationEvents.generationId))
+        .where(and(
+          selectedGenerationEventCondition,
+          inArray(chatGenerationEvents.assistantMessageId, assistantMessageIdsNeedingFullTranscript),
+          eq(chatGenerationEvents.eventKind, "transcript"),
+          or(
+            isNull(chatGenerations.acceptedThroughSeq),
+            lte(chatGenerationEvents.generationSeq, chatGenerations.acceptedThroughSeq),
+          ),
+        ))
+        .orderBy(
+          asc(chatGenerationEvents.generationId),
+          asc(chatGenerationEvents.generationSeq),
+        );
+      for (const eventRow of transcriptEventRows) {
+        if (!eventRow.assistantMessageId) continue;
+        const entry = eventRow.payload.entry;
+        if (!entry || typeof entry !== "object" || Array.isArray(entry)) continue;
+        const transcript = transcriptByAssistantMessageId.get(eventRow.assistantMessageId);
+        if (transcript) transcript.push(entry as ChatStreamTranscriptEntry);
+        else transcriptByAssistantMessageId.set(
+          eventRow.assistantMessageId,
+          [entry as ChatStreamTranscriptEntry],
+        );
+      }
+    }
+    const transcriptSummaryByAssistantMessageId = new Map<
+      string,
+      MessageHydrationRow["transcriptSummary"]
+    >();
+    if (!includeTranscript && assistantGenerationPairs.length > 0) {
+      const summaryRows = await db
+        .select({
+          assistantMessageId: chatGenerationEvents.assistantMessageId,
+          entryCount: sql<number>`count(*)`,
+          startedAt: sql<string | null>`min(${chatGenerationEvents.payload}->'entry'->>'ts')`,
+          endedAt: sql<string | null>`max(${chatGenerationEvents.payload}->'entry'->>'ts')`,
+        })
+        .from(chatGenerationEvents)
+        .innerJoin(chatGenerations, eq(chatGenerations.id, chatGenerationEvents.generationId))
+        .where(and(
+          selectedGenerationEventCondition,
+          eq(chatGenerationEvents.eventKind, "transcript"),
+          or(
+            isNull(chatGenerations.acceptedThroughSeq),
+            lte(chatGenerationEvents.generationSeq, chatGenerations.acceptedThroughSeq),
+          ),
+        ))
+        .groupBy(chatGenerationEvents.assistantMessageId);
+      for (const summaryRow of summaryRows) {
+        if (!summaryRow.assistantMessageId) continue;
+        transcriptSummaryByAssistantMessageId.set(summaryRow.assistantMessageId, {
+          entryCount: Number(summaryRow.entryCount),
+          startedAt: summaryRow.startedAt,
+          endedAt: summaryRow.endedAt,
+        });
+      }
+    }
     const nativeSteerTranscriptPayloadByMessageId = new Map<string, Record<string, unknown> | null>();
     if (nativeSteerAssistantMessageIds.length > 0) {
       const transcriptPayloadRows = await db
@@ -2858,10 +2950,15 @@ export function chatService(db: Db) {
       const includeRowTranscript = includeTranscript
         || Boolean(generationId && nativeSteerTargetGenerationIds.has(generationId));
       const transcriptPayload = nativeSteerTranscriptPayloadByMessageId.get(row.id) ?? row.structuredPayload;
-      const transcript = includeRowTranscript ? chatTranscriptFromPayload(transcriptPayload) : [];
+      const ledgerTranscript = transcriptByAssistantMessageId.get(row.id);
+      const transcript = includeRowTranscript
+        ? ledgerTranscript?.length
+          ? ledgerTranscript
+          : chatTranscriptFromPayload(transcriptPayload)
+        : [];
       const transcriptSummary = includeRowTranscript
         ? chatTranscriptSummaryFromEntries(transcript)
-        : row.transcriptSummary ?? null;
+        : transcriptSummaryByAssistantMessageId.get(row.id) ?? row.transcriptSummary ?? null;
       const structuredPayload = effectiveStructuredPayload(row);
       return {
         ...row,
@@ -3536,9 +3633,46 @@ export function chatService(db: Db) {
         .where(and(eq(chatMessages.conversationId, conversationId), eq(chatMessages.id, messageId)))
         .then((rows) => rows[0] ?? null);
       if (!row) return null;
+      const generation = await db
+        .select({
+          generationId: chatGenerationEvents.generationId,
+          acceptedThroughSeq: chatGenerations.acceptedThroughSeq,
+        })
+        .from(chatGenerationEvents)
+        .innerJoin(chatGenerations, eq(chatGenerations.id, chatGenerationEvents.generationId))
+        .where(eq(chatGenerationEvents.assistantMessageId, messageId))
+        .orderBy(
+          desc(chatGenerations.createdAt),
+          desc(chatGenerationEvents.recordedAt),
+          desc(chatGenerationEvents.generationSeq),
+        )
+        .limit(1)
+        .then((rows) => rows[0] ?? null);
+      const transcript = generation
+        ? await db
+          .select({ payload: chatGenerationEvents.payload })
+          .from(chatGenerationEvents)
+          .where(and(
+            eq(chatGenerationEvents.generationId, generation.generationId),
+            eq(chatGenerationEvents.assistantMessageId, messageId),
+            eq(chatGenerationEvents.eventKind, "transcript"),
+            generation.acceptedThroughSeq === null
+              ? undefined
+              : lte(chatGenerationEvents.generationSeq, generation.acceptedThroughSeq),
+          ))
+          .orderBy(asc(chatGenerationEvents.generationSeq))
+          .then((events) => events.flatMap((event) => {
+            const entry = event.payload.entry;
+            return entry && typeof entry === "object" && !Array.isArray(entry)
+              ? [entry as ChatStreamTranscriptEntry]
+              : [];
+          }))
+        : [];
       return {
         messageId: row.id,
-        transcript: chatTranscriptFromPayload(row.structuredPayload),
+        transcript: transcript.length > 0
+          ? transcript
+          : chatTranscriptFromPayload(row.structuredPayload),
       };
   }
 

--- a/server/src/services/knowledge-portability/organization-portability.core.ts
+++ b/server/src/services/knowledge-portability/organization-portability.core.ts
@@ -14,6 +14,7 @@ import type {
   OrganizationSkill
 } from "@rudderhq/shared";
 import {
+  AGENT_RUN_CONCURRENCY_DEFAULT,
   AUTOMATION_CATCH_UP_POLICIES,
   AUTOMATION_CONCURRENCY_POLICIES,
   AUTOMATION_TRIGGER_KINDS,
@@ -502,6 +503,7 @@ export const COMPANY_LOGO_CONTENT_TYPE_EXTENSIONS: Record<string, string> = {
 };
 
 export const COMPANY_LOGO_FILE_NAME = "organization-logo";
+const LEGACY_PORTABLE_AGENT_RUN_CONCURRENCY_DEFAULT = 3;
 
 export const RUNTIME_DEFAULT_RULES: Array<{ path: string[]; value: unknown }> = [
   { path: ["heartbeat", "cooldownSec"], value: 10 },
@@ -511,7 +513,6 @@ export const RUNTIME_DEFAULT_RULES: Array<{ path: string[]; value: unknown }> = 
   { path: ["heartbeat", "wakeOnAutomation"], value: true },
   { path: ["heartbeat", "wakeOnDemand"], value: true },
   { path: ["heartbeat", "preflightEnabled"], value: true },
-  { path: ["heartbeat", "maxConcurrentRuns"], value: 3 },
 ];
 
 export const ADAPTER_DEFAULT_RULES_BY_TYPE: Record<string, Array<{ path: string[]; value: unknown }>> = {
@@ -632,6 +633,16 @@ export function clonePortableRecord(value: unknown) {
   return structuredClone(value) as Record<string, unknown>;
 }
 
+export function materializePortableRuntimeConfig(runtimeConfig: unknown) {
+  const next = clonePortableRecord(runtimeConfig) ?? {};
+  const heartbeat = isPlainRecord(next.heartbeat) ? { ...next.heartbeat } : {};
+  if (heartbeat.maxConcurrentRuns === undefined) {
+    heartbeat.maxConcurrentRuns = AGENT_RUN_CONCURRENCY_DEFAULT;
+  }
+  next.heartbeat = heartbeat;
+  return next;
+}
+
 export function isEmptyObject(value: unknown): boolean {
   return isPlainRecord(value) && Object.keys(value).length === 0;
 }
@@ -663,9 +674,17 @@ export function stripEmptyValues(value: unknown, opts?: { preserveEmptyStrings?:
   return value;
 }
 
-export function disableImportedTimerHeartbeat(runtimeConfig: unknown) {
+export function disableImportedTimerHeartbeat(
+  runtimeConfig: unknown,
+  options?: { preserveLegacyMissingConcurrencyDefault?: boolean },
+) {
   const next = clonePortableRecord(runtimeConfig) ?? {};
   const heartbeat = isPlainRecord(next.heartbeat) ? { ...next.heartbeat } : {};
+  if (heartbeat.maxConcurrentRuns === undefined) {
+    heartbeat.maxConcurrentRuns = options?.preserveLegacyMissingConcurrencyDefault
+      ? LEGACY_PORTABLE_AGENT_RUN_CONCURRENCY_DEFAULT
+      : AGENT_RUN_CONCURRENCY_DEFAULT;
+  }
   heartbeat.enabled = false;
   next.heartbeat = heartbeat;
   return next;

--- a/server/src/services/knowledge-portability/organization-portability.export.ts
+++ b/server/src/services/knowledge-portability/organization-portability.export.ts
@@ -34,6 +34,7 @@ import {
   COMPANY_LOGO_FILE_NAME,
   exportPortableProjectExecutionWorkspacePolicy,
   isPlainRecord,
+  materializePortableRuntimeConfig,
   normalizeSkillKey,
   normalizeSkillSlug,
   RUNTIME_DEFAULT_RULES,
@@ -460,7 +461,7 @@ export function createOrganizationPortabilityExportHandlers(context: ExportConte
           },
         ) as Record<string, unknown>;
         const portableRuntimeConfig = pruneDefaultLikeValue(
-          normalizePortableConfig(agent.runtimeConfig),
+          normalizePortableConfig(materializePortableRuntimeConfig(agent.runtimeConfig)),
           {
             dropFalseBooleans: true,
             defaultRules: RUNTIME_DEFAULT_RULES,

--- a/server/src/services/knowledge-portability/organization-portability.import.ts
+++ b/server/src/services/knowledge-portability/organization-portability.import.ts
@@ -39,6 +39,7 @@ import {
   type ImportBehaviorOptions,
 } from "./organization-portability.core.js";
 import {
+  findPaperclipExtensionPath,
   inferContentTypeFromPath,
   isPortableBinaryFile,
   normalizePortablePath,
@@ -46,7 +47,10 @@ import {
   portableFileToBuffer,
   readPortableTextFile,
 } from "./organization-portability.files.js";
-import { parseFrontmatterMarkdown } from "./organization-portability.package.js";
+import {
+  parseFrontmatterMarkdown,
+  parseYamlFile,
+} from "./organization-portability.package.js";
 import type { createOrganizationPortabilityPreviewHandlers } from "./organization-portability.preview.js";
 
 type ImportContext = {
@@ -88,6 +92,14 @@ export function createOrganizationPortabilityImportHandlers(context: ImportConte
     }
 
     const sourceManifest = plan.source.manifest;
+    const extensionPath = findPaperclipExtensionPath(plan.source.files);
+    const extension = extensionPath
+      ? parseYamlFile(readPortableTextFile(plan.source.files, extensionPath) ?? "")
+      : {};
+    // Older rudder/v1 exports omitted the then-default concurrency of three.
+    // Current exports materialize the field, while extension-free partial
+    // imports intentionally receive the current default.
+    const preserveLegacyMissingConcurrencyDefault = asString(extension.schema) === "rudder/v1";
     const warnings = [...plan.preview.warnings];
     const include = plan.include;
 
@@ -296,7 +308,9 @@ export function createOrganizationPortabilityImportHandlers(context: ImportConte
           reportsTo: null,
           agentRuntimeType: effectiveAdapterType,
           agentRuntimeConfig: agentRuntimeConfigWithoutSkills,
-          runtimeConfig: disableImportedTimerHeartbeat(manifestAgent.runtimeConfig),
+          runtimeConfig: disableImportedTimerHeartbeat(manifestAgent.runtimeConfig, {
+            preserveLegacyMissingConcurrencyDefault,
+          }),
           budgetMonthlyCents: manifestAgent.budgetMonthlyCents,
           permissions: manifestAgent.permissions,
           metadata: manifestAgent.metadata,

--- a/tests/e2e/agent-auto-name.spec.ts
+++ b/tests/e2e/agent-auto-name.spec.ts
@@ -35,6 +35,9 @@ test.describe("Agent auto naming", () => {
     await expect(
       newAgentMain.getByRole("button", { name: /Operator Assistant/ })
     ).toBeVisible();
+    await expect(
+      newAgentMain.getByRole("spinbutton", { name: "Agent run concurrency" })
+    ).toHaveValue("8");
     await newAgentMain.getByRole("button", { name: "Create agent" }).click();
 
     await expect(page).toHaveURL(/\/agents\/(?!new(?:\/|$))[^/]+(?:\/dashboard)?$/, { timeout: 15_000 });
@@ -53,11 +56,13 @@ test.describe("Agent auto naming", () => {
         title: string | null;
         role: string;
         icon: string | null;
+        runtimeConfig: { heartbeat?: { maxConcurrentRuns?: number } };
       };
       expect(agent.title).toBe("Operator Assistant");
       expect(agent.role).toBe("ceo");
       expect(agent.name).toBe(suggestedName);
       expect(agent.icon).toMatch(/^oreo:bloom:rose-milk:/);
+      expect(agent.runtimeConfig.heartbeat?.maxConcurrentRuns).toBe(8);
     }).toPass({ timeout: 15_000, intervals: [250, 500, 1_000] });
   });
 

--- a/tests/e2e/agent-config-advanced-options.spec.ts
+++ b/tests/e2e/agent-config-advanced-options.spec.ts
@@ -154,7 +154,7 @@ test.describe("Agent configuration advanced options", () => {
     await expect(page.getByRole("button", { name: "Ultra", exact: true }).first()).toBeVisible();
     const runConcurrencyInput = page.getByRole("spinbutton", { name: "Agent run concurrency" });
     await expect(runConcurrencyInput).toBeVisible();
-    await expect(runConcurrencyInput).toHaveValue("3");
+    await expect(runConcurrencyInput).toHaveValue("8");
     await expect(page.getByRole("switch", { name: "Preflight before timer run", exact: true })).toBeChecked();
 
     const advancedButton = page.getByRole("button", { name: "Advanced options", exact: true }).first();

--- a/tests/e2e/chat-streaming.spec.ts
+++ b/tests/e2e/chat-streaming.spec.ts
@@ -137,6 +137,50 @@ process.stdin.on("end", async () => {
   return stubPath;
 }
 
+async function createLargeTranscriptCodexStub(entryCount = 1_000) {
+  const stubDir = await fs.mkdtemp(path.join(os.tmpdir(), "rudder-chat-large-transcript-"));
+  const stubPath = path.join(stubDir, "codex");
+  await fs.writeFile(stubPath, `#!/usr/bin/env node
+let input = "";
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => {
+  input += chunk;
+});
+process.stdin.on("end", () => {
+  const sentinel = input.match(/(__RUDDER_RESULT_[a-f0-9-]+__)/i)?.[1] ?? "__RUDDER_RESULT_TEST__";
+  const send = (event) => process.stdout.write(JSON.stringify(event) + "\\n");
+  send({ type: "thread.started", thread_id: "large-transcript-e2e", model: "gpt-5.4" });
+  for (let index = 0; index < ${entryCount}; index += 1) {
+    send({
+      type: "item.completed",
+      item: {
+        id: "reason-" + index,
+        type: "reasoning",
+        text: "production-shaped reasoning " + index + " " + "x".repeat(1050),
+      },
+    });
+  }
+  const body = "Ledger-backed long transcript completed.";
+  const finalText = body + "\\n" + sentinel + JSON.stringify({
+    kind: "message",
+    body,
+    structuredPayload: null,
+  });
+  send({
+    type: "item.completed",
+    item: { id: "final-message", type: "agent_message", text: finalText },
+  });
+  send({
+    type: "turn.completed",
+    result: finalText,
+    usage: { input_tokens: 2, cached_input_tokens: 0, output_tokens: 2 },
+  });
+});
+`, "utf8");
+  await fs.chmod(stubPath, 0o755);
+  return stubPath;
+}
+
 function currentChatId(pageUrl: string) {
   const chatId = new URL(pageUrl).pathname.split("/").pop();
   expect(chatId).toBeTruthy();
@@ -371,6 +415,68 @@ test.describe("Chat streaming", () => {
     await expect(transcriptItem.locator('button[aria-label="Expand command details"]').first()).toBeVisible({ timeout: 15_000 });
     await expect(page.getByText(/__RUDDER_RESULT_/)).toHaveCount(0);
     await expect(page.getByText(/"kind":"message"/)).toHaveCount(0);
+  });
+
+  test("completes and reloads a production-shaped long transcript without embedding it in the message", async ({ page }) => {
+    test.setTimeout(240_000);
+    const stubPath = await createLargeTranscriptCodexStub();
+    const orgRes = await page.request.post("/api/orgs", {
+      data: { name: `Large-Transcript-${Date.now()}` },
+    });
+    expect(orgRes.ok()).toBe(true);
+    const organization = await orgRes.json();
+    const chatAgent = await createE2EChatAgent(page.request, organization.id, {
+      name: "Large Transcript Agent",
+      command: stubPath,
+    });
+
+    await page.goto("/");
+    await page.evaluate((orgId) => {
+      window.localStorage.setItem("rudder.selectedOrganizationId", orgId);
+    }, organization.id);
+    await page.goto(`/chat?agentId=${chatAgent.id}`);
+
+    const composer = page.locator(".rudder-mdxeditor-content").first();
+    await composer.fill("Produce a production-shaped long transcript");
+    await page.getByRole("button", { name: "Send" }).click();
+    await expect(page.getByTestId("chat-assistant-message").last()).toContainText(
+      "Ledger-backed long transcript completed.",
+      { timeout: 200_000 },
+    );
+    await expect(page.getByText("The assistant reply could not be completed.", { exact: false })).toHaveCount(0);
+
+    const chatId = currentChatId(page.url());
+    const assistantMessage = await e2eDb.query.chatMessages.findFirst({
+      where: (table, { and, eq }) => and(
+        eq(table.conversationId, chatId),
+        eq(table.role, "assistant"),
+      ),
+    });
+    expect(assistantMessage).toBeTruthy();
+    expect(assistantMessage?.structuredPayload?.__chatTranscript).toBeUndefined();
+
+    const transcriptEvents = await e2eDb.query.chatGenerationEvents.findMany({
+      columns: { id: true },
+      where: (table, { and, eq }) => and(
+        eq(table.assistantMessageId, assistantMessage!.id),
+        eq(table.eventKind, "transcript"),
+      ),
+    });
+    expect(transcriptEvents.length).toBeGreaterThanOrEqual(1_000);
+
+    const transcriptRes = await page.request.get(
+      `/api/chats/${chatId}/messages/${assistantMessage!.id}/transcript`,
+    );
+    expect(transcriptRes.ok()).toBe(true);
+    const transcriptPayload = await transcriptRes.json() as { transcript: unknown[] };
+    expect(transcriptPayload.transcript.length).toBeGreaterThanOrEqual(1_000);
+
+    await page.reload();
+    await expect(page.getByTestId("chat-assistant-message").last()).toContainText(
+      "Ledger-backed long transcript completed.",
+      { timeout: 30_000 },
+    );
+    await expect(page.getByRole("button", { name: /Worked for/ }).last()).toBeVisible();
   });
 
   test("renders each live Work Transcript delta once", async ({ page }) => {

--- a/ui/src/components/OnboardingWizard.runtime-config.test.tsx
+++ b/ui/src/components/OnboardingWizard.runtime-config.test.tsx
@@ -307,6 +307,11 @@ describe("OnboardingWizard runtime config", () => {
             dangerouslySkipPermissions: false,
             permissionMode: "auto",
           }),
+          runtimeConfig: {
+            heartbeat: expect.objectContaining({
+              maxConcurrentRuns: 8,
+            }),
+          },
         }));
       });
     });

--- a/ui/src/components/agent-config-defaults.test.ts
+++ b/ui/src/components/agent-config-defaults.test.ts
@@ -8,9 +8,9 @@ import {
 } from "./AgentConfigForm";
 
 describe("agent config defaults", () => {
-  it("defaults new agents to three concurrent runs", () => {
+  it("defaults new agents to eight concurrent runs", () => {
     expect(defaultCreateValues.maxConcurrentRuns).toBe(AGENT_RUN_CONCURRENCY_DEFAULT);
-    expect(defaultCreateValues.maxConcurrentRuns).toBe(3);
+    expect(defaultCreateValues.maxConcurrentRuns).toBe(8);
   });
 
   it("defaults timer heartbeat preflight on for new agents", () => {


### PR DESCRIPTION
## Summary

- default new agent run concurrency to 8 while preserving legacy rudder/v1 imports at 3
- persist streaming and queued chat transcripts incrementally in the generation event ledger
- hydrate transcript views from the ledger with Stop and Steer cutoffs
- prevent cross-instance Stop admission races from overwriting stopped messages as failed

## Validation

- pnpm -r typecheck
- pnpm build
- pnpm product-logic:check
- pnpm lint --changed
- targeted server and UI Vitest suites
- Playwright concurrency default workflows: 2 passed
- production-shaped long transcript Playwright regression: 1,019 ledger events, reload and lazy transcript passed
- independent reviewer: Approved

## Risk

No schema migration or data rewrite. Legacy embedded transcripts remain readable. Production deployment is intentionally not included.