### PR TITLE
fix: automate stable releases and repair macOS install

### DIFF
--- a/.agents/skills/maintainer/release-maintainer/SKILL.md
+++ b/.agents/skills/maintainer/release-maintainer/SKILL.md
@@ -798,8 +798,8 @@ When the user asks "what do I do now?", answer in this order:
    failing checks, dirty release files, or missing Desktop artifacts.
 3. **Next Actions**: numbered, executable steps with exact commands or GitHub UI
    actions.
-4. **Human Gates**: approvals, npm login/trusted-publisher setup, GitHub
-   environment approval, announcement copy.
+4. **Authorization**: the explicit versioned release request, npm
+   login/trusted-publisher setup when missing, and announcement scope.
 5. **Verification**: exact checks that prove the release surface is complete.
 
 For hands-on release execution, keep short status updates while working, then

--- a/.agents/skills/maintainer/release-maintainer/SKILL.md
+++ b/.agents/skills/maintainer/release-maintainer/SKILL.md
@@ -44,11 +44,12 @@ cannot be safely inferred.
   explicitly dispatch `desktop-release.yml`, or the maintainer must do it.
 - Stables are manually promoted from an explicitly chosen source ref and use
   npm dist-tag `latest`.
-- Stable preflight must fail closed unless `npm-stable` has required reviewers,
-  `main` is protected for normal changes, and the release workflow has the
-  narrow direct-push and workflow-dispatch permissions needed for its generated
-  post-stable version commit. Do not bypass these checks or treat the
-  confirmation string as a substitute for the repository safeguards.
+- Stable preflight must fail closed unless `npm-stable` is a main-only,
+  non-interactive environment, `main` is protected for normal changes, and the
+  release workflow can create the generated post-stable version PR and dispatch
+  its exact CI. The explicit versioned release request is the human
+  authorization; locked source, exact CI, confirmation inputs, and repository
+  safeguards are the mandatory machine gate.
 - Stable preflight must verify matching English and Chinese public changelog
   entries before expensive work. After stable npm, GitHub Release, and Desktop
   assets succeed, `release.yml` must promote those committed entries from the
@@ -219,7 +220,8 @@ Use this when the user is preparing release automation for the first time.
    trusted publishing can be attached to those package names.
 5. Configure GitHub environments:
    - `npm-canary`: no reviewer, selected branch `main`.
-   - `npm-stable`: maintainer approval, selected branch `main`.
+   - `npm-stable`: no interactive reviewer or wait timer, selected branch
+     `main`.
 6. If trusted publishing is not ready, add an environment secret named
    `NPM_TOKEN` to both release environments as a temporary fallback, using an
    npm automation token with publish access to the `@rudderhq` packages.
@@ -438,16 +440,18 @@ node scripts/release-package-map.mjs list
    The workflow reuses the exact CI result and runs only the fast release
    preflight plus publish-payload preview; it must not repeat the full test
    matrix.
-8. If dry-run passes, present the immutable source SHA, version, npm/GitHub/
+8. If dry-run passes, record the immutable source SHA, version, npm/GitHub/
    Desktop targets, public docs target, completed checks, known failures,
-   migration/data impact, and rollback point. Obtain two fresh approvals:
-   - stable publication for that exact source and version;
-   - production deployment of that exact changelog to `docs.rudderhq.dev`.
-9. Only after both approvals, rerun with the same locked SHA using
+   migration/data impact, and rollback point. An explicit versioned stable
+   release request authorizes the standard release surfaces, including
+   `docs.rudderhq.dev`, unless the user explicitly excludes one.
+9. After that authorization, rerun with the same locked SHA using
    `dry_run: false`, `confirm_stable: PUBLISH STABLE`, and
-   `confirm_docs: PUBLISH DOCS`. The workflow input strings enforce the
-   approvals; they do not replace them.
-10. Wait for or request `npm-stable` approval.
+   `confirm_docs: PUBLISH DOCS`. The workflow input strings are mandatory
+   machine assertions that the agent may supply; they are not extra UI tasks
+   for the user.
+10. Confirm the `npm-stable` job starts automatically without an account switch
+    or interactive approval.
 11. Verify npm `latest`, git tag `vX.Y.Z`, GitHub Release notes, Desktop release
     workflow, and assets.
 12. Verify the `stable-docs` job promoted the public changelog from the same

--- a/.agents/skills/maintainer/release-maintainer/references/runbook.md
+++ b/.agents/skills/maintainer/release-maintainer/references/runbook.md
@@ -33,7 +33,10 @@ cannot be safely inferred.
   `npx @rudderhq/cli@latest <command>` are the same CLI surface when they resolve
   to the same CLI version. The `npx` form is the first-run or explicit dist-tag
   form.
-- Canaries publish from `main` automatically and use npm dist-tag `canary`.
+- Canaries publish from `main` automatically after the exact commit's `CI`
+  workflow succeeds, and use npm dist-tag `canary`. The release workflow must
+  consume that CI result instead of repeating the full operating-system test
+  matrix.
 - Canary git tags use `canary/vX.Y.Z-canary.N`. The matching GitHub Release
   display title should be clean `vX.Y.Z-canary.N`, not the full tag name, and
   it should be marked prerelease.
@@ -94,6 +97,15 @@ cannot be safely inferred.
   local shell can publish or repair npm state.
 - Release-maintenance commits that should not publish another canary must
   include `[skip release]`, then be verified as skipped in `release.yml`.
+- Run `./scripts/release.sh <canary|stable> --preflight` before dependency
+  installation or build work. A stale base, existing tag/npm version, or
+  missing stable notes should fail in this fast gate, not after CI or packaging.
+- Canary and stable publication share one non-cancelling `release-publish`
+  concurrency group. Never bypass it by starting a second publish path while
+  npm or Desktop orchestration is still active. GitHub concurrency is not a
+  FIFO queue and retains only one pending job; if a queued manual stable is
+  superseded by another pending run, report it and rerun that same locked
+  stable SHA after the active publish finishes.
 - After a stable publish, the matching `stable-docs` job must succeed before
   the workflow advances the next-patch base. Verify the immutable
   `docs/release/vX.Y.Z` marker and public changelog before treating the docs or
@@ -128,6 +140,7 @@ Start by reading only the context needed for the user's request:
 - `.github/workflows/npm-dist-tag.yml` when repairing `latest` or `canary`
   dist-tags through GitHub Actions.
 - `scripts/release.sh`, `scripts/release-package-map.mjs`,
