### PR TITLE
feat(chat): link failures to exact agent runs

### DIFF
--- a/desktop/scripts/smoke.mjs
+++ b/desktop/scripts/smoke.mjs
@@ -2891,6 +2891,23 @@ async function verifyChatSidePanelBrowser(page, baseUrl, companyId, issuePrefix,
     }
     const browserUrlInput = browserView.getByLabel("Browser URL");
     await browserUrlInput.waitFor({ state: "visible", timeout: 15_000 });
+    const sideHostRadii = await page.evaluate(() => {
+      const host = Array.from(document.querySelectorAll(
+        "[data-testid='live-surface-runtime-host'][data-target-kind='browser']",
+      )).find((candidate) => candidate.getAttribute("data-owner-id")?.startsWith("side:"));
+      if (!host) throw new Error("Side Browser runtime host was unavailable");
+      const style = getComputedStyle(host);
+      return [
+        style.borderTopLeftRadius,
+        style.borderTopRightRadius,
+        style.borderBottomRightRadius,
+        style.borderBottomLeftRadius,
+      ];
+    });
+    assert.ok(
+      sideHostRadii.every((radius) => Number.parseFloat(radius) > 0),
+      `Side Browser runtime host must preserve all workspace-card corners (received ${sideHostRadii.join(", ")})`,
+    );
 
     const fixtureUrl = `${fixture.url}/operator`;
     await browserUrlInput.fill(fixtureUrl);

--- a/desktop/scripts/smoke.mjs
+++ b/desktop/scripts/smoke.mjs
@@ -3429,17 +3429,21 @@ async function verifyChatSidePanelBrowser(page, baseUrl, companyId, issuePrefix,
           nestedCardCount: root.querySelectorAll(".workspace-main-card").length,
           panel: rect(panel),
           root: rect(root),
+          rootBackgroundAlpha: backgroundAlpha(root),
           rootBorderRadius: getComputedStyle(root).borderRadius,
           rootPadding: getComputedStyle(root).padding,
           tablist: rect(tablist),
+          tablistBackgroundAlpha: backgroundAlpha(tablist),
         };
       });
       const withinTwoPixels = (left, right) => Math.abs(left - right) <= 2;
       assert.equal(fullBleed.nestedCardCount, 0, "Main Browser must not be nested in another workspace card");
       assert.ok(
-        Number.parseFloat(fullBleed.rootBorderRadius) > 0,
-        `Main Workbench must use the shared workspace-card radius (received ${fullBleed.rootBorderRadius})`,
+        fullBleed.rootBorderRadius === "0px" || fullBleed.rootBorderRadius === "",
+        `Main Workbench must leave its shell backdrop transparent (received radius ${fullBleed.rootBorderRadius})`,
       );
+      assert.equal(fullBleed.rootBackgroundAlpha, 0, "Main Workbench shell backdrop must be transparent");
+      assert.equal(fullBleed.tablistBackgroundAlpha, 0, "Main Workbench tab strip must be transparent");
       assert.equal(fullBleed.rootPadding, "0px", "Main Workbench must not inset the Browser surface");
       assert.ok(
         Number.parseFloat(fullBleed.hostBottomLeftRadius) > 0

--- a/doc/plans/2026-07-24-chat-failure-run-navigation.md
+++ b/doc/plans/2026-07-24-chat-failure-run-navigation.md
@@ -1,0 +1,47 @@
+---
+title: Chat failure Agent Run navigation
+date: 2026-07-24
+kind: implementation
+status: in_progress
+area: chat
+entities:
+  - messenger_chat
+  - agent_runs
+related_plans:
+  - 2026-07-21-chat-agent-run-conversation-grouping.md
+---
+
+# Chat Failure Agent Run Navigation
+
+## Approved Design
+
+- A failed runtime-backed assistant message exposes a neutral `Open run` action
+  for that message's exact Agent Run, alongside `Retry` when retry is available.
+- The target requires both a run id and an agent id. Agent identity resolves in
+  this order: the message replying agent, the conversation runtime agent, then
+  the conversation preferred agent. Without a complete target, Chat does not
+  render a dead link.
+- The link opens the existing organization-aware Agent Run route in the current
+  workspace. The short run id remains plain diagnostic text.
+- The failure action area may wrap on narrow screens.
+- Unit coverage proves exact per-message target resolution, retryable and
+  non-retryable rendering, missing-identity behavior, coexistence with Retry,
+  and exact hrefs. End-to-end coverage verifies the real failure message route
+  and navigation.
+- Synchronize `RUN.CHAT.AGENT.001` and `CHAT.LIFECYCLE.001` with the approved
+  direct failed-message-to-run navigation behavior.
+
+## Interfaces
+
+No API, schema, or shared type changes are required.
+
+## User-Approved Follow-Up
+
+- Treat the top Agent Run summary card as the single failure-summary source in
+  run detail. It retains `Run failed`, the operator-facing message, error code,
+  and action guidance.
+- Remove the duplicate bottom `Failure details` block. Transcript and Raw views
+  continue to preserve the original diagnostic evidence.
+- This is a presentation-only deduplication. `RUN.RESULT.001` remains satisfied
+  by the top summary and transcript evidence, so no Product Logic Registry
+  change is required.

--- a/doc/product/domains/collaboration/chat-messenger-im.md
+++ b/doc/product/domains/collaboration/chat-messenger-im.md
@@ -215,6 +215,10 @@ Product model:
   navigation collapses matching runs with the same normalized conversation
   identity into one entry, while individual attempts remain available through
   the run detail's `Chat Replies` evidence.
+- A run-backed failed assistant message exposes `Open run` for that exact
+  message attempt, independent of the conversation's newest run. Chat omits the
+  action when either run attribution or agent identity is unavailable, so it
+  does not render a dead Agent Run link.
 - Chat and issues are parallel ways to move tasks forward. Chat organizes work
   through an ongoing conversation; issues add explicit status, ownership,
   priority, dependencies, and review structure.
@@ -342,6 +346,9 @@ Flow:
 8. The operator can open the conversation menu to inspect its newest linked
    Agent Run, then use `Chat Replies` to move between distinct attempts without
    expanding duplicate conversation entries in the Agent Runs navigation.
+   A run-backed failed assistant message instead opens that message's exact
+   Agent Run directly; retryable failures keep this action alongside Retry, and
+   failures without complete run and agent attribution expose no run action.
 9. Chat can continue executing the task conversationally or create/link an
    issue, automation, or approval when the operator asks for that additional
    structure. The assistant must not emit an issue proposal merely because the

--- a/doc/product/domains/execution/agent-runs.md
+++ b/doc/product/domains/execution/agent-runs.md
@@ -243,6 +243,10 @@ Flow:
     menu opens the newest linked Agent Run, and Agent Detail Run context links
     back to Messenger. Within a conversation group, `Chat Replies` opens each
     individual attempt without duplicating the group in Agent Runs navigation.
+16. A run-backed failed assistant message can open its exact attributed Agent
+    Run directly, independent of the conversation's newest run. Chat omits
+    the action when it cannot resolve both the message run id and agent
+    identity, so it does not render a dead run link.
 
 Invariants:
 

--- a/server/src/__tests__/organization-skills-installation.test.ts
+++ b/server/src/__tests__/organization-skills-installation.test.ts
@@ -1,0 +1,552 @@
+import {
+  agents,
+  applyPendingMigrations,
+  createDb,
+  ensurePostgresDatabase,
+  organizationSkills,
+  organizations,
+} from "@rudderhq/db";
+import { eq } from "drizzle-orm";
+import { randomUUID } from "node:crypto";
+import fs from "node:fs";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { organizationSkillService } from "../services/organization-skills.js";
+
+type EmbeddedPostgresInstance = {
+  initialise(): Promise<void>;
+  start(): Promise<void>;
+  stop(): Promise<void>;
+};
+
+type EmbeddedPostgresCtor = new (opts: {
+  databaseDir: string;
+  user: string;
+  password: string;
+  port: number;
+  persistent: boolean;
+  initdbFlags?: string[];
+  onLog?: (message: unknown) => void;
+  onError?: (message: unknown) => void;
+}) => EmbeddedPostgresInstance;
+
+const PINNED_REF = "a".repeat(40);
+const UPDATED_REF = "b".repeat(40);
+
+async function getEmbeddedPostgresCtor(): Promise<EmbeddedPostgresCtor> {
+  const mod = await import("embedded-postgres");
+  return mod.default as EmbeddedPostgresCtor;
+}
+
+async function getAvailablePort(): Promise<number> {
+  return await new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.unref();
+    server.on("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        server.close(() => reject(new Error("Failed to allocate test port")));
+        return;
+      }
+      const { port } = address;
+      server.close((error) => {
+        if (error) reject(error);
+        else resolve(port);
+      });
+    });
+  });
+}
+
+async function startTempDatabase() {
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "rudder-org-skill-install-db-"));
+  const port = await getAvailablePort();
+  const EmbeddedPostgres = await getEmbeddedPostgresCtor();
+  const instance = new EmbeddedPostgres({
+    databaseDir: dataDir,
+    user: "rudder",
+    password: "rudder",
+    port,
+    persistent: true,
+    initdbFlags: ["--encoding=UTF8", "--locale=C"],
+    onLog: () => {},
+    onError: () => {},
+  });
+  await instance.initialise();
+  await instance.start();
+
+  const adminConnectionString = `postgres://rudder:rudder@127.0.0.1:${port}/postgres`;
+  await ensurePostgresDatabase(adminConnectionString, "rudder");
+  const connectionString = `postgres://rudder:rudder@127.0.0.1:${port}/rudder`;
+  await applyPendingMigrations(connectionString);
+  return { connectionString, dataDir, instance };
+}
+
+function githubTreeResponse() {
+  return new Response(JSON.stringify({
+    tree: [
+      { path: "skills/offline-skill/SKILL.md", type: "blob" },
+      { path: "skills/offline-skill/references/guide.md", type: "blob" },
+      { path: "skills/offline-skill/scripts/run.sh", type: "blob" },
+    ],
+  }));
+}
+
+describe("organization skill local installations", () => {
+  let db!: ReturnType<typeof createDb>;
+  let instance: EmbeddedPostgresInstance | null = null;
+  let dataDir = "";
+  let rudderHome = "";
+  let previousRudderHome: string | undefined;
+
+  beforeAll(async () => {
+    previousRudderHome = process.env.RUDDER_HOME;
+    rudderHome = fs.mkdtempSync(path.join(os.tmpdir(), "rudder-org-skill-install-home-"));
+    process.env.RUDDER_HOME = rudderHome;
+
+    const started = await startTempDatabase();
+    db = createDb(started.connectionString);
+    instance = started.instance;
+    dataDir = started.dataDir;
+  }, 20_000);
+
+  afterEach(async () => {
+    vi.unstubAllGlobals();
+    await db.delete(agents);
+    await db.delete(organizationSkills);
+    await db.delete(organizations);
+  });
+
+  afterAll(async () => {
+    await instance?.stop();
+    fs.rmSync(dataDir, { recursive: true, force: true });
+    fs.rmSync(rudderHome, { recursive: true, force: true });
+    if (previousRudderHome === undefined) delete process.env.RUDDER_HOME;
+    else process.env.RUDDER_HOME = previousRudderHome;
+  });
+
+  it("installs the complete remote tree once and reuses it offline", { timeout: 30_000 }, async () => {
+    const orgId = randomUUID();
+    const agentId = randomUUID();
+    await db.insert(organizations).values({
+      id: orgId,
+      name: "Offline Skill Org",
+      urlKey: "offline-skill-org",
+      issuePrefix: "OSO",
+      status: "active",
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      orgId,
+      name: "Builder",
+      workspaceKey: "builder",
+      role: "engineer",
+      status: "idle",
+      agentRuntimeType: "codex_local",
+      agentRuntimeConfig: {},
+    });
+
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.includes("/git/trees/")) return githubTreeResponse();
+      if (url.endsWith("/SKILL.md")) {
+        return new Response("---\nname: Offline Skill\ndescription: Works offline.\n---\n\n# Offline\n");
+      }
+      if (url.endsWith("/references/guide.md")) return new Response("# Local guide\n");
+      if (url.endsWith("/scripts/run.sh")) return new Response("echo local\n");
+      return new Response("not found", { status: 404 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const skillSvc = organizationSkillService(db, { deploymentMode: "local_trusted" });
+    const sourceUrl = `https://github.com/acme/skills/tree/${PINNED_REF}/skills/offline-skill`;
+    const imported = await skillSvc.importFromSource(orgId, sourceUrl);
+    const skill = imported.imported[0]!;
+
+    expect(skill).toMatchObject({
+      sourceType: "github",
+      sourceLocator: sourceUrl,
+      sourceRef: PINNED_REF,
+      fileInventory: [
+        { path: "references/guide.md", kind: "reference" },
+        { path: "scripts/run.sh", kind: "script" },
+        { path: "SKILL.md", kind: "skill" },
+      ],
+    });
+
+    vi.stubGlobal("fetch", vi.fn(async () => {
+      throw new Error("offline");
+    }));
+
+    const guide = await skillSvc.readFile(orgId, skill.id, "references/guide.md");
+    expect(guide).toMatchObject({
+      content: "# Local guide\n",
+      editable: true,
+    });
+
+    const firstRuntime = await skillSvc.listRealizedSkillEntriesForAgent(
+      orgId,
+      agentId,
+      "codex_local",
+      {},
+      [`org:${skill.key}`],
+    );
+    const secondRuntime = await skillSvc.listRealizedSkillEntriesForAgent(
+      orgId,
+      agentId,
+      "codex_local",
+      {},
+      [`org:${skill.key}`],
+    );
+    const installedPath = firstRuntime.find((entry) => entry.key === `org:${skill.key}`)?.source;
+    expect(installedPath).toBeTruthy();
+    expect(secondRuntime.find((entry) => entry.key === `org:${skill.key}`)?.source).toBe(installedPath);
+    await expect(fs.promises.readFile(path.join(installedPath!, "scripts", "run.sh"), "utf8"))
+      .resolves.toBe("echo local\n");
+  });
+
+  it("edits an installed remote skill and realizes the edited content", { timeout: 30_000 }, async () => {
+    const orgId = randomUUID();
+    const agentId = randomUUID();
+    await db.insert(organizations).values({
+      id: orgId,
+      name: "Editable Skill Org",
+      urlKey: "editable-skill-org",
+      issuePrefix: "ESO",
+      status: "active",
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      orgId,
+      name: "Editor",
+      workspaceKey: "editor",
+      role: "engineer",
+      status: "idle",
+      agentRuntimeType: "codex_local",
+      agentRuntimeConfig: {},
+    });
+
+    vi.stubGlobal("fetch", vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.includes("/git/trees/")) return githubTreeResponse();
+      if (url.endsWith("/SKILL.md")) {
+        return new Response("---\nname: Offline Skill\ndescription: Original.\n---\n\n# Original\n");
+      }
+      if (url.endsWith("/references/guide.md")) return new Response("# Original guide\n");
+      if (url.endsWith("/scripts/run.sh")) return new Response("echo original\n");
+      return new Response("not found", { status: 404 });
+    }));
+
+    const skillSvc = organizationSkillService(db, { deploymentMode: "local_trusted" });
+    const sourceUrl = `https://github.com/acme/skills/tree/${PINNED_REF}/skills/offline-skill`;
+    const skill = (await skillSvc.importFromSource(orgId, sourceUrl)).imported[0]!;
+    const edited = "---\nname: Offline Skill\ndescription: Edited locally.\n---\n\n# Edited\n";
+
+    await expect(skillSvc.updateFile(orgId, skill.id, "SKILL.md", edited)).resolves.toMatchObject({
+      content: edited,
+      editable: true,
+    });
+
+    vi.stubGlobal("fetch", vi.fn(async () => {
+      throw new Error("offline");
+    }));
+    const runtimeEntries = await skillSvc.listRealizedSkillEntriesForAgent(
+      orgId,
+      agentId,
+      "codex_local",
+      {},
+      [`org:${skill.key}`],
+    );
+    const installedPath = runtimeEntries.find((entry) => entry.key === `org:${skill.key}`)?.source;
+    await expect(fs.promises.readFile(path.join(installedPath!, "SKILL.md"), "utf8"))
+      .resolves.toBe(edited);
+  });
+
+  it("keeps Rudder-bundled skills read-only at the service boundary", { timeout: 30_000 }, async () => {
+    const orgId = randomUUID();
+    await db.insert(organizations).values({
+      id: orgId,
+      name: "Bundled Skill Org",
+      urlKey: "bundled-skill-org",
+      issuePrefix: "BSO",
+      status: "active",
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    const skillSvc = organizationSkillService(db, { deploymentMode: "local_trusted" });
+    const bundled = (await skillSvc.list(orgId)).find((skill) => skill.key === "rudder/rudder-docs")!;
+
+    expect(bundled).toMatchObject({
+      editable: false,
+      editableReason: "Bundled Rudder skills are read-only.",
+    });
+    await expect(skillSvc.updateFile(
+      orgId,
+      bundled.id,
+      "SKILL.md",
+      "# Mutated bundled skill\n",
+    )).rejects.toThrow("Bundled Rudder skills are read-only.");
+  });
+
+  it("migrates a community preset before editing without mutating its provenance source", { timeout: 30_000 }, async () => {
+    const orgId = randomUUID();
+    const agentId = randomUUID();
+    await db.insert(organizations).values({
+      id: orgId,
+      name: "Community Skill Org",
+      urlKey: "community-skill-org",
+      issuePrefix: "CSO",
+      status: "active",
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      orgId,
+      name: "Researcher",
+      workspaceKey: "researcher",
+      role: "researcher",
+      status: "idle",
+      agentRuntimeType: "codex_local",
+      agentRuntimeConfig: {},
+    });
+
+    const skillSvc = organizationSkillService(db, { deploymentMode: "local_trusted" });
+    const community = (await skillSvc.list(orgId)).find((skill) => skill.slug === "deep-research")!;
+    const provenanceFile = path.join(community.sourceLocator!, "SKILL.md");
+    const original = await fs.promises.readFile(provenanceFile, "utf8");
+    const edited = original.replace("# Deep Research", "# Organization Research");
+
+    try {
+      expect(community).toMatchObject({
+        sourceBadge: "community",
+        editable: true,
+      });
+      await skillSvc.updateFile(orgId, community.id, "SKILL.md", edited);
+      await expect(fs.promises.readFile(provenanceFile, "utf8")).resolves.toBe(original);
+      await expect(skillSvc.readFile(orgId, community.id, "SKILL.md")).resolves.toMatchObject({
+        content: edited,
+        editable: true,
+      });
+
+      const runtime = await skillSvc.listRealizedSkillEntriesForAgent(
+        orgId,
+        agentId,
+        "codex_local",
+        {},
+        [`org:${community.key}`],
+      );
+      expect(runtime.find((entry) => entry.key === `org:${community.key}`)?.source)
+        .toContain(`${path.sep}__installed__${path.sep}`);
+    } finally {
+      await fs.promises.writeFile(provenanceFile, original, "utf8");
+    }
+  });
+
+  it("installs a complete catalog package while preserving catalog provenance", { timeout: 30_000 }, async () => {
+    const orgId = randomUUID();
+    const agentId = randomUUID();
+    await db.insert(organizations).values({
+      id: orgId,
+      name: "Catalog Skill Org",
+      urlKey: "catalog-skill-org",
+      issuePrefix: "KSO",
+      status: "active",
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      orgId,
+      name: "Catalog User",
+      workspaceKey: "catalog-user",
+      role: "engineer",
+      status: "idle",
+      agentRuntimeType: "codex_local",
+      agentRuntimeConfig: {},
+    });
+
+    const skillSvc = organizationSkillService(db, { deploymentMode: "local_trusted" });
+    const [result] = await skillSvc.importPackageFiles(orgId, {
+      "skills/catalog-helper/SKILL.md": "---\nname: Catalog Helper\n---\n\n# Catalog Helper\n",
+      "skills/catalog-helper/references/guide.md": "# Catalog guide\n",
+      "skills/catalog-helper/scripts/run.sh": "echo catalog\n",
+    });
+    const skill = result!.skill;
+
+    expect(skill).toMatchObject({
+      sourceType: "catalog",
+      sourceLocator: null,
+      fileInventory: expect.arrayContaining([
+        { path: "references/guide.md", kind: "reference" },
+        { path: "scripts/run.sh", kind: "script" },
+      ]),
+    });
+    const runtime = await skillSvc.listRealizedSkillEntriesForAgent(
+      orgId,
+      agentId,
+      "codex_local",
+      {},
+      [`org:${skill.key}`],
+    );
+    const installedPath = runtime.find((entry) => entry.key === `org:${skill.key}`)?.source;
+    expect(installedPath).toContain(`${path.sep}__installed__${path.sep}`);
+    await expect(fs.promises.readFile(path.join(installedPath!, "references", "guide.md"), "utf8"))
+      .resolves.toBe("# Catalog guide\n");
+  });
+
+  it("preserves the previous installation when an update download fails", { timeout: 30_000 }, async () => {
+    const orgId = randomUUID();
+    await db.insert(organizations).values({
+      id: orgId,
+      name: "Atomic Update Org",
+      urlKey: "atomic-update-org",
+      issuePrefix: "AUO",
+      status: "active",
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    vi.stubGlobal("fetch", vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.includes("/git/trees/")) return githubTreeResponse();
+      if (url.endsWith("/SKILL.md")) {
+        return new Response("---\nname: Offline Skill\ndescription: Stable.\n---\n\n# Stable\n");
+      }
+      if (url.endsWith("/references/guide.md")) return new Response("# Stable guide\n");
+      if (url.endsWith("/scripts/run.sh")) return new Response("echo stable\n");
+      return new Response("not found", { status: 404 });
+    }));
+
+    const skillSvc = organizationSkillService(db, { deploymentMode: "local_trusted" });
+    const pinnedSource = `https://github.com/acme/skills/tree/${PINNED_REF}/skills/offline-skill`;
+    const skill = (await skillSvc.importFromSource(orgId, pinnedSource)).imported[0]!;
+    const branchSource = "https://github.com/acme/skills/tree/main/skills/offline-skill";
+    await db
+      .update(organizationSkills)
+      .set({
+        sourceLocator: branchSource,
+        metadata: {
+          ...(skill.metadata ?? {}),
+          trackingRef: "main",
+        },
+      })
+      .where(eq(organizationSkills.id, skill.id));
+
+    vi.stubGlobal("fetch", vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.includes("/commits/main")) {
+        return new Response(JSON.stringify({ sha: UPDATED_REF }));
+      }
+      if (url.includes("/git/trees/")) return githubTreeResponse();
+      if (url.endsWith("/SKILL.md")) {
+        return new Response("---\nname: Offline Skill\ndescription: New.\n---\n\n# New\n");
+      }
+      if (url.endsWith("/references/guide.md")) {
+        return new Response("download failed", { status: 503 });
+      }
+      if (url.endsWith("/scripts/run.sh")) return new Response("echo new\n");
+      return new Response("not found", { status: 404 });
+    }));
+
+    await expect(skillSvc.installUpdate(orgId, skill.id)).rejects.toThrow(
+      "Failed to fetch",
+    );
+    await expect(skillSvc.readFile(orgId, skill.id, "SKILL.md")).resolves.toMatchObject({
+      content: "---\nname: Offline Skill\ndescription: Stable.\n---\n\n# Stable\n",
+    });
+    await expect(skillSvc.readFile(orgId, skill.id, "references/guide.md")).resolves.toMatchObject({
+      content: "# Stable guide\n",
+    });
+  });
+
+  it("deduplicates concurrent legacy remote migration", { timeout: 30_000 }, async () => {
+    const orgId = randomUUID();
+    const agentId = randomUUID();
+    const skillId = randomUUID();
+    const skillKey = "acme/skills/legacy-skill";
+    await db.insert(organizations).values({
+      id: orgId,
+      name: "Legacy Migration Org",
+      urlKey: "legacy-migration-org",
+      issuePrefix: "LMO",
+      status: "active",
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      orgId,
+      name: "Migrator",
+      workspaceKey: "migrator",
+      role: "engineer",
+      status: "idle",
+      agentRuntimeType: "codex_local",
+      agentRuntimeConfig: {},
+    });
+    await db.insert(organizationSkills).values({
+      id: skillId,
+      orgId,
+      key: skillKey,
+      slug: "legacy-skill",
+      name: "Legacy Skill",
+      description: "Legacy remote row.",
+      markdown: "---\nname: Legacy Skill\ndescription: Legacy remote row.\n---\n",
+      sourceType: "github",
+      sourceLocator: `https://github.com/acme/skills/tree/${PINNED_REF}/skills/legacy-skill`,
+      sourceRef: PINNED_REF,
+      trustLevel: "scripts_executables",
+      compatibility: "compatible",
+      fileInventory: [
+        { path: "SKILL.md", kind: "skill" },
+        { path: "references/guide.md", kind: "reference" },
+      ],
+      metadata: {
+        sourceKind: "github",
+        owner: "acme",
+        repo: "skills",
+        ref: PINNED_REF,
+        repoSkillDir: "skills/legacy-skill",
+      },
+    });
+
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.includes("/git/trees/")) {
+        return new Response(JSON.stringify({
+          tree: [
+            { path: "skills/legacy-skill/SKILL.md", type: "blob" },
+            { path: "skills/legacy-skill/references/guide.md", type: "blob" },
+          ],
+        }));
+      }
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      if (url.endsWith("/SKILL.md")) {
+        return new Response("---\nname: Legacy Skill\ndescription: Migrated.\n---\n");
+      }
+      if (url.endsWith("/references/guide.md")) return new Response("# Migrated guide\n");
+      return new Response("not found", { status: 404 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const skillSvc = organizationSkillService(db, { deploymentMode: "local_trusted" });
+    const realize = () => skillSvc.listRealizedSkillEntriesForAgent(
+      orgId,
+      agentId,
+      "codex_local",
+      {},
+      [`org:${skillKey}`],
+    );
+    const [first, second] = await Promise.all([realize(), realize()]);
+
+    expect(first.find((entry) => entry.key === `org:${skillKey}`)?.source)
+      .toBe(second.find((entry) => entry.key === `org:${skillKey}`)?.source);
+    expect(fetchMock.mock.calls.filter(([input]) => String(input).includes("/git/trees/"))).toHaveLength(1);
+    const stored = await db
+      .select()
+      .from(organizationSkills)
+      .where(eq(organizationSkills.id, skillId))
+      .then((rows) => rows[0]!);
+    expect(stored.metadata).toMatchObject({ installationVersion: 1 });
+  });
+});

