### PR TITLE
feat(chat): open skill references in side panel

### DIFF
--- a/tests/e2e/chat-rich-references.spec.ts
+++ b/tests/e2e/chat-rich-references.spec.ts
@@ -7,12 +7,92 @@ import { E2E_DATABASE_URL } from "./support/e2e-env";
 const e2eDb = createDb(E2E_DATABASE_URL);
 
 test.describe("Chat rich references", () => {
+  test("opens an assistant skill token's SKILL.md in the current Chat Side Panel", async ({ page }) => {
+    const suffix = Date.now();
+    const orgRes = await page.request.post("/api/orgs", {
+      data: { name: `Chat-Skill-Ref-${suffix}` },
+    });
+    expect(orgRes.ok(), await orgRes.text()).toBe(true);
+    const organization = await orgRes.json() as { id: string; issuePrefix: string; urlKey: string };
+    const agent = await createE2EChatAgent(page.request, organization.id, {
+      name: "Skill Reference Agent",
+    }) as { id: string };
+
+    const skillSlug = `side-panel-skill-${suffix}`;
+    const skillRes = await page.request.post(`/api/orgs/${organization.id}/skills`, {
+      data: {
+        name: "Side Panel Skill",
+        slug: skillSlug,
+        markdown: `---\nname: ${skillSlug}\ndescription: Opens in the current Chat Side Panel.\n---\n\n# Side Panel Skill\n\nInspectable skill body.\n`,
+      },
+    });
+    expect(skillRes.ok(), await skillRes.text()).toBe(true);
+    const skill = await skillRes.json() as { id: string; key: string; slug: string };
+
+    const syncRes = await page.request.post(
+      `/api/agents/${agent.id}/skills/sync?orgId=${encodeURIComponent(organization.id)}`,
+      { data: { desiredSkills: [`org:${skill.key}`] } },
+    );
+    expect(syncRes.ok(), await syncRes.text()).toBe(true);
+
+    const chatRes = await page.request.post(`/api/orgs/${organization.id}/chats`, {
+      data: {
+        title: "Skill Side Panel chat",
+        preferredAgentId: agent.id,
+        issueCreationMode: "manual_approval",
+        planMode: false,
+        initialMessage: { body: "Show the referenced skill beside this chat." },
+      },
+    });
+    expect(chatRes.ok(), await chatRes.text()).toBe(true);
+    const chat = await chatRes.json() as { id: string };
+
+    await e2eDb.insert(chatMessages).values({
+      id: randomUUID(),
+      orgId: organization.id,
+      conversationId: chat.id,
+      role: "assistant",
+      kind: "message",
+      status: "completed",
+      body: `Use [${skill.slug}](skill://org/${skill.id}?ref=${skill.slug}) for this review.`,
+      replyingAgentId: agent.id,
+      chatTurnId: randomUUID(),
+      turnVariant: 0,
+    });
+
+    await page.goto("/");
+    await page.evaluate((orgId) => {
+      window.localStorage.setItem("rudder.selectedOrganizationId", orgId);
+    }, organization.id);
+    await page.goto(`/${organization.urlKey}/messenger/chat/${chat.id}`);
+
+    const assistantMessage = page.getByTestId("chat-assistant-message").last();
+    const skillToken = assistantMessage.locator("[data-skill-token='true']");
+    await expect(skillToken).toHaveText(skill.slug, { timeout: 15_000 });
+    await expect(assistantMessage).toContainText("for this review.");
+    await skillToken.click();
+
+    const sidePanel = page.getByTestId("chat-side-panel");
+    await expect(sidePanel).toBeVisible({ timeout: 15_000 });
+    await expect(sidePanel.getByRole("tab", { name: skill.slug, exact: true })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    await expect(page.getByRole("heading", { name: "Side Panel Skill", exact: true })).toBeVisible();
+    await expect(page.getByText("Inspectable skill body.", { exact: true })).toBeVisible();
+    await expect(page).toHaveURL(new RegExp(`/${organization.urlKey}/messenger/chat/${chat.id}$`));
+    const screenshotPath = process.env.RUDDER_SKILL_REFERENCE_SCREENSHOT?.trim();
+    if (screenshotPath) {
+      await page.screenshot({ path: screenshotPath, fullPage: true });
+    }
+  });
+
   test("renders issue and issue comment cards from assistant richReferences and opens the target", async ({ page }) => {
     const orgRes = await page.request.post("/api/orgs", {
       data: { name: `Chat-Rich-Refs-${Date.now()}` },
     });
     expect(orgRes.ok()).toBe(true);
-    const organization = await orgRes.json();
+    const organization = await orgRes.json() as { id: string; issuePrefix: string; urlKey: string };
     await createE2EChatAgent(page.request, organization.id, { name: "Reference Agent" });
 
     const issueRes = await page.request.post(`/api/orgs/${organization.id}/issues`, {
@@ -41,6 +121,7 @@ test.describe("Chat rich references", () => {
         title: "Rich reference chat",
         issueCreationMode: "manual_approval",
         planMode: false,
+        initialMessage: { body: "Show the related issue and review comment." },
       },
     });
     expect(chatRes.ok()).toBe(true);
@@ -70,7 +151,7 @@ test.describe("Chat rich references", () => {
       window.localStorage.setItem("rudder.selectedOrganizationId", orgId);
     }, organization.id);
 
-    await page.goto(`/${organization.issuePrefix}/messenger/chat/${chat.id}`);
+    await page.goto(`/${organization.urlKey}/messenger/chat/${chat.id}`);
 
     const assistantMessage = page.getByTestId("chat-assistant-message").last();
     await expect(assistantMessage).toContainText("I found the relevant issue and review comment.", { timeout: 15_000 });
@@ -85,11 +166,11 @@ test.describe("Chat rich references", () => {
     const commentLink = richReferences.getByRole("link", { name: `Open comment on issue ${issueLabel}` });
     await expect(commentLink).toHaveAttribute(
       "href",
-      new RegExp(`/${organization.issuePrefix}/issues/${issueRouteRef}#comment-${comment.id}$`),
+      new RegExp(`/${organization.urlKey}/issues/${issueRouteRef}#comment-${comment.id}$`),
     );
     await commentLink.click();
 
-    await expect(page).toHaveURL(new RegExp(`/${organization.issuePrefix}/issues/${issueRouteRef}#comment-${comment.id}$`));
+    await expect(page).toHaveURL(new RegExp(`/${organization.urlKey}/issues/${issueRouteRef}#comment-${comment.id}$`));
     await expect(page.getByRole("heading", { name: "Chat rich reference target" })).toBeVisible({ timeout: 15_000 });
     await expect(page.getByText("add the missing Playwright coverage", { exact: false })).toBeVisible({ timeout: 15_000 });
   });

--- a/ui/src/components/MarkdownBody.test.tsx
+++ b/ui/src/components/MarkdownBody.test.tsx
@@ -2035,6 +2035,65 @@ describe("MarkdownBody", () => {
     expect(html).not.toContain("skill://org/skill-1");
   });
 
+  it("routes an actionable skill token to its SKILL.md while keeping the details action", () => {
+    const html = renderToStaticMarkup(
+      <ThemeProvider>
+        <MarkdownBody
+          onLinkClick={() => true}
+          skillReferences={[
+            {
+              href: "skill://org/skill-1?ref=build-advisor",
+              label: "build-advisor",
+              displayName: "Build Advisor",
+              detailsHref: "/library?skill=skill-1&skillFile=SKILL.md",
+              openHref: "library-file://file?p=skills%2Fbuild-advisor%2FSKILL.md",
+            },
+          ]}
+        >
+          {"Use [build-advisor](skill://org/skill-1?ref=build-advisor) carefully"}
+        </MarkdownBody>
+      </ThemeProvider>,
+    );
+
+    expect(html).toContain('href="library-file://file?p=skills%2Fbuild-advisor%2FSKILL.md"');
+    expect(html).toContain('href="/library?skill=skill-1&amp;skillFile=SKILL.md"');
+    expect(html).toContain(" carefully");
+  });
+
+  it("keeps historical local skill references actionable without current preview metadata", () => {
+    const html = renderToStaticMarkup(
+      <ThemeProvider>
+        <MarkdownBody onLinkClick={() => true}>
+          {"Use [local-helper](skill://local/%2Fworkspace%2F.agents%2Fskills%2Flocal-helper?ref=local-helper)"}
+        </MarkdownBody>
+      </ThemeProvider>,
+    );
+
+    expect(html).toContain('href="/workspace/.agents/skills/local-helper/SKILL.md"');
+    expect(html).toContain('data-skill-token="true"');
+  });
+
+  it("prefers a historical local skill path over an organization skill with the same label", () => {
+    const html = renderToStaticMarkup(
+      <ThemeProvider>
+        <MarkdownBody
+          onLinkClick={() => true}
+          skillReferences={[{
+            href: "skill://org/org-helper?ref=helper",
+            label: "helper",
+            displayName: "Organization Helper",
+            openHref: "library-file://file?p=skills%2Fhelper%2FSKILL.md",
+          }]}
+        >
+          {"Use [helper](skill://local/%2Fworkspace%2F.agents%2Fskills%2Fhelper?ref=helper)"}
+        </MarkdownBody>
+      </ThemeProvider>,
+    );
+
+    expect(html).toContain('href="/workspace/.agents/skills/helper/SKILL.md"');
+    expect(html).not.toContain('href="library-file://file?p=skills%2Fhelper%2FSKILL.md"');
+  });
+
   it("renders markdown when agent comments contain escaped newline sequences", () => {
     const html = renderToStaticMarkup(
       <ThemeProvider>

--- a/ui/src/components/MarkdownBody.tsx
+++ b/ui/src/components/MarkdownBody.tsx
@@ -15,7 +15,11 @@ import {
 } from "../lib/markdown-normalize";
 import { mentionChipInlineStyle, mentionChipNavigationPath, parseMentionChipHref, stripMentionChipLabelPrefix, type ParsedMentionChip } from "../lib/mention-chips";
 import { applyOrganizationPrefix, extractOrganizationPrefixFromPath } from "../lib/organization-routes";
-import { formatSkillReferenceDisplayLabel, parseSkillReference } from "../lib/skill-reference";
+import {
+  formatSkillReferenceDisplayLabel,
+  parseSkillReference,
+  resolveSkillReferenceOpenHref,
+} from "../lib/skill-reference";
 import { cn } from "../lib/utils";
 import { InspectableImage } from "./InspectableImage";
 import type { MentionOption } from "./MarkdownEditor";
@@ -1131,7 +1135,13 @@ export function MarkdownBody({
           <SkillReferenceToken
             label={skillLabel}
             preview={preview}
+            fallbackOpenHref={resolveSkillReferenceOpenHref(skillReference.href)}
             sourceAttributes={sourceAttributesForNode(node)}
+            onOpen={onLinkClick
+              ? (event, targetHref, targetLabel) => {
+                  handleMarkdownLinkClick(event, targetHref, targetLabel);
+                }
+              : undefined}
           />
         );
       }

--- a/ui/src/components/SkillReferenceToken.tsx
+++ b/ui/src/components/SkillReferenceToken.tsx
@@ -3,6 +3,7 @@ import { CHAT_ANNOTATION_TEXT_IGNORE_ATTRIBUTE } from "@/lib/chat-response-annot
 import { skillTokenIconInlineStyle } from "@/lib/skill-reference";
 import { cn } from "@/lib/utils";
 import { ArrowUpRight, Boxes } from "lucide-react";
+import type { MouseEvent } from "react";
 
 export interface MarkdownSkillReferencePreview {
   href: string;
@@ -12,34 +13,42 @@ export interface MarkdownSkillReferencePreview {
   categoryLabel?: string | null;
   locationLabel?: string | null;
   detailsHref?: string | null;
+  openHref?: string | null;
 }
 
 interface SkillReferenceTokenProps {
   label: string;
   preview?: MarkdownSkillReferencePreview | null;
+  fallbackOpenHref?: string | null;
   sourceAttributes?: Record<string, string | undefined>;
+  onOpen?: (event: MouseEvent<HTMLAnchorElement>, href: string, label: string) => void;
 }
 
 export function SkillReferenceToken({
   label,
   preview,
+  fallbackOpenHref,
   sourceAttributes,
+  onOpen,
 }: SkillReferenceTokenProps) {
   const displayName = preview?.displayName?.trim() || label;
   const description = preview?.description?.trim() || null;
   const categoryLabel = preview?.categoryLabel?.trim() || null;
   const locationLabel = preview?.locationLabel?.trim() || null;
   const detailsHref = preview?.detailsHref?.trim() || null;
+  const openHref = fallbackOpenHref?.trim() || preview?.openHref?.trim() || null;
   const hasPreview = Boolean(description || categoryLabel || locationLabel || detailsHref);
   const hoverCardScrollRef = useScrollbarActivityRef();
-  const tokenContent = detailsHref ? (
+  const tokenHref = onOpen ? (openHref ?? detailsHref) : detailsHref;
+  const tokenContent = tokenHref ? (
     <a
       className="rudder-skill-token"
       data-skill-token="true"
-      href={detailsHref}
+      href={tokenHref}
       aria-label={`${displayName} skill`}
       style={skillTokenIconInlineStyle()}
       {...sourceAttributes}
+      onClick={(event) => onOpen?.(event, tokenHref, displayName)}
     >
       {label}
     </a>

--- a/ui/src/lib/agent-skill-mentions.test.ts
+++ b/ui/src/lib/agent-skill-mentions.test.ts
@@ -54,6 +54,7 @@ describe("buildAgentSkillMentionOptions", () => {
         sourceBadge: "local",
         sourceLocator: "/workspace/skills/alpha-test",
         sourcePath: "/workspace/skills/alpha-test/SKILL.md",
+        workspaceEditPath: "skills/alpha-test/SKILL.md",
       }),
     ];
 
@@ -185,6 +186,7 @@ describe("buildAgentSkillMentionOptions", () => {
       skillMarkdownTarget: "skill://org/org-alpha-test?ref=alpha-test",
       skillDisplayName: "Alpha Test",
       skillDetailsHref: "/library?skill=org-alpha-test&skillFile=SKILL.md",
+      skillOpenHref: "library-file://file?p=skills%2Falpha-test%2FSKILL.md",
     });
     expect(options.find((option) => option.name === "build-advisor")).toMatchObject({
       skillRefLabel: "build-advisor",
@@ -196,9 +198,11 @@ describe("buildAgentSkillMentionOptions", () => {
       skillCategoryLabel: "Agent skill",
       skillLocationLabel: "AGENT_HOME/skills",
       skillDetailsHref: null,
+      skillOpenHref: "/workspace/agents/ella/skills/agent-helper/SKILL.md",
     });
     expect(options.find((option) => option.name === "global-helper")).toMatchObject({
       skillMarkdownTarget: "skill://local/%2FUsers%2Ftest%2F.agents%2Fskills%2Fglobal-helper?ref=global-helper",
+      skillOpenHref: "/Users/test/.agents/skills/global-helper/SKILL.md",
     });
     expect(options.find((option) => option.name === "global-helper")).toMatchObject({
       skillDisplayName: "global-helper",
@@ -251,6 +255,7 @@ describe("buildAgentSkillMentionOptions", () => {
       skillRefLabel: "alpha-test",
       skillMarkdownTarget: "skill://agent/agent-1/org%3Aorganization%2Forg-1%2Falpha-test?ref=organization%2Forg-1%2Falpha-test",
       skillDetailsHref: null,
+      skillOpenHref: "/workspace/skills/alpha-test/SKILL.md",
     });
   });
 });

--- a/ui/src/lib/agent-skill-mentions.ts
+++ b/ui/src/lib/agent-skill-mentions.ts
@@ -1,4 +1,5 @@
 import {
+  buildLibraryFileMentionHref,
   buildOrganizationSkillSearchText,
   formatOrganizationSkillPublicRef,
   type Agent,
@@ -26,6 +27,7 @@ export interface SkillMentionOption {
   skillCategoryLabel: string | null;
   skillLocationLabel: string | null;
   skillDetailsHref: string | null;
+  skillOpenHref: string | null;
 }
 
 function normalizeMarkdownTarget(candidate: string | null | undefined) {
@@ -35,6 +37,13 @@ function normalizeMarkdownTarget(candidate: string | null | undefined) {
     return trimmed;
   }
   return `${trimmed}/SKILL.md`;
+}
+
+function organizationSkillOpenHref(skill: OrganizationSkillListItem) {
+  if (skill.workspaceEditPath) {
+    return buildLibraryFileMentionHref(skill.workspaceEditPath);
+  }
+  return normalizeMarkdownTarget(skill.sourcePath);
 }
 
 function isActiveSkillEntry(entry: AgentSkillEntry) {
@@ -146,6 +155,9 @@ export function buildAgentSkillMentionOptions(params: {
         skillCategoryLabel: null,
         skillLocationLabel: null,
         skillDetailsHref: organizationSkill ? buildLibrarySkillHref(organizationSkill.id) : null,
+        skillOpenHref: organizationSkill
+          ? organizationSkillOpenHref(organizationSkill)
+          : normalizeMarkdownTarget(entry.sourcePath ?? entry.targetPath),
       });
       continue;
     }
@@ -172,6 +184,7 @@ export function buildAgentSkillMentionOptions(params: {
       skillCategoryLabel: normalizeOptionalText(entry.originLabel) ?? "Agent skill",
       skillLocationLabel: normalizeOptionalText(entry.locationLabel),
       skillDetailsHref: null,
+      skillOpenHref: sourceTarget,
     });
   }
 
@@ -216,6 +229,7 @@ export function buildOrganizationSkillMentionOptions(params: {
         skillCategoryLabel: "Org skill",
         skillLocationLabel: normalizeOptionalText(skill.sourceLabel ?? skill.sourcePath),
         skillDetailsHref: buildLibrarySkillHref(skill.id),
+        skillOpenHref: organizationSkillOpenHref(skill),
       };
     })
     .filter((option): option is SkillMentionOption => option !== null)

--- a/ui/src/lib/chat-skill-options.test.ts
+++ b/ui/src/lib/chat-skill-options.test.ts
@@ -5,6 +5,7 @@ import type {
 import { describe, expect, it } from "vitest";
 import {
   buildChatSkillOptions,
+  buildChatSkillReferenceOptions,
   filterChatSkillOptions,
 } from "./chat-skill-options";
 
@@ -108,6 +109,48 @@ describe("chat-skill-options", () => {
     ]);
   });
 
+  it("keeps disabled organization skills resolvable for historical messages", () => {
+    const alphaTest = makeSkill({
+      id: "org-alpha-test",
+      key: "organization/org-1/alpha-test",
+      slug: "alpha-test",
+      name: "Alpha Test",
+      sourceType: "local_path",
+      sourcePath: "/workspace/skills/alpha-test/SKILL.md",
+      workspaceEditPath: "skills/alpha-test/SKILL.md",
+    });
+    const options = buildChatSkillReferenceOptions({
+      agent: { id: "agent-1", urlKey: "nia" },
+      orgUrlKey: "acme",
+      organizationSkills: [alphaTest],
+      skillSnapshot: {
+        agentRuntimeType: "codex_local",
+        supported: true,
+        mode: "persistent",
+        desiredSkills: [],
+        entries: [{
+          key: "alpha-test",
+          selectionKey: "org:organization/org-1/alpha-test",
+          runtimeName: "alpha-test",
+          desired: false,
+          configurable: true,
+          alwaysEnabled: false,
+          managed: true,
+          state: "available",
+          sourceClass: "organization",
+          sourcePath: "/workspace/skills/alpha-test",
+        }],
+        warnings: [],
+      },
+    });
+
+    expect(options).toHaveLength(1);
+    expect(options[0]).toMatchObject({
+      skillMarkdownTarget: "skill://org/org-alpha-test?ref=alpha-test",
+      skillOpenHref: "library-file://file?p=skills%2Falpha-test%2FSKILL.md",
+    });
+  });
+
   it("filters enabled skills by search text", () => {
     const filtered = filterChatSkillOptions(
       [
@@ -123,6 +166,7 @@ describe("chat-skill-options", () => {
           skillCategoryLabel: null,
           skillLocationLabel: null,
           skillDetailsHref: "/library?skill=bundle-build-advisor&skillFile=SKILL.md",
+          skillOpenHref: "/workspace/skills/build-advisor/SKILL.md",
         },
       ],
       "advisor",

--- a/ui/src/lib/chat-skill-options.ts
+++ b/ui/src/lib/chat-skill-options.ts
@@ -5,6 +5,7 @@ import type {
 } from "@rudderhq/shared";
 import {
   buildAgentSkillMentionOptions,
+  buildOrganizationSkillMentionOptions,
   type SkillMentionOption,
 } from "./agent-skill-mentions";
 
@@ -15,6 +16,25 @@ export function buildChatSkillOptions(params: {
   skillSnapshot: AgentSkillSnapshot | null | undefined;
 }) {
   return buildAgentSkillMentionOptions(params);
+}
+
+export function buildChatSkillReferenceOptions(params: {
+  agent: Pick<Agent, "id" | "urlKey"> | null | undefined;
+  orgUrlKey: string | null | undefined;
+  organizationSkills: OrganizationSkillListItem[] | null | undefined;
+  skillSnapshot: AgentSkillSnapshot | null | undefined;
+}) {
+  const optionsByTarget = new Map<string, SkillMentionOption>();
+  for (const option of buildOrganizationSkillMentionOptions({
+    orgUrlKey: params.orgUrlKey,
+    organizationSkills: params.organizationSkills,
+  })) {
+    optionsByTarget.set(option.skillMarkdownTarget, option);
+  }
+  for (const option of buildAgentSkillMentionOptions(params)) {
+    optionsByTarget.set(option.skillMarkdownTarget, option);
+  }
+  return [...optionsByTarget.values()];
 }
 
 export function filterChatSkillOptions(

--- a/ui/src/lib/skill-reference.test.ts
+++ b/ui/src/lib/skill-reference.test.ts
@@ -6,6 +6,7 @@ import {
   isMarkdownSkillPath,
   parseSkillReference,
   removeSkillReferenceFromMarkdown,
+  resolveSkillReferenceOpenHref,
 } from "./skill-reference";
 
 describe("skill-reference", () => {
@@ -71,6 +72,16 @@ describe("skill-reference", () => {
       href: "skill://agent/agent-1/agent%3Ahelper?ref=agent-helper",
       label: "agent-helper",
     });
+  });
+
+  it("recovers an openable SKILL.md path from historical local references", () => {
+    expect(resolveSkillReferenceOpenHref(
+      "skill://local/%2Fworkspace%2F.agents%2Fskills%2Flocal-helper?ref=local-helper",
+    )).toBe("/workspace/.agents/skills/local-helper/SKILL.md");
+    expect(resolveSkillReferenceOpenHref(
+      "/workspace/.agents/skills/local-helper/SKILL.md",
+    )).toBe("/workspace/.agents/skills/local-helper/SKILL.md");
+    expect(resolveSkillReferenceOpenHref("skill://org/skill-123?ref=build-advisor")).toBeNull();
   });
 
   it("removes a skill reference as a whole markdown token", () => {

--- a/ui/src/lib/skill-reference.ts
+++ b/ui/src/lib/skill-reference.ts
@@ -77,6 +77,23 @@ export function isSkillReferenceHref(value: string | null | undefined) {
   return value?.trim().startsWith(SKILL_REFERENCE_SCHEME) ?? false;
 }
 
+export function resolveSkillReferenceOpenHref(value: string | null | undefined) {
+  const href = value?.trim() ?? "";
+  if (!href) return null;
+  if (isCanonicalSkillMarkdownPath(href)) return href;
+  if (!href.startsWith(`${SKILL_REFERENCE_SCHEME}local/`)) return null;
+  try {
+    const parsed = new URL(href);
+    const sourcePath = decodeSkillPathSegment(parsed.pathname.replace(/^\/+/u, ""));
+    if (!sourcePath) return null;
+    return isCanonicalSkillMarkdownPath(sourcePath)
+      ? sourcePath
+      : `${sourcePath.replace(/\/+$/u, "")}/SKILL.md`;
+  } catch {
+    return null;
+  }
+}
+
 function decodeSkillPathSegment(value: string | null | undefined) {
   const raw = value?.trim() ?? "";
   if (!raw) return "";

--- a/ui/src/pages/Chat.messages.tsx
+++ b/ui/src/pages/Chat.messages.tsx
@@ -53,7 +53,11 @@ import { mergeNativeSteerTranscriptEntries } from "@/lib/chat-stream-state";
 import { mentionChipInlineStyle, mentionChipNavigationPath, parseMentionChipHref, stripMentionChipLabelPrefix, type ParsedMentionChip } from "@/lib/mention-chips";
 import { applyOrganizationPrefix, extractOrganizationPrefixFromPath } from "@/lib/organization-routes";
 import { Link } from "@/lib/router";
-import { formatSkillReferenceDisplayLabel, parseSkillReference } from "@/lib/skill-reference";
+import {
+  formatSkillReferenceDisplayLabel,
+  parseSkillReference,
+  resolveSkillReferenceOpenHref,
+} from "@/lib/skill-reference";
 import { statusBadge, statusBadgeDefault } from "@/lib/status-colors";
 import { agentUrl, cn, relativeTime } from "@/lib/utils";
 import {
@@ -1342,7 +1346,19 @@ export function ChatUserPlainTextBody({
             ?? skillPreviewByLabel.get(normalizeSkillReferenceLookupKey(part.label))
             ?? null;
           const skillLabel = formatSkillReferenceDisplayLabel(preview?.label) || part.label;
-          return <SkillReferenceToken key={`${part.href}-${index}`} label={skillLabel} preview={preview} />;
+          return (
+            <SkillReferenceToken
+              key={`${part.href}-${index}`}
+              label={skillLabel}
+              preview={preview}
+              fallbackOpenHref={resolveSkillReferenceOpenHref(part.href)}
+              onOpen={onMarkdownLinkClick
+                ? (event, targetHref, targetLabel) => {
+                    handlePlainTextLinkClick(event, targetHref, targetLabel);
+                  }
+                : undefined}
+            />
+          );
         }
 
         const mention = resolvedMentionFromCurrentOptions(part.mention, mentions);

--- a/ui/src/pages/Chat.tsx
+++ b/ui/src/pages/Chat.tsx
@@ -98,7 +98,11 @@ import {
   type ChatResponseAnnotationState,
 } from "@/lib/chat-response-annotations";
 import { resolveRequestedPreferredAgentId } from "@/lib/chat-route-state";
-import { buildChatSkillOptions, filterChatSkillOptions } from "@/lib/chat-skill-options";
+import {
+  buildChatSkillOptions,
+  buildChatSkillReferenceOptions,
+  filterChatSkillOptions,
+} from "@/lib/chat-skill-options";
 import {
   chatStopRecoveryActionKey,
   clearPendingChatStopRecovery,
@@ -2238,8 +2242,16 @@ function ChatWorkspace() { const { conversationId } = useParams<{ conversationId
       agent: activeSkillAgent,
       orgUrlKey: selectedOrganization?.urlKey ?? "organization",
       organizationSkills,
-      skillSnapshot: activeAgentSkillSnapshot, }), [activeAgentSkillSnapshot, activeSkillAgent, organizationSkills, selectedOrganization?.urlKey], ); const chatSkillReferences = useMemo<MarkdownSkillReferencePreview[]>(
-    () => availableChatSkills.map((skill) => ({
+      skillSnapshot: activeAgentSkillSnapshot, }), [activeAgentSkillSnapshot, activeSkillAgent, organizationSkills, selectedOrganization?.urlKey], ); const referenceChatSkills = useMemo(
+    () => buildChatSkillReferenceOptions({
+      agent: activeSkillAgent,
+      orgUrlKey: selectedOrganization?.urlKey ?? "organization",
+      organizationSkills,
+      skillSnapshot: activeAgentSkillSnapshot,
+    }),
+    [activeAgentSkillSnapshot, activeSkillAgent, organizationSkills, selectedOrganization?.urlKey],
+  ); const chatSkillReferences = useMemo<MarkdownSkillReferencePreview[]>(
+    () => referenceChatSkills.map((skill) => ({
       href: skill.skillMarkdownTarget,
       label: skill.skillRefLabel,
       displayName: skill.skillDisplayName,
@@ -2247,7 +2259,8 @@ function ChatWorkspace() { const { conversationId } = useParams<{ conversationId
       categoryLabel: skill.skillCategoryLabel,
       locationLabel: skill.skillLocationLabel,
       detailsHref: skill.skillDetailsHref,
-    })), [availableChatSkills], ); const chatSkillDetailsHrefByTarget = useMemo(
+      openHref: skill.skillOpenHref,
+    })), [referenceChatSkills], ); const chatSkillDetailsHrefByTarget = useMemo(
     () => new Map(
       availableChatSkills
         .filter((skill) => skill.skillMarkdownTarget && skill.skillDetailsHref)


### PR DESCRIPTION
## Summary
- make Chat skill tokens open the referenced SKILL.md in the current Side Panel
- keep the hover-card View details action pointing to the Library skill detail
- keep historical disabled org/local skill references actionable, including same-slug local/org collisions

## Validation
- pnpm -r typecheck
- pnpm build
- pnpm lint
- pnpm product-logic:check
- 102 focused Vitest tests
- Playwright: skill token opens selected Side Panel tab, renders SKILL.md, and preserves Chat URL
- independent reviewer and verifier checks passed

## Product Logic Alignment
- Read CHAT.RICH.REFERENCE.RENDERING.001 and CHAT.SIDE.PANEL.001
- No doc/product/** files changed
- Implementation restores/extends the existing supported internal-reference and Library Side Panel behavior
- Proposed clarifying contract delta remains pending explicit approval: state that ordinary clicks on Chat skill tokens resolve their SKILL.md as a Library/local-file Side Panel target while View details remains separate