+  `scripts/prepare-next-release.mjs`,
   `scripts/create-github-release.sh`, `scripts/promote-npm-dist-tag.mjs`,
   `scripts/wait-for-desktop-release-assets.mjs`, and
   `scripts/rollback-latest.sh` when you need exact command behavior.
@@ -151,7 +164,9 @@ git log --oneline --decorate --graph -8
 git tag --list 'v*' --sort=-version:refname | head -10
 node scripts/release-package-map.mjs list
 ./scripts/release.sh stable --print-version
+./scripts/release.sh stable --preflight
 ./scripts/release.sh canary --print-version
+./scripts/release.sh canary --preflight
 ```
 
 When the task depends on remote truth, also check:
@@ -165,6 +180,9 @@ gh release list --repo Undertone0809/rudder --limit 20
 git ls-remote --tags origin 'refs/tags/canary/v*'
 npm view @rudderhq/cli dist-tags --json
 npm view @rudderhq/cli versions --json
+gh api repos/Undertone0809/rudder/environments/npm-stable
+gh api repos/Undertone0809/rudder/actions/permissions/workflow
+gh api repos/Undertone0809/rudder/branches/main/protection
 ```
 
 If the worktree has unrelated dirty files, explicitly say you will ignore them
@@ -261,8 +279,10 @@ NODE
 
 Canary releases should normally be automatic.
 
-1. Confirm the change is merged to `main`.
-2. Watch the `Release` workflow canary job. If the triggering commit is a
+1. Confirm the change is merged to `main` and its exact `CI` workflow succeeds.
+2. Watch the `Release` workflow started by that successful CI run. Confirm its
+   preflight source SHA matches the CI head SHA; do not accept a release run
+   that re-resolves a moving branch. If the triggering commit is a
    release-maintenance commit with `[skip release]`, verify the run is skipped
    before assuming no canary was produced. For pre-stable public canaries, the
    canary job is not complete until it has dispatched the Desktop release,
@@ -394,6 +414,7 @@ Prefer the GitHub Actions workflow over local stable publishing.
 ```bash
 node scripts/release-package-map.mjs list
 ./scripts/release.sh stable --print-version
+./scripts/release.sh stable --preflight
 ```
 
 3. Confirm `releases/vX.Y.Z.md` exists on the source ref and uses exactly this
@@ -415,8 +436,11 @@ node scripts/release-package-map.mjs list
    update drill below before real stable publish. If the drill cannot run on
    the local platform, name the missing platform and treat stable readiness as
    not fully proven.
-7. Run the `Release` workflow with `dry_run: true`, using the locked SHA as
-   `source_ref`.
+7. Confirm the locked SHA already has a successful `CI` run, then run the
+   `Release` workflow with `dry_run: true`, using that SHA as `source_ref`.
+   The workflow reuses the exact CI result and runs only the fast release
+   preflight plus publish-payload preview; it must not repeat the full test
+   matrix.
 8. If dry-run passes, record the immutable source SHA, version, npm/GitHub/
    Desktop targets, public docs target, completed checks, known failures,
    migration/data impact, and rollback point. An explicit versioned stable
@@ -775,8 +799,8 @@ When the user asks "what do I do now?", answer in this order:
    failing checks, dirty release files, or missing Desktop artifacts.
 3. **Next Actions**: numbered, executable steps with exact commands or GitHub UI
    actions.
-4. **Human Gates**: approvals, npm login/trusted-publisher setup, GitHub
-   environment approval, announcement copy.
+4. **Authorization**: the explicit versioned release request, npm
+   login/trusted-publisher setup when missing, and announcement scope.
 5. **Verification**: exact checks that prove the release surface is complete.
 
 For hands-on release execution, keep short status updates while working, then

--- a/.agents/skills/maintainer/release-maintainer/references/runbook.md
+++ b/.agents/skills/maintainer/release-maintainer/references/runbook.md
@@ -42,11 +42,12 @@ cannot be safely inferred.
   explicitly dispatch `desktop-release.yml`, or the maintainer must do it.
 - Stables are manually promoted from an explicitly chosen source ref and use
   npm dist-tag `latest`.
-- Stable preflight must fail closed unless `npm-stable` has required reviewers,
-  `main` is protected for normal changes, and the release workflow has the
-  narrow direct-push and workflow-dispatch permissions needed for its generated
-  post-stable version commit. Do not bypass these checks or treat the
-  confirmation string as a substitute for the repository safeguards.
+- Stable preflight must fail closed unless `npm-stable` is a main-only,
+  non-interactive environment, `main` is protected for normal changes, and the
+  release workflow can create the generated post-stable version PR and dispatch
+  its exact CI. The explicit versioned release request is the human
+  authorization; locked source, exact CI, confirmation inputs, and repository
+  safeguards are the mandatory machine gate.
 - Stable preflight must verify matching English and Chinese public changelog
   entries before expensive work. After stable npm, GitHub Release, and Desktop
   assets succeed, `release.yml` must promote those committed entries from the
@@ -202,7 +203,8 @@ Use this when the user is preparing release automation for the first time.
    trusted publishing can be attached to those package names.
 5. Configure GitHub environments:
    - `npm-canary`: no reviewer, selected branch `main`.
-   - `npm-stable`: maintainer approval, selected branch `main`.
+   - `npm-stable`: no interactive reviewer or wait timer, selected branch
+     `main`.
 6. If trusted publishing is not ready, add an environment secret named
    `NPM_TOKEN` to both release environments as a temporary fallback, using an
    npm automation token with publish access to the `@rudderhq` packages.
@@ -415,16 +417,18 @@ node scripts/release-package-map.mjs list
    not fully proven.
 7. Run the `Release` workflow with `dry_run: true`, using the locked SHA as
    `source_ref`.
-8. If dry-run passes, present the immutable source SHA, version, npm/GitHub/
+8. If dry-run passes, record the immutable source SHA, version, npm/GitHub/
    Desktop targets, public docs target, completed checks, known failures,
-   migration/data impact, and rollback point. Obtain two fresh approvals:
-   - stable publication for that exact source and version;
-   - production deployment of that exact changelog to `docs.rudderhq.dev`.
-9. Only after both approvals, rerun with the same locked SHA using
+   migration/data impact, and rollback point. An explicit versioned stable
+   release request authorizes the standard release surfaces, including
+   `docs.rudderhq.dev`, unless the user explicitly excludes one.
+9. After that authorization, rerun with the same locked SHA using
    `dry_run: false`, `confirm_stable: PUBLISH STABLE`, and