--- a/server/src/__tests__/organization-skills-installation.test.ts
+++ b/server/src/__tests__/organization-skills-installation.test.ts
@@ -595,6 +595,9 @@ describe("organization skill local installations", () => {
         `https://github.com/acme/skills/tree/${PINNED_REF}/skills/direct-transition`,
       )).imported[0]!;
       expect(remote.metadata).toMatchObject({ installationVersion: 1 });
+      const remoteRuntime = await skillSvc.listRuntimeSkillEntries(orgId);
+      const installedPath = remoteRuntime.find((entry) => entry.key === remote.key)?.source;
+      expect(installedPath).toContain(`${path.sep}__installed__${path.sep}`);
 
       const local = (await skillSvc.importFromSource(orgId, localSkillDir)).imported[0]!;
       expect(local.id).toBe(remote.id);
@@ -605,7 +608,237 @@ describe("organization skill local installations", () => {
       expect(local.metadata).not.toMatchObject({ installationVersion: 1 });
       const runtime = await skillSvc.listRuntimeSkillEntries(orgId);
       expect(runtime.find((entry) => entry.key === local.key)?.source).toBe(path.resolve(localSkillDir));
+      await expect(fs.promises.stat(installedPath!).catch(() => null)).resolves.toBeNull();
     } finally {
+      await fs.promises.rm(localSkillDir, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves the managed installation when a direct local replacement fails to persist", { timeout: 30_000 }, async () => {
+    const orgId = randomUUID();
+    const localSkillDir = await fs.promises.mkdtemp(
+      path.join(os.tmpdir(), "rudder-direct-transition-rollback-"),
+    );
+    await db.insert(organizations).values({
+      id: orgId,
+      name: "Direct Transition Rollback Org",
+      urlKey: "direct-transition-rollback-org",
+      issuePrefix: "DTR",
+      status: "active",
+      requireBoardApprovalForNewAgents: false,
+    });
+    await fs.promises.writeFile(
+      path.join(localSkillDir, "SKILL.md"),
+      "---\nkey: acme/skills/direct-transition\nname: Direct Transition\n---\n\n# Local\n",
+      "utf8",
+    );
+
+    vi.stubGlobal("fetch", vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.includes("/git/trees/")) {
+        return new Response(JSON.stringify({
+          tree: [{ path: "skills/direct-transition/SKILL.md", type: "blob" }],
+        }));
+      }
+      if (url.endsWith("/SKILL.md")) {
+        return new Response("---\nname: Direct Transition\n---\n\n# Remote\n");
+      }
+      return new Response("not found", { status: 404 });
+    }));
+
+    try {
+      const skillSvc = organizationSkillService(db, { deploymentMode: "local_trusted" });
+      const remote = (await skillSvc.importFromSource(
+        orgId,
+        `https://github.com/acme/skills/tree/${PINNED_REF}/skills/direct-transition`,
+      )).imported[0]!;
+      const runtime = await skillSvc.listRuntimeSkillEntries(orgId);
+      const installedPath = runtime.find((entry) => entry.key === remote.key)?.source;
+      expect(installedPath).toContain(`${path.sep}__installed__${path.sep}`);
+
+      const realUpdate = db.update.bind(db);
+      const updateSpy = vi.spyOn(db, "update").mockImplementation(((table: unknown) => {
+        const builder = realUpdate(table as never) as unknown as {
+          set: (values: Record<string, unknown>) => unknown;
+        };
+        const realSet = builder.set.bind(builder);
+        builder.set = (values: Record<string, unknown>) => {
+          if (values.sourceType === "local_path") {
+            throw new Error("simulated local transition persistence failure");
+          }
+          return realSet(values);
+        };
+        return builder;
+      }) as typeof db.update);
+
+      try {
+        await expect(skillSvc.importFromSource(orgId, localSkillDir)).rejects.toThrow(
+          "simulated local transition persistence failure",
+        );
+      } finally {
+        updateSpy.mockRestore();
+      }
+
+      await expect(fs.promises.stat(installedPath!)).resolves.toMatchObject({});
+      await expect(skillSvc.getById(remote.id)).resolves.toMatchObject({
+        sourceType: "github",
+        metadata: expect.objectContaining({ installationVersion: 1 }),
+      });
+    } finally {
+      await fs.promises.rm(localSkillDir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects using a managed installation as its own direct local replacement", { timeout: 30_000 }, async () => {
+    const orgId = randomUUID();
+    await db.insert(organizations).values({
+      id: orgId,
+      name: "Managed Source Rejection Org",
+      urlKey: "managed-source-rejection-org",
+      issuePrefix: "MSR",
+      status: "active",
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    vi.stubGlobal("fetch", vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.includes("/git/trees/")) {
+        return new Response(JSON.stringify({
+          tree: [{ path: "skills/direct-transition/SKILL.md", type: "blob" }],
+        }));
+      }
+      if (url.endsWith("/SKILL.md")) {
+        return new Response(
+          "---\nkey: acme/skills/direct-transition\nname: Direct Transition\n---\n\n# Remote\n",
+        );
+      }
+      return new Response("not found", { status: 404 });
+    }));
+
+    const skillSvc = organizationSkillService(db, { deploymentMode: "local_trusted" });
+    const remote = (await skillSvc.importFromSource(
+      orgId,
+      `https://github.com/acme/skills/tree/${PINNED_REF}/skills/direct-transition`,
+    )).imported[0]!;
+    const runtime = await skillSvc.listRuntimeSkillEntries(orgId);
+    const installedPath = runtime.find((entry) => entry.key === remote.key)?.source;
+
+    await expect(skillSvc.importFromSource(orgId, installedPath!)).rejects.toThrow(
+      "Managed organization skill installations cannot be imported",
+    );
+    await expect(fs.promises.stat(path.join(installedPath!, "SKILL.md"))).resolves.toMatchObject({});
+    await expect(skillSvc.getById(remote.id)).resolves.toMatchObject({
+      sourceType: "github",
+      metadata: expect.objectContaining({ installationVersion: 1 }),
+    });
+  });
+
+  it("keeps a direct local replacement when legacy migration finishes later", { timeout: 30_000 }, async () => {
+    const orgId = randomUUID();
+    const agentId = randomUUID();
+    const skillId = randomUUID();
+    const skillKey = "acme/skills/migration-race";
+    const localSkillDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "rudder-migration-race-"));
+    await db.insert(organizations).values({
+      id: orgId,
+      name: "Migration Race Org",
+      urlKey: "migration-race-org",
+      issuePrefix: "MRO",
+      status: "active",
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      orgId,
+      name: "Race Agent",
+      workspaceKey: "race-agent",
+      role: "engineer",
+      status: "idle",
+      agentRuntimeType: "codex_local",
+      agentRuntimeConfig: {},
+    });
+    await db.insert(organizationSkills).values({
+      id: skillId,
+      orgId,
+      key: skillKey,
+      slug: "migration-race",
+      name: "Migration Race",
+      description: "Legacy remote row.",
+      markdown: "---\nname: Migration Race\n---\n\n# Legacy\n",
+      sourceType: "github",
+      sourceLocator: `https://github.com/acme/skills/tree/${PINNED_REF}/skills/migration-race`,
+      sourceRef: PINNED_REF,
+      trustLevel: "markdown_only",
+      compatibility: "compatible",
+      fileInventory: [{ path: "SKILL.md", kind: "skill" }],
+      metadata: {
+        sourceKind: "github",
+        owner: "acme",
+        repo: "skills",
+        ref: PINNED_REF,
+        trackingRef: "main",
+        repoSkillDir: "skills/migration-race",
+      },
+    });
+    await fs.promises.writeFile(
+      path.join(localSkillDir, "SKILL.md"),
+      `---\nkey: ${skillKey}\nname: Migration Race\n---\n\n# Local wins\n`,
+      "utf8",
+    );
+
+    let releaseRemoteFetch!: () => void;
+    const remoteFetchBlocked = new Promise<void>((resolve) => {
+      releaseRemoteFetch = resolve;
+    });
+    let markRemoteFetchStarted!: () => void;
+    const remoteFetchStarted = new Promise<void>((resolve) => {
+      markRemoteFetchStarted = resolve;
+    });
+    vi.stubGlobal("fetch", vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.includes("/git/trees/")) {
+        return new Response(JSON.stringify({
+          tree: [{ path: "skills/migration-race/SKILL.md", type: "blob" }],
+        }));
+      }
+      if (url.endsWith("/SKILL.md")) {
+        markRemoteFetchStarted();
+        await remoteFetchBlocked;
+        return new Response("---\nname: Migration Race\n---\n\n# Remote loses\n");
+      }
+      return new Response("not found", { status: 404 });
+    }));
+
+    try {
+      const skillSvc = organizationSkillService(db, { deploymentMode: "local_trusted" });
+      const realization = skillSvc.listRealizedSkillEntriesForAgent(
+        orgId,
+        agentId,
+        "codex_local",
+        {},
+        [`org:${skillKey}`],
+      );
+      await remoteFetchStarted;
+
+      const local = (await skillSvc.importFromSource(orgId, localSkillDir)).imported[0]!;
+      releaseRemoteFetch();
+      const realized = await realization;
+
+      expect(local).toMatchObject({
+        id: skillId,
+        sourceType: "local_path",
+        sourceLocator: path.resolve(localSkillDir),
+      });
+      expect(realized.find((entry) => entry.key === `org:${skillKey}`)?.source)
+        .toBe(path.resolve(localSkillDir));
+      const stored = await skillSvc.getById(skillId);
+      expect(stored).toMatchObject({
+        sourceType: "local_path",
+        sourceLocator: path.resolve(localSkillDir),
+      });
+      expect(stored?.metadata).not.toMatchObject({ installationVersion: 1 });
+    } finally {
+      releaseRemoteFetch();
       await fs.promises.rm(localSkillDir, { recursive: true, force: true });
     }
   });

--- a/server/src/__tests__/organization-skills-installation.test.ts
+++ b/server/src/__tests__/organization-skills-installation.test.ts
@@ -328,6 +328,87 @@ describe("organization skill local installations", () => {
     )).rejects.toThrow("Bundled Rudder skills are read-only.");
   });
 
