### PR TITLE
fix: keep canary preflight output machine-readable

### DIFF
--- a/scripts/release-canary-guard.test.mjs
+++ b/scripts/release-canary-guard.test.mjs
@@ -136,6 +136,24 @@ afterEach(() => {
 });
 
 describe("release canary base guard", () => {
+  it("keeps canary preflight stdout machine-readable when stable notes already exist", () => {
+    const { repo } = createReleaseRepo();
+    mkdirSync(join(repo, "releases"), { recursive: true });
+    writeJson(join(repo, "cli", "package.json"), {
+      name: "@rudderhq/cli",
+      version: "99.99.99",
+    });
+    writeFileSync(join(repo, "releases", "v99.99.99.md"), "## New Features\n\n## Improvements\n\n## Bug Fixes\n");
+    exec("git", ["add", "."], { cwd: repo });
+    exec("git", ["commit", "-m", "prepare canary fixture"], { cwd: repo });
+
+    const result = runPreflight(repo, "canary");
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe("99.99.99-canary.0\n");
+    expect(result.stderr).toContain("Stable release notes already exist");
+  }, 30000);
+
   it("fails before deriving a canary when the committed base has a stable remote tag", () => {
     const { repo } = createReleaseRepo();
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -204,7 +204,7 @@ if [ "$channel" = "stable" ]; then
 fi
 
 if [ "$channel" = "canary" ] && [ -f "$NOTES_FILE" ]; then
-  release_info "  ✓ Stable release notes already exist at $NOTES_FILE"
+  release_info "  ✓ Stable release notes already exist at $NOTES_FILE" >&2
 fi
 
 if git_local_tag_exists "$tag_name" || git_remote_tag_exists "$tag_name" "$PUBLISH_REMOTE"; then


### PR DESCRIPTION
## Summary
- send human-readable stable-notes diagnostics to stderr during canary preflight
- keep stdout as the single derived canary version consumed by GitHub Actions outputs
- add a regression test covering the stable-notes-present path

## Verification
- release canary guard: 6/6
- release workflow contract: 7/7
- lint and diff check pass