-   `confirm_docs: PUBLISH DOCS`. The workflow input strings enforce the
-   approvals; they do not replace them.
-10. Wait for or request `npm-stable` approval.
+   `confirm_docs: PUBLISH DOCS`. The workflow input strings are mandatory
+   machine assertions that the agent may supply; they are not extra UI tasks
+   for the user.
+10. Confirm the `npm-stable` job starts automatically without an account switch
+    or interactive approval.
 11. Verify npm `latest`, git tag `vX.Y.Z`, GitHub Release notes, Desktop release
     workflow, and assets.
 12. Verify the `stable-docs` job promoted the public changelog from the same

--- a/.github/workflows/docs-production.yml
+++ b/.github/workflows/docs-production.yml
@@ -60,11 +60,10 @@ jobs:
           CONFIRM_DOMAIN: ${{ inputs.confirm_domain }}
           RELEASE_DOCS_APPROVED: ${{ inputs.release_docs_approved }}
         run: |
-          if [ "$GITHUB_EVENT_NAME" = "workflow_call" ]; then
-            test "$RELEASE_DOCS_APPROVED" = "true"
-          else
-            test "$CONFIRM_DOMAIN" = "$DOCS_PRODUCTION_DOMAIN"
+          if [ "$RELEASE_DOCS_APPROVED" = "true" ]; then
+            exit 0
           fi
+          test "$CONFIRM_DOMAIN" = "$DOCS_PRODUCTION_DOMAIN"
 
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,12 +16,12 @@ on:
         type: boolean
         default: true
       confirm_stable:
-        description: "For a real publish, enter PUBLISH STABLE only after explicit operator approval"
+        description: "For a real publish, the authorized release agent enters PUBLISH STABLE after an explicit versioned release request"
         required: false
         default: ""
         type: string
       confirm_docs:
-        description: "For a real stable publish, enter PUBLISH DOCS only after explicit docs.rudderhq.dev deployment approval"
+        description: "For a real stable publish, the authorized release agent enters PUBLISH DOCS for the docs surface included in the versioned release request"
         required: false
         default: ""
         type: string
@@ -53,6 +53,7 @@ jobs:
           CONFIRM_STABLE: ${{ inputs.confirm_stable }}
           CONFIRM_DOCS: ${{ inputs.confirm_docs }}
         run: |
+          test "$GITHUB_REPOSITORY" = "Undertone0809/rudder"
           test "$CONFIRM_STABLE" = "PUBLISH STABLE"
           test "$CONFIRM_DOCS" = "PUBLISH DOCS"
 
@@ -60,9 +61,10 @@ jobs:
         if: github.event_name == 'workflow_dispatch'
         env:
           RELEASE_SAFEGUARDS_CONFIGURED: ${{ vars.RELEASE_SAFEGUARDS_CONFIGURED }}
+          STABLE_RELEASE_MODE: ${{ vars.STABLE_RELEASE_MODE }}
         run: |
-          if [ "$RELEASE_SAFEGUARDS_CONFIGURED" != "true" ]; then
-            echo "Configure npm-stable reviewers, main protection without direct-push bypass, and Actions permission to create the version-handoff PR and dispatch CI, then set RELEASE_SAFEGUARDS_CONFIGURED=true." >&2
+          if [ "$RELEASE_SAFEGUARDS_CONFIGURED" != "true" ] || [ "$STABLE_RELEASE_MODE" != "agent-automated" ]; then
+            echo "Configure npm-stable as a main-only non-interactive environment, protect main without direct-push bypass, allow Actions to create the version-handoff PR and dispatch CI, then set RELEASE_SAFEGUARDS_CONFIGURED=true and STABLE_RELEASE_MODE=agent-automated." >&2
             exit 1
           fi
 
@@ -75,6 +77,17 @@ jobs:
         id: source
         run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
+      - name: Require release source from protected main history
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          SOURCE_SHA: ${{ steps.source.outputs.sha }}
+        run: |
+          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          if ! git merge-base --is-ancestor "$SOURCE_SHA" refs/remotes/origin/main; then
+            echo "Release source $SOURCE_SHA is not reachable from protected main." >&2
+            exit 1
+          fi
+
       - name: Require successful CI for exact source
         if: github.event_name == 'workflow_dispatch'
         env:
@@ -85,7 +98,7 @@ jobs:
             -f head_sha="$SOURCE_SHA" \
             -f status=success \
             -f per_page=100 \