+  it("rejects deletion of Rudder-bundled and capability-bundled skills", { timeout: 30_000 }, async () => {
+    const orgId = randomUUID();
+    await db.insert(organizations).values({
+      id: orgId,
+      name: "Protected Bundled Skill Org",
+      urlKey: "protected-bundled-skill-org",
+      issuePrefix: "PBS",
+      status: "active",
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    const skillSvc = organizationSkillService(db, { deploymentMode: "local_trusted" });
+    const skills = await skillSvc.list(orgId);
+    const bundled = skills.find((skill) => skill.key === "rudder/rudder-docs")!;
+    const capabilityBundled = skills.find((skill) => skill.key === "rudder/browser")!;
+
+    await expect(skillSvc.deleteSkill(orgId, bundled.id)).rejects.toThrow(
+      "Bundled Rudder skills are read-only.",
+    );
+    await expect(skillSvc.deleteSkill(orgId, capabilityBundled.id)).rejects.toThrow(
+      "Bundled Rudder skills are read-only.",
+    );
+    await expect(skillSvc.getById(bundled.id)).resolves.toMatchObject({ id: bundled.id });
+    await expect(skillSvc.getById(capabilityBundled.id)).resolves.toMatchObject({
+      id: capabilityBundled.id,
+    });
+  });
+
+  it("does not replace an existing bundled identity through package or local imports", { timeout: 30_000 }, async () => {
+    const orgId = randomUUID();
+    const localReplacementDir = await fs.promises.mkdtemp(
+      path.join(os.tmpdir(), "rudder-bundled-replacement-"),
+    );
+    await db.insert(organizations).values({
+      id: orgId,
+      name: "Bundled Replacement Org",
+      urlKey: "bundled-replacement-org",
+      issuePrefix: "BRO",
+      status: "active",
+      requireBoardApprovalForNewAgents: false,
+    });
+    const replacementMarkdown = [
+      "---",
+      "key: rudder/rudder-docs",
+      "name: Replacement Docs",
+      "---",
+      "",
+      "# Replacement",
+      "",
+    ].join("\n");
+    await fs.promises.writeFile(
+      path.join(localReplacementDir, "SKILL.md"),
+      replacementMarkdown,
+      "utf8",
+    );
+
+    try {
+      const skillSvc = organizationSkillService(db, { deploymentMode: "local_trusted" });
+      const originalListItem = (await skillSvc.list(orgId)).find(
+        (skill) => skill.key === "rudder/rudder-docs",
+      )!;
+      const original = (await skillSvc.getById(originalListItem.id))!;
+
+      await skillSvc.importPackageFiles(orgId, {
+        "skills/replacement-docs/SKILL.md": replacementMarkdown,
+      });
+      await skillSvc.importFromSource(orgId, localReplacementDir);
+
+      const preserved = await skillSvc.getById(original.id);
+      expect(preserved).toMatchObject({
+        id: original.id,
+        key: "rudder/rudder-docs",
+        sourceType: "local_path",
+        markdown: original.markdown,
+        metadata: expect.objectContaining({ sourceKind: "rudder_bundled" }),
+      });
+    } finally {
+      await fs.promises.rm(localReplacementDir, { recursive: true, force: true });
+    }
+  });
+
   it("migrates a community preset before editing without mutating its provenance source", { timeout: 30_000 }, async () => {
     const orgId = randomUUID();
     const agentId = randomUUID();
@@ -431,6 +512,153 @@ describe("organization skill local installations", () => {
     expect(installedPath).toContain(`${path.sep}__installed__${path.sep}`);
     await expect(fs.promises.readFile(path.join(installedPath!, "references", "guide.md"), "utf8"))
       .resolves.toBe("# Catalog guide\n");
+  });
+
+  it("keeps local_path imports direct and editable without managed installation", { timeout: 30_000 }, async () => {
+    const orgId = randomUUID();
+    const localSkillDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "rudder-direct-local-skill-"));
+    await db.insert(organizations).values({
+      id: orgId,
+      name: "Direct Local Skill Org",
+      urlKey: "direct-local-skill-org",
+      issuePrefix: "DLS",
+      status: "active",
+      requireBoardApprovalForNewAgents: false,
+    });
+    await fs.promises.mkdir(path.join(localSkillDir, "references"), { recursive: true });
+    await fs.promises.writeFile(
+      path.join(localSkillDir, "SKILL.md"),
+      "---\nname: Direct Local\ndescription: Direct source.\n---\n\n# Direct Local\n",
+      "utf8",
+    );
+    await fs.promises.writeFile(
+      path.join(localSkillDir, "references", "guide.md"),
+      "# Direct guide\n",
+      "utf8",
+    );
+
+    try {
+      const skillSvc = organizationSkillService(db, { deploymentMode: "local_trusted" });
+      const skill = (await skillSvc.importFromSource(orgId, localSkillDir)).imported[0]!;
+
+      expect(skill).toMatchObject({
+        sourceType: "local_path",
+        sourceLocator: path.resolve(localSkillDir),
+      });
+      expect(skill.metadata).not.toMatchObject({ installationVersion: 1 });
+
+      const runtime = await skillSvc.listRuntimeSkillEntries(orgId);
+      expect(runtime.find((entry) => entry.key === skill.key)?.source).toBe(path.resolve(localSkillDir));
+
+      const edited = "# Edited direct guide\n";
+      await skillSvc.updateFile(orgId, skill.id, "references/guide.md", edited);
+      await expect(fs.promises.readFile(path.join(localSkillDir, "references", "guide.md"), "utf8"))
+        .resolves.toBe(edited);
+    } finally {
+      await fs.promises.rm(localSkillDir, { recursive: true, force: true });
+    }
+  });
+
+  it("clears managed installation state when a local_path import replaces a remote row", { timeout: 30_000 }, async () => {
+    const orgId = randomUUID();
+    const localSkillDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "rudder-local-replacement-"));
+    await db.insert(organizations).values({
+      id: orgId,
+      name: "Local Replacement Org",
+      urlKey: "local-replacement-org",
+      issuePrefix: "LRO",
+      status: "active",
+      requireBoardApprovalForNewAgents: false,
+    });
+    await fs.promises.writeFile(
+      path.join(localSkillDir, "SKILL.md"),
+      "---\nkey: acme/skills/direct-transition\nname: Direct Transition\n---\n\n# Local bytes\n",
+      "utf8",
+    );
+    vi.stubGlobal("fetch", vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.includes("/git/trees/")) {
+        return new Response(JSON.stringify({
+          tree: [{ path: "skills/direct-transition/SKILL.md", type: "blob" }],
+        }));
+      }
+      if (url.endsWith("/SKILL.md")) {
+        return new Response("---\nname: Direct Transition\n---\n\n# Remote bytes\n");
+      }
+      return new Response("not found", { status: 404 });
+    }));
+
+    try {
+      const skillSvc = organizationSkillService(db, { deploymentMode: "local_trusted" });
+      const remote = (await skillSvc.importFromSource(
+        orgId,
+        `https://github.com/acme/skills/tree/${PINNED_REF}/skills/direct-transition`,
+      )).imported[0]!;
+      expect(remote.metadata).toMatchObject({ installationVersion: 1 });
+
+      const local = (await skillSvc.importFromSource(orgId, localSkillDir)).imported[0]!;
+      expect(local.id).toBe(remote.id);
+      expect(local).toMatchObject({
+        sourceType: "local_path",
+        sourceLocator: path.resolve(localSkillDir),
+      });
+      expect(local.metadata).not.toMatchObject({ installationVersion: 1 });
+      const runtime = await skillSvc.listRuntimeSkillEntries(orgId);
+      expect(runtime.find((entry) => entry.key === local.key)?.source).toBe(path.resolve(localSkillDir));
+    } finally {
+      await fs.promises.rm(localSkillDir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps list and detail reconciliation free of remote installation", { timeout: 30_000 }, async () => {
+    const orgId = randomUUID();
+    const skillId = randomUUID();
+    await db.insert(organizations).values({
+      id: orgId,
+      name: "Metadata Only Org",
+      urlKey: "metadata-only-org",
+      issuePrefix: "MDO",
+      status: "active",
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(organizationSkills).values({
+      id: skillId,
+      orgId,
+      key: "acme/skills/metadata-only",
+      slug: "metadata-only",
+      name: "Metadata Only",
+      description: "Must not download during metadata reads.",
+      markdown: "---\nname: Metadata Only\n---\n",
+      sourceType: "github",
+      sourceLocator: "https://github.com/acme/skills/tree/main/skills/metadata-only",
+      sourceRef: PINNED_REF,
+      trustLevel: "markdown_only",
+      compatibility: "compatible",
+      fileInventory: [{ path: "SKILL.md", kind: "skill" }],
+      metadata: {
+        sourceKind: "github",
+        owner: "acme",
+        repo: "skills",
+        ref: PINNED_REF,
+        trackingRef: "main",
+        repoSkillDir: "skills/metadata-only",
+      },
+    });
+    const fetchMock = vi.fn(async () => {
+      throw new Error("metadata reads must stay offline");
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const skillSvc = organizationSkillService(db, { deploymentMode: "local_trusted" });
+    await expect(skillSvc.list(orgId)).resolves.toContainEqual(expect.objectContaining({
+      id: skillId,
+      editable: true,
+    }));
+    await expect(skillSvc.detail(orgId, skillId)).resolves.toMatchObject({
+      id: skillId,
+      editable: true,
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("preserves the previous installation when an update download fails", { timeout: 30_000 }, async () => {
@@ -749,6 +977,7 @@ describe("organization skill local installations", () => {
     expect(stored.sourceRef).toBe(PINNED_REF);
     expect(stored.metadata).toMatchObject({
       ref: PINNED_REF,
+      trackingRef: "main",
       installationVersion: 1,
     });
   });

--- a/server/src/__tests__/organization-skills-installation.test.ts
+++ b/server/src/__tests__/organization-skills-installation.test.ts
@@ -208,6 +208,42 @@ describe("organization skill local installations", () => {
       .resolves.toBe("echo local\n");
   });
 
+  it("installs sibling files when importing a GitHub blob SKILL.md URL", { timeout: 30_000 }, async () => {
+    const orgId = randomUUID();
+    await db.insert(organizations).values({
+      id: orgId,
+      name: "Blob Skill Org",
+      urlKey: "blob-skill-org",
+      issuePrefix: "BLO",
+      status: "active",
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    vi.stubGlobal("fetch", vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.includes("/git/trees/")) return githubTreeResponse();
+      if (url.endsWith("/SKILL.md")) {
+        return new Response("---\nname: Offline Skill\ndescription: Blob import.\n---\n");
+      }
+      if (url.endsWith("/references/guide.md")) return new Response("# Blob guide\n");
+      if (url.endsWith("/scripts/run.sh")) return new Response("echo blob\n");
+      return new Response("not found", { status: 404 });
+    }));
+
+    const skillSvc = organizationSkillService(db, { deploymentMode: "local_trusted" });
+    const sourceUrl = `https://github.com/acme/skills/blob/${PINNED_REF}/skills/offline-skill/SKILL.md`;
+    const skill = (await skillSvc.importFromSource(orgId, sourceUrl)).imported[0]!;
+
+    expect(skill.fileInventory).toEqual([
+      { path: "references/guide.md", kind: "reference" },
+      { path: "scripts/run.sh", kind: "script" },
+      { path: "SKILL.md", kind: "skill" },
+    ]);
+    await expect(skillSvc.readFile(orgId, skill.id, "references/guide.md")).resolves.toMatchObject({
+      content: "# Blob guide\n",
+    });
+  });
+
   it("edits an installed remote skill and realizes the edited content", { timeout: 30_000 }, async () => {
     const orgId = randomUUID();
     const agentId = randomUUID();
@@ -461,6 +497,84 @@ describe("organization skill local installations", () => {
     });
   });
 
+  it("restores the previous installation when update persistence fails", { timeout: 30_000 }, async () => {
+    const orgId = randomUUID();
+    await db.insert(organizations).values({
+      id: orgId,
+      name: "Persistence Rollback Org",
+      urlKey: "persistence-rollback-org",
+      issuePrefix: "PRO",
+      status: "active",
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    vi.stubGlobal("fetch", vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.includes("/git/trees/")) return githubTreeResponse();
+      if (url.endsWith("/SKILL.md")) {
+        return new Response("---\nname: Offline Skill\ndescription: Stable.\n---\n\n# Stable\n");
+      }
+      if (url.endsWith("/references/guide.md")) return new Response("# Stable guide\n");
+      if (url.endsWith("/scripts/run.sh")) return new Response("echo stable\n");
+      return new Response("not found", { status: 404 });
+    }));
+
+    const skillSvc = organizationSkillService(db, { deploymentMode: "local_trusted" });
+    const pinnedSource = `https://github.com/acme/skills/tree/${PINNED_REF}/skills/offline-skill`;
+    const skill = (await skillSvc.importFromSource(orgId, pinnedSource)).imported[0]!;
+    await db
+      .update(organizationSkills)
+      .set({
+        sourceLocator: "https://github.com/acme/skills/tree/main/skills/offline-skill",
+        metadata: { ...(skill.metadata ?? {}), trackingRef: "main" },
+      })
+      .where(eq(organizationSkills.id, skill.id));
+
+    vi.stubGlobal("fetch", vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.includes("/commits/main")) {
+        return new Response(JSON.stringify({ sha: UPDATED_REF }));
+      }
+      if (url.includes("/git/trees/")) return githubTreeResponse();
+      if (url.endsWith("/SKILL.md")) {
+        return new Response("---\nname: Offline Skill\ndescription: New.\n---\n\n# New\n");
+      }
+      if (url.endsWith("/references/guide.md")) return new Response("# New guide\n");
+      if (url.endsWith("/scripts/run.sh")) return new Response("echo new\n");
+      return new Response("not found", { status: 404 });
+    }));
+
+    const realUpdate = db.update.bind(db);
+    const updateSpy = vi.spyOn(db, "update").mockImplementation(((table: unknown) => {
+      const builder = realUpdate(table as never) as unknown as {
+        set: (values: Record<string, unknown>) => unknown;
+      };
+      const realSet = builder.set.bind(builder);
+      builder.set = (values: Record<string, unknown>) => {
+        if (values.sourceRef === UPDATED_REF) {
+          throw new Error("simulated database persistence failure");
+        }
+        return realSet(values);
+      };
+      return builder;
+    }) as typeof db.update);
+
+    try {
+      await expect(skillSvc.installUpdate(orgId, skill.id)).rejects.toThrow(
+        "simulated database persistence failure",
+      );
+    } finally {
+      updateSpy.mockRestore();
+    }
+
+    await expect(skillSvc.readFile(orgId, skill.id, "SKILL.md")).resolves.toMatchObject({
+      content: "---\nname: Offline Skill\ndescription: Stable.\n---\n\n# Stable\n",
+    });
+    await expect(skillSvc.readFile(orgId, skill.id, "references/guide.md")).resolves.toMatchObject({
+      content: "# Stable guide\n",
+    });
+  });
+
   it("deduplicates concurrent legacy remote migration", { timeout: 30_000 }, async () => {
     const orgId = randomUUID();
     const agentId = randomUUID();
@@ -548,5 +662,94 @@ describe("organization skill local installations", () => {
       .where(eq(organizationSkills.id, skillId))
       .then((rows) => rows[0]!);
     expect(stored.metadata).toMatchObject({ installationVersion: 1 });
+  });
+
+  it("migrates a legacy branch row from its pinned sourceRef", { timeout: 30_000 }, async () => {
+    const orgId = randomUUID();
+    const agentId = randomUUID();
+    const skillId = randomUUID();
+    const skillKey = "acme/skills/pinned-legacy";
+    await db.insert(organizations).values({
+      id: orgId,
+      name: "Pinned Legacy Org",
+      urlKey: "pinned-legacy-org",
+      issuePrefix: "PLO",
+      status: "active",
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      orgId,
+      name: "Pinned Migrator",
+      workspaceKey: "pinned-migrator",
+      role: "engineer",
+      status: "idle",
+      agentRuntimeType: "codex_local",
+      agentRuntimeConfig: {},
+    });
+    await db.insert(organizationSkills).values({
+      id: skillId,
+      orgId,
+      key: skillKey,
+      slug: "pinned-legacy",
+      name: "Pinned Legacy",
+      description: "Pinned legacy row.",
+      markdown: "---\nname: Pinned Legacy\n---\n",
+      sourceType: "github",
+      sourceLocator: "https://github.com/acme/skills/tree/main/skills/pinned-legacy",
+      sourceRef: PINNED_REF,
+      trustLevel: "markdown_only",
+      compatibility: "compatible",
+      fileInventory: [{ path: "SKILL.md", kind: "skill" }],
+      metadata: {
+        sourceKind: "github",
+        owner: "acme",
+        repo: "skills",
+        ref: PINNED_REF,
+        trackingRef: "main",
+        repoSkillDir: "skills/pinned-legacy",
+      },
+    });
+
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.includes("/commits/main")) {
+        return new Response(JSON.stringify({ sha: UPDATED_REF }));
+      }
+      if (url.includes("/git/trees/")) {
+        return new Response(JSON.stringify({
+          tree: [{ path: "skills/pinned-legacy/SKILL.md", type: "blob" }],
+        }));
+      }
+      if (url.endsWith("/SKILL.md")) {
+        return new Response("---\nname: Pinned Legacy\n---\n\n# Pinned bytes\n");
+      }
+      return new Response("not found", { status: 404 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const skillSvc = organizationSkillService(db, { deploymentMode: "local_trusted" });
+    await skillSvc.listRealizedSkillEntriesForAgent(
+      orgId,
+      agentId,
+      "codex_local",
+      {},
+      [`org:${skillKey}`],
+    );
+
+    expect(fetchMock.mock.calls.some(([input]) =>
+      String(input).includes(`/git/trees/${PINNED_REF}`))).toBe(true);
+    expect(fetchMock.mock.calls.some(([input]) =>
+      String(input).includes(`/git/trees/${UPDATED_REF}`))).toBe(false);
+    const stored = await db
+      .select()
+      .from(organizationSkills)
+      .where(eq(organizationSkills.id, skillId))
+      .then((rows) => rows[0]!);
+    expect(stored.sourceRef).toBe(PINNED_REF);
+    expect(stored.metadata).toMatchObject({
+      ref: PINNED_REF,
+      installationVersion: 1,
+    });
   });
 });

--- a/server/src/__tests__/organization-skills-reference.test.ts
+++ b/server/src/__tests__/organization-skills-reference.test.ts
@@ -217,7 +217,7 @@ describe("organization skill references", () => {
     expect(skills.find((skill) => skill.slug === "deep-research")).toMatchObject({
       sourceBadge: "community",
       sourceLabel: "Community preset",
-      editable: false,
+      editable: true,
     });
 
     const skillCreator = skills.find((skill) => skill.slug === "skill-creator");

--- a/server/src/services/knowledge-portability/organization-skills.catalog.ts
+++ b/server/src/services/knowledge-portability/organization-skills.catalog.ts
@@ -49,6 +49,7 @@ export type ImportedSkill = {
   trustLevel: OrganizationSkillTrustLevel;
   compatibility: OrganizationSkillCompatibility;
   fileInventory: OrganizationSkillFileInventoryEntry[];
+  files?: Record<string, string | Uint8Array>;
   metadata: Record<string, unknown> | null;
 };
 
@@ -83,6 +84,7 @@ export type SkillSourceMeta = {
   workspaceId?: string;
   workspaceName?: string;
   workspaceCwd?: string;
+  installationVersion?: number;
 };
 
 export type LocalSkillInventoryMode = "full" | "project_root";
@@ -1094,6 +1096,18 @@ export function mergeRequiredBundledSkillKeys(
 }
 
 export function normalizeSkillDirectory(skill: OrganizationSkill) {
+  const metadata = getSkillMeta(skill);
+  if (
+    metadata.installationVersion === 1
+    && !isBundledRudderSourceKind(asString(metadata.sourceKind))
+  ) {
+    return path.resolve(
+      resolveManagedSkillsRoot(skill.orgId),
+      "__installed__",
+      buildSkillRuntimeName(skill.key, skill.slug),
+    );
+  }
+  if (asString(metadata.sourceKind) === "community_preset") return null;
   if ((skill.sourceType !== "local_path" && skill.sourceType !== "catalog") || !skill.sourceLocator) return null;
   const resolved = path.resolve(skill.sourceLocator);
   if (path.basename(resolved).toLowerCase() === "skill.md") {
@@ -1202,11 +1216,11 @@ export function deriveSkillSourceInfo(skill: OrganizationSkill): {
 
   if (asString(metadata.sourceKind) === "community_preset") {
     return {
-      editable: false,
-      editableReason: "Community preset skills are read-only.",
+      editable: true,
+      editableReason: null,
       sourceLabel: "Community preset",
       sourceBadge: "community",
-      sourcePath: null,
+      sourcePath: localSkillDir,
     };
   }
 
@@ -1214,11 +1228,11 @@ export function deriveSkillSourceInfo(skill: OrganizationSkill): {
     const owner = asString(metadata.owner) ?? null;
     const repo = asString(metadata.repo) ?? null;
     return {
-      editable: false,
-      editableReason: "Skills.sh-managed skills are read-only.",
+      editable: true,
+      editableReason: null,
       sourceLabel: skill.sourceLocator ?? (owner && repo ? `${owner}/${repo}` : null),
       sourceBadge: "skills_sh",
-      sourcePath: null,
+      sourcePath: localSkillDir,
     };
   }
 
@@ -1226,21 +1240,21 @@ export function deriveSkillSourceInfo(skill: OrganizationSkill): {
     const owner = asString(metadata.owner) ?? null;
     const repo = asString(metadata.repo) ?? null;
     return {
-      editable: false,
-      editableReason: "Remote GitHub skills are read-only. Fork or import locally to edit them.",
+      editable: true,
+      editableReason: null,
       sourceLabel: owner && repo ? `${owner}/${repo}` : skill.sourceLocator,
       sourceBadge: "github",
-      sourcePath: null,
+      sourcePath: localSkillDir,
     };
   }
 
   if (skill.sourceType === "url") {
     return {
-      editable: false,
-      editableReason: "URL-based skills are read-only. Save them locally to edit them.",
+      editable: true,
+      editableReason: null,
       sourceLabel: skill.sourceLocator,
       sourceBadge: "url",
-      sourcePath: null,
+      sourcePath: localSkillDir,
     };
   }
 
@@ -1272,11 +1286,11 @@ export function deriveSkillSourceInfo(skill: OrganizationSkill): {
   }
 
   return {
-    editable: false,
-    editableReason: "This skill source is read-only.",
+    editable: true,
+    editableReason: null,
     sourceLabel: skill.sourceLocator,
     sourceBadge: "catalog",
-    sourcePath: null,
+    sourcePath: localSkillDir,
   };
 }
 

--- a/server/src/services/knowledge-portability/organization-skills.sources.ts
+++ b/server/src/services/knowledge-portability/organization-skills.sources.ts
@@ -204,6 +204,35 @@ export async function fetchText(url: string) {
   return response.text();
 }
 
+export async function fetchBytes(url: string) {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw unprocessable(`Failed to fetch ${url}: ${response.status}`);
+  }
+  return new Uint8Array(await response.arrayBuffer());
+}
+
+async function mapWithConcurrency<T, R>(
+  values: T[],
+  concurrency: number,
+  operation: (value: T, index: number) => Promise<R>,
+) {
+  const out = new Array<R>(values.length);
+  let nextIndex = 0;
+  const workers = Array.from(
+    { length: Math.min(Math.max(1, concurrency), values.length) },
+    async () => {
+      while (nextIndex < values.length) {
+        const index = nextIndex;
+        nextIndex += 1;
+        out[index] = await operation(values[index]!, index);
+      }
+    },
+  );
+  await Promise.all(workers);
+  return out;
+}
+
 export async function fetchJson<T>(url: string): Promise<T> {
   const response = await fetch(url, {
     headers: {
@@ -751,7 +780,8 @@ export async function readUrlSkillImports(
       const repoSkillPath = basePrefix ? `${basePrefix}${relativeSkillPath}` : relativeSkillPath;
       const markdown = await fetchText(resolveRawGitHubUrl(parsed.owner, parsed.repo, ref, repoSkillPath));
       const parsedMarkdown = parseFrontmatterMarkdown(markdown);
-      const skillDir = path.posix.dirname(relativeSkillPath);
+      const rawSkillDir = path.posix.dirname(relativeSkillPath);
+      const skillDir = rawSkillDir === "." ? "" : rawSkillDir;
       const slug = deriveImportedSkillSlug(parsedMarkdown.frontmatter, path.posix.basename(skillDir));
       const skillKey = readCanonicalSkillKey(
         parsedMarkdown.frontmatter,
@@ -773,12 +803,37 @@ export async function readUrlSkillImports(
         ),
       };
       const inventory = filteredPaths
-        .filter((entry) => entry === relativeSkillPath || entry.startsWith(`${skillDir}/`))
-        .map((entry) => ({
-          path: entry === relativeSkillPath ? "SKILL.md" : entry.slice(skillDir.length + 1),
-          kind: classifyInventoryKind(entry === relativeSkillPath ? "SKILL.md" : entry.slice(skillDir.length + 1)),
-        }))
+        .filter((entry) =>
+          entry === relativeSkillPath
+          || (skillDir ? entry.startsWith(`${skillDir}/`) : true))
+        .map((entry) => {
+          const relativePath = entry === relativeSkillPath
+            ? "SKILL.md"
+            : skillDir
+              ? entry.slice(skillDir.length + 1)
+              : entry;
+          return {
+            path: relativePath,
+            kind: classifyInventoryKind(relativePath),
+          };
+        })
         .sort((left, right) => left.path.localeCompare(right.path));
+      const repoSkillDir = normalizeGitHubSkillDirectory(
+        basePrefix ? `${basePrefix}${skillDir}` : skillDir,
+        slug,
+      );
+      const downloadedFiles = await mapWithConcurrency(
+        inventory,
+        8,
+        async (entry) => {
+          if (entry.path === "SKILL.md") return [entry.path, markdown] as const;
+          const repoPath = normalizePortablePath(path.posix.join(repoSkillDir, entry.path));
+          return [
+            entry.path,
+            await fetchBytes(resolveRawGitHubUrl(parsed.owner, parsed.repo, ref, repoPath)),
+          ] as const;
+        },
+      );
       skills.push({
         key: deriveCanonicalSkillKey(orgId, {
           slug,
@@ -796,6 +851,7 @@ export async function readUrlSkillImports(
         trustLevel: deriveTrustLevel(inventory),
         compatibility: "compatible",
         fileInventory: inventory,
+        files: Object.fromEntries(downloadedFiles),
         metadata,
       });
     }
@@ -842,6 +898,7 @@ export async function readUrlSkillImports(
         trustLevel: deriveTrustLevel(inventory),
         compatibility: "compatible",
         fileInventory: inventory,
+        files: { "SKILL.md": markdown },
         metadata,
       }],
       warnings,

--- a/server/src/services/knowledge-portability/organization-skills.sources.ts
+++ b/server/src/services/knowledge-portability/organization-skills.sources.ts
@@ -764,11 +764,14 @@ export async function readUrlSkillImports(
       ? allPaths.filter((entry) => entry.startsWith(basePrefix))
       : allPaths;
     const relativePaths = scopedPaths.map((entry) => basePrefix ? entry.slice(basePrefix.length) : entry);
-    const filteredPaths = parsed.filePath
-      ? relativePaths.filter((entry) => entry === path.posix.relative(parsed.basePath || ".", parsed.filePath!))
-      : relativePaths;
+    const selectedFilePath = parsed.filePath
+      ? path.posix.relative(parsed.basePath || ".", parsed.filePath)
+      : null;
+    const filteredPaths = relativePaths;
     const skillPaths = filteredPaths.filter(
-      (entry) => path.posix.basename(entry).toLowerCase() === "skill.md",
+      (entry) =>
+        path.posix.basename(entry).toLowerCase() === "skill.md"
+        && (!selectedFilePath || entry === selectedFilePath),
     );
     if (skillPaths.length === 0) {
       throw unprocessable(

--- a/server/src/services/knowledge-portability/organization-skills.ts
+++ b/server/src/services/knowledge-portability/organization-skills.ts
@@ -342,6 +342,20 @@ export function organizationSkillService(
   async function installAndUpsertImportedSkills(orgId: string, skills: ImportedSkill[]) {
     const out: OrganizationSkill[] = [];
     for (const skill of skills) {
+      const existing = await getByKey(orgId, skill.key);
+      if (
+        existing
+        && isBundledRudderSourceKind(asString(getSkillMeta(existing).sourceKind))
+      ) {
+        out.push(existing);
+        continue;
+      }
+      if (skill.sourceType === "local_path") {
+        const [persisted] = await upsertImportedSkills(orgId, [skill]);
+        if (!persisted) throw notFound("Failed to persist organization skill");
+        out.push(persisted);
+        continue;
+      }
       out.push(await installImportedSkill(
         orgId,
         skill,
@@ -1512,6 +1526,8 @@ export function organizationSkillService(
             ...(imported.metadata ?? {}),
             sourceKind: asString(skill.metadata?.sourceKind)
               ?? asString(imported.metadata?.sourceKind),
+            trackingRef: asString(skill.metadata?.trackingRef)
+              ?? asString(imported.metadata?.trackingRef),
           },
         },
         async (installed) => {
@@ -1721,23 +1737,17 @@ export function organizationSkillService(
     for (const skill of imported) {
       const existing = await getByKey(orgId, skill.key);
       const existingMeta = existing ? getSkillMeta(existing) : {};
-      const incomingMeta = skill.metadata && isPlainRecord(skill.metadata) ? skill.metadata : {};
-      const incomingOwner = asString(incomingMeta.owner);
-      const incomingRepo = asString(incomingMeta.repo);
-      const incomingKind = asString(incomingMeta.sourceKind);
       if (
         existing
         && isBundledRudderSourceKind(asString(existingMeta.sourceKind))
-        && incomingKind === "github"
-        && incomingOwner === "rudder"
-        && incomingRepo === "rudder"
       ) {
         out.push(existing);
         continue;
       }
 
       const metadata = {
-        ...(existingMeta.installationVersion === ORGANIZATION_SKILL_INSTALLATION_VERSION
+        ...(skill.sourceType !== "local_path"
+          && existingMeta.installationVersion === ORGANIZATION_SKILL_INSTALLATION_VERSION
           ? { installationVersion: ORGANIZATION_SKILL_INSTALLATION_VERSION }
           : {}),
         ...(skill.metadata ?? {}),
@@ -1825,6 +1835,9 @@ export function organizationSkillService(
     if (!row) return null;
 
     const skill = toCompanySkill(row);
+    if (isBundledRudderSourceKind(asString(getSkillMeta(skill).sourceKind))) {
+      throw unprocessable("Bundled Rudder skills are read-only.");
+    }
 
     await enabledSkills.removeSkillKeys(orgId, [skill.key]);
 

--- a/server/src/services/knowledge-portability/organization-skills.ts
+++ b/server/src/services/knowledge-portability/organization-skills.ts
@@ -23,6 +23,7 @@ import {
   toBundledRudderSkillKey,
 } from "@rudderhq/shared";
 import { and, asc, eq } from "drizzle-orm";
+import { randomUUID } from "node:crypto";
 import { promises as fs } from "node:fs";
 import path from "node:path";
 import { conflict, notFound, unprocessable } from "../../errors.js";
@@ -77,7 +78,6 @@ import {
   listLegacyUserHomeLocalScanSkillIds,
   listStaleBundledSkillIds,
   listStaleCommunityPresetSkillIds,
-  normalizeGitHubSkillDirectory,
   normalizePackageFileMap,
   normalizePortablePath,
   normalizeSelectionRef,
@@ -103,7 +103,6 @@ import {
 } from "./organization-skills.catalog.js";
 import { createOrganizationSkillScanHandlers } from "./organization-skills.scans.js";
 import {
-  fetchText,
   parseFrontmatterMarkdown,
   parseSkillImportSourceInput,
   readCommunityPresetFallbackImport,
@@ -114,8 +113,10 @@ import {
   resolveBundledSkillsRoot,
   resolveCommunityPresetSkillsRoot,
   resolveGitHubCommitSha,
-  resolveRawGitHubUrl,
 } from "./organization-skills.sources.js";
+
+const ORGANIZATION_SKILL_INSTALLATION_VERSION = 1;
+const skillInstallationPromises = new Map<string, Promise<string>>();
 
 export function organizationSkillService(
   db: Db,
@@ -134,6 +135,159 @@ export function organizationSkillService(
     projects,
     upsertImportedSkills,
   });
+
+  function normalizeInstalledFilePath(relativePath: string) {
+    const portable = relativePath.replace(/\\/g, "/");
+    if (
+      portable.startsWith("/")
+      || /^[A-Za-z]:\//.test(portable)
+      || portable.split("/").some((segment) => segment === "..")
+    ) {
+      throw unprocessable(`Invalid skill file path: ${relativePath}`);
+    }
+    const normalized = normalizePortablePath(portable);
+    if (!normalized) {
+      throw unprocessable(`Invalid skill file path: ${relativePath}`);
+    }
+    return normalized;
+  }
+
+  function resolveInstalledSkillDirectory(orgId: string, key: string, slug: string) {
+    const managedRoot = path.resolve(resolveManagedSkillsRoot(orgId));
+    const installedRoot = path.resolve(managedRoot, "__installed__");
+    const target = path.resolve(installedRoot, buildSkillRuntimeName(key, slug));
+    const relative = path.relative(installedRoot, target);
+    if (!relative || relative.startsWith("..") || path.isAbsolute(relative)) {
+      throw unprocessable("Invalid organization skill installation path.");
+    }
+    return target;
+  }
+
+  async function removeInstalledSkillDirectory(orgId: string, skill: OrganizationSkill) {
+    if (getSkillMeta(skill).installationVersion !== ORGANIZATION_SKILL_INSTALLATION_VERSION) return;
+    await fs.rm(
+      resolveInstalledSkillDirectory(orgId, skill.key, skill.slug),
+      { recursive: true, force: true },
+    );
+  }
+
+  async function mapWithConcurrency<T>(
+    values: T[],
+    concurrency: number,
+    operation: (value: T) => Promise<void>,
+  ) {
+    let nextIndex = 0;
+    const workers = Array.from(
+      { length: Math.min(Math.max(1, concurrency), values.length) },
+      async () => {
+        while (nextIndex < values.length) {
+          const index = nextIndex;
+          nextIndex += 1;
+          await operation(values[index]!);
+        }
+      },
+    );
+    await Promise.all(workers);
+  }
+
+  async function readImportedSkillFiles(skill: ImportedSkill) {
+    const files = new Map<string, string | Uint8Array>();
+    for (const [rawPath, content] of Object.entries(skill.files ?? {})) {
+      files.set(normalizeInstalledFilePath(rawPath), content);
+    }
+    if (skill.packageDir) {
+      await mapWithConcurrency(skill.fileInventory, 8, async (entry) => {
+        const relativePath = normalizeInstalledFilePath(entry.path);
+        if (files.has(relativePath)) return;
+        files.set(
+          relativePath,
+          await fs.readFile(path.resolve(skill.packageDir!, relativePath)),
+        );
+      });
+    }
+    for (const entry of skill.fileInventory) {
+      const relativePath = normalizeInstalledFilePath(entry.path);
+      if (!files.has(relativePath)) {
+        throw unprocessable(`Skill source did not provide declared file: ${relativePath}`);
+      }
+    }
+    return files;
+  }
+
+  async function replaceInstalledSkillDirectory(
+    orgId: string,
+    skill: Pick<ImportedSkill, "key" | "slug" | "fileInventory">,
+    files: Map<string, string | Uint8Array>,
+  ) {
+    const target = resolveInstalledSkillDirectory(orgId, skill.key, skill.slug);
+    const parent = path.dirname(target);
+    const staging = path.join(parent, `.${path.basename(target)}.staging-${randomUUID()}`);
+    const backup = path.join(parent, `.${path.basename(target)}.backup-${randomUUID()}`);
+    let movedExisting = false;
+
+    await fs.mkdir(staging, { recursive: true });
+    try {
+      await mapWithConcurrency(skill.fileInventory, 8, async (entry) => {
+        const relativePath = normalizeInstalledFilePath(entry.path);
+        const targetPath = path.resolve(staging, relativePath);
+        const relativeTarget = path.relative(staging, targetPath);
+        if (relativeTarget.startsWith("..") || path.isAbsolute(relativeTarget)) {
+          throw unprocessable(`Invalid skill file path: ${entry.path}`);
+        }
+        const content = files.get(relativePath);
+        if (content === undefined) {
+          throw unprocessable(`Skill source did not provide declared file: ${relativePath}`);
+        }
+        await fs.mkdir(path.dirname(targetPath), { recursive: true });
+        await fs.writeFile(targetPath, content);
+      });
+      const skillFile = await fs.stat(path.join(staging, "SKILL.md")).catch(() => null);
+      if (!skillFile?.isFile()) {
+        throw unprocessable("Installed skill is missing SKILL.md.");
+      }
+
+      await fs.mkdir(parent, { recursive: true });
+      const existing = await fs.stat(target).catch(() => null);
+      if (existing) {
+        await fs.rename(target, backup);
+        movedExisting = true;
+      }
+      try {
+        await fs.rename(staging, target);
+      } catch (error) {
+        if (movedExisting) {
+          try {
+            await fs.rename(backup, target);
+            movedExisting = false;
+          } catch {
+            // Preserve the backup for operator recovery if the rollback rename fails.
+          }
+        }
+        throw error;
+      }
+      if (movedExisting) {
+        await fs.rm(backup, { recursive: true, force: true }).catch(() => {});
+        movedExisting = false;
+      }
+      return target;
+    } finally {
+      await fs.rm(staging, { recursive: true, force: true });
+    }
+  }
+
+  async function installImportedSkill(orgId: string, skill: ImportedSkill) {
+    const sourceKind = asString(skill.metadata?.sourceKind);
+    if (isBundledRudderSourceKind(sourceKind)) return skill;
+    const files = await readImportedSkillFiles(skill);
+    await replaceInstalledSkillDirectory(orgId, skill, files);
+    return {
+      ...skill,
+      metadata: {
+        ...(skill.metadata ?? {}),
+        installationVersion: ORGANIZATION_SKILL_INSTALLATION_VERSION,
+      },
+    };
+  }
 
   async function getAgentWorkspaceRow(orgId: string, agentId: string): Promise<AgentWorkspaceRow> {
     const row = await db
@@ -304,7 +458,9 @@ export function organizationSkillService(
     const toPersist = presetSkills.filter((skill) => {
       const existing = existingByKey.get(skill.key);
       if (!existing) return true;
-      return asString((existing.metadata as Record<string, unknown> | null | undefined)?.sourceKind) === "community_preset";
+      const existingMetadata = isPlainRecord(existing.metadata) ? existing.metadata : {};
+      return asString(existingMetadata.sourceKind) === "community_preset"
+        && existingMetadata.installationVersion !== ORGANIZATION_SKILL_INSTALLATION_VERSION;
     });
     const persisted = toPersist.length > 0 ? await upsertImportedSkills(orgId, toPersist) : [];
     const stalePresetIds = listStaleCommunityPresetSkillIds(existingRows, currentCommunityPresetKeys);
@@ -335,7 +491,7 @@ export function organizationSkillService(
       await db
         .delete(organizationSkills)
         .where(eq(organizationSkills.id, skill.id));
-      await fs.rm(resolveRuntimeSkillMaterializedPath(orgId, skill), { recursive: true, force: true });
+      await removeInstalledSkillDirectory(orgId, skill);
     }
   }
 
@@ -358,7 +514,7 @@ export function organizationSkillService(
       await db
         .delete(organizationSkills)
         .where(eq(organizationSkills.id, skill.id));
-      await fs.rm(resolveRuntimeSkillMaterializedPath(orgId, skill), { recursive: true, force: true });
+      await removeInstalledSkillDirectory(orgId, skill);
     }
   }
 
@@ -817,10 +973,16 @@ export function organizationSkillService(
         const skill = skillByKey.get(entry.organizationSkillKey);
         if (!skill) continue;
         let source = normalizeSkillDirectory(skill);
+        if (
+          source
+          && !(await fs.stat(path.join(source, "SKILL.md")).catch(() => null))?.isFile()
+        ) {
+          source = null;
+        }
         if (!source) {
           source = options.materializeMissing === false
-            ? resolveRuntimeSkillMaterializedPath(orgId, skill)
-            : await materializeRuntimeSkillFiles(orgId, skill).catch(() => null);
+            ? null
+            : await ensureInstalledSkill(orgId, skill).catch(() => null);
         }
         if (!source) continue;
         out.push({
@@ -968,8 +1130,9 @@ export function organizationSkillService(
 
     const source = deriveSkillSourceInfo(skill);
     let content = "";
+    const localSkillDirectory = normalizeSkillDirectory(skill);
 
-    if (skill.sourceType === "local_path" || skill.sourceType === "catalog") {
+    if (localSkillDirectory) {
       const absolutePath = resolveLocalSkillFilePath(skill, normalizedPath);
       if (absolutePath) {
         content = await fs.readFile(absolutePath, "utf8");
@@ -978,24 +1141,10 @@ export function organizationSkillService(
       } else {
         throw notFound("Skill file not found");
       }
-    } else if (skill.sourceType === "github" || skill.sourceType === "skills_sh") {
-      const metadata = getSkillMeta(skill);
-      const owner = asString(metadata.owner);
-      const repo = asString(metadata.repo);
-      const ref = skill.sourceRef ?? asString(metadata.ref) ?? "main";
-      const repoSkillDir = normalizeGitHubSkillDirectory(asString(metadata.repoSkillDir), skill.slug);
-      if (!owner || !repo) {
-        throw unprocessable("Skill source metadata is incomplete.");
-      }
-      const repoPath = normalizePortablePath(path.posix.join(repoSkillDir, normalizedPath));
-      content = await fetchText(resolveRawGitHubUrl(owner, repo, ref, repoPath));
-    } else if (skill.sourceType === "url") {
-      if (normalizedPath !== "SKILL.md") {
-        throw notFound("This skill source only exposes SKILL.md");
-      }
+    } else if (normalizedPath === "SKILL.md") {
       content = skill.markdown;
     } else {
-      throw unprocessable("Unsupported skill source.");
+      throw notFound("Skill file is not installed yet.");
     }
 
     return {
@@ -1076,13 +1225,16 @@ export function organizationSkillService(
 
   async function updateFile(orgId: string, skillId: string, relativePath: string, content: string): Promise<OrganizationSkillFileDetail> {
     await ensureSkillInventoryCurrent(orgId);
-    const skill = await getById(skillId);
+    let skill = await getById(skillId);
     if (!skill || skill.orgId !== orgId) throw notFound("Skill not found");
 
     const source = deriveSkillSourceInfo(skill);
-    if (!source.editable || skill.sourceType !== "local_path") {
+    if (!source.editable) {
       throw unprocessable(source.editableReason ?? "This skill cannot be edited.");
     }
+    await ensureInstalledSkill(orgId, skill);
+    skill = await getById(skillId);
+    if (!skill || skill.orgId !== orgId) throw notFound("Skill not found");
 
     const normalizedPath = normalizePortablePath(relativePath);
     const absolutePath = resolveLocalSkillFilePath(skill, normalizedPath);
@@ -1166,56 +1318,131 @@ export function organizationSkillService(
       throw unprocessable(`Skill ${skill.key} could not be re-imported from its source.`);
     }
 
-    const imported = await upsertImportedSkills(orgId, [matching]);
+    const installed = await installImportedSkill(orgId, {
+      ...matching,
+      key: skill.key,
+      slug: skill.slug,
+      sourceType: skill.sourceType,
+      sourceLocator: skill.sourceLocator,
+      metadata: {
+        ...(matching.metadata ?? {}),
+        ...(skill.metadata ?? {}),
+      },
+    });
+    const imported = await upsertImportedSkills(orgId, [installed]);
     return imported[0] ?? null;
   }
 
-  async function materializeCatalogSkillFiles(
-    orgId: string,
-    skill: ImportedSkill,
-    normalizedFiles: Record<string, string>,
-  ) {
-    const packageDir = skill.packageDir ? normalizePortablePath(skill.packageDir) : null;
-    if (!packageDir) return null;
-    const catalogRoot = path.resolve(resolveManagedSkillsRoot(orgId), "__catalog__");
-    const skillDir = path.resolve(catalogRoot, buildSkillRuntimeName(skill.key, skill.slug));
-    await fs.rm(skillDir, { recursive: true, force: true });
-    await fs.mkdir(skillDir, { recursive: true });
-
-    for (const entry of skill.fileInventory) {
-      const sourcePath = entry.path === "SKILL.md"
-        ? `${packageDir}/SKILL.md`
-        : `${packageDir}/${entry.path}`;
-      const content = normalizedFiles[sourcePath];
-      if (typeof content !== "string") continue;
-      const targetPath = path.resolve(skillDir, entry.path);
-      await fs.mkdir(path.dirname(targetPath), { recursive: true });
-      await fs.writeFile(targetPath, content, "utf8");
+  async function ensureInstalledSkill(orgId: string, skill: OrganizationSkill) {
+    const existingDirectory = normalizeSkillDirectory(skill);
+    if (
+      existingDirectory
+      && (await fs.stat(path.join(existingDirectory, "SKILL.md")).catch(() => null))?.isFile()
+    ) {
+      return existingDirectory;
+    }
+    if (isBundledRudderSourceKind(asString(skill.metadata?.sourceKind))) {
+      throw unprocessable("Bundled Rudder skill files are unavailable.");
     }
 
-    return skillDir;
-  }
+    const lockKey = `${orgId}:${skill.id}`;
+    const existingInstall = skillInstallationPromises.get(lockKey);
+    if (existingInstall) return existingInstall;
 
-  async function materializeRuntimeSkillFiles(orgId: string, skill: OrganizationSkill) {
-    const runtimeRoot = path.resolve(resolveManagedSkillsRoot(orgId), "__runtime__");
-    const skillDir = path.resolve(runtimeRoot, buildSkillRuntimeName(skill.key, skill.slug));
-    await fs.rm(skillDir, { recursive: true, force: true });
-    await fs.mkdir(skillDir, { recursive: true });
+    const installation = (async () => {
+      const target = resolveInstalledSkillDirectory(orgId, skill.key, skill.slug);
+      if ((await fs.stat(path.join(target, "SKILL.md")).catch(() => null))?.isFile()) {
+        if (getSkillMeta(skill).installationVersion !== ORGANIZATION_SKILL_INSTALLATION_VERSION) {
+          await db
+            .update(organizationSkills)
+            .set({
+              metadata: {
+                ...(skill.metadata ?? {}),
+                installationVersion: ORGANIZATION_SKILL_INSTALLATION_VERSION,
+              },
+              updatedAt: new Date(),
+            })
+            .where(eq(organizationSkills.id, skill.id));
+        }
+        return target;
+      }
 
-    for (const entry of skill.fileInventory) {
-      const detail = await readFile(orgId, skill.id, entry.path).catch(() => null);
-      if (!detail) continue;
-      const targetPath = path.resolve(skillDir, entry.path);
-      await fs.mkdir(path.dirname(targetPath), { recursive: true });
-      await fs.writeFile(targetPath, detail.content, "utf8");
+      let imported: ImportedSkill | null = null;
+      if (
+        skill.sourceType === "github"
+        || skill.sourceType === "skills_sh"
+        || skill.sourceType === "url"
+      ) {
+        if (!skill.sourceLocator) {
+          throw unprocessable("Skill source locator is missing.");
+        }
+        const parsed = parseSkillImportSourceInput(skill.sourceLocator);
+        const result = await readUrlSkillImports(
+          orgId,
+          parsed.resolvedSource,
+          parsed.requestedSkillSlug ?? skill.slug,
+        );
+        imported = result.skills.find((entry) => entry.key === skill.key)
+          ?? result.skills.find((entry) => entry.slug === skill.slug)
+          ?? result.skills[0]
+          ?? null;
+      } else if (
+        (skill.sourceType === "local_path" || skill.sourceType === "catalog")
+        && skill.sourceLocator
+      ) {
+        const sourceDirectory = path.basename(skill.sourceLocator).toLowerCase() === "skill.md"
+          ? path.dirname(skill.sourceLocator)
+          : skill.sourceLocator;
+        imported = {
+          key: skill.key,
+          slug: skill.slug,
+          name: skill.name,
+          description: skill.description,
+          markdown: skill.markdown,
+          packageDir: path.resolve(sourceDirectory),
+          sourceType: skill.sourceType,
+          sourceLocator: skill.sourceLocator,
+          sourceRef: skill.sourceRef,
+          trustLevel: skill.trustLevel,
+          compatibility: skill.compatibility,
+          fileInventory: skill.fileInventory,
+          metadata: skill.metadata ?? {},
+        };
+      }
+      if (!imported) {
+        throw unprocessable(`Skill ${skill.key} could not be installed from its source.`);
+      }
+
+      const installed = await installImportedSkill(orgId, {
+        ...imported,
+        key: skill.key,
+        slug: skill.slug,
+        sourceType: skill.sourceType,
+        sourceLocator: skill.sourceLocator,
+        sourceRef: skill.sourceRef,
+        metadata: {
+          ...(imported.metadata ?? {}),
+          ...(skill.metadata ?? {}),
+        },
+      });
+      await db
+        .update(organizationSkills)
+        .set({
+          metadata: installed.metadata,
+          updatedAt: new Date(),
+        })
+        .where(eq(organizationSkills.id, skill.id));
+      return resolveInstalledSkillDirectory(orgId, skill.key, skill.slug);
+    })();
+
+    skillInstallationPromises.set(lockKey, installation);
+    try {
+      return await installation;
+    } finally {
+      if (skillInstallationPromises.get(lockKey) === installation) {
+        skillInstallationPromises.delete(lockKey);
+      }
     }
-
-    return skillDir;
-  }
-
-  function resolveRuntimeSkillMaterializedPath(orgId: string, skill: OrganizationSkill) {
-    const runtimeRoot = path.resolve(resolveManagedSkillsRoot(orgId), "__runtime__");
-    return path.resolve(runtimeRoot, buildSkillRuntimeName(skill.key, skill.slug));
   }
 
   async function listRuntimeSkillEntries(
@@ -1233,10 +1460,16 @@ export function organizationSkillService(
         continue;
       }
       let source = normalizeSkillDirectory(skill);
+      if (
+        source
+        && !(await fs.stat(path.join(source, "SKILL.md")).catch(() => null))?.isFile()
+      ) {
+        source = null;
+      }
       if (!source) {
         source = options.materializeMissing === false
-          ? resolveRuntimeSkillMaterializedPath(orgId, skill)
-          : await materializeRuntimeSkillFiles(orgId, skill).catch(() => null);
+          ? null
+          : await ensureInstalledSkill(orgId, skill).catch(() => null);
       }
       if (!source) continue;
 
@@ -1266,11 +1499,21 @@ export function organizationSkillService(
     if (importedSkills.length === 0) return [];
 
     for (const skill of importedSkills) {
-      if (skill.sourceType !== "catalog") continue;
-      const materializedDir = await materializeCatalogSkillFiles(orgId, skill, normalizedFiles);
-      if (materializedDir) {
-        skill.sourceLocator = materializedDir;
+      const packageDir = skill.packageDir ? normalizePortablePath(skill.packageDir) : null;
+      if (!packageDir) continue;
+      const packageFiles: Record<string, string> = {};
+      for (const entry of skill.fileInventory) {
+        const sourcePath = entry.path === "SKILL.md"
+          ? `${packageDir}/SKILL.md`
+          : `${packageDir}/${entry.path}`;
+        const content = normalizedFiles[sourcePath];
+        if (typeof content !== "string") {
+          throw unprocessable(`Skill package did not provide declared file: ${sourcePath}`);
+        }
+        packageFiles[entry.path] = content;
       }
+      skill.files = packageFiles;
+      skill.packageDir = null;
     }
 
     const conflictStrategy = options?.onConflict ?? "replace";
@@ -1356,7 +1599,10 @@ export function organizationSkillService(
 
     if (toPersist.length === 0) return out;
 
-    const persisted = await upsertImportedSkills(orgId, toPersist);
+    const installedSkills = await Promise.all(
+      toPersist.map((skill) => installImportedSkill(orgId, skill)),
+    );
+    const persisted = await upsertImportedSkills(orgId, installedSkills);
     for (let index = 0; index < prepared.length; index += 1) {
       const persistedSkill = persisted[index];
       const preparedSkill = prepared[index];
@@ -1395,6 +1641,9 @@ export function organizationSkillService(
       }
 
       const metadata = {
+        ...(existingMeta.installationVersion === ORGANIZATION_SKILL_INSTALLATION_VERSION
+          ? { installationVersion: ORGANIZATION_SKILL_INSTALLATION_VERSION }
+          : {}),
         ...(skill.metadata ?? {}),
         skillKey: skill.key,
       };
@@ -1467,7 +1716,10 @@ export function organizationSkillService(
         skill.key = deriveCanonicalSkillKey(orgId, skill);
       }
     }
-    const imported = await upsertImportedSkills(orgId, filteredSkills);
+    const installedSkills = await Promise.all(
+      filteredSkills.map((skill) => installImportedSkill(orgId, skill)),
+    );
+    const imported = await upsertImportedSkills(orgId, installedSkills);
     return { imported, warnings };
   }
 
@@ -1487,7 +1739,7 @@ export function organizationSkillService(
       .delete(organizationSkills)
       .where(eq(organizationSkills.id, skillId));
 
-    await fs.rm(resolveRuntimeSkillMaterializedPath(orgId, skill), { recursive: true, force: true });
+    await removeInstalledSkillDirectory(orgId, skill);
 
     return skill;
   }

--- a/server/src/services/knowledge-portability/organization-skills.ts
+++ b/server/src/services/knowledge-portability/organization-skills.ts
@@ -322,13 +322,7 @@ export function organizationSkillService(
   ) {
     const sourceKind = asString(skill.metadata?.sourceKind);
     if (isBundledRudderSourceKind(sourceKind)) return persist(skill);
-    const installed = {
-      ...skill,
-      metadata: {
-        ...(skill.metadata ?? {}),
-        installationVersion: ORGANIZATION_SKILL_INSTALLATION_VERSION,
-      },
-    };
+    const installed = markImportedSkillInstalled(skill);
     const files = await readImportedSkillFiles(installed);
     return withSkillMutationLock(orgId, installed.key, () =>
       replaceInstalledSkillDirectory(
@@ -337,6 +331,88 @@ export function organizationSkillService(
         files,
         () => persist(installed),
       ));
+  }
+
+  function markImportedSkillInstalled(skill: ImportedSkill): ImportedSkill {
+    return {
+      ...skill,
+      metadata: {
+        ...(skill.metadata ?? {}),
+        installationVersion: ORGANIZATION_SKILL_INSTALLATION_VERSION,
+      },
+    };
+  }
+
+  function hasUnchangedInstallationSource(
+    current: OrganizationSkill,
+    snapshot: OrganizationSkill,
+  ) {
+    return current.sourceType === snapshot.sourceType
+      && current.sourceLocator === snapshot.sourceLocator
+      && current.sourceRef === snapshot.sourceRef
+      && getSkillMeta(current).installationVersion
+      === getSkillMeta(snapshot).installationVersion
+      && current.updatedAt.getTime() === snapshot.updatedAt.getTime();
+  }
+
+  async function resolveCurrentSkillDirectory(skill: OrganizationSkill) {
+    const directory = normalizeSkillDirectory(skill);
+    if (
+      directory
+      && (await fs.stat(path.join(directory, "SKILL.md")).catch(() => null))?.isFile()
+    ) {
+      return directory;
+    }
+    return null;
+  }
+
+  async function assertDirectLocalSourceIsUnmanaged(orgId: string, skill: ImportedSkill) {
+    const sourcePath = skill.packageDir ?? skill.sourceLocator;
+    if (!sourcePath) throw unprocessable("Local skill source path is missing.");
+    const sourceDirectory = path.basename(sourcePath).toLowerCase() === "skill.md"
+      ? path.dirname(sourcePath)
+      : sourcePath;
+    const managedInstalledRoot = path.resolve(resolveManagedSkillsRoot(orgId), "__installed__");
+    const [resolvedSource, resolvedManagedRoot] = await Promise.all([
+      fs.realpath(path.resolve(sourceDirectory)).catch(() => path.resolve(sourceDirectory)),
+      fs.realpath(managedInstalledRoot).catch(() => managedInstalledRoot),
+    ]);
+    const relative = path.relative(resolvedManagedRoot, resolvedSource);
+    if (!relative || (!relative.startsWith("..") && !path.isAbsolute(relative))) {
+      throw unprocessable(
+        "Managed organization skill installations cannot be imported as direct local sources.",
+      );
+    }
+  }
+
+  async function upsertDirectLocalSkill(
+    orgId: string,
+    skill: ImportedSkill,
+  ): Promise<OrganizationSkill> {
+    return withSkillMutationLock(orgId, skill.key, async () => {
+      await assertDirectLocalSourceIsUnmanaged(orgId, skill);
+      const existing = await getByKey(orgId, skill.key);
+      if (
+        existing
+        && isBundledRudderSourceKind(asString(getSkillMeta(existing).sourceKind))
+      ) {
+        return existing;
+      }
+
+      const [persisted] = await upsertImportedSkills(orgId, [skill]);
+      if (!persisted) throw notFound("Failed to persist organization skill");
+
+      // The database transition must succeed before retiring the managed copy so
+      // a failed local-path upsert leaves the previous installation runnable.
+      if (
+        existing
+        && getSkillMeta(existing).installationVersion
+        === ORGANIZATION_SKILL_INSTALLATION_VERSION
+      ) {
+        await removeInstalledSkillDirectory(orgId, existing);
+      }
+      return persisted;
+    });
   }
 
   async function installAndUpsertImportedSkills(orgId: string, skills: ImportedSkill[]) {
@@ -351,9 +427,7 @@ export function organizationSkillService(
         continue;
       }
       if (skill.sourceType === "local_path") {
-        const [persisted] = await upsertImportedSkills(orgId, [skill]);
-        if (!persisted) throw notFound("Failed to persist organization skill");
-        out.push(persisted);
+        out.push(await upsertDirectLocalSkill(orgId, skill));
         continue;
       }
       out.push(await installImportedSkill(
@@ -1439,19 +1513,31 @@ export function organizationSkillService(
     const installation = (async () => {
       const target = resolveInstalledSkillDirectory(orgId, skill.key, skill.slug);
       if ((await fs.stat(path.join(target, "SKILL.md")).catch(() => null))?.isFile()) {
-        if (getSkillMeta(skill).installationVersion !== ORGANIZATION_SKILL_INSTALLATION_VERSION) {
-          await db
-            .update(organizationSkills)
-            .set({
-              metadata: {
-                ...(skill.metadata ?? {}),
-                installationVersion: ORGANIZATION_SKILL_INSTALLATION_VERSION,
-              },
-              updatedAt: new Date(),
-            })
-            .where(eq(organizationSkills.id, skill.id));
-        }
-        return target;
+        return withSkillMutationLock(orgId, skill.key, async () => {
+          const current = await getById(skill.id);
+          if (!current) throw notFound(`Skill ${skill.key} no longer exists.`);
+          if (!hasUnchangedInstallationSource(current, skill)) {
+            const currentDirectory = await resolveCurrentSkillDirectory(current);
+            if (currentDirectory) return currentDirectory;
+            throw conflict(`Skill ${skill.key} changed while installation was prepared.`);
+          }
+          if (
+            getSkillMeta(current).installationVersion
+            !== ORGANIZATION_SKILL_INSTALLATION_VERSION
+          ) {
+            await db
+              .update(organizationSkills)
+              .set({
+                metadata: {
+                  ...(current.metadata ?? {}),
+                  installationVersion: ORGANIZATION_SKILL_INSTALLATION_VERSION,
+                },
+                updatedAt: new Date(),
+              })
+              .where(eq(organizationSkills.id, current.id));
+          }
+          return target;
+        });
       }
 
       let imported: ImportedSkill | null = null;
@@ -1512,42 +1598,54 @@ export function organizationSkillService(
         throw unprocessable(`Skill ${skill.key} could not be installed from its source.`);
       }
 
-      return installImportedSkill(
-        orgId,
-        {
-          ...imported,
-          key: skill.key,
-          slug: skill.slug,
-          sourceType: skill.sourceType,
-          sourceLocator: skill.sourceLocator,
-          sourceRef: skill.sourceRef ?? imported.sourceRef,
-          metadata: {
-            ...(skill.metadata ?? {}),
-            ...(imported.metadata ?? {}),
-            sourceKind: asString(skill.metadata?.sourceKind)
-              ?? asString(imported.metadata?.sourceKind),
-            trackingRef: asString(skill.metadata?.trackingRef)
-              ?? asString(imported.metadata?.trackingRef),
+      const installed = markImportedSkillInstalled({
+        ...imported,
+        key: skill.key,
+        slug: skill.slug,
+        sourceType: skill.sourceType,
+        sourceLocator: skill.sourceLocator,
+        sourceRef: skill.sourceRef ?? imported.sourceRef,
+        metadata: {
+          ...(skill.metadata ?? {}),
+          ...(imported.metadata ?? {}),
+          sourceKind: asString(skill.metadata?.sourceKind)
+            ?? asString(imported.metadata?.sourceKind),
+          trackingRef: asString(skill.metadata?.trackingRef)
+            ?? asString(imported.metadata?.trackingRef),
+        },
+      });
+      const files = await readImportedSkillFiles(installed);
+      return withSkillMutationLock(orgId, skill.key, async () => {
+        const current = await getById(skill.id);
+        if (!current) throw notFound(`Skill ${skill.key} no longer exists.`);
+        if (!hasUnchangedInstallationSource(current, skill)) {
+          const currentDirectory = await resolveCurrentSkillDirectory(current);
+          if (currentDirectory) return currentDirectory;
+          throw conflict(`Skill ${skill.key} changed while installation was prepared.`);
+        }
+        return replaceInstalledSkillDirectory(
+          orgId,
+          installed,
+          files,
+          async () => {
+            await db
+              .update(organizationSkills)
+              .set({
+                name: installed.name,
+                description: installed.description,
+                markdown: installed.markdown,
+                sourceRef: installed.sourceRef,
+                trustLevel: installed.trustLevel,
+                compatibility: installed.compatibility,
+                fileInventory: serializeFileInventory(installed.fileInventory),
+                metadata: installed.metadata,
+                updatedAt: new Date(),
+              })
+              .where(eq(organizationSkills.id, skill.id));
+            return resolveInstalledSkillDirectory(orgId, skill.key, skill.slug);
           },
-        },
-        async (installed) => {
-          await db
-            .update(organizationSkills)
-            .set({
-              name: installed.name,
-              description: installed.description,
-              markdown: installed.markdown,
-              sourceRef: installed.sourceRef,
-              trustLevel: installed.trustLevel,
-              compatibility: installed.compatibility,
-              fileInventory: serializeFileInventory(installed.fileInventory),
-              metadata: installed.metadata,
-              updatedAt: new Date(),
-            })
-            .where(eq(organizationSkills.id, skill.id));
-          return resolveInstalledSkillDirectory(orgId, skill.key, skill.slug);
-        },
-      );
+        );
+      });
     })();
 
     skillInstallationPromises.set(lockKey, installation);

--- a/server/src/services/knowledge-portability/organization-skills.ts
+++ b/server/src/services/knowledge-portability/organization-skills.ts
@@ -117,6 +117,7 @@ import {
 
 const ORGANIZATION_SKILL_INSTALLATION_VERSION = 1;
 const skillInstallationPromises = new Map<string, Promise<string>>();
+const skillMutationLocks = new Map<string, Promise<void>>();
 
 export function organizationSkillService(
   db: Db,
@@ -190,6 +191,29 @@ export function organizationSkillService(
     await Promise.all(workers);
   }
 
+  async function withSkillMutationLock<T>(
+    orgId: string,
+    skillKey: string,
+    operation: () => Promise<T>,
+  ) {
+    const lockKey = `${orgId}:${skillKey}`;
+    const previous = skillMutationLocks.get(lockKey) ?? Promise.resolve();
+    let release!: () => void;
+    const current = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    skillMutationLocks.set(lockKey, current);
+    await previous.catch(() => {});
+    try {
+      return await operation();
+    } finally {
+      release();
+      if (skillMutationLocks.get(lockKey) === current) {
+        skillMutationLocks.delete(lockKey);
+      }
+    }
+  }
+
   async function readImportedSkillFiles(skill: ImportedSkill) {
     const files = new Map<string, string | Uint8Array>();
     for (const [rawPath, content] of Object.entries(skill.files ?? {})) {
@@ -214,10 +238,11 @@ export function organizationSkillService(
     return files;
   }
 
-  async function replaceInstalledSkillDirectory(
+  async function replaceInstalledSkillDirectory<T>(
     orgId: string,
     skill: Pick<ImportedSkill, "key" | "slug" | "fileInventory">,
     files: Map<string, string | Uint8Array>,
+    persist: () => Promise<T>,
   ) {
     const target = resolveInstalledSkillDirectory(orgId, skill.key, skill.slug);
     const parent = path.dirname(target);
@@ -265,28 +290,69 @@ export function organizationSkillService(
         }
         throw error;
       }
+      let persisted: T;
+      try {
+        persisted = await persist();
+      } catch (error) {
+        await fs.rm(target, { recursive: true, force: true }).catch(() => {});
+        if (movedExisting) {
+          try {
+            await fs.rename(backup, target);
+            movedExisting = false;
+          } catch {
+            // Preserve the backup for operator recovery if rollback cannot restore it.
+          }
+        }
+        throw error;
+      }
       if (movedExisting) {
         await fs.rm(backup, { recursive: true, force: true }).catch(() => {});
         movedExisting = false;
       }
-      return target;
+      return persisted;
     } finally {
       await fs.rm(staging, { recursive: true, force: true });
     }
   }
 
-  async function installImportedSkill(orgId: string, skill: ImportedSkill) {
+  async function installImportedSkill<T>(
+    orgId: string,
+    skill: ImportedSkill,
+    persist: (installed: ImportedSkill) => Promise<T>,
+  ) {
     const sourceKind = asString(skill.metadata?.sourceKind);
-    if (isBundledRudderSourceKind(sourceKind)) return skill;
-    const files = await readImportedSkillFiles(skill);
-    await replaceInstalledSkillDirectory(orgId, skill, files);
-    return {
+    if (isBundledRudderSourceKind(sourceKind)) return persist(skill);
+    const installed = {
       ...skill,
       metadata: {
         ...(skill.metadata ?? {}),
         installationVersion: ORGANIZATION_SKILL_INSTALLATION_VERSION,
       },
     };
+    const files = await readImportedSkillFiles(installed);
+    return withSkillMutationLock(orgId, installed.key, () =>
+      replaceInstalledSkillDirectory(
+        orgId,
+        installed,
+        files,
+        () => persist(installed),
+      ));
+  }
+
+  async function installAndUpsertImportedSkills(orgId: string, skills: ImportedSkill[]) {
+    const out: OrganizationSkill[] = [];
+    for (const skill of skills) {
+      out.push(await installImportedSkill(
+        orgId,
+        skill,
+        async (installed) => {
+          const [persisted] = await upsertImportedSkills(orgId, [installed]);
+          if (!persisted) throw notFound("Failed to persist organization skill");
+          return persisted;
+        },
+      ));
+    }
+    return out;
   }
 
   async function getAgentWorkspaceRow(orgId: string, agentId: string): Promise<AgentWorkspaceRow> {
@@ -1318,19 +1384,26 @@ export function organizationSkillService(
       throw unprocessable(`Skill ${skill.key} could not be re-imported from its source.`);
     }
 
-    const installed = await installImportedSkill(orgId, {
-      ...matching,
-      key: skill.key,
-      slug: skill.slug,
-      sourceType: skill.sourceType,
-      sourceLocator: skill.sourceLocator,
-      metadata: {
-        ...(matching.metadata ?? {}),
-        ...(skill.metadata ?? {}),
+    return installImportedSkill(
+      orgId,
+      {
+        ...matching,
+        key: skill.key,
+        slug: skill.slug,
+        sourceType: skill.sourceType,
+        sourceLocator: skill.sourceLocator,
+        metadata: {
+          ...(skill.metadata ?? {}),
+          ...(matching.metadata ?? {}),
+          sourceKind: asString(skill.metadata?.sourceKind)
+            ?? asString(matching.metadata?.sourceKind),
+        },
       },
-    });
-    const imported = await upsertImportedSkills(orgId, [installed]);
-    return imported[0] ?? null;
+      async (installed) => {
+        const [persisted] = await upsertImportedSkills(orgId, [installed]);
+        return persisted ?? null;
+      },
+    );
   }
 
   async function ensureInstalledSkill(orgId: string, skill: OrganizationSkill) {
@@ -1376,7 +1449,19 @@ export function organizationSkillService(
         if (!skill.sourceLocator) {
           throw unprocessable("Skill source locator is missing.");
         }
-        const parsed = parseSkillImportSourceInput(skill.sourceLocator);
+        const skillMetadata = getSkillMeta(skill);
+        const owner = asString(skillMetadata.owner);
+        const repo = asString(skillMetadata.repo);
+        const repoSkillDir = asString(skillMetadata.repoSkillDir);
+        const migrationSource = (
+          (skill.sourceType === "github" || skill.sourceType === "skills_sh")
+          && skill.sourceRef
+          && owner
+          && repo
+        )
+          ? `https://github.com/${owner}/${repo}/tree/${skill.sourceRef}${repoSkillDir ? `/${repoSkillDir}` : ""}`
+          : skill.sourceLocator;
+        const parsed = parseSkillImportSourceInput(migrationSource);
         const result = await readUrlSkillImports(
           orgId,
           parsed.resolvedSource,
@@ -1413,26 +1498,40 @@ export function organizationSkillService(
         throw unprocessable(`Skill ${skill.key} could not be installed from its source.`);
       }
 
-      const installed = await installImportedSkill(orgId, {
-        ...imported,
-        key: skill.key,
-        slug: skill.slug,
-        sourceType: skill.sourceType,
-        sourceLocator: skill.sourceLocator,
-        sourceRef: skill.sourceRef,
-        metadata: {
-          ...(imported.metadata ?? {}),
-          ...(skill.metadata ?? {}),
+      return installImportedSkill(
+        orgId,
+        {
+          ...imported,
+          key: skill.key,
+          slug: skill.slug,
+          sourceType: skill.sourceType,
+          sourceLocator: skill.sourceLocator,
+          sourceRef: skill.sourceRef ?? imported.sourceRef,
+          metadata: {
+            ...(skill.metadata ?? {}),
+            ...(imported.metadata ?? {}),
+            sourceKind: asString(skill.metadata?.sourceKind)
+              ?? asString(imported.metadata?.sourceKind),
+          },
         },
-      });
-      await db
-        .update(organizationSkills)
-        .set({
-          metadata: installed.metadata,
-          updatedAt: new Date(),
-        })
-        .where(eq(organizationSkills.id, skill.id));
-      return resolveInstalledSkillDirectory(orgId, skill.key, skill.slug);
+        async (installed) => {
+          await db
+            .update(organizationSkills)
+            .set({
+              name: installed.name,
+              description: installed.description,
+              markdown: installed.markdown,
+              sourceRef: installed.sourceRef,
+              trustLevel: installed.trustLevel,
+              compatibility: installed.compatibility,
+              fileInventory: serializeFileInventory(installed.fileInventory),
+              metadata: installed.metadata,
+              updatedAt: new Date(),
+            })
+            .where(eq(organizationSkills.id, skill.id));
+          return resolveInstalledSkillDirectory(orgId, skill.key, skill.slug);
+        },
+      );
     })();
 
     skillInstallationPromises.set(lockKey, installation);
@@ -1599,10 +1698,7 @@ export function organizationSkillService(
 
     if (toPersist.length === 0) return out;
 
-    const installedSkills = await Promise.all(
-      toPersist.map((skill) => installImportedSkill(orgId, skill)),
-    );
-    const persisted = await upsertImportedSkills(orgId, installedSkills);
+    const persisted = await installAndUpsertImportedSkills(orgId, toPersist);
     for (let index = 0; index < prepared.length; index += 1) {
       const persistedSkill = persisted[index];
       const preparedSkill = prepared[index];
@@ -1716,10 +1812,7 @@ export function organizationSkillService(
         skill.key = deriveCanonicalSkillKey(orgId, skill);
       }
     }
-    const installedSkills = await Promise.all(
-      filteredSkills.map((skill) => installImportedSkill(orgId, skill)),
-    );
-    const imported = await upsertImportedSkills(orgId, installedSkills);
+    const imported = await installAndUpsertImportedSkills(orgId, filteredSkills);
     return { imported, warnings };
   }
 

--- a/tests/e2e/chat-error-toast.spec.ts
+++ b/tests/e2e/chat-error-toast.spec.ts
@@ -77,7 +77,6 @@ test.describe("Chat error recovery", () => {
       window.localStorage.setItem("rudder.selectedOrganizationId", orgId);
     }, organization.id);
     await page.goto(`/${organization.issuePrefix}/messenger/chat?agentId=${chatAgent.id}`);
-
     const composer = page.locator(".rudder-mdxeditor-content").first();
     await expect(composer).toBeVisible({ timeout: 15_000 });
     await composer.fill("Ask me which topic to explore");
@@ -170,6 +169,7 @@ test.describe("Chat error recovery", () => {
     }, organization.id);
 
     await page.goto(`/${organization.issuePrefix}/messenger/chat?agentId=${chatAgent.id}`);
+    const organizationPath = new URL(page.url()).pathname.split("/")[1];
 
     const composer = page.locator(".rudder-mdxeditor-content").first();
     await expect(composer).toBeVisible({ timeout: 15_000 });
@@ -189,6 +189,8 @@ test.describe("Chat error recovery", () => {
     const failedMessagesRes = await page.request.get(`/api/chats/${chatId}/messages`);
     expect(failedMessagesRes.ok()).toBe(true);
     const failedMessages = await failedMessagesRes.json() as Array<{
+      runId: string | null;
+      replyingAgentId: string | null;
       role: string;
       status: string;
       structuredPayload?: {
@@ -202,6 +204,8 @@ test.describe("Chat error recovery", () => {
     }>;
     const failedAssistant = failedMessages.find((message) => message.role === "assistant");
     expect(failedAssistant).toMatchObject({
+      runId: expect.any(String),
+      replyingAgentId: chatAgent.id,
       status: "failed",
       structuredPayload: {
         recoverableFailure: {
@@ -212,6 +216,13 @@ test.describe("Chat error recovery", () => {
         },
       },
     });
+    const failedRunId = failedAssistant?.runId;
+    expect(failedRunId).toBeTruthy();
+    await expect(failedMessage.getByRole("link", { name: "Open run" })).toHaveAttribute(
+      "href",
+      `/${organizationPath}/agents/${chatAgent.urlKey}/runs/${failedRunId}`,
+    );
+    await expect(failedMessage.getByRole("button", { name: "Retry" })).toBeVisible();
 
     await failedMessage.getByRole("button", { name: "Retry" }).click();
 

--- a/tests/e2e/chat-runtime-boot-failure.spec.ts
+++ b/tests/e2e/chat-runtime-boot-failure.spec.ts
@@ -22,7 +22,7 @@ async function createBrokenChatAgent(page: Page, orgId: string) {
     },
   });
   expect(agentRes.ok()).toBe(true);
-  return agentRes.json() as Promise<{ id: string; name: string }>;
+  return agentRes.json() as Promise<{ id: string; name: string; urlKey: string }>;
 }
 
 test("chat runtime boot failures are non-retryable in the real chat UI", async ({ page }) => {
@@ -40,9 +40,10 @@ test("chat runtime boot failures are non-retryable in the real chat UI", async (
   await expect(composer).toBeVisible({ timeout: 15_000 });
   await composer.fill("Trigger the broken runtime");
   await page.getByRole("button", { name: "Send" }).click();
-  await expect(page).toHaveURL(new RegExp(`/${organization.issuePrefix}/messenger/chat/[^/?#]+$`), {
+  await expect(page).toHaveURL(/\/[^/]+\/messenger\/chat\/[^/?#]+$/, {
     timeout: 15_000,
   });
+  const organizationPath = new URL(page.url()).pathname.split("/")[1];
   const chatId = new URL(page.url()).pathname.split("/").pop();
   expect(chatId).toBeTruthy();
 
@@ -55,6 +56,8 @@ test("chat runtime boot failures are non-retryable in the real chat UI", async (
   const messagesRes = await page.request.get(`/api/chats/${chatId}/messages`);
   expect(messagesRes.ok()).toBe(true);
   const messages = await messagesRes.json() as Array<{
+    runId: string | null;
+    replyingAgentId: string | null;
     role: string;
     status: string;
     structuredPayload: {
@@ -69,6 +72,8 @@ test("chat runtime boot failures are non-retryable in the real chat UI", async (
   }>;
   const assistantMessage = messages.find((message) => message.role === "assistant");
   expect(assistantMessage).toMatchObject({
+    runId: expect.any(String),
+    replyingAgentId: agent.id,
     status: "failed",
     structuredPayload: {
       recoverableFailure: {
@@ -80,4 +85,16 @@ test("chat runtime boot failures are non-retryable in the real chat UI", async (
       },
     },
   });
+
+  const runId = assistantMessage?.runId;
+  expect(runId).toBeTruthy();
+  const openRun = failedAssistant.getByRole("link", { name: "Open run" });
+  await expect(openRun).toHaveAttribute(
+    "href",
+    `/${organizationPath}/agents/${agent.urlKey}/runs/${runId}`,
+  );
+  await openRun.click();
+  await expect(page).toHaveURL(new RegExp(
+    `/${organizationPath}/agents/${agent.urlKey}/runs/${runId}(?:[?#]|$)`,
+  ));
 });

--- a/tests/e2e/messenger-saved-views.spec.ts
+++ b/tests/e2e/messenger-saved-views.spec.ts
@@ -221,6 +221,12 @@ test.describe("Messenger Saved Views", () => {
 
     const mainWorkbench = page.getByTestId("messenger-main-workbench");
     await expect(mainWorkbench).toBeVisible();
+    await expect(mainWorkbench).not.toHaveClass(/workspace-main-card/);
+    await expect(mainWorkbench).toHaveCSS("background-color", "rgba(0, 0, 0, 0)");
+    await expect(mainWorkbench.getByRole("tablist")).toHaveCSS(
+      "background-color",
+      "rgba(0, 0, 0, 0)",
+    );
     await expect(mainWorkbench.locator(
       `[role="tab"][data-view-instance-id="${movedInstanceId}"][aria-selected="true"]`,
     )).toBeVisible();

--- a/tests/e2e/run-transcript-detail.spec.ts
+++ b/tests/e2e/run-transcript-detail.spec.ts
@@ -444,6 +444,22 @@ test.describe("Run transcript detail", () => {
       createdAt: new Date("2026-06-26T06:15:55.226Z"),
       updatedAt: new Date("2026-06-26T06:16:31.946Z"),
     });
+    await e2eDb.insert(heartbeatRunEvents).values({
+      orgId: organization.id,
+      runId,
+      agentId: agent.id,
+      seq: 100,
+      eventType: "transcript.entry",
+      stream: "system",
+      level: "info",
+      message: "chat transcript entry",
+      payload: {
+        kind: "assistant",
+        text: "Partial assistant output preserved before the recoverable failure.",
+        ts: "2026-06-26T06:16:30.946Z",
+      },
+      createdAt: new Date("2026-06-26T06:16:30.946Z"),
+    });
 
     await page.addInitScript((orgId: string) => {
       window.localStorage.setItem("rudder.selectedOrganizationId", orgId);
@@ -456,9 +472,12 @@ test.describe("Run transcript detail", () => {
     await expect(summaryCard.getByText("Run failed")).toBeVisible({ timeout: 15_000 });
     await expect(summaryCard.getByText(userMessage)).toBeVisible();
     await expect(summaryCard.getByText("The run hit a system-level execution problem.", { exact: false })).toHaveCount(0);
+    await expect(detailPane.getByText("Transcript", { exact: true })).toBeVisible({ timeout: 15_000 });
+    await expect(detailPane.getByRole("button", { name: "Raw" })).toBeVisible();
+    await expect(detailPane.getByText("Failure details", { exact: true })).toHaveCount(0);
 
     const listPane = page.getByTestId("agent-runs-list-pane");
-    await expect(listPane.getByText("The assistant finished without a final Rudder reply", { exact: false })).toBeVisible();
+    await expect(listPane.getByText("The run hit a system-level execution problem.", { exact: false })).toBeVisible();
   });
 
   test("does not promote stderr excerpts for failed or successful run detail pages", async ({ page }) => {

--- a/tests/e2e/run-transcript-detail.spec.ts
+++ b/tests/e2e/run-transcript-detail.spec.ts
@@ -106,6 +106,15 @@ test.describe("Run transcript detail", () => {
     await expect(rudderDisclosure).toHaveCSS("opacity", "0");
     await rudderMcpRow.hover();
     await expect(rudderDisclosure).toHaveCSS("opacity", "1");
+    const rudderDuration = rudderMcpRow.locator("[data-transcript-action-duration='true']");
+    const durationBox = await rudderDuration.boundingBox();
+    const disclosureBox = await rudderDisclosure.boundingBox();
+    expect(durationBox).not.toBeNull();
+    expect(disclosureBox).not.toBeNull();
+    expect(Math.abs(
+      ((durationBox?.y ?? 0) + (durationBox?.height ?? 0) / 2)
+      - ((disclosureBox?.y ?? 0) + (disclosureBox?.height ?? 0) / 2),
+    )).toBeLessThanOrEqual(1);
     await page.mouse.move(0, 0);
     await expect(rudderDisclosure).toHaveCSS("opacity", "0");
 
@@ -129,18 +138,23 @@ test.describe("Run transcript detail", () => {
 
     await githubMcpRow.click();
     await expect(page.getByText("Undertone0809/rudder", { exact: false })).toBeVisible();
+    await expect(page.getByText("Transcript renderer discussion", { exact: false })).toBeVisible();
     await rudderMcpRow.click();
     await expect(page.getByText("eeb73ad1-e000-4dce-9d47-23106fa36bbc", { exact: false })).toBeVisible();
-    await expect(page.getByText("rudder-tools", { exact: false }).first()).toBeVisible();
+    await expect(page.getByText("Transcript loaded", { exact: false })).toBeVisible();
+    await expect(page.getByText("rudder-tools", { exact: false })).toHaveCount(0);
+    await expect(page.getByText("structuredContent", { exact: false })).toHaveCount(0);
+    await expect(page.getByText("_meta", { exact: false })).toHaveCount(0);
     await page.mouse.move(0, 0);
     await rudderMcpRow.blur();
     await expect(rudderDisclosure).toHaveCSS("opacity", "0");
 
-    const skillUseRow = page.getByRole("button", { name: /Expand tool details/ }).filter({ hasText: "Use flomo-local-api skill" });
-    await expect(skillUseRow).toHaveCount(1);
+    const skillSummary = page.getByTitle("/Users/zeeland/.codex/skills/flomo-local-api/SKILL.md");
+    await expect(skillSummary).toBeVisible();
+    const skillUseRow = page.getByRole("button", { name: /tool details: Use flomo-local-api skill/ });
+    await expect(skillUseRow).toHaveCount(0);
     await expect(page.getByText("/Users/zeeland/.codex/skills/flomo-local-api/SKILL.md", { exact: false })).toHaveCount(0);
-    await skillUseRow.click();
-    await expect(page.getByText("/Users/zeeland/.codex/skills/flomo-local-api/SKILL.md", { exact: false })).toBeVisible();
+    await expect(skillSummary.locator("xpath=..").locator("[data-transcript-action-row-disclosure='true']")).toHaveCount(0);
 
     await expect(page.getByText("Agent memory updated", { exact: false })).toBeVisible();
     await expect(page.getByText("Gabriel updated stable memory instructions.", { exact: false })).toBeVisible();

--- a/ui/src/components/transcript/RunTranscriptView.blocks.tsx
+++ b/ui/src/components/transcript/RunTranscriptView.blocks.tsx
@@ -45,7 +45,8 @@ import {
   truncate,
 } from "./RunTranscriptView.common";
 import { formatSemanticDigest, getTodoListCompletedCount } from "./RunTranscriptView.normalize";
-import { describeToolSemanticInfo, formatCommandTerminalOutput, formatToolPayload, isCommandTool } from "./RunTranscriptView.semantic";
+import { formatNiceToolRequest, formatNiceToolResponse } from "./RunTranscriptView.presentation";
+import { describeToolSemanticInfo, formatCommandTerminalOutput, isCommandTool } from "./RunTranscriptView.semantic";
 import { formatMemoryScopeLabel, stripWrappedShell } from "./RunTranscriptView.shell";
 import { getTranscriptAgentAvatarInfo, TranscriptAgentAvatarIcon } from "./TranscriptAgentAvatarIcon";
 
@@ -632,12 +633,13 @@ export function TranscriptToolCard({
         : "text-emerald-700 dark:text-emerald-300";
   const duration = formatTranscriptDuration(block.ts, block.endTs);
   const command = getToolCommand(block);
-  const requestText = command ?? (formatToolPayload(block.input) || "<empty>");
+  const requestText = command ?? formatNiceToolRequest(block.name, block.input);
   const responseText = command
     ? formatCommandTerminalOutput(block.result)
     : block.result
-      ? formatToolPayload(block.result)
+      ? formatNiceToolResponse(block.name, block.input, block.result)
       : "Waiting for result...";
+  const canExpand = semantic.actionKind !== "skill";
   const detailsClass = cn(
     "space-y-3",
     block.status === "error" && "rounded-xl border border-red-500/20 bg-red-500/[0.06] p-3",
@@ -680,17 +682,19 @@ export function TranscriptToolCard({
             {summary}
           </div>
         </div>
-        <button
-          type="button"
-          className="mt-0.5 inline-flex h-5 w-5 items-center justify-center text-muted-foreground transition-colors hover:text-foreground"
-          onClick={() => setOpen((value) => !value)}
-          aria-expanded={open}
-          aria-label={open ? `Collapse ${isCommand ? "command" : "tool"} details` : `Expand ${isCommand ? "command" : "tool"} details`}
-        >
-          <DisclosureChevron open={open} className="h-4 w-4" />
-        </button>
+        {canExpand ? (
+          <button
+            type="button"
+            className="mt-0.5 inline-flex h-5 w-5 items-center justify-center text-muted-foreground transition-colors hover:text-foreground"
+            onClick={() => setOpen((value) => !value)}
+            aria-expanded={open}
+            aria-label={open ? `Collapse ${isCommand ? "command" : "tool"} details` : `Expand ${isCommand ? "command" : "tool"} details`}
+          >
+            <DisclosureChevron open={open} className="h-4 w-4" />
+          </button>
+        ) : null}
       </div>
-      {open && (
+      {canExpand && open && (
         <div className="motion-disclosure-enter mt-3">
           {command ? (
             <CommandTerminalDetail command={requestText} output={responseText} status={block.status} />

--- a/ui/src/components/transcript/RunTranscriptView.chat.tsx
+++ b/ui/src/components/transcript/RunTranscriptView.chat.tsx
@@ -4,7 +4,8 @@ import { cn } from "../../lib/utils";
 import { CommandTerminalDetail, DisclosureChevron, ExpandableTranscriptResponsePre, areAllToolEntriesErrored, renderTranscriptBlock } from "./RunTranscriptView.blocks";
 import { ChatTranscriptAction, ChatTranscriptTurn, TranscriptActionIcon, TranscriptActionIconCategory, TranscriptActionIconStatus, TranscriptAgentInspection, TranscriptAnnotationSourceContext, TranscriptBlock, TranscriptDensity, TranscriptMarkdownLinkClickHandler, TranscriptSentAnnotationContext, TranscriptToolCardEntry, TranscriptToolSemanticInfo, asRecord, compactWhitespace, formatTranscriptDuration, getTranscriptTimestampTitle, isInternalTranscriptLifecycleEntry, truncate } from "./RunTranscriptView.common";
 import { formatSemanticDigest, normalizeChatTranscriptTurns, summarizeToolResult } from "./RunTranscriptView.normalize";
-import { describeToolSemanticInfo, extractMcpToolDetails, formatCommandTerminalOutput, formatToolPayload, isCommandTool } from "./RunTranscriptView.semantic";
+import { formatNiceToolRequest, formatNiceToolResponse } from "./RunTranscriptView.presentation";
+import { describeToolSemanticInfo, extractMcpToolDetails, formatCommandTerminalOutput, isCommandTool } from "./RunTranscriptView.semantic";
 import { stripWrappedShell } from "./RunTranscriptView.shell";
 import { TranscriptAgentAvatarIcon, getTranscriptAgentAvatarInfo } from "./TranscriptAgentAvatarIcon";
 import { transcriptAgentInspectionForTool } from "./TranscriptAgentInspection";
@@ -282,17 +283,18 @@ export function TranscriptChatToolActionRow({
   const compact = density === "compact";
   const isCommand = isCommandTool(block.name, block.input);
   const command = getToolCommand(block);
-  const requestText = command ?? (formatToolPayload(block.input) || "<empty>");
+  const requestText = command ?? formatNiceToolRequest(block.name, block.input);
   const responseText = shouldHideChatToolResult(semantic)
     ? null
     : command
       ? formatCommandTerminalOutput(block.result)
       : block.result
-        ? formatToolPayload(block.result)
+        ? formatNiceToolResponse(block.name, block.input, block.result)
         : block.status === "running"
           ? "Waiting for result..."
           : null;
-  const canExpand = Boolean(command || responseText || (!isCommand && requestText !== "<empty>"));
+  const canExpand = semantic.actionKind !== "skill"
+    && Boolean(command || responseText || (!isCommand && requestText !== "<empty>"));
   const [open, setOpen] = useState(inline || (defaultOpenOnError && block.status === "error"));
   const duration = quiet ? null : formatTranscriptDuration(block.ts, block.endTs);
   const statusText =
@@ -404,27 +406,32 @@ export function TranscriptChatToolActionRow({
           <span id={summaryLabelId} className={cn("min-w-0 flex-1 break-words text-foreground/84", compact ? "text-xs leading-5" : "text-sm leading-6")}>
             {displaySummary}
           </span>
-          {duration ? (
-            <span className={cn("text-[10px] font-medium tabular-nums text-muted-foreground", trailingOffsetClass)}>
-              {duration}
-            </span>
-          ) : null}
-          {statusText ? (
-            <span id={statusLabelId} className={cn("text-[10px] font-medium", rowTone, trailingOffsetClass)}>
-              {statusText}
-            </span>
-          ) : null}
-          {canExpand && !inline && !inspectAgent ? (
-            <span
-              className={cn(
-                "inline-flex h-5 w-5 items-center justify-center text-muted-foreground opacity-0 transition-opacity group-hover/activity-row:opacity-100 group-focus-visible/activity-row:opacity-100 [@media(hover:none)]:opacity-100 [@media(pointer:coarse)]:opacity-100",
-                chevronOffsetClass,
-              )}
-              data-transcript-action-row-disclosure="true"
-            >
-              <DisclosureChevron open={open} className="h-4 w-4" />
-            </span>
-          ) : null}
+          <span
+            className="ml-auto inline-flex h-5 shrink-0 items-center gap-1.5 self-center"
+            data-transcript-action-trailing="true"
+          >
+            {duration ? (
+              <span
+                className="inline-flex h-5 items-center text-[10px] font-medium tabular-nums text-muted-foreground"
+                data-transcript-action-duration="true"
+              >
+                {duration}
+              </span>
+            ) : null}
+            {statusText ? (
+              <span id={statusLabelId} className={cn("inline-flex h-5 items-center text-[10px] font-medium", rowTone)}>
+                {statusText}
+              </span>
+            ) : null}
+            {canExpand && !inline && !inspectAgent ? (
+              <span
+                className="inline-flex h-5 w-5 shrink-0 items-center justify-center text-muted-foreground opacity-0 transition-opacity group-hover/activity-row:opacity-100 group-focus-visible/activity-row:opacity-100 [@media(hover:none)]:opacity-100 [@media(pointer:coarse)]:opacity-100"
+                data-transcript-action-row-disclosure="true"
+              >
+                <DisclosureChevron open={open} className="block h-4 w-4" />
+              </span>
+            ) : null}
+          </span>
         </button>
       )}
       {canExpand && open ? (

--- a/ui/src/components/transcript/RunTranscriptView.mcp-skill-presentation.test.tsx
+++ b/ui/src/components/transcript/RunTranscriptView.mcp-skill-presentation.test.tsx
@@ -1,0 +1,170 @@
+// @vitest-environment node
+
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import type { TranscriptEntry } from "../../agent-runtimes";
+import { ThemeProvider } from "../../context/ThemeContext";
+import { RunTranscriptView } from "./RunTranscriptView";
+import { TranscriptChatToolActionRow } from "./RunTranscriptView.chat";
+import {
+  formatNiceToolRequest,
+  formatNiceToolResponse,
+} from "./RunTranscriptView.presentation";
+
+const mcpInput = {
+  id: "exec-1",
+  args: {
+    url: "https://api.github.com/repos/astral-sh/ruff",
+    tabId: "tab-1",
+  },
+  tool: "rudder_browser_navigate",
+  server: "rudder-tools",
+  invocation: {
+    id: "exec-1",
+    status: "inProgress",
+  },
+};
+
+const mcpResponse = JSON.stringify({
+  content: [{
+    type: "text",
+    text: JSON.stringify({
+      tabId: "tab-1",
+      url: "https://api.github.com/repos/astral-sh/ruff",
+    }),
+  }],
+  structuredContent: {
+    tabId: "tab-1",
+    url: "https://api.github.com/repos/astral-sh/ruff",
+    title: "api.github.com/repos/astral-sh/ruff",
+  },
+  _meta: null,
+});
+
+describe("Nice transcript MCP payloads", () => {
+  it("projects only args for MCP input and structuredContent for MCP response", () => {
+    expect(formatNiceToolRequest("mcp__rudder-tools__rudder_browser_navigate", mcpInput))
+      .toBe(JSON.stringify(mcpInput.args, null, 2));
+    expect(formatNiceToolResponse(
+      "mcp__rudder-tools__rudder_browser_navigate",
+      mcpInput,
+      mcpResponse,
+    )).toBe(JSON.stringify({
+      tabId: "tab-1",
+      url: "https://api.github.com/repos/astral-sh/ruff",
+      title: "api.github.com/repos/astral-sh/ruff",
+    }, null, 2));
+  });
+
+  it("renders the reduced MCP projection in expanded chat details", () => {
+    const html = renderToStaticMarkup(
+      <ThemeProvider>
+        <TranscriptChatToolActionRow
+          inline
+          density="compact"
+          block={{
+            ts: "2026-07-24T00:00:00.000Z",
+            endTs: "2026-07-24T00:00:01.000Z",
+            name: "mcp__rudder-tools__rudder_browser_navigate",
+            input: mcpInput,
+            result: mcpResponse,
+            status: "completed",
+          }}
+        />
+      </ThemeProvider>,
+    );
+
+    expect(html).toContain("Input");
+    expect(html).toContain("Response");
+    expect(html).toContain("&quot;url&quot;:");
+    expect(html).toContain("&quot;title&quot;:");
+    expect(html).not.toContain("&quot;args&quot;:");
+    expect(html).not.toContain("&quot;invocation&quot;:");
+    expect(html).not.toContain("&quot;structuredContent&quot;:");
+    expect(html).not.toContain("&quot;content&quot;:");
+    expect(html).not.toContain("&quot;_meta&quot;:");
+  });
+
+  it("keeps the complete MCP envelope in Raw mode", () => {
+    const entries: TranscriptEntry[] = [
+      {
+        kind: "tool_call",
+        ts: "2026-07-24T00:00:00.000Z",
+        name: "mcp__rudder-tools__rudder_browser_navigate",
+        toolUseId: "mcp-1",
+        input: mcpInput,
+      },
+      {
+        kind: "tool_result",
+        ts: "2026-07-24T00:00:01.000Z",
+        toolUseId: "mcp-1",
+        content: mcpResponse,
+        isError: false,
+      },
+    ];
+    const html = renderToStaticMarkup(
+      <ThemeProvider>
+        <RunTranscriptView mode="raw" entries={entries} />
+      </ThemeProvider>,
+    );
+
+    expect(html).toContain("&quot;args&quot;:");
+    expect(html).toContain("&quot;invocation&quot;:");
+    expect(html).toContain("&quot;structuredContent&quot;:");
+    expect(html).toContain("&quot;content&quot;:");
+  });
+});
+
+describe("Nice transcript skill activity", () => {
+  const skillEntries: TranscriptEntry[] = [
+    {
+      kind: "tool_call",
+      ts: "2026-07-24T00:00:00.000Z",
+      name: "command_execution",
+      toolUseId: "skill-1",
+      input: {
+        command: "sed -n '1,240p' /workspace/.agents/skills/systematic-debugging/SKILL.md",
+        cwd: "/workspace",
+      },
+    },
+    {
+      kind: "tool_result",
+      ts: "2026-07-24T00:00:01.000Z",
+      toolUseId: "skill-1",
+      content: "# Systematic Debugging",
+      isError: false,
+    },
+  ];
+
+  it.each(["chat", "detail"] as const)(
+    "does not offer raw-command disclosure for skill use in %s presentation",
+    (presentation) => {
+      const html = renderToStaticMarkup(
+        <ThemeProvider>
+          <RunTranscriptView
+            density="compact"
+            presentation={presentation}
+            entries={skillEntries}
+          />
+        </ThemeProvider>,
+      );
+
+      expect(html).toContain("Use ");
+      expect(html).toContain("systematic-debugging");
+      expect(html).not.toContain("Expand command details");
+      expect(html).not.toContain("data-transcript-action-row-disclosure");
+      expect(html).not.toContain("sed -n");
+    },
+  );
+
+  it("keeps the original skill command available in Raw mode", () => {
+    const html = renderToStaticMarkup(
+      <ThemeProvider>
+        <RunTranscriptView mode="raw" entries={skillEntries} />
+      </ThemeProvider>,
+    );
+
+    expect(html).toContain("sed -n");
+    expect(html).toContain("SKILL.md");
+  });
+});

--- a/ui/src/components/transcript/RunTranscriptView.presentation.ts
+++ b/ui/src/components/transcript/RunTranscriptView.presentation.ts
@@ -1,0 +1,40 @@
+import { asRecord } from "./RunTranscriptView.common";
+import {
+  extractMcpToolDetails,
+  formatToolPayload,
+} from "./RunTranscriptView.semantic";
+
+function parseJsonRecord(value: string): Record<string, unknown> | null {
+  try {
+    return asRecord(JSON.parse(value));
+  } catch {
+    return null;
+  }
+}
+
+export function formatNiceToolRequest(
+  name: string,
+  input: unknown,
+): string {
+  const mcpDetails = extractMcpToolDetails(name, input);
+  return formatToolPayload(mcpDetails ? (mcpDetails.args ?? {}) : input) || "<empty>";
+}
+
+export function formatNiceToolResponse(
+  name: string,
+  input: unknown,
+  result: string | undefined,
+): string | null {
+  if (!result) return null;
+  if (!extractMcpToolDetails(name, input)) return formatToolPayload(result);
+
+  const response = parseJsonRecord(result);
+  if (
+    response
+    && Object.prototype.hasOwnProperty.call(response, "structuredContent")
+  ) {
+    return formatToolPayload(response.structuredContent);
+  }
+
+  return formatToolPayload(result);
+}

--- a/ui/src/components/workbench/MessengerMainWorkbench.test.tsx
+++ b/ui/src/components/workbench/MessengerMainWorkbench.test.tsx
@@ -510,7 +510,7 @@ function tabs() {
 }
 
 describe("MessengerMainWorkbench", () => {
-  it("renders one rounded workspace card without nesting another Browser card", () => {
+  it("renders a transparent full-bleed workbench without nesting another Browser card", () => {
     renderWorkbench();
     openKinds(["browser", "local_app", "library_document", "automation"]);
 
@@ -518,7 +518,8 @@ describe("MessengerMainWorkbench", () => {
       '[data-testid="messenger-main-workbench"]',
     )!;
     expect(workbench.querySelectorAll('[role="tablist"]')).toHaveLength(1);
-    expect(workbench.className).toContain("workspace-main-card");
+    expect(workbench.className).not.toContain("workspace-main-card");
+    expect(workbench.className).not.toMatch(/\brounded/);
     expect(workbench.className).not.toMatch(/\bp-[1-9]/);
     expect(workbench.querySelector('[data-testid="browser-main-card"]')).toBeNull();
     expect(workbench.querySelector('[data-testid="messenger-main-live-surface-anchor"]'))

--- a/ui/src/components/workbench/MessengerMainWorkbench.tsx
+++ b/ui/src/components/workbench/MessengerMainWorkbench.tsx
@@ -868,7 +868,7 @@ export function MessengerMainWorkbench({
   return (
     <div
       className={cn(
-        "workspace-main-card flex h-full min-h-0 min-w-0 flex-col overflow-hidden",
+        "flex h-full min-h-0 min-w-0 flex-col overflow-hidden",
         className,
       )}
       data-testid="messenger-main-workbench"

--- a/ui/src/context/LiveSurfaceRuntimeContext.test.tsx
+++ b/ui/src/context/LiveSurfaceRuntimeContext.test.tsx
@@ -191,7 +191,7 @@ describe("LiveSurfaceRuntimeProvider", () => {
     expect(container?.querySelector('[data-testid="live-surface-runtime-host"]')
       ?.getAttribute("data-owner-id")).toBe("side:chat-a:view-a");
     expect(container?.querySelector('[data-testid="live-surface-runtime-host"]')
-      ?.className).not.toContain("rounded-b-[var(--desktop-workspace-radius)]");
+      ?.className).toContain("rounded-[var(--desktop-workspace-radius)]");
 
     act(() => {
       physicalBefore?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
@@ -208,6 +208,7 @@ describe("LiveSurfaceRuntimeProvider", () => {
     expect(host?.style.left).toBe("300px");
     expect(host?.style.width).toBe("900px");
     expect(host?.className).toContain("rounded-b-[var(--desktop-workspace-radius)]");
+    expect(host?.className).not.toContain("rounded-[var(--desktop-workspace-radius)]");
   });
 
   it("claims an active Side owner before its opening animation has geometry", () => {

--- a/ui/src/context/LiveSurfaceRuntimeContext.tsx
+++ b/ui/src/context/LiveSurfaceRuntimeContext.tsx
@@ -813,9 +813,11 @@ export function LiveSurfaceRuntimeLayer() {
             hidden={!visible}
             inert={inert ? true : undefined}
             className={`fixed flex min-h-0 flex-col overflow-hidden bg-[color:var(--surface-panel)] ${
-              owner?.ownerId.startsWith("main:")
-                ? "rounded-b-[var(--desktop-workspace-radius)]"
-                : ""
+              owner?.ownerId.startsWith("side:")
+                ? "rounded-[var(--desktop-workspace-radius)]"
+                : owner?.ownerId.startsWith("main:")
+                  ? "rounded-b-[var(--desktop-workspace-radius)]"
+                  : ""
             }`}
             style={{
               height: rect ? `${rect.height}px` : "0px",

--- a/ui/src/fixtures/runTranscriptFixtures.ts
+++ b/ui/src/fixtures/runTranscriptFixtures.ts
@@ -150,7 +150,18 @@ export const runTranscriptFixtureEntries: TranscriptEntry[] = [
     ts: "2026-03-11T15:22:26.214Z",
     toolUseId: "mcp_fixture_pr",
     toolName: "mcp__github__fetch_pr",
-    content: "Fetched PR transcript renderer discussion",
+    content: JSON.stringify({
+      content: [{
+        type: "text",
+        text: "{\"number\":473,\"title\":\"Transcript renderer discussion\"}",
+      }],
+      structuredContent: {
+        number: 473,
+        title: "Transcript renderer discussion",
+        state: "open",
+      },
+      _meta: null,
+    }),
     isError: false,
   },
   {
@@ -181,7 +192,17 @@ export const runTranscriptFixtureEntries: TranscriptEntry[] = [
     ts: "2026-03-11T15:22:26.400Z",
     toolUseId: "mcp_fixture_rudder_chat",
     toolName: "mcp__rudder-tools__rudder_chat_transcript",
-    content: "Fetched Rudder chat transcript",
+    content: JSON.stringify({
+      content: [{
+        type: "text",
+        text: "{\"entryCount\":3,\"summary\":\"Transcript loaded\"}",
+      }],
+      structuredContent: {
+        entryCount: 3,
+        summary: "Transcript loaded",
+      },
+      _meta: null,
+    }),
     isError: false,
   },
   {

--- a/ui/src/pages/AgentDetail.run-log.tsx
+++ b/ui/src/pages/AgentDetail.run-log.tsx
@@ -7,7 +7,6 @@ import {
   DialogTitle
 } from "@/components/ui/dialog";
 import { Tabs } from "@/components/ui/tabs";
-import { Link } from "@/lib/router";
 import {
   type HeartbeatRun,
   type HeartbeatRunEvent,
@@ -36,7 +35,6 @@ import { RunTranscriptView, type TranscriptMode } from "../components/transcript
 import { useLiveRunTranscripts } from "../components/transcript/useLiveRunTranscripts";
 import { shouldPollLiveRunBackfill } from "../lib/live-run-backfill";
 import { queryKeys } from "../lib/queryKeys";
-import { getRunFailureDisplay } from "../lib/run-detail-display";
 import { heartbeatRunEventsToTranscriptEntries, mergeTranscriptEntries } from "../lib/run-detail-events";
 import { cn } from "../lib/utils";
 import { asNonEmptyString, asRecord, findScrollContainer, formatEnvForDisplay, formatInvocationValueForDisplay, InvocationSkillEvidence, LIVE_SCROLL_BOTTOM_TOLERANCE_PX, readInvocationAgentInstructionStack, readScrollMetrics, redactPathText, redactPathValue, RunEventsList, RunLogChunk, runLogChunkDedupeKey, ScrollContainer, scrollToContainerBottom, utf8ByteLength, WorkspaceOperationsSection } from "./AgentDetail.helpers";
@@ -58,7 +56,6 @@ export function LogViewer({ run, agentRuntimeType }: { run: HeartbeatRun; agentR
   const [isStreamingConnected, setIsStreamingConnected] = useState(false);
   const [transcriptMode, setTranscriptMode] = useState<TranscriptMode>("nice");
   const [activeDetailTab, setActiveDetailTab] = useState<RunDetailTab>("transcript");
-  const failureDisplay = getRunFailureDisplay(run);
   const [transcriptModalOpen, setTranscriptModalOpen] = useState(false);
   const [transcriptDialogMotion, setTranscriptDialogMotion] = useState({
     fromX: "0px",
@@ -806,25 +803,6 @@ export function LogViewer({ run, agentRuntimeType }: { run: HeartbeatRun; agentR
           </div>
         </DialogContent>
       </Dialog>
-
-      {(run.status === "failed" || run.status === "timed_out") && (
-        <div className="rounded-lg border border-red-300 dark:border-red-500/30 bg-red-50 dark:bg-red-950/20 p-3 space-y-2">
-          <div className="text-xs font-medium text-red-700 dark:text-red-300">Failure details</div>
-          {failureDisplay && (
-            <div className="text-xs text-red-600 dark:text-red-200">
-              <span className="text-red-700 dark:text-red-300">{failureDisplay.title}: </span>
-              {redactPathText(failureDisplay.body, censorUsernameInLogs)}
-              {failureDisplay.actionPath && failureDisplay.actionLabel && (
-                <div className="mt-1">
-                  <Link to={failureDisplay.actionPath} className="text-xs font-medium text-red-700 underline dark:text-red-300">
-                    {failureDisplay.actionLabel}
-                  </Link>
-                </div>
-              )}
-            </div>
-          )}
-        </div>
-      )}
 
     </div>
   );

--- a/ui/src/pages/Chat.messages.test.tsx
+++ b/ui/src/pages/Chat.messages.test.tsx
@@ -4,7 +4,7 @@ import type { TranscriptEntry } from "@/agent-runtimes";
 import { __clearWebsiteMetadataIconCacheForTests } from "@/components/MarkdownBody";
 import type { MentionOption } from "@/components/MarkdownEditor";
 import { ThemeProvider } from "@/context/ThemeContext";
-import { buildAgentMentionHref, buildAutomationMentionHref, buildIssueMentionHref, type ChatMessage } from "@rudderhq/shared";
+import { buildAgentMentionHref, buildAutomationMentionHref, buildIssueMentionHref, type Agent, type ChatMessage } from "@rudderhq/shared";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ReactNode } from "react";
 import { act } from "react";
@@ -138,6 +138,37 @@ function message(overrides: Partial<ChatMessage>): ChatMessage {
   };
 }
 
+function agent(overrides: Partial<Agent> = {}): Agent {
+  return {
+    id: "agent-1",
+    orgId: "org-1",
+    name: "Chat Agent",
+    urlKey: "chat-agent",
+    role: "engineer",
+    title: null,
+    icon: "robot",
+    status: "active",
+    reportsTo: null,
+    capabilities: null,
+    agentRuntimeType: "codex_local",
+    agentRuntimeConfig: {},
+    runtimeConfig: {},
+    budgetMonthlyCents: 0,
+    spentMonthlyCents: 0,
+    pauseReason: null,
+    pausedAt: null,
+    permissions: {
+      canCreateAgents: false,
+      canManageSkills: false,
+    },
+    lastHeartbeatAt: null,
+    metadata: null,
+    createdAt: new Date("2026-06-15T10:00:00.000Z"),
+    updatedAt: new Date("2026-06-15T10:00:00.000Z"),
+    ...overrides,
+  };
+}
+
 async function waitForIssueStatus(container: HTMLElement, status: string) {
   await act(async () => {
     await vi.waitFor(() => {
@@ -146,7 +177,7 @@ async function waitForIssueStatus(container: HTMLElement, status: string) {
   });
 }
 
-function renderChatMessageItem(messageToRender: ChatMessage) {
+function renderChatMessageItem(messageToRender: ChatMessage, agents: Agent[] = []) {
   const onForkMessage = vi.fn();
   return render(
     <ThemeProvider>
@@ -199,7 +230,7 @@ function renderChatMessageItem(messageToRender: ChatMessage) {
           },
         }}
         message={messageToRender}
-        agents={[]}
+        agents={agents}
         decisionNote=""
         onDecisionNoteChange={vi.fn()}
         decisionNoteMentions={[]}
@@ -758,6 +789,63 @@ describe("assistant chat message rendering", () => {
 });
 
 describe("failed chat transcript rendering", () => {
+  function renderWithOrganizationPath(messageToRender: ChatMessage, agents: Agent[] = []) {
+    const previousLocation = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+    window.history.replaceState({}, "", "/MARAAA/messenger/chat/chat-1");
+    try {
+      return renderChatMessageItem(messageToRender, agents);
+    } finally {
+      window.history.replaceState({}, "", previousLocation);
+    }
+  }
+
+  it("shows the exact failed-message run beside Retry", () => {
+    const container = renderWithOrganizationPath(
+      message({
+        runId: "run-failed-exact",
+        replyingAgentId: "agent-failed-exact",
+        structuredPayload: {
+          recoverableFailure: {
+            code: "chat_adapter_failed",
+            retryable: true,
+            runId: "run-failed-exact",
+          },
+        },
+      }),
+      [agent({ id: "agent-failed-exact", urlKey: "agent-failed-slug" })],
+    );
+
+    expect(container.innerHTML).toContain('href="/MARAAA/agents/agent-failed-slug/runs/run-failed-exact"');
+    expect(container.textContent).toContain("Open run");
+    expect(container.textContent).toContain("Retry");
+    expect(container.textContent).toContain("Run run-fail");
+  });
+
+  it("shows Open run for a non-retryable failure and hides it without agent identity", () => {
+    const nonRetryable = renderWithOrganizationPath(message({
+      runId: "run-boot",
+      replyingAgentId: "agent-boot",
+      structuredPayload: {
+        recoverableFailure: {
+          code: "chat_runtime_boot_failed",
+          retryable: false,
+          runId: "run-boot",
+        },
+      },
+    }));
+
+    expect(nonRetryable.innerHTML).toContain('href="/MARAAA/agents/agent-boot/runs/run-boot"');
+    expect(nonRetryable.textContent).toContain("Open run");
+    expect(nonRetryable.textContent).not.toContain("Retry");
+
+    const missingAgent = renderWithOrganizationPath(message({
+      runId: "run-orphaned",
+      replyingAgentId: null,
+    }));
+    expect(missingAgent.textContent).not.toContain("Open run");
+    expect(missingAgent.querySelector('a[href*="/runs/"]')).toBeNull();
+  });
+
   it("keeps failed process details and the failed assistant message visibly marked", () => {
     const entries: TranscriptEntry[] = [
       {

--- a/ui/src/pages/Chat.messages.tsx
+++ b/ui/src/pages/Chat.messages.tsx
@@ -55,7 +55,7 @@ import { applyOrganizationPrefix, extractOrganizationPrefixFromPath } from "@/li
 import { Link } from "@/lib/router";
 import { formatSkillReferenceDisplayLabel, parseSkillReference } from "@/lib/skill-reference";
 import { statusBadge, statusBadgeDefault } from "@/lib/status-colors";
-import { agentUrl, cn, relativeTime } from "@/lib/utils";
+import { agentRouteRef, agentUrl, cn, relativeTime } from "@/lib/utils";
 import {
   ISSUE_PRIORITIES,
   ISSUE_STATUSES,
@@ -90,7 +90,7 @@ import {
 } from "lucide-react";
 import { useEffect, useMemo, useRef, useState, type ClipboardEvent as ReactClipboardEvent, type MouseEvent as ReactMouseEvent, type ReactNode, type RefObject } from "react";
 import { chatForkSystemMessageParts, readStructuredPayloadString, sideChatStartedSystemMessageParts } from "./Chat.message-system-parts";
-import { ApprovalAction, AskUserAnswerRecord, AskUserAnswerValue, ChatAttachmentList, PendingAttachmentPreview, approvalNeedsAction, askUserQuestionTitle, askUserRequestFromMessage, assistantStateLabel, canContinueInterruptedChatMessage, canRetryFailedChatMessage, displayedChatMessageState, formatAskUserAnswerMessage, issueProposalFromMessage, issueProposalPrincipalLabel, operationProposalDecisionNoteFromMessage, operationProposalFromMessage, operationProposalStatusFromMessage, pendingAttachmentKey, proposalReviewBannerCopy, proposalReviewStatus, recoverableFailureFromMessage, shouldHideSteerFallbackAssistantBubble, statusChipClassName } from "./Chat.parts";
+import { ApprovalAction, AskUserAnswerRecord, AskUserAnswerValue, ChatAttachmentList, PendingAttachmentPreview, approvalNeedsAction, askUserQuestionTitle, askUserRequestFromMessage, assistantStateLabel, canContinueInterruptedChatMessage, canRetryFailedChatMessage, displayedChatMessageState, formatAskUserAnswerMessage, issueProposalFromMessage, issueProposalPrincipalLabel, operationProposalDecisionNoteFromMessage, operationProposalFromMessage, operationProposalStatusFromMessage, pendingAttachmentKey, proposalReviewBannerCopy, proposalReviewStatus, recoverableFailureFromMessage, resolveChatMessageAgentRunTarget, shouldHideSteerFallbackAssistantBubble, statusChipClassName } from "./Chat.parts";
 import { ChatInlineVisualContent } from "./ChatInlineVisual";
 
 export { readStructuredPayloadString } from "./Chat.message-system-parts";
@@ -2289,6 +2289,21 @@ export function ChatMessageItem({
   const canContinueInterrupted = Boolean(onContinueInterruptedMessage) && canContinueInterruptedChatMessage(message);
   const recoverableFailure = displayedState === "failed" ? recoverableFailureFromMessage(message) : null;
   const canRetryFailed = Boolean(onRetryFailedMessage) && canRetryFailedChatMessage(message);
+  const failedRunTarget = displayedState === "failed"
+    ? resolveChatMessageAgentRunTarget(message, conversation)
+    : null;
+  const failedRunAgent = failedRunTarget
+    ? agents?.find((agent) => agent.id === failedRunTarget.agentId)
+    : null;
+  const failedRunAgentRef = failedRunAgent
+    ? agentRouteRef(failedRunAgent)
+    : failedRunTarget?.agentId;
+  const failedRunHref = failedRunTarget
+    ? applyOrganizationPrefix(
+        `/agents/${failedRunAgentRef}/runs/${failedRunTarget.runId}`,
+        currentOrganizationPrefixFromLocation(),
+      )
+    : null;
   const failedMessageTitle = recoverableFailure?.phase === "runtime_boot" || recoverableFailure?.action === "repair_runtime"
     ? "Runtime unavailable"
     : "Response failed";
@@ -2332,7 +2347,7 @@ export function ChatMessageItem({
           ) : null}
           {displayedState === "failed" ? (
             <div
-              className="mb-3 flex max-w-[72ch] items-start gap-3 rounded-[var(--radius-lg)] border border-destructive/30 bg-destructive/10 px-3 py-2.5 text-destructive"
+              className="mb-3 flex max-w-[72ch] flex-wrap items-start gap-3 rounded-[var(--radius-lg)] border border-destructive/30 bg-destructive/10 px-3 py-2.5 text-destructive"
             >
               <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" aria-hidden />
               <div className="min-w-0 flex-1" role="alert" aria-live="assertive">
@@ -2347,15 +2362,27 @@ export function ChatMessageItem({
                   </div>
                 ) : null}
               </div>
-              {canRetryFailed ? (
-                <button
-                  type="button"
-                  className="inline-flex h-7 shrink-0 items-center gap-1.5 rounded-md border border-destructive/30 bg-background/70 px-2 text-xs font-medium text-destructive transition-colors hover:bg-background"
-                  onClick={() => onRetryFailedMessage?.(message)}
-                >
-                  <RotateCcw className="h-3.5 w-3.5" aria-hidden />
-                  Retry
-                </button>
+              {failedRunHref || canRetryFailed ? (
+                <div className="ml-7 flex shrink-0 flex-wrap items-center justify-end gap-2 sm:ml-0">
+                  {failedRunHref ? (
+                    <Link
+                      to={failedRunHref}
+                      className="inline-flex h-7 items-center rounded-md border border-border bg-background/70 px-2 text-xs font-medium text-foreground transition-colors hover:bg-background"
+                    >
+                      Open run
+                    </Link>
+                  ) : null}
+                  {canRetryFailed ? (
+                    <button
+                      type="button"
+                      className="inline-flex h-7 items-center gap-1.5 rounded-md border border-destructive/30 bg-background/70 px-2 text-xs font-medium text-destructive transition-colors hover:bg-background"
+                      onClick={() => onRetryFailedMessage?.(message)}
+                    >
+                      <RotateCcw className="h-3.5 w-3.5" aria-hidden />
+                      Retry
+                    </button>
+                  ) : null}
+                </div>
               ) : null}
             </div>
           ) : null}

--- a/ui/src/pages/Chat.parts.tsx
+++ b/ui/src/pages/Chat.parts.tsx
@@ -635,6 +635,17 @@ export type ChatBranchPreview = { chatTurnId: string; turnVariant: number };
 
 export type ChatAgentRunTarget = { runId: string; agentId: string };
 
+export function resolveChatMessageAgentRunTarget(
+  message: Pick<ChatMessage, "runId" | "replyingAgentId">,
+  conversation: Pick<ChatConversation, "chatRuntime" | "preferredAgentId">,
+): ChatAgentRunTarget | null {
+  if (!message.runId) return null;
+  const agentId = message.replyingAgentId
+    ?? conversation.chatRuntime.runtimeAgentId
+    ?? conversation.preferredAgentId;
+  return agentId ? { runId: message.runId, agentId } : null;
+}
+
 export function resolveLatestChatAgentRunTarget(
   messages: readonly ChatMessage[],
   conversation: Pick<ChatConversation, "chatRuntime" | "preferredAgentId">,
@@ -646,11 +657,9 @@ export function resolveLatestChatAgentRunTarget(
       latestMessage = message;
     }
   }
-  if (!latestMessage?.runId) return null;
-  const agentId = latestMessage.replyingAgentId
-    ?? conversation.chatRuntime.runtimeAgentId
-    ?? conversation.preferredAgentId;
-  return agentId ? { runId: latestMessage.runId, agentId } : null;
+  return latestMessage
+    ? resolveChatMessageAgentRunTarget(latestMessage, conversation)
+    : null;
 }
 
 export function ChatAgentRunMenuItem({

--- a/ui/src/pages/Chat.test.tsx
+++ b/ui/src/pages/Chat.test.tsx
@@ -65,6 +65,7 @@ import {
   parseAskUserAnswerMessage,
   rememberChatProjectId,
   rememberChatProjectIdForAgent,
+  resolveChatMessageAgentRunTarget,
   resolveDefaultDraftChatProjectId,
   resolveDraftIssueContext,
   resolveLatestChatAgentRunTarget,
@@ -279,6 +280,51 @@ function conversation(overrides: Partial<ChatConversation>): ChatConversation {
 }
 
 describe("latest Chat Agent Run target", () => {
+  it("resolves one message using the replying, runtime, then preferred agent", () => {
+    const runMessage = message({
+      role: "assistant",
+      kind: "message",
+      runId: "run-exact",
+      replyingAgentId: "agent-replying",
+    });
+    const runtimeConversation = conversation({
+      preferredAgentId: "agent-preferred",
+      chatRuntime: {
+        sourceType: "agent",
+        sourceLabel: "Runtime agent",
+        runtimeAgentId: "agent-runtime",
+        agentRuntimeType: "codex",
+        model: null,
+        available: true,
+        error: null,
+      },
+    });
+
+    expect(resolveChatMessageAgentRunTarget(runMessage, runtimeConversation)).toEqual({
+      runId: "run-exact",
+      agentId: "agent-replying",
+    });
+    expect(resolveChatMessageAgentRunTarget(
+      { ...runMessage, replyingAgentId: null },
+      runtimeConversation,
+    )).toEqual({ runId: "run-exact", agentId: "agent-runtime" });
+    expect(resolveChatMessageAgentRunTarget(
+      { ...runMessage, replyingAgentId: null },
+      conversation({ preferredAgentId: "agent-preferred" }),
+    )).toEqual({ runId: "run-exact", agentId: "agent-preferred" });
+  });
+
+  it("requires both a run and an agent for a message target", () => {
+    expect(resolveChatMessageAgentRunTarget(
+      message({ role: "assistant", runId: null, replyingAgentId: "agent-1" }),
+      conversation({}),
+    )).toBeNull();
+    expect(resolveChatMessageAgentRunTarget(
+      message({ role: "assistant", runId: "run-1", replyingAgentId: null }),
+      conversation({ preferredAgentId: null }),
+    )).toBeNull();
+  });
+
   it("selects the newest runtime-backed assistant message by createdAt across variants", () => {
     const target = resolveLatestChatAgentRunTarget([
       message({


### PR DESCRIPTION
## Summary
- add an organization-aware Open run action for failed Chat messages that targets the exact attributed Agent Run
- preserve Retry behavior and hide incomplete legacy targets
- remove the duplicate bottom Failure details block from Agent Run detail
- synchronize RUN.CHAT.AGENT.001 and CHAT.LIFECYCLE.001

## Test plan
- pnpm test:run ui/src/pages/Chat.test.tsx ui/src/pages/Chat.messages.test.tsx
- pnpm --filter @rudderhq/ui typecheck
- pnpm product-logic:check
- targeted Playwright coverage for runtime boot failure, retryable adapter failure, and Run detail error-summary deduplication
- pnpm lint
- pnpm -r typecheck
- pnpm build

## Verification
- independent spec and quality review: approved
- independent real-environment verifier: passed desktop and narrow-screen navigation/layout checks

## Known unrelated check
- full pnpm test:run currently has one pre-existing/concurrent CLI capability-parity failure around inlineAnnotations; this commit does not touch that area.