### PR TITLE
fix(ui): remove obsolete desktop chat clearance

### DIFF
--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -1370,10 +1370,6 @@
     background: var(--desktop-content-surface-light);
   }
 
-  .chat-desktop-toolbar-clearance {
-    height: 2.75rem;
-  }
-
   .chat-load-error-offset {
     margin-top: 1.5rem;
   }
@@ -1390,53 +1386,6 @@
 
   .chat-messages-scroll-content {
     padding-top: 1rem;
-  }
-
-  @media (min-width: 768px) {
-    html.desktop-shell-macos [data-testid="chat-main-workspace-card"]:has(> [data-testid="chat-desktop-toolbar-clearance"]) {
-      isolation: isolate;
-    }
-
-    html.desktop-shell-macos [data-testid="chat-main-workspace-card"] .chat-messages-scroll-content {
-      padding-top: calc(2.75rem + 1rem);
-    }
-
-    html.desktop-shell-macos [data-testid="chat-main-workspace-card"]:has(> [data-testid="chat-desktop-toolbar-clearance"]) > [data-testid="chat-load-error"] {
-      margin-top: calc(2.75rem + 1.5rem);
-    }
-
-    html.desktop-shell-macos [data-testid="chat-main-workspace-card"]:has(> [data-testid="chat-desktop-toolbar-clearance"]) > [data-testid="chat-conversation-loading-state"] {
-      padding-top: calc(2.75rem + 1rem);
-    }
-
-    html.desktop-shell-macos [data-testid="chat-main-workspace-card"] > [data-testid="chat-desktop-toolbar-clearance"] {
-      position: absolute;
-      inset: 0 0 auto;
-      z-index: 20;
-      height: 2.75rem;
-      overflow: hidden;
-      border-bottom: 1px solid color-mix(in oklab, var(--desktop-content-border-light) 42%, transparent);
-      border-top-left-radius: max(0px, calc(var(--desktop-workspace-radius) - 1px));
-      border-top-right-radius: max(0px, calc(var(--desktop-workspace-radius) - 1px));
-      background: color-mix(in oklab, var(--desktop-content-surface-light) 26%, transparent);
-      box-shadow:
-        inset 0 1px 0 rgb(255 255 255 / 0.58),
-        inset 1px 0 0 rgb(255 255 255 / 0.16),
-        inset -1px 0 0 rgb(255 255 255 / 0.1);
-      -webkit-backdrop-filter: blur(18px) saturate(128%);
-      backdrop-filter: blur(18px) saturate(128%);
-    }
-
-    html.dark.desktop-shell-macos [data-testid="chat-main-workspace-card"] > [data-testid="chat-desktop-toolbar-clearance"] {
-      border-bottom-color: color-mix(in oklab, var(--desktop-content-border-dark) 36%, transparent);
-      background: color-mix(in oklab, var(--desktop-content-surface-dark) 24%, transparent);
-      box-shadow:
-        inset 0 1px 0 rgb(255 255 255 / 0.12),
-        inset 1px 0 0 rgb(255 255 255 / 0.05),
-        inset -1px 0 0 rgb(255 255 255 / 0.04);
-      -webkit-backdrop-filter: blur(18px) saturate(132%);
-      backdrop-filter: blur(18px) saturate(132%);
-    }
   }
 
   .workspace-column-resizer {

--- a/ui/src/lib/index-css.test.ts
+++ b/ui/src/lib/index-css.test.ts
@@ -421,16 +421,7 @@ describe("index.css motion rules", () => {
     const darkWorkspaceShell = cssBlock("html.dark.desktop-shell-macos .workspace-shell");
     const lightDesktopWorkspaceCards = cssBlock("html.desktop-shell-macos :is(.workspace-context-card, .workspace-main-card)");
     const darkDesktopWorkspaceCards = cssBlock("html.dark.desktop-shell-macos :is(.workspace-context-card, .workspace-main-card)");
-    const activeChatCardSelector = 'html.desktop-shell-macos [data-testid="chat-main-workspace-card"]:has(> [data-testid="chat-desktop-toolbar-clearance"])';
-    const chatHeaderSelector = 'html.desktop-shell-macos [data-testid="chat-main-workspace-card"] > [data-testid="chat-desktop-toolbar-clearance"]';
-    const darkChatHeaderSelector = 'html.dark.desktop-shell-macos [data-testid="chat-main-workspace-card"] > [data-testid="chat-desktop-toolbar-clearance"]';
-    const lightChatCard = cssBlock(activeChatCardSelector);
-    const lightChatHeader = cssBlock(chatHeaderSelector);
-    const darkChatHeader = cssBlock(darkChatHeaderSelector);
-    const chatMessages = cssBlock('html.desktop-shell-macos [data-testid="chat-main-workspace-card"] .chat-messages-scroll-content');
-    const chatLoadError = cssBlock(`${activeChatCardSelector} > [data-testid="chat-load-error"]`);
-    const chatLoadingState = cssBlock(`${activeChatCardSelector} > [data-testid="chat-conversation-loading-state"]`);
-    const chatToolbarClearance = cssBlock(".chat-desktop-toolbar-clearance");
+    const chatMessages = cssBlock(".chat-messages-scroll-content");
     const chatLoadErrorOffset = cssBlock(".chat-load-error-offset");
     const chatLoadingOffset = cssBlock(".chat-conversation-loading-offset");
 
@@ -446,25 +437,11 @@ describe("index.css motion rules", () => {
     expect(darkDesktopWorkspaceCards).toContain("background: var(--desktop-content-surface-dark)");
     expect(lightDesktopWorkspaceCards).not.toContain("backdrop-filter");
     expect(darkDesktopWorkspaceCards).not.toContain("backdrop-filter");
-    expect(lightChatCard).toContain("isolation: isolate");
-    expect(lightChatCard).not.toContain("linear-gradient");
-    expect(chatMessages).toContain("padding-top: calc(2.75rem + 1rem)");
-    expect(chatLoadError).toContain("margin-top: calc(2.75rem + 1.5rem)");
-    expect(chatLoadingState).toContain("padding-top: calc(2.75rem + 1rem)");
-    expect(chatToolbarClearance).toContain("height: 2.75rem");
+    expect(chatMessages).toContain("padding-top: 1rem");
     expect(chatLoadErrorOffset).toContain("margin-top: 1.5rem");
     expect(chatLoadingOffset).toContain("padding-top: 1rem");
     expect(chatLoadingOffset).toContain("padding-bottom: 1rem");
-    expect(lightChatHeader).toContain("position: absolute");
-    expect(lightChatHeader).toContain("inset: 0 0 auto");
-    expect(lightChatHeader).toContain("height: 2.75rem");
-    expect(lightChatHeader).toContain("border-top-left-radius: max(0px, calc(var(--desktop-workspace-radius) - 1px))");
-    expect(lightChatHeader).toContain("border-top-right-radius: max(0px, calc(var(--desktop-workspace-radius) - 1px))");
-    expect(lightChatHeader).toContain("var(--desktop-content-surface-light) 26%");
-    expect(lightChatHeader).toContain("backdrop-filter: blur(18px) saturate(128%)");
-    expect(darkChatHeader).toContain("var(--desktop-content-surface-dark) 24%");
-    expect(darkChatHeader).toContain("backdrop-filter: blur(18px) saturate(132%)");
-    expect(activeChatCardSelector).toContain(":has(>");
+    expect(indexCss).not.toContain("chat-desktop-toolbar-clearance");
     expect(indexCss).not.toContain("html.desktop-shell-macos :is(.workspace-context-header, .workspace-main-header)");
   });
 


### PR DESCRIPTION
Removes the unused macOS Messenger desktop clearance and its dead glass-header CSS after the DOM contract stopped rendering that element.

Validation:
- focused CSS suite: 37/37 passed
- lint passed
- product logic check passed
- browser and independent black-box acceptance passed
- full typecheck/build remain blocked by the existing actionKind baseline errors on main
- full test run: 5302 passed, 20 failed from existing PostgreSQL init, transcript/annotation, and Vite lifecycle failures