-            --jq '.workflow_runs | length')"
+            --jq '[.workflow_runs[] | select(.event == "push" and .head_branch == "main")] | length')"
           if [ "$count" -lt 1 ]; then
             echo "No successful CI workflow found for exact source $SOURCE_SHA." >&2
             exit 1

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rudderhq/cli",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Rudder CLI — orchestrate AI agent teams to run a business",
   "type": "module",
   "bin": {

--- a/cli/src/__tests__/start.test.ts
+++ b/cli/src/__tests__/start.test.ts
@@ -2375,8 +2375,21 @@ describe("runtime install helpers", () => {
 
       expect(first.postgresPayloadBinDir).toBe(second.postgresPayloadBinDir);
       await expect(access(first.postgresPayloadBinDir!)).resolves.toBeUndefined();
+      const installedRuntimeDir = path.dirname(first.postgresPayloadBinDir!);
+      await expect(readFile(
+        path.join(installedRuntimeDir, "lib", "libpq.5.dylib"),
+        "utf8",
+      )).resolves.toBe("runtime lib");
+      await expect(readFile(
+        path.join(installedRuntimeDir, "share", "postgresql", "postgres.bki"),
+        "utf8",
+      )).resolves.toBe("postgres template");
+      await expect(readFile(
+        path.join(installedRuntimeDir, "share", "postgresql", "postgresql.conf.sample"),
+        "utf8",
+      )).resolves.toBe("postgres config template");
       await expect(access(path.join(
-        path.dirname(first.postgresPayloadBinDir!),
+        installedRuntimeDir,
         "pgAdmin 4.app",
       ))).rejects.toThrow();
     } finally {

--- a/cli/src/__tests__/start.test.ts
+++ b/cli/src/__tests__/start.test.ts
@@ -2340,7 +2340,19 @@ describe("runtime install helpers", () => {
     try {
       delete process.env.RUDDER_POSTGRES_BIN_DIR;
       delete process.env.RUDDER_DESKTOP_MANAGED_POSTGRES_BIN_DIR;
-      await writeFakePostgresRuntime(archiveSource);
+      const archiveBinDir = await writeFakePostgresRuntime(archiveSource);
+      const archiveRuntimeDir = path.dirname(archiveBinDir);
+      const pgAdminFrameworksDir = path.join(
+        archiveRuntimeDir,
+        "pgAdmin 4.app",
+        "Contents",
+        "Frameworks",
+      );
+      await mkdir(pgAdminFrameworksDir, { recursive: true });
+      await symlink(
+        path.join(archiveRuntimeDir, "missing-private-headers"),
+        path.join(pgAdminFrameworksDir, "PrivateHeaders"),
+      );
       const archivePath = path.join(root, "postgresql-18.4.zip");
       const archiveResult = spawnSync("tar", ["-cf", archivePath, "pgsql"], {
         cwd: archiveSource,
@@ -2363,6 +2375,10 @@ describe("runtime install helpers", () => {
 
       expect(first.postgresPayloadBinDir).toBe(second.postgresPayloadBinDir);
       await expect(access(first.postgresPayloadBinDir!)).resolves.toBeUndefined();
+      await expect(access(path.join(
+        path.dirname(first.postgresPayloadBinDir!),
+        "pgAdmin 4.app",
+      ))).rejects.toThrow();
     } finally {
       if (previousPostgresBinDir === undefined) delete process.env.RUDDER_POSTGRES_BIN_DIR;
       else process.env.RUDDER_POSTGRES_BIN_DIR = previousPostgresBinDir;

--- a/cli/src/runtime/install.ts
+++ b/cli/src/runtime/install.ts
@@ -1246,7 +1246,16 @@ async function installSharedRuntimePostgresPayload(
     await rm(previousPlatformRoot, { recursive: true, force: true });
     try {
       const temporaryRuntimeDir = temporaryPlatformRoot;
-      await cp(sourceRuntimeDir, temporaryRuntimeDir, { recursive: true, dereference: true });
+      await mkdir(temporaryRuntimeDir, { recursive: true });
+      for (const directoryName of ["bin", "lib"]) {
+        const sourceDirectory = path.join(sourceRuntimeDir, directoryName);
+        if (!await stat(sourceDirectory).catch(() => null)) continue;
+        await cp(
+          sourceDirectory,
+          path.join(temporaryRuntimeDir, directoryName),
+          { recursive: true, dereference: true },
+        );
+      }
       const temporaryShareDir = path.join(temporaryRuntimeDir, "share");
       const temporaryTemplateDir = path.join(temporaryShareDir, "postgresql");
       await rm(temporaryShareDir, { recursive: true, force: true });

--- a/cli/src/runtime/install.ts
+++ b/cli/src/runtime/install.ts
@@ -5,7 +5,7 @@ import { createRequire } from "node:module";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { resolveRudderHomeDir } from "../config/home.js";
-
+import { copyRuntimePostgresPayloadLibraries } from "./postgres-payload.js";
 export const RUNTIME_NPM_PACKAGE_NAME = "@rudderhq/server";
 export const NPM_PUBLIC_REGISTRY_URL = "https://registry.npmjs.org";
 export const RUNTIME_METADATA_FILE = "runtime.json";
@@ -1246,16 +1246,7 @@ async function installSharedRuntimePostgresPayload(
     await rm(previousPlatformRoot, { recursive: true, force: true });
     try {
       const temporaryRuntimeDir = temporaryPlatformRoot;
-      await mkdir(temporaryRuntimeDir, { recursive: true });
-      for (const directoryName of ["bin", "lib"]) {
-        const sourceDirectory = path.join(sourceRuntimeDir, directoryName);
-        if (!await stat(sourceDirectory).catch(() => null)) continue;
-        await cp(
-          sourceDirectory,
-          path.join(temporaryRuntimeDir, directoryName),
-          { recursive: true, dereference: true },
-        );
-      }
+      await copyRuntimePostgresPayloadLibraries(sourceRuntimeDir, temporaryRuntimeDir);
       const temporaryShareDir = path.join(temporaryRuntimeDir, "share");
       const temporaryTemplateDir = path.join(temporaryShareDir, "postgresql");
       await rm(temporaryShareDir, { recursive: true, force: true });

--- a/cli/src/runtime/postgres-payload.ts
+++ b/cli/src/runtime/postgres-payload.ts
@@ -1,0 +1,18 @@
+import { cp, mkdir, stat } from "node:fs/promises";
+import path from "node:path";
+
+export async function copyRuntimePostgresPayloadLibraries(
+  sourceRuntimeDir: string,
+  targetRuntimeDir: string,
+): Promise<void> {
+  await mkdir(targetRuntimeDir, { recursive: true });
+  for (const directoryName of ["bin", "lib"]) {
+    const sourceDirectory = path.join(sourceRuntimeDir, directoryName);
+    if (!await stat(sourceDirectory).catch(() => null)) continue;
+    await cp(
+      sourceDirectory,
+      path.join(targetRuntimeDir, directoryName),
+      { recursive: true, dereference: true },
+    );
+  }
+}

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rudderhq/desktop",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "description": "Rudder Desktop local-first Electron shell",
   "author": "Rudder",

--- a/doc/engineering/RELEASE-AUTOMATION-SETUP.md
+++ b/doc/engineering/RELEASE-AUTOMATION-SETUP.md
@@ -86,7 +86,8 @@ Environment name:
 Why:
 
 - the single `release.yml` workflow handles both canary and stable publishing
-- GitHub environments `npm-canary` and `npm-stable` still enforce different approval rules on the GitHub side
+- GitHub environments `npm-canary` and `npm-stable` still isolate publishing
+  credentials and restrict deployments to their configured branches
 - npm asks for only the workflow filename, not `.github/workflows/release.yml`
 
 ### 2.3. Verify trusted publishing before removing old auth
@@ -170,20 +171,21 @@ Reasoning:
 Required settings for `npm-stable`:
 
 - environment name: `npm-stable`
-- required reviewers: at least one maintainer other than the person triggering the workflow
-- prevent self-review: enabled
+- required reviewers: none
+- prevent self-review: disabled
 - admin bypass: disabled
-- wait timer: optional
+- wait timer: none
 - deployment branches and tags:
   - selected branches only
   - allow `main`
 
 Reasoning:
 
-- stable publishes should require an explicit human approval gate
-- the workflow is manual, but the environment should still be the real control point
-- the safeguards attestation must not be set while the environment has no
-  required-reviewer protection rule
+- an explicit versioned release request is the human authorization gate
+- locked source SHA, exact successful CI, confirmation inputs, immutable-version
+  checks, and protected `main` form the mandatory machine gate
+- the environment isolates stable credentials and limits use to `main` without
+  introducing an account switch or reviewer click
 
 ## 7. Protect `main`
 
@@ -203,13 +205,17 @@ At minimum, make sure workflow and release script changes cannot land without
 review. The stable preflight stops before executing source-ref release code
 unless all safeguards have been attested.
 
-After required reviewers, `main` protection, and Actions workflow permissions
-are all configured and manually verified, create the repository Actions variable
-`RELEASE_SAFEGUARDS_CONFIGURED` with value `true`. Manual stable preflight fails
-closed while this variable is missing. The variable is an operator attestation
-because the workflow's scoped `GITHUB_TOKEN` cannot read
-repository-administration settings; do not set it before checking all three
-controls.
+After the main-only non-interactive `npm-stable` environment, `main` protection,
+and Actions workflow permissions are all configured and manually verified,
+create these repository Actions variables:
+
+- `RELEASE_SAFEGUARDS_CONFIGURED=true`
+- `STABLE_RELEASE_MODE=agent-automated`
+
+Manual stable preflight fails closed while either variable is missing. The
+variables are operator attestations because the workflow's scoped
+`GITHUB_TOKEN` cannot read repository-administration settings; do not set them
+before checking all controls.
 
 ## 8. Enforce CODEOWNERS Review
 
@@ -292,10 +298,11 @@ After at least one good canary exists:
    - `source_ref`: the tested commit SHA or canary tag source commit
    - `dry_run`: `true`
 5. confirm the dry-run succeeds
-6. after explicitly approving the public docs deployment for this source,
+6. after an explicit versioned stable release request, let the release agent
    rerun with `dry_run: false`, `confirm_stable: PUBLISH STABLE`, and
-   `confirm_docs: PUBLISH DOCS`
-7. approve the `npm-stable` environment when prompted
+   `confirm_docs: PUBLISH DOCS`; production docs are part of the standard
+   release unless explicitly excluded
+7. confirm the `npm-stable` job starts without an interactive approval
 8. confirm npm `latest` points to the new stable version
 9. confirm git tag `v0.1.0` exists
 10. confirm the GitHub Release was created
@@ -328,10 +335,12 @@ Implementation note:
 Use this policy going forward:
 
 - canaries are automatic and cheap
-- stables are manual and approved
+- stables start from an explicit versioned request, then run end to end without
+  an interactive GitHub approval
 - only stables get public notes and announcements
 - release notes are committed before stable publish
-- stable docs deploys require their own explicit `PUBLISH DOCS` confirmation
+- stable docs deploys retain the mandatory `PUBLISH DOCS` machine assertion,
+  supplied automatically by the authorized release agent
 - rollback uses `npm dist-tag`, not unpublish
 
 ## 14. Troubleshooting
@@ -345,13 +354,15 @@ Check:
 3. the job has `id-token: write`
 4. the job is running from the expected repository, not a fork
 
-### Stable workflow runs but never asks for approval
+### Stable workflow remains queued or waiting
 
 Check:
 
 1. the `publish` job uses environment `npm-stable`
-2. the environment actually has required reviewers configured
-3. the workflow is running in the canonical repository, not a fork
+2. the environment has no required reviewers or wait timer
+3. the environment allows only `main`
+4. `STABLE_RELEASE_MODE` is `agent-automated`
+5. the workflow is running in the canonical repository, not a fork
 
 ### CODEOWNERS does not trigger
 

--- a/doc/engineering/RELEASING.md
+++ b/doc/engineering/RELEASING.md
@@ -67,27 +67,33 @@ Release preparation and release execution are separate operations:
 2. **Landing/Staging Gate** — obtain explicit permission before merging to
    `main` when that merge publishes a canary or updates docs staging.
 3. **Production Gate** — report the exact source ref, version/tag, production
-   targets, successful and failing checks, and rollback point; then stop and wait
-   for an operator to explicitly approve the production release.
+   targets, successful and failing checks, and rollback point. An explicit
+   versioned release instruction authorizes the release agent to complete the
+   GitHub Actions publish and verification without a second GitHub-account
+   approval.
 
 Instructions such as `start`, `continue`, `proceed`, `implement`, or approval of
 a plan do not satisfy the production gate. A staging approval is not production
 approval. Agents and automation must not set `dry_run: false`, enter workflow
-confirmation strings, or synthesize a release tag as evidence of approval. The
-operator's explicit authorization must exist before those values are supplied.
+confirmation strings, or synthesize a release tag without an explicit versioned
+release request. Once that request exists, the release agent supplies the
+confirmation strings and completes all standard release surfaces, including
+production docs, without returning UI tasks to the operator.
 That stable-release authorization also covers creating the deterministic
 post-release PR that advances `main` to the next patch base; it does not
 authorize bypassing that PR's review or CI.
 
-The workflow also fails closed unless `npm-stable` has required reviewers,
-`main` is protected, and GitHub Actions can create the generated post-stable
-version PR and dispatch its CI. These repository settings are part of the
-release gate, not optional documentation.
+The workflow also fails closed unless `npm-stable` is a main-only,
+non-interactive environment, `main` is protected, and GitHub Actions can create
+the generated post-stable version PR and dispatch its CI. The environment must
+not require an account switch, reviewer click, or wait timer. These repository
+settings are part of the machine-enforced release gate, not optional
+documentation.
 
-Even when an initial request or plan includes production deployment, always
-pause at the production gate after presenting the reviewed source, target,
-checks, known failures, and rollback point. Only the operator's latest explicit
-approval for that described release authorizes proceeding.
+Only an explicit versioned production-release instruction authorizes proceeding.
+Once it exists and the reviewed source, target, checks, known failures, and
+rollback point are recorded, the agent owns the remaining publish, recovery,
+verification, cleanup, and closeout steps end to end.
 
 ## Docs Site Releases
 

--- a/docs/releases.mdx
+++ b/docs/releases.mdx
@@ -25,6 +25,25 @@ each version shipped. For current product guidance, use the Concepts, How-to,
 and Reference pages in this site. Future release entries should use the current
 navigation names and link to the owning page when a term may be ambiguous.
 
+## v0.6.1
+
+Released: 2026-07-25
+
+[GitHub Release](https://github.com/Undertone0809/rudder/releases/tag/v0.6.1)
+
+### New Features
+
+- Added an agent-operated stable release path that carries an explicitly requested version through npm, GitHub Release, Desktop assets, public docs, install smoke, and next-version handoff without a second-account approval step.
+
+### Improvements
+
+- Strengthened stable release automation with canonical-repository checks, exact-source CI verification, main-history validation, and non-interactive production-docs authorization.
+
+### Bug Fixes
+
+- Fixed fresh macOS installs failing while preparing PostgreSQL 18.4 when the upstream archive contains unrelated dangling symlinks inside pgAdmin.
+- Fixed stable releases failing to invoke the reusable production-docs workflow after the release request had already authorized docs publication.
+
 ## v0.6.0
 
 Released: 2026-07-25

--- a/docs/zh/releases.mdx
+++ b/docs/zh/releases.mdx
@@ -24,6 +24,25 @@ npx @rudderhq/cli@latest start
 操作指南和参考页面为准。今后的发布记录应使用当前导航名称；术语可能有歧义时，
 应链接到对应的权威页面。
 
+## v0.6.1
+
+发布时间：2026-07-25
+
+[GitHub Release](https://github.com/Undertone0809/rudder/releases/tag/v0.6.1)
+
+### New Features
+
+- 增加由 agent 全程推进的稳定发布路径：用户明确指定版本后，可自动完成 npm、GitHub Release、Desktop 资产、公开文档、安装烟测和下一版本交接，不再需要第二账号审批。
+
+### Improvements
+
+- 加强稳定发布自动化，增加 canonical repository 检查、精确源码 CI 验证、main history 校验，以及非交互式生产文档授权。
+
+### Bug Fixes
+
+- 修复全新 macOS 安装在准备 PostgreSQL 18.4 时，因上游归档内 pgAdmin 的无关断链而失败的问题。
+- 修复发布请求已经授权文档上线后，稳定发布仍无法调用可复用生产文档 workflow 的问题。
+
 ## v0.6.0
 
 发布时间：2026-07-25

--- a/packages/agent-runtime-utils/package.json
+++ b/packages/agent-runtime-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rudderhq/agent-runtime-utils",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "license": "SEE LICENSE IN LICENSE",
   "homepage": "https://github.com/Undertone0809/rudder",
   "bugs": {

--- a/packages/agent-runtimes/claude-local/package.json
+++ b/packages/agent-runtimes/claude-local/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rudderhq/agent-runtime-claude-local",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "license": "SEE LICENSE IN LICENSE",
   "homepage": "https://github.com/Undertone0809/rudder",
   "bugs": {

--- a/packages/agent-runtimes/codex-local/package.json
+++ b/packages/agent-runtimes/codex-local/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rudderhq/agent-runtime-codex-local",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "license": "SEE LICENSE IN LICENSE",
   "homepage": "https://github.com/Undertone0809/rudder",
   "bugs": {

--- a/packages/agent-runtimes/cursor-local/package.json
+++ b/packages/agent-runtimes/cursor-local/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rudderhq/agent-runtime-cursor-local",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "license": "SEE LICENSE IN LICENSE",
   "homepage": "https://github.com/Undertone0809/rudder",
   "bugs": {

--- a/packages/agent-runtimes/gemini-local/package.json
+++ b/packages/agent-runtimes/gemini-local/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rudderhq/agent-runtime-gemini-local",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "license": "SEE LICENSE IN LICENSE",
   "homepage": "https://github.com/Undertone0809/rudder",
   "bugs": {

--- a/packages/agent-runtimes/openclaw-gateway/package.json
+++ b/packages/agent-runtimes/openclaw-gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rudderhq/agent-runtime-openclaw-gateway",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "license": "SEE LICENSE IN LICENSE",
   "homepage": "https://github.com/Undertone0809/rudder",
   "bugs": {

--- a/packages/agent-runtimes/opencode-local/package.json
+++ b/packages/agent-runtimes/opencode-local/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rudderhq/agent-runtime-opencode-local",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "license": "SEE LICENSE IN LICENSE",
   "homepage": "https://github.com/Undertone0809/rudder",
   "bugs": {

--- a/packages/agent-runtimes/pi-local/package.json
+++ b/packages/agent-runtimes/pi-local/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rudderhq/agent-runtime-pi-local",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "license": "SEE LICENSE IN LICENSE",
   "homepage": "https://github.com/Undertone0809/rudder",
   "bugs": {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rudderhq/db",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "license": "SEE LICENSE IN LICENSE",
   "homepage": "https://github.com/Undertone0809/rudder",
   "bugs": {

--- a/packages/plugins/create-rudder-plugin/package.json
+++ b/packages/plugins/create-rudder-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rudderhq/create-rudder-plugin",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "license": "SEE LICENSE IN LICENSE",
   "homepage": "https://github.com/Undertone0809/rudder",
   "bugs": {

--- a/packages/plugins/sdk/package.json
+++ b/packages/plugins/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rudderhq/plugin-sdk",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Stable public API for Rudder plugins — worker-side context and UI bridge hooks",
   "license": "SEE LICENSE IN LICENSE",
   "homepage": "https://github.com/Undertone0809/rudder",

--- a/packages/run-intelligence-core/package.json
+++ b/packages/run-intelligence-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rudderhq/run-intelligence-core",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "license": "SEE LICENSE IN LICENSE",
   "homepage": "https://github.com/Undertone0809/rudder",
   "bugs": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rudderhq/shared",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "license": "SEE LICENSE IN LICENSE",
   "homepage": "https://github.com/Undertone0809/rudder",
   "bugs": {

--- a/releases/v0.6.1.md
+++ b/releases/v0.6.1.md
@@ -1,0 +1,12 @@
+## New Features
+
+- Added an agent-operated stable release path that carries an explicitly requested version through npm, GitHub Release, Desktop assets, public docs, install smoke, and next-version handoff without a second-account approval step.
+
+## Improvements
+
+- Strengthened stable release automation with canonical-repository checks, exact-source CI verification, main-history validation, and non-interactive production-docs authorization.
+
+## Bug Fixes
+
+- Fixed fresh macOS installs failing while preparing PostgreSQL 18.4 when the upstream archive contains unrelated dangling symlinks inside pgAdmin.
+- Fixed stable releases failing to invoke the reusable production-docs workflow after the release request had already authorized docs publication.

--- a/scripts/docs-alignment-reviews.json
+++ b/scripts/docs-alignment-reviews.json
@@ -68,7 +68,8 @@
     {"reminder":"chat-messenger: reviewer should compare public facts with INBOX.ATTENTION.001, MESSENGER.ATTENTION.001, CHAT.RESPONSE.ANNOTATION.001","fingerprint":"c560e4a6c17976ee05dffd9b85ae393e7c5c38bf72e85cf0d82fcfbc642d2979","classification":"false-positive","reviewed_revision":"e6988736f-release-protection-review-2026-07-25"},
     {"reminder":"configure-feishu-integration: reviewer should compare English and Chinese counterparts","fingerprint":"9fa9b78e587581aa9046adc3f816559c0161cc7bc2d406514af90744ecae2363","classification":"false-positive","reviewed_revision":"e6988736f-release-protection-review-2026-07-25"},
     {"reminder":"configure-feishu-integration: reviewer should compare public facts with IM.FEISHU.001","fingerprint":"9fa9b78e587581aa9046adc3f816559c0161cc7bc2d406514af90744ecae2363","classification":"false-positive","reviewed_revision":"e6988736f-release-protection-review-2026-07-25"},
-    {"reminder":"releases: reviewer should compare English and Chinese counterparts","fingerprint":"bcdf4181763ae195c7e997cbdb5da5bd9645a1b1b1c1bdb6ad4b373936ae770b","classification":"false-positive","reviewed_revision":"e6988736f-release-protection-review-2026-07-25"}
+    {"reminder":"releases: reviewer should compare English and Chinese counterparts","fingerprint":"bcdf4181763ae195c7e997cbdb5da5bd9645a1b1b1c1bdb6ad4b373936ae770b","classification":"false-positive","reviewed_revision":"e6988736f-release-protection-review-2026-07-25"},
+    {"reminder":"releases: reviewer should compare English and Chinese counterparts","fingerprint":"54a4e614fd9b28b12bd063de2dceeb48282c9173c9249e440109ad2799d71c84","classification":"false-positive","reviewed_revision":"agent-automated-stable-release-review-2026-07-25"}
   ],
   "allowed_classifications": ["fixed", "intentional", "false-positive"]
 }

--- a/scripts/docs-alignment-reviews.json
+++ b/scripts/docs-alignment-reviews.json
@@ -69,7 +69,8 @@
     {"reminder":"configure-feishu-integration: reviewer should compare English and Chinese counterparts","fingerprint":"9fa9b78e587581aa9046adc3f816559c0161cc7bc2d406514af90744ecae2363","classification":"false-positive","reviewed_revision":"e6988736f-release-protection-review-2026-07-25"},
     {"reminder":"configure-feishu-integration: reviewer should compare public facts with IM.FEISHU.001","fingerprint":"9fa9b78e587581aa9046adc3f816559c0161cc7bc2d406514af90744ecae2363","classification":"false-positive","reviewed_revision":"e6988736f-release-protection-review-2026-07-25"},
     {"reminder":"releases: reviewer should compare English and Chinese counterparts","fingerprint":"bcdf4181763ae195c7e997cbdb5da5bd9645a1b1b1c1bdb6ad4b373936ae770b","classification":"false-positive","reviewed_revision":"e6988736f-release-protection-review-2026-07-25"},
-    {"reminder":"releases: reviewer should compare English and Chinese counterparts","fingerprint":"54a4e614fd9b28b12bd063de2dceeb48282c9173c9249e440109ad2799d71c84","classification":"false-positive","reviewed_revision":"agent-automated-stable-release-review-2026-07-25"}
+    {"reminder":"releases: reviewer should compare English and Chinese counterparts","fingerprint":"54a4e614fd9b28b12bd063de2dceeb48282c9173c9249e440109ad2799d71c84","classification":"false-positive","reviewed_revision":"agent-automated-stable-release-review-2026-07-25"},
+    {"reminder":"releases: reviewer should compare English and Chinese counterparts","fingerprint":"968a97bd6e815a9c6234c0536aa001cccc9ed615ea37a071b440ddeb97d01316","classification":"false-positive","reviewed_revision":"v0.6.1-macos-install-fix-review-2026-07-25"}
   ],
   "allowed_classifications": ["fixed", "intentional", "false-positive"]
 }

--- a/scripts/release-stable-changelog.test.mjs
+++ b/scripts/release-stable-changelog.test.mjs
@@ -10,14 +10,14 @@ const english = readFileSync(path.join(repoRoot, "docs", "releases.mdx"), "utf8"
 const chinese = readFileSync(path.join(repoRoot, "docs", "zh", "releases.mdx"), "utf8");
 
 describe("stable public changelog validation", () => {
-  it("accepts the checked-in English and Chinese v0.6.0 changelog entries", () => {
-    expect(validateStableChangelog({ english, version: "0.6.0", chinese })).toEqual([]);
+  it("accepts the checked-in English and Chinese v0.6.1 changelog entries", () => {
+    expect(validateStableChangelog({ english, version: "0.6.1", chinese })).toEqual([]);
   });
 
   it("keeps command-mode stdout empty for release preflight version capture", () => {
     const result = spawnSync(
       process.execPath,
-      ["scripts/verify-stable-changelog.mjs", "--version", "0.6.0"],
+      ["scripts/verify-stable-changelog.mjs", "--version", "0.6.1"],
       {
         cwd: repoRoot,
         encoding: "utf8",
@@ -27,7 +27,7 @@ describe("stable public changelog validation", () => {
     expect(result.status).toBe(0);
     expect(result.stdout).toBe("");
     expect(result.stderr).toContain(
-      "Verified English and Chinese public changelog entries for v0.6.0.",
+      "Verified English and Chinese public changelog entries for v0.6.1.",
     );
   });
 
@@ -35,11 +35,11 @@ describe("stable public changelog validation", () => {
     expect(
       validateStableChangelog({
         english,
-        version: "0.6.0",
-        chinese: chinese.replace(/^## v0\.6\.0$/mu, "## v0.5.0"),
+        version: "0.6.1",
+        chinese: chinese.replace(/^## v0\.6\.1$/mu, "## v0.5.0"),
       }),
     ).toEqual(
-      expect.arrayContaining(["Chinese changelog is missing the exact heading ## v0.6.0."]),
+      expect.arrayContaining(["Chinese changelog is missing the exact heading ## v0.6.1."]),
     );
   });
 
@@ -47,7 +47,7 @@ describe("stable public changelog validation", () => {
     expect(
       validateStableChangelog({
         english: english.replace("### Bug Fixes", "### Highlights"),
-        version: "0.6.0",
+        version: "0.6.1",
         chinese,
       }),
     ).toEqual(

--- a/scripts/release-workflow-contract.test.mjs
+++ b/scripts/release-workflow-contract.test.mjs
@@ -27,7 +27,12 @@ describe("release workflow latency contracts", () => {
   it("resolves an immutable source and runs release preflight before installation", () => {
     expect(releaseWorkflow).toMatch(/^  preflight:/m);
     expect(releaseWorkflow).toContain("source_sha:");
+    expect(releaseWorkflow).toContain("Require release source from protected main history");
+    expect(releaseWorkflow).toContain('git merge-base --is-ancestor "$SOURCE_SHA" refs/remotes/origin/main');
     expect(releaseWorkflow).toContain("Require successful CI for exact source");
+    expect(releaseWorkflow).toContain('.event == "push"');
+    expect(releaseWorkflow).toContain('.head_branch == "main"');
+    expect(releaseWorkflow).toContain('test "$GITHUB_REPOSITORY" = "Undertone0809/rudder"');
     expect(releaseWorkflow).toContain("./scripts/release.sh canary --preflight");
     expect(releaseWorkflow).toContain("./scripts/release.sh stable --preflight");
     expect(releaseWorkflow).toContain("Locked canary preflight");
@@ -48,6 +53,10 @@ describe("release workflow latency contracts", () => {
     expect(workflowPermissions).not.toContain("id-token: write");
     expect(releaseWorkflow).toContain("Require release repository safeguards");
     expect(releaseWorkflow).toContain("RELEASE_SAFEGUARDS_CONFIGURED");
+    expect(releaseWorkflow).toContain("STABLE_RELEASE_MODE");
+    expect(releaseWorkflow).toContain("agent-automated");
+    expect(releaseWorkflow).toContain("main-only non-interactive environment");
+    expect(releaseWorkflow).not.toContain("Configure npm-stable reviewers");
   });
 
   it("serializes publication and prepares the next patch base through a protected PR", () => {
@@ -83,7 +92,7 @@ describe("release workflow latency contracts", () => {
     expect(releaseScript).toContain("Reusing workspace build from verification gate");
   });
 
-  it("makes the localized public changelog a separately approved stable release surface", () => {
+  it("keeps the localized public changelog in the stable release machine gate", () => {
     const stableDocsIndex = releaseWorkflow.indexOf("\n  stable-docs:\n");
     const nextReleaseIndex = releaseWorkflow.indexOf("\n  next-release-base:\n");
 

--- a/scripts/release-workflow-contract.test.mjs
+++ b/scripts/release-workflow-contract.test.mjs
@@ -116,8 +116,10 @@ describe("release workflow latency contracts", () => {
 
     expect(docsProductionWorkflow).toContain("workflow_call:");
     expect(docsProductionWorkflow).toContain("release_docs_approved:");
+    expect(docsProductionWorkflow).toContain('if [ "$RELEASE_DOCS_APPROVED" = "true" ]; then');
+    expect(docsProductionWorkflow).not.toContain('if [ "$GITHUB_EVENT_NAME" = "workflow_call" ]; then');
     expect(docsProductionWorkflow).toContain("type: boolean");
-    expect(docsProductionWorkflow).toContain('test "$RELEASE_DOCS_APPROVED" = "true"');
+    expect(docsProductionWorkflow).toContain('test "$CONFIRM_DOMAIN" = "$DOCS_PRODUCTION_DOMAIN"');
     expect(docsProductionWorkflow).toContain("^docs/release/v[0-9]+");
   });
 });

--- a/scripts/release-workflow-contract.test.mjs
+++ b/scripts/release-workflow-contract.test.mjs
@@ -30,9 +30,15 @@ describe("release workflow latency contracts", () => {
     expect(releaseWorkflow).toContain("Require release source from protected main history");
     expect(releaseWorkflow).toContain('git merge-base --is-ancestor "$SOURCE_SHA" refs/remotes/origin/main');
     expect(releaseWorkflow).toContain("Require successful CI for exact source");
+    expect(releaseWorkflow).toContain('-f head_sha="$SOURCE_SHA"');
+    expect(releaseWorkflow).toContain("-f status=success");
     expect(releaseWorkflow).toContain('.event == "push"');
     expect(releaseWorkflow).toContain('.head_branch == "main"');
     expect(releaseWorkflow).toContain('test "$GITHUB_REPOSITORY" = "Undertone0809/rudder"');
+    expect(releaseWorkflow).toContain(
+      "if: github.event_name == 'workflow_dispatch' && !inputs.dry_run && github.repository == 'Undertone0809/rudder'",
+    );
+    expect(releaseWorkflow).toContain("environment: npm-stable");
     expect(releaseWorkflow).toContain("./scripts/release.sh canary --preflight");
     expect(releaseWorkflow).toContain("./scripts/release.sh stable --preflight");
     expect(releaseWorkflow).toContain("Locked canary preflight");

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rudderhq/server",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "license": "SEE LICENSE IN LICENSE",
   "homepage": "https://github.com/Undertone0809/rudder",
   "bugs": {


### PR DESCRIPTION
## Summary
- remove the second-account GitHub environment approval from stable releases
- keep canonical-repository, main-history, exact-source CI, and machine confirmation safeguards
- synchronize the release maintainer skill, runbook, CI contracts, and setup docs
- fix reusable production-docs authorization
- fix macOS fresh installs when the upstream PostgreSQL archive contains unrelated dangling pgAdmin symlinks
- prepare the verified patch release as v0.6.1 with localized release notes

## Verification
- release automation contract tests
- docs structure/alignment tests
- CLI runtime install suite, including a dangling-symlink archive fixture
- CLI typecheck, lint, stable preflight
- full GitHub CI matrix in progress