### PR TITLE
feat(costs): improve usage analysis

### DIFF
--- a/doc/plans/2026-07-25-costs-usage-analysis.md
+++ b/doc/plans/2026-07-25-costs-usage-analysis.md
@@ -1,0 +1,132 @@
+---
+title: Improve Costs Usage Analysis
+date: 2026-07-25
+kind: implementation
+status: implemented
+area: ui
+entities:
+  - costs_overview
+  - cost_aggregation
+  - date_ranges
+issue: R6Z-23
+related_plans: []
+supersedes: []
+related_code:
+  - ui/src/pages/Costs.tsx
+  - ui/src/pages/Costs.distribution.tsx
+  - ui/src/hooks/useDateRange.ts
+  - ui/src/lib/date-range-cache.ts
+  - packages/shared/src/types/cost.ts
+  - server/src/routes/costs.ts
+  - server/src/services/costs.ts
+  - tests/e2e/cost-trend.spec.ts
+commit_refs: []
+updated_at: 2026-07-25
+---
+
+# Improve Costs Usage Analysis
+
+## Summary
+
+Turn the Costs Overview into a usage-analysis surface with a rolling 24-hour
+range, explicit hourly or daily trend aggregation, four usage metrics, and
+responsive Agent and Project distribution charts. Keep the Finance ledger in
+its dedicated tab and preserve existing budget, provider, and biller behavior.
+
+## Problem
+
+The current Overview mixes inference usage with finance-ledger summaries,
+supports only daily trends, omits cached-token and runtime-duration metrics,
+and excludes unattributed cost events from Project totals. Its Custom range
+also starts empty, while low-contrast trend labels and clipped top ticks make
+the existing chart difficult to read.
+
+## Scope
+
+In scope:
+
+- add a minute-aligned rolling 24-hour preset and explicit `hour` / `day`
+  trend granularity across shared, API, route, service, cache, and UI layers;
+- default the first Custom selection to the latest seven local calendar days,
+  preserve later selections, and reject reversed date ranges;
+- aggregate cumulative overlapping `heartbeat_runs` duration into cost
+  summaries without a schema migration;
+- include an Unattributed row in Project aggregation while keeping only real
+  Project IDs eligible for trend filtering;
+- replace Overview finance and expandable Agent-ledger cards with four usage
+  metrics and reusable Token/Cost distribution panels;
+- improve trend axis contrast, spacing, hourly labels, complete tooltips, and
+  narrow-screen behavior;
+- align `BUDGET.ENFORCEMENT.001` and its code/test registry entries.
+
+Out of scope:
+
+- changing budget enforcement, provider quota, biller, or Finance semantics;
+- persisting cost-summary rollups or adding database columns;
+- treating overlapping runs as unique wall-clock time.
+
+## Implementation Plan
+
+1. Extend date-range helpers and hook state with `24h`, Custom defaults,
+   reversed-range validation, and a returned trend granularity.
+2. Add the shared granularity contract and active duration field, then thread
+   granularity through UI API calls, query keys, route validation, and service
+   calls.
+3. Implement UTC hourly trend buckets, cumulative clipped run duration, and
+   Unattributed Project aggregation in the cost service.
+4. Refactor Costs Overview metrics and trend formatting, conditionally fetch
+   Finance only for its tab, and add responsive accessible distribution
+   panels with bounded `Other` grouping.
+5. Add helper, route, PostgreSQL service, component, and Playwright coverage,
+   then update the authorized Product Logic contract.
+6. Run focused and repository-wide validation, inspect desktop and narrow UI
+   screenshots, and obtain independent reviewer and verifier checks.
+
+## Design Notes
+
+- Hour buckets are UTC-aligned identifiers; axis and tooltip presentation use
+  the browser's local time zone.
+- Active duration sums each run once after clipping its interval to the
+  selected range. Running runs end at the earlier of query time and range end.
+- Distribution totals come from the same cost-event aggregations as the
+  summary. Project rows retain a null ID for Unattributed, but null IDs never
+  enter the trend-filter request.
+- Finance queries are enabled only while the Finance tab is active.
+
+## Success Criteria
+
+- Last 24 Hours produces hourly buckets and local-hour labels.
+- Estimated cost, total tokens, cached tokens, and active duration match their
+  documented aggregation semantics.
+- Project distribution includes Unattributed and both distribution panels
+  support Token/Cost toggles, Other grouping, empty states, and responsive
+  layouts.
+- Custom immediately loads a valid seven-day range and never queries a reversed
+  interval.
+- Finance remains functional in its tab and is absent from Overview.
+
+## Validation
+
+- Focused Vitest coverage passed: 29 date-range, Costs component, and route
+  tests.
+- PostgreSQL-backed cost rollup coverage passed: 9 tests for hour/day buckets,
+  clipped active duration, Unattributed rows, and deterministic single-Project
+  Run attribution.
+- Playwright passed all 3 cases in `tests/e2e/cost-trend.spec.ts`, including
+  the rolling 24-hour workflow, Custom defaults, metrics, responsive
+  distributions, and large token totals.
+- Full lint, repository typecheck, build, changed-import lint, focused
+  typechecks, and `pnpm product-logic:check` (79 contracts) passed.
+- The repository-wide `pnpm test:run` completed with 5,392 passing, 729
+  skipped, and 58 failures caused by host workspace environment pollution,
+  shared PostgreSQL exhaustion, unrelated timeouts, and current-main route
+  drift. All changed focused suites above passed independently.
+- The actual Costs page was inspected in Chromium at desktop and 390-pixel
+  viewport widths; both screenshots are attached to the issue handoff.
+- Independent implementation review and verification completed; the review's
+  Project attribution and metric-toggle accessibility findings were fixed and
+  re-reviewed with no remaining blockers.
+
+## Open Issues
+
+None.

--- a/doc/product/domains/governance-and-visibility/approvals-budgets-activity.md
+++ b/doc/product/domains/governance-and-visibility/approvals-budgets-activity.md
@@ -15,7 +15,12 @@ related_code:
   - server/src/services/issue-approvals.ts
   - server/src/services/budgets.ts
   - server/src/services/costs.ts
+  - server/src/routes/costs.ts
   - server/src/services/activity.ts
+  - packages/shared/src/types/cost.ts
+  - ui/src/hooks/useDateRange.ts
+  - ui/src/lib/date-range-cache.ts
+  - ui/src/pages/Costs.tsx
 related_tests:
   - server/src/__tests__/approvals-service.test.ts
   - server/src/__tests__/approval-routes-chat-application.test.ts
@@ -23,6 +28,8 @@ related_tests:
   - server/src/__tests__/costs-service.test.ts
   - server/src/__tests__/costs-rollups-service.test.ts
   - server/src/__tests__/activity-service.test.ts
+  - ui/src/lib/date-range-cache.test.ts
+  - ui/src/pages/Costs.test.tsx
   - tests/e2e/cost-trend.spec.ts
 edit_policy: user_confirmed_only
 ---
@@ -72,20 +79,37 @@ Flow:
    window where supported.
 3. Budget service checks monthly UTC period limits and thresholds.
 4. Soft alerts surface spend pressure; hard limits pause or block further work.
-5. UI/API readbacks show spend trend and budget state.
+5. Costs UI/API readbacks expose estimated spend, unified total tokens, cached
+   input tokens, cumulative overlapping Agent Run duration, explicit UTC
+   hourly or daily trends, and Agent/Project distributions for the selected
+   range.
+6. Project distribution retains an Unattributed bucket so visible usage totals
+   reconcile with the organization summary; only valid Project IDs are
+   accepted as trend filters.
+7. Budget state and Finance ledger readbacks remain available on their owning
+   tabs without changing hard-stop enforcement semantics.
 
 Invariants:
 
 - Hard-stop budget behavior must block new hidden work when limit is reached.
 - Cost rollups must retain source run/event identity for audit.
+- Active duration counts each started run once, clips it to the selected
+  interval, counts parallel runtime cumulatively, and excludes queued runs
+  without `startedAt`.
+- A rolling 24-hour Costs range uses explicit hourly aggregation; longer and
+  calendar ranges use explicit daily aggregation.
 
 Evidence:
 
 - `server/src/__tests__/budgets-service.test.ts`,
   `server/src/__tests__/costs-service.test.ts`, and
-  `server/src/__tests__/costs-rollups-service.test.ts` cover budget/cost
-  service behavior.
-- `tests/e2e/cost-trend.spec.ts` covers visible cost trend behavior.
+  `server/src/__tests__/costs-rollups-service.test.ts` cover budget/cost route,
+  hourly/daily trend, run-duration, and attribution behavior.
+- `ui/src/lib/date-range-cache.test.ts` and `ui/src/pages/Costs.test.tsx` cover
+  date-window, trend-label, distribution, and empty-state presentation
+  behavior.
+- `tests/e2e/cost-trend.spec.ts` covers the visible rolling 24-hour, Custom,
+  metric, trend, and responsive distribution workflow.
 
 ## ACTIVITY.AUDIT.001
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -222,7 +222,7 @@ export type {
   ChatStreamEvent, ChatStreamFinalEvent, ChatStreamQueuedEvent, ChatStreamTranscriptEntry, ChatStreamTranscriptEntryEvent, ChatStreamTranscriptTextEntry, ChatStreamTranscriptTodoItem,
   ChatStreamTranscriptTodoItemStatus, ChatTerminalOutboxStatus, ChatTranscriptGenerationProvenance, ChatTranscriptSummary, ChatWorkManifestItem, ChatWorkManifestResponse, ChatWorkManifestTargetType, CostByAgent, CostByAgentModel, CostByBiller, CostByProject, CostByProviderModel, CostEvent,
   CostSummary,
-  CostTrendPoint, CostWindowSpendRow, CreateOrganizationResourceRequest, CreateProjectInlineResourceInput, DashboardSummary, DocumentFormat, EnvBinding, ExecutionWorkspace, ExecutionWorkspaceMode, ExecutionWorkspaceProviderType, ExecutionWorkspaceStatus, ExecutionWorkspaceStrategy, ExecutionWorkspaceStrategyType, FeishuIntegrationSettings, FinanceByBiller,
+  CostTrendGranularity, CostTrendPoint, CostWindowSpendRow, CreateOrganizationResourceRequest, CreateProjectInlineResourceInput, DashboardSummary, DocumentFormat, EnvBinding, ExecutionWorkspace, ExecutionWorkspaceMode, ExecutionWorkspaceProviderType, ExecutionWorkspaceStatus, ExecutionWorkspaceStrategy, ExecutionWorkspaceStrategyType, FeishuIntegrationSettings, FinanceByBiller,
   FinanceByKind, FinanceEvent, FinanceSummary, Goal,
   GoalDependencies,
   GoalDependencyPreview, GoogleCalendarConnectResponse, GoogleCalendarOAuthConfig, GoogleCalendarSyncResponse, HeartbeatRecoveryMode,

--- a/packages/shared/src/types/cost.ts
+++ b/packages/shared/src/types/cost.ts
@@ -37,10 +37,14 @@ export interface CostSummary {
   totalTokens: number;
   eventCount: number;
   tokenEventCount: number;
+  /** Cumulative agent-runtime time overlapping the selected range. */
+  activeDurationMs: number;
 }
 
+export type CostTrendGranularity = "hour" | "day";
+
 export interface CostTrendPoint {
-  /** UTC day bucket formatted as YYYY-MM-DD. */
+  /** UTC day (YYYY-MM-DD) or hour (ISO timestamp) bucket. */
   date: string;
   costCents: number;
   inputTokens: number;

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -66,7 +66,7 @@ export type {
   ChatStreamEvent, ChatStreamFinalEvent, ChatStreamQueuedEvent, ChatStreamTranscriptEntry, ChatStreamTranscriptEntryEvent, ChatStreamTranscriptTextEntry, ChatStreamTranscriptTodoItem,
   ChatStreamTranscriptTodoItemStatus, ChatTerminalOutboxStatus, ChatTranscriptGenerationProvenance, ChatTranscriptSummary, ChatWorkManifestItem, ChatWorkManifestResponse, ChatWorkManifestTargetType
 } from "./chat.js";
-export type { CostByAgent, CostByAgentModel, CostByBiller, CostByProject, CostByProviderModel, CostEvent, CostSummary, CostTrendPoint, CostWindowSpendRow } from "./cost.js";
+export type { CostByAgent, CostByAgentModel, CostByBiller, CostByProject, CostByProviderModel, CostEvent, CostSummary, CostTrendGranularity, CostTrendPoint, CostWindowSpendRow } from "./cost.js";
 export type {
   AgentCustomIntegrationBinding,
   CustomIntegration,

--- a/server/src/__tests__/costs-rollups-service.test.ts
+++ b/server/src/__tests__/costs-rollups-service.test.ts
@@ -1,4 +1,5 @@
 import {
+  activityLog,
   agents,
   applyPendingMigrations,
   costEvents,
@@ -6,7 +7,9 @@ import {
   createDb,
   ensurePostgresDatabase,
   heartbeatRuns,
+  issues,
   organizations,
+  projects,
 } from "@rudderhq/db";
 import { and, eq } from "drizzle-orm";
 import { randomUUID } from "node:crypto";
@@ -121,13 +124,16 @@ describe("costService monthly spend rollups", () => {
     db = createDb(started.connectionString);
     instance = started.instance;
     dataDir = started.dataDir;
-  }, 20_000);
+  }, 60_000);
 
   afterEach(async () => {
     vi.clearAllMocks();
     await db.delete(costEvents);
     await db.delete(costMonthlySpendRollups);
+    await db.delete(activityLog);
+    await db.delete(issues);
     await db.delete(heartbeatRuns);
+    await db.delete(projects);
     await db.delete(agents);
     await db.delete(organizations);
   });
@@ -410,5 +416,274 @@ describe("costService monthly spend rollups", () => {
     expect(mockBudgetService.evaluateCostEvent).toHaveBeenCalledTimes(2);
     const events = await db.select().from(costEvents).where(eq(costEvents.heartbeatRunId, run!.id));
     expect(events).toHaveLength(1);
+  });
+
+  it("aggregates explicit UTC hour and day trend buckets", async () => {
+    const { orgId, agentId } = await seedOrgAndAgent();
+    await db.insert(costEvents).values([
+      {
+        orgId,
+        agentId,
+        provider: "openai",
+        biller: "openai",
+        billingType: "metered_api",
+        model: "gpt-5",
+        inputTokens: 100,
+        cachedInputTokens: 20,
+        outputTokens: 10,
+        costCents: 25,
+        occurredAt: new Date("2026-06-19T10:15:00.000Z"),
+      },
+      {
+        orgId,
+        agentId,
+        provider: "openai",
+        biller: "openai",
+        billingType: "metered_api",
+        model: "gpt-5",
+        inputTokens: 200,
+        cachedInputTokens: 40,
+        outputTokens: 20,
+        costCents: 50,
+        occurredAt: new Date("2026-06-19T11:05:00.000Z"),
+      },
+    ]);
+    const costs = costService(db);
+    const range = {
+      from: new Date("2026-06-19T10:00:00.000Z"),
+      to: new Date("2026-06-19T11:59:59.999Z"),
+    };
+
+    const hourly = await costs.trend(orgId, range, "hour");
+    const daily = await costs.trend(orgId, range, "day");
+
+    expect(hourly.map((row) => ({ date: row.date, costCents: row.costCents }))).toEqual([
+      { date: "2026-06-19T10:00:00.000Z", costCents: 25 },
+      { date: "2026-06-19T11:00:00.000Z", costCents: 50 },
+    ]);
+    expect(daily.map((row) => ({ date: row.date, costCents: row.costCents }))).toEqual([
+      { date: "2026-06-19", costCents: 75 },
+    ]);
+  });
+
+  it("clips and cumulatively sums each started run once within the selected range", async () => {
+    const { orgId, agentId } = await seedOrgAndAgent();
+    await db.insert(heartbeatRuns).values([
+      {
+        orgId,
+        agentId,
+        status: "completed",
+        startedAt: new Date("2026-06-19T09:00:00.000Z"),
+        finishedAt: new Date("2026-06-19T10:30:00.000Z"),
+      },
+      {
+        orgId,
+        agentId,
+        status: "completed",
+        startedAt: new Date("2026-06-19T10:15:00.000Z"),
+        finishedAt: new Date("2026-06-19T11:15:00.000Z"),
+      },
+      {
+        orgId,
+        agentId,
+        status: "running",
+        startedAt: new Date("2026-06-19T10:30:00.000Z"),
+        finishedAt: null,
+      },
+      {
+        orgId,
+        agentId,
+        status: "completed",
+        startedAt: new Date("2026-06-19T10:30:00.000Z"),
+        finishedAt: new Date("2026-06-19T11:00:00.000Z"),
+      },
+      {
+        orgId,
+        agentId,
+        status: "queued",
+        startedAt: null,
+        finishedAt: null,
+      },
+    ]);
+
+    const summary = await costService(db).summary(orgId, {
+      from: new Date("2026-06-19T10:00:00.000Z"),
+      to: new Date("2026-06-19T12:00:00.000Z"),
+    });
+
+    expect(summary.activeDurationMs).toBe(210 * 60_000);
+  });
+
+  it("includes unattributed cost events in project aggregation totals", async () => {
+    const { orgId, agentId } = await seedOrgAndAgent();
+    const projectId = randomUUID();
+    await db.insert(projects).values({
+      id: projectId,
+      orgId,
+      name: "Attributed Project",
+    });
+    const foreignOrgId = randomUUID();
+    await db.insert(organizations).values({
+      id: foreignOrgId,
+      name: "Foreign Rollup Test",
+      urlKey: `foreign-rollup-${foreignOrgId.slice(0, 8)}`,
+      issuePrefix: foreignOrgId.replaceAll("-", "").slice(0, 6).toUpperCase(),
+      requireBoardApprovalForNewAgents: false,
+    });
+    const foreignProjectId = randomUUID();
+    await db.insert(projects).values({
+      id: foreignProjectId,
+      orgId: foreignOrgId,
+      name: "Foreign Project",
+    });
+    await db.insert(costEvents).values([
+      {
+        orgId,
+        agentId,
+        projectId,
+        provider: "openai",
+        biller: "openai",
+        billingType: "metered_api",
+        model: "gpt-5",
+        inputTokens: 100,
+        cachedInputTokens: 20,
+        outputTokens: 10,
+        costCents: 25,
+        occurredAt: new Date("2026-06-19T10:15:00.000Z"),
+      },
+      {
+        orgId,
+        agentId,
+        projectId: null,
+        provider: "openai",
+        biller: "openai",
+        billingType: "metered_api",
+        model: "gpt-5",
+        inputTokens: 200,
+        cachedInputTokens: 40,
+        outputTokens: 20,
+        costCents: 50,
+        occurredAt: new Date("2026-06-19T10:45:00.000Z"),
+      },
+      {
+        orgId,
+        agentId,
+        projectId: foreignProjectId,
+        provider: "openai",
+        biller: "openai",
+        billingType: "metered_api",
+        model: "gpt-5",
+        inputTokens: 50,
+        cachedInputTokens: 10,
+        outputTokens: 5,
+        costCents: 30,
+        occurredAt: new Date("2026-06-19T11:00:00.000Z"),
+      },
+    ]);
+
+    const rows = await costService(db).byProject(orgId);
+
+    expect(rows.map((row) => ({
+      projectId: row.projectId,
+      projectName: row.projectName,
+      costCents: row.costCents,
+    }))).toEqual([
+      { projectId: null, projectName: null, costCents: 80 },
+      { projectId, projectName: "Attributed Project", costCents: 25 },
+    ]);
+    expect(rows.reduce((sum, row) => sum + row.costCents, 0)).toBe(105);
+  });
+
+  it("attributes a run to only its latest linked project", async () => {
+    const { orgId, agentId } = await seedOrgAndAgent();
+    const olderProjectId = randomUUID();
+    const latestProjectId = randomUUID();
+    await db.insert(projects).values([
+      { id: olderProjectId, orgId, name: "Older Project" },
+      { id: latestProjectId, orgId, name: "Latest Project" },
+    ]);
+
+    const runId = randomUUID();
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      orgId,
+      agentId,
+      status: "completed",
+      startedAt: new Date("2026-06-19T10:00:00.000Z"),
+      finishedAt: new Date("2026-06-19T10:30:00.000Z"),
+    });
+
+    const olderIssueId = randomUUID();
+    const latestIssueId = randomUUID();
+    await db.insert(issues).values([
+      {
+        id: olderIssueId,
+        orgId,
+        projectId: olderProjectId,
+        title: "Older project issue",
+      },
+      {
+        id: latestIssueId,
+        orgId,
+        projectId: latestProjectId,
+        title: "Latest project issue",
+      },
+    ]);
+    await db.insert(activityLog).values([
+      {
+        orgId,
+        actorId: "test",
+        action: "issue.updated",
+        entityType: "issue",
+        entityId: olderIssueId,
+        runId,
+        createdAt: new Date("2026-06-19T10:05:00.000Z"),
+      },
+      {
+        orgId,
+        actorId: "test",
+        action: "issue.updated",
+        entityType: "issue",
+        entityId: latestIssueId,
+        runId,
+        createdAt: new Date("2026-06-19T10:10:00.000Z"),
+      },
+    ]);
+    await db.insert(costEvents).values({
+      orgId,
+      agentId,
+      heartbeatRunId: runId,
+      provider: "openai",
+      biller: "openai",
+      billingType: "metered_api",
+      model: "gpt-5",
+      inputTokens: 100,
+      cachedInputTokens: 20,
+      outputTokens: 10,
+      costCents: 40,
+      occurredAt: new Date("2026-06-19T10:15:00.000Z"),
+    });
+
+    const costs = costService(db);
+    const range = {
+      from: new Date("2026-06-19T10:00:00.000Z"),
+      to: new Date("2026-06-19T10:59:59.999Z"),
+    };
+    const [summary, rows, olderTrend, latestTrend] = await Promise.all([
+      costs.summary(orgId, range),
+      costs.byProject(orgId, range),
+      costs.trend(orgId, range, "hour", { projectId: olderProjectId }),
+      costs.trend(orgId, range, "hour", { projectId: latestProjectId }),
+    ]);
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      projectId: latestProjectId,
+      projectName: "Latest Project",
+      costCents: 40,
+    });
+    expect(rows.reduce((sum, row) => sum + row.costCents, 0)).toBe(summary.spendCents);
+    expect(olderTrend).toEqual([]);
+    expect(latestTrend.map((row) => row.costCents)).toEqual([40]);
   });
 });

--- a/server/src/__tests__/costs-service.test.ts
+++ b/server/src/__tests__/costs-service.test.ts
@@ -179,7 +179,7 @@ describe("cost routes", () => {
     expect(mockCostService.trend).toHaveBeenCalledWith("organization-1", {
       from: new Date("2026-03-01T00:00:00.000Z"),
       to: new Date("2026-03-07T23:59:59.999Z"),
-    }, undefined);
+    }, "day", undefined);
   });
 
   it("passes agent and project filters to cost trend routes", async () => {
@@ -190,16 +190,38 @@ describe("cost routes", () => {
         from: "2026-03-01T00:00:00.000Z",
         agentId: "agent-1",
         projectId: "project-1",
+        granularity: "hour",
       });
 
     expect(res.status).toBe(200);
     expect(mockCostService.trend).toHaveBeenCalledWith("organization-1", {
       from: new Date("2026-03-01T00:00:00.000Z"),
       to: undefined,
-    }, {
+    }, "hour", {
       agentId: "agent-1",
       projectId: "project-1",
     });
+  });
+
+  it("rejects unsupported trend granularities", async () => {
+    const app = await createApp();
+    const res = await request(app)
+      .get("/api/orgs/organization-1/costs/trend")
+      .query({ granularity: "minute" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/granularity/i);
+    expect(mockCostService.trend).not.toHaveBeenCalled();
+  });
+
+  it("rejects reversed date ranges", async () => {
+    const app = await createApp();
+    const res = await request(app)
+      .get("/api/orgs/organization-1/costs/summary")
+      .query({ from: "2026-03-08T00:00:00.000Z", to: "2026-03-01T00:00:00.000Z" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/must not be later/i);
   });
 
   it("returns finance summary rows for valid requests", async () => {

--- a/server/src/routes/costs.ts
+++ b/server/src/routes/costs.ts
@@ -99,7 +99,16 @@ export function costRoutes(db: Db) {
     const to = toRaw ? new Date(toRaw) : undefined;
     if (from && isNaN(from.getTime())) throw badRequest("invalid 'from' date");
     if (to && isNaN(to.getTime())) throw badRequest("invalid 'to' date");
+    if (from && to && from > to) throw badRequest("'from' date must not be later than 'to' date");
     return (from || to) ? { from, to } : undefined;
+  }
+
+  function parseTrendGranularity(query: Record<string, unknown>) {
+    const granularity = firstQueryValue(query.granularity) ?? "day";
+    if (granularity !== "hour" && granularity !== "day") {
+      throw badRequest("invalid 'granularity' value");
+    }
+    return granularity;
   }
 
   function parseLimit(query: Record<string, unknown>) {
@@ -145,8 +154,9 @@ export function costRoutes(db: Db) {
     const orgId = req.params.orgId as string;
     assertCompanyAccess(req, orgId);
     const range = parseDateRange(req.query);
+    const granularity = parseTrendGranularity(req.query);
     const filter = parseTrendFilter(req.query);
-    const rows = await costs.trend(orgId, range, filter);
+    const rows = await costs.trend(orgId, range, granularity, filter);
     res.json(rows);
   });
 

--- a/server/src/services/costs.ts
+++ b/server/src/services/costs.ts
@@ -1,7 +1,7 @@
 import type { Db } from "@rudderhq/db";
-import { activityLog, agents, costEvents, costMonthlySpendRollups, issues, organizations, projects } from "@rudderhq/db";
-import { ADDITIONAL_CACHED_INPUT_TOKEN_PROVIDERS } from "@rudderhq/shared";
-import { and, desc, eq, gte, isNotNull, isNull, lt, lte, or, sql, type SQLWrapper } from "drizzle-orm";
+import { activityLog, agents, costEvents, costMonthlySpendRollups, heartbeatRuns, issues, organizations, projects } from "@rudderhq/db";
+import { ADDITIONAL_CACHED_INPUT_TOKEN_PROVIDERS, type CostTrendGranularity } from "@rudderhq/shared";
+import { and, desc, eq, gte, isNotNull, isNull, lt, lte, or, sql, type SQL, type SQLWrapper } from "drizzle-orm";
 import { notFound, unprocessable } from "../errors.js";
 import { budgetService, type BudgetServiceHooks } from "./budgets.js";
 
@@ -425,18 +425,54 @@ export function costService(db: Db, budgetHooks: BudgetServiceHooks = {}) {
       if (range?.from) conditions.push(gte(costEvents.occurredAt, range.from));
       if (range?.to) conditions.push(lte(costEvents.occurredAt, range.to));
 
-      const [summaryRow] = await db
-        .select({
-          total: sumNumberSql(costEvents.costCents),
-          inputTokens: promptInputTokenCountSql(),
-          cachedInputTokens: sumNumberSql(costEvents.cachedInputTokens),
-          outputTokens: sumNumberSql(costEvents.outputTokens),
-          totalTokens: totalTokenCountSql(),
-          eventCount: sql<number>`count(*)::int`,
-          tokenEventCount: tokenEventCountSql(),
-        })
-        .from(costEvents)
-        .where(and(...conditions));
+      const now = new Date();
+      const activeEnd = range?.to && range.to < now ? range.to : now;
+      const activeConditions: SQL[] = [
+        eq(heartbeatRuns.orgId, orgId),
+        isNotNull(heartbeatRuns.startedAt),
+        lte(heartbeatRuns.startedAt, activeEnd),
+      ];
+      if (range?.from) {
+        activeConditions.push(
+          or(isNull(heartbeatRuns.finishedAt), gte(heartbeatRuns.finishedAt, range.from))!,
+        );
+      }
+      const nowTimestamp = sql`${now.toISOString()}::timestamptz`;
+      const clippedStart = range?.from
+        ? sql`greatest(${heartbeatRuns.startedAt}, ${range.from.toISOString()}::timestamptz)`
+        : sql`${heartbeatRuns.startedAt}`;
+      const clippedEnd = range?.to
+        ? sql`least(
+            coalesce(${heartbeatRuns.finishedAt}, ${nowTimestamp}),
+            ${range.to.toISOString()}::timestamptz,
+            ${nowTimestamp}
+          )`
+        : sql`least(coalesce(${heartbeatRuns.finishedAt}, ${nowTimestamp}), ${nowTimestamp})`;
+
+      const [[summaryRow], [durationRow]] = await Promise.all([
+        db
+          .select({
+            total: sumNumberSql(costEvents.costCents),
+            inputTokens: promptInputTokenCountSql(),
+            cachedInputTokens: sumNumberSql(costEvents.cachedInputTokens),
+            outputTokens: sumNumberSql(costEvents.outputTokens),
+            totalTokens: totalTokenCountSql(),
+            eventCount: sql<number>`count(*)::int`,
+            tokenEventCount: tokenEventCountSql(),
+          })
+          .from(costEvents)
+          .where(and(...conditions)),
+        db
+          .select({
+            activeDurationMs: sql<number>`
+              coalesce(sum(
+                greatest(extract(epoch from (${clippedEnd} - ${clippedStart})) * 1000, 0)
+              ), 0)::double precision
+            `,
+          })
+          .from(heartbeatRuns)
+          .where(and(...activeConditions)),
+      ]);
 
       const {
         total,
@@ -465,16 +501,24 @@ export function costService(db: Db, budgetHooks: BudgetServiceHooks = {}) {
         totalTokens: Number(totalTokens),
         eventCount: Number(eventCount),
         tokenEventCount: Number(tokenEventCount),
+        activeDurationMs: Number(durationRow?.activeDurationMs ?? 0),
       };
     },
 
-    trend: async (orgId: string, range?: CostDateRange, filter: CostTrendFilter = {}) => {
+    trend: async (
+      orgId: string,
+      range?: CostDateRange,
+      granularity: CostTrendGranularity = "day",
+      filter: CostTrendFilter = {},
+    ) => {
       const conditions: ReturnType<typeof eq>[] = [eq(costEvents.orgId, orgId)];
       if (range?.from) conditions.push(gte(costEvents.occurredAt, range.from));
       if (range?.to) conditions.push(lte(costEvents.occurredAt, range.to));
       if (filter.agentId) conditions.push(eq(costEvents.agentId, filter.agentId));
 
-      const dateBucket = sql<string>`to_char(date_trunc('day', ${costEvents.occurredAt} at time zone 'UTC'), 'YYYY-MM-DD')`;
+      const dateBucket = granularity === "hour"
+        ? sql<string>`to_char(date_trunc('hour', ${costEvents.occurredAt} at time zone 'UTC'), 'YYYY-MM-DD"T"HH24:00:00.000"Z"')`
+        : sql<string>`to_char(date_trunc('day', ${costEvents.occurredAt} at time zone 'UTC'), 'YYYY-MM-DD')`;
       const costCentsExpr = sumNumberSql(costEvents.costCents);
       const inputTokensExpr = promptInputTokenCountSql();
       const cachedInputTokensExpr = sumNumberSql(costEvents.cachedInputTokens);
@@ -484,7 +528,7 @@ export function costService(db: Db, budgetHooks: BudgetServiceHooks = {}) {
       if (filter.projectId) {
         const issueIdAsText = sql<string>`${issues.id}::text`;
         const runProjectLinks = db
-          .selectDistinctOn([activityLog.runId, issues.projectId], {
+          .selectDistinctOn([activityLog.runId], {
             runId: activityLog.runId,
             projectId: issues.projectId,
           })
@@ -504,7 +548,7 @@ export function costService(db: Db, budgetHooks: BudgetServiceHooks = {}) {
               isNotNull(issues.projectId),
             ),
           )
-          .orderBy(activityLog.runId, issues.projectId, desc(activityLog.createdAt))
+          .orderBy(activityLog.runId, desc(activityLog.createdAt), desc(activityLog.id))
           .as("run_project_links");
         const effectiveProjectId = sql<string | null>`coalesce(${costEvents.projectId}, ${runProjectLinks.projectId})`;
         conditions.push(sql`${effectiveProjectId} = ${filter.projectId}` as ReturnType<typeof eq>);
@@ -724,7 +768,7 @@ export function costService(db: Db, budgetHooks: BudgetServiceHooks = {}) {
     byProject: async (orgId: string, range?: CostDateRange) => {
       const issueIdAsText = sql<string>`${issues.id}::text`;
       const runProjectLinks = db
-        .selectDistinctOn([activityLog.runId, issues.projectId], {
+        .selectDistinctOn([activityLog.runId], {
           runId: activityLog.runId,
           projectId: issues.projectId,
         })
@@ -744,7 +788,7 @@ export function costService(db: Db, budgetHooks: BudgetServiceHooks = {}) {
             isNotNull(issues.projectId),
           ),
         )
-        .orderBy(activityLog.runId, issues.projectId, desc(activityLog.createdAt))
+        .orderBy(activityLog.runId, desc(activityLog.createdAt), desc(activityLog.id))
         .as("run_project_links");
 
       const effectiveProjectId = sql<string | null>`coalesce(${costEvents.projectId}, ${runProjectLinks.projectId})`;
@@ -756,7 +800,7 @@ export function costService(db: Db, budgetHooks: BudgetServiceHooks = {}) {
 
       return db
         .select({
-          projectId: effectiveProjectId,
+          projectId: projects.id,
           projectName: projects.name,
           costCents: costCentsExpr,
           inputTokens: promptInputTokenCountSql(),
@@ -765,9 +809,15 @@ export function costService(db: Db, budgetHooks: BudgetServiceHooks = {}) {
         })
         .from(costEvents)
         .leftJoin(runProjectLinks, eq(costEvents.heartbeatRunId, runProjectLinks.runId))
-        .innerJoin(projects, sql`${projects.id} = ${effectiveProjectId}`)
-        .where(and(...conditions, sql`${effectiveProjectId} is not null`))
-        .groupBy(effectiveProjectId, projects.name)
+        .leftJoin(
+          projects,
+          and(
+            sql`${projects.id} = ${effectiveProjectId}`,
+            eq(projects.orgId, orgId),
+          ),
+        )
+        .where(and(...conditions))
+        .groupBy(projects.id, projects.name)
         .orderBy(desc(costCentsExpr));
     },
   };

--- a/tests/e2e/cost-trend.spec.ts
+++ b/tests/e2e/cost-trend.spec.ts
@@ -5,8 +5,14 @@ function daysAgoUtc(days: number): string {
   return date.toISOString();
 }
 
+function hoursAgoUtc(hours: number): string {
+  const date = new Date(Date.now() - hours * 3_600_000);
+  date.setMinutes(15, 0, 0);
+  return date.toISOString();
+}
+
 test.describe("Cost trend chart", () => {
-  test("shows token volume and estimated spend on the organization costs page", async ({ page }) => {
+  test("shows rolling hourly usage metrics and responsive distributions", async ({ page }) => {
     const orgRes = await page.request.post("/api/orgs", {
       data: {
         name: `Cost-Trend-${Date.now()}`,
@@ -41,10 +47,19 @@ test.describe("Cost trend chart", () => {
     expect(secondAgentRes.ok()).toBe(true);
     const secondAgent = await secondAgentRes.json() as { id: string };
 
+    const projectRes = await page.request.post(`/api/orgs/${organization.id}/projects`, {
+      data: {
+        name: "Cost Visibility",
+        status: "in_progress",
+      },
+    });
+    expect(projectRes.ok()).toBe(true);
+    const project = await projectRes.json() as { id: string };
+
     for (const event of [
-      { agentId: agent.id, inputTokens: 600, cachedInputTokens: 150, outputTokens: 250, costCents: 123, occurredAt: daysAgoUtc(0) },
-      { agentId: agent.id, inputTokens: 300, cachedInputTokens: 50, outputTokens: 450, costCents: 456, occurredAt: daysAgoUtc(0) },
-      { agentId: secondAgent.id, inputTokens: 700, cachedInputTokens: 100, outputTokens: 200, costCents: 234, occurredAt: daysAgoUtc(0) },
+      { agentId: agent.id, projectId: project.id, inputTokens: 600, cachedInputTokens: 150, outputTokens: 250, costCents: 123, occurredAt: hoursAgoUtc(1) },
+      { agentId: agent.id, projectId: null, inputTokens: 300, cachedInputTokens: 50, outputTokens: 450, costCents: 456, occurredAt: hoursAgoUtc(2) },
+      { agentId: secondAgent.id, projectId: null, inputTokens: 700, cachedInputTokens: 100, outputTokens: 200, costCents: 234, occurredAt: hoursAgoUtc(3) },
     ]) {
       const eventRes = await page.request.post(`/api/orgs/${organization.id}/cost-events`, {
         data: {
@@ -63,17 +78,58 @@ test.describe("Cost trend chart", () => {
     }, organization.id);
 
     await page.goto(`/${organization.issuePrefix}/costs`, { waitUntil: "domcontentloaded" });
+    const hourlyTrendResponse = page.waitForResponse((response) => {
+      const url = new URL(response.url());
+      return url.pathname === `/api/orgs/${organization.id}/costs/trend`
+        && url.searchParams.get("granularity") === "hour";
+    });
+    await page.getByRole("button", { name: "Last 24 Hours" }).click();
+    expect((await hourlyTrendResponse).ok()).toBe(true);
 
     const chart = page.getByTestId("cost-trend-chart");
     await expect(chart).toBeVisible();
     await expect(chart.getByText("Inference trend")).toBeVisible();
+    await expect(chart.getByText("Hourly token volume", { exact: false })).toBeVisible();
     await expect(chart.getByText(/Estimated spend\s+\$8\.13/)).toBeVisible();
     await expect(chart.getByText("$8.13")).toBeVisible();
+    await expect(chart.locator('[data-slot="tooltip-trigger"]')).toHaveCount(25);
+
+    await expect(page.getByTestId("cost-metric-estimated-cost")).toBeVisible();
+    await expect(page.getByTestId("cost-metric-total-tokens")).toContainText("2.5k");
+    await expect(page.getByTestId("cost-metric-cached-tokens")).toContainText("300");
+    await expect(page.getByTestId("cost-metric-active-duration")).toBeVisible();
 
     await chart.getByRole("button", { name: "Agent" }).click();
     await expect(chart.getByText("2 agents")).toBeVisible();
     await expect(chart.getByText("Cost Analyst")).toBeVisible();
     await expect(chart.getByText("Budget Reviewer")).toBeVisible();
+
+    const agentDistribution = page.getByTestId("distribution-agent-distribution");
+    const projectDistribution = page.getByTestId("distribution-project-distribution");
+    await expect(agentDistribution).toBeVisible();
+    await expect(projectDistribution).toBeVisible();
+    await expect(projectDistribution.getByText("Cost Visibility")).toBeVisible();
+    await expect(projectDistribution.getByText("Unattributed", { exact: true })).toBeVisible();
+    await projectDistribution.getByRole("button", { name: "Cost" }).click();
+    await expect(projectDistribution.getByText("$6.90")).toBeVisible();
+
+    await page.getByRole("button", { name: "Custom" }).click();
+    const customStart = page.getByLabel("Custom start date");
+    const customEnd = page.getByLabel("Custom end date");
+    await expect(customStart).not.toHaveValue("");
+    await expect(customEnd).not.toHaveValue("");
+    const rememberedStart = await customStart.inputValue();
+    await expect(chart).toBeVisible();
+    await page.getByRole("button", { name: "Month to Date" }).click();
+    await page.getByRole("button", { name: "Custom" }).click();
+    await expect(customStart).toHaveValue(rememberedStart);
+
+    await page.setViewportSize({ width: 390, height: 780 });
+    for (const panel of [agentDistribution, projectDistribution]) {
+      await expect.poll(async () => panel.evaluate((element) =>
+        element.getBoundingClientRect().right <= document.documentElement.clientWidth,
+      )).toBe(true);
+    }
   });
 
   test("auto-aligns the narrow agent comparison chart to recent data", async ({ page }) => {
@@ -211,7 +267,7 @@ test.describe("Cost trend chart", () => {
 
     await expect(page.getByText("Internal server error")).toHaveCount(0);
     await expect(page.getByTestId("cost-trend-chart")).toBeVisible();
-    await expect(page.getByText(/2\.7B tokens across request-scoped events/)).toBeVisible();
+    await expect(page.getByTestId("cost-metric-total-tokens")).toContainText("2.7B");
     await expect(page.getByTestId("workspace-main-card").getByText("large-token-project", { exact: true })).toBeVisible();
   });
 });

--- a/ui/src/api/costs.ts
+++ b/ui/src/api/costs.ts
@@ -5,6 +5,7 @@ import type {
   CostByProject,
   CostByProviderModel,
   CostSummary,
+  CostTrendGranularity,
   CostTrendPoint,
   CostWindowSpendRow,
   FinanceByBiller,
@@ -31,8 +32,16 @@ export const costsApi = {
     api.get<CostSummary>(`/orgs/${orgId}/costs/summary${dateParams(from, to)}`),
   byAgent: (orgId: string, from?: string, to?: string) =>
     api.get<CostByAgent[]>(`/orgs/${orgId}/costs/by-agent${dateParams(from, to)}`),
-  trend: (orgId: string, from?: string, to?: string, filter?: { agentId?: string; projectId?: string }) =>
-    api.get<CostTrendPoint[]>(`/orgs/${orgId}/costs/trend${dateParams(from, to, filter)}`),
+  trend: (
+    orgId: string,
+    from?: string,
+    to?: string,
+    granularity: CostTrendGranularity = "day",
+    filter?: { agentId?: string; projectId?: string },
+  ) =>
+    api.get<CostTrendPoint[]>(
+      `/orgs/${orgId}/costs/trend${dateParams(from, to, { granularity, ...filter })}`,
+    ),
   byAgentModel: (orgId: string, from?: string, to?: string) =>
     api.get<CostByAgentModel[]>(`/orgs/${orgId}/costs/by-agent-model${dateParams(from, to)}`),
   byProject: (orgId: string, from?: string, to?: string) =>

--- a/ui/src/hooks/useDateRange.ts
+++ b/ui/src/hooks/useDateRange.ts
@@ -1,9 +1,11 @@
-import { floorDateToMinuteIso, resolvePresetDateRange } from "@/lib/date-range-cache";
+import { defaultCustomDateRange, floorDateToMinuteIso, resolvePresetDateRange } from "@/lib/date-range-cache";
+import type { CostTrendGranularity } from "@rudderhq/shared";
 import { useEffect, useMemo, useRef, useState } from "react";
 
-export type DatePreset = "mtd" | "7d" | "30d" | "ytd" | "all" | "custom";
+export type DatePreset = "24h" | "mtd" | "7d" | "30d" | "ytd" | "all" | "custom";
 
 export const PRESET_LABELS: Record<DatePreset, string> = {
+  "24h": "Last 24 Hours",
   mtd: "Month to Date",
   "7d": "Last 7 Days",
   "30d": "Last 30 Days",
@@ -12,7 +14,7 @@ export const PRESET_LABELS: Record<DatePreset, string> = {
   custom: "Custom",
 };
 
-export const PRESET_KEYS: DatePreset[] = ["mtd", "7d", "30d", "ytd", "all", "custom"];
+export const PRESET_KEYS: DatePreset[] = ["24h", "mtd", "7d", "30d", "ytd", "all", "custom"];
 
 export interface UseDateRangeResult {
   preset: DatePreset;
@@ -26,12 +28,15 @@ export interface UseDateRangeResult {
   to: string;
   /** false when preset=custom but both dates are not yet selected */
   customReady: boolean;
+  customError: string | null;
+  trendGranularity: CostTrendGranularity;
 }
 
 export function useDateRange(initialPreset: DatePreset = "mtd"): UseDateRangeResult {
   const [preset, setPreset] = useState<DatePreset>(initialPreset);
-  const [customFrom, setCustomFrom] = useState("");
-  const [customTo, setCustomTo] = useState("");
+  const [initialCustomRange] = useState(() => defaultCustomDateRange());
+  const [customFrom, setCustomFrom] = useState(initialCustomRange.from);
+  const [customTo, setCustomTo] = useState(initialCustomRange.to);
 
   // tick at the next calendar minute boundary, then every 60s, so sliding presets
   // (7d, 30d) advance their upper bound in sync with wall clock minutes rather than
@@ -65,7 +70,11 @@ export function useDateRange(initialPreset: DatePreset = "mtd"): UseDateRangeRes
   // minuteTick drives re-evaluation of sliding presets once per minute.
   }, [preset, customFrom, customTo, minuteTick]);
 
-  const customReady = preset !== "custom" || (!!customFrom && !!customTo);
+  const customReady = preset !== "custom" || (!!from && !!to);
+  const customError =
+    preset === "custom" && customFrom && customTo && !customReady
+      ? "Start date must be on or before end date."
+      : null;
 
   return {
     preset,
@@ -77,5 +86,7 @@ export function useDateRange(initialPreset: DatePreset = "mtd"): UseDateRangeRes
     from,
     to,
     customReady,
+    customError,
+    trendGranularity: preset === "24h" ? "hour" : "day",
   };
 }

--- a/ui/src/lib/date-range-cache.test.ts
+++ b/ui/src/lib/date-range-cache.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  defaultCustomDateRange,
   floorDateToMinuteIso,
   resolvePresetDateRange,
 } from "./date-range-cache";
@@ -20,6 +21,24 @@ describe("date range cache helpers", () => {
     });
 
     expect(second).toEqual(first);
+  });
+
+  it("resolves Last 24 Hours as an exact minute-aligned rolling window", () => {
+    expect(resolvePresetDateRange({
+      preset: "24h",
+      now: new Date("2026-06-19T01:51:37.432Z"),
+    })).toEqual({
+      from: "2026-06-18T01:51:00.000Z",
+      to: "2026-06-19T01:51:00.000Z",
+      customReady: true,
+    });
+  });
+
+  it("defaults Custom to the latest seven local calendar days", () => {
+    expect(defaultCustomDateRange(new Date(2026, 5, 19, 13, 24))).toEqual({
+      from: "2026-06-13",
+      to: "2026-06-19",
+    });
   });
 
   it("preserves custom local-day boundaries", () => {
@@ -44,5 +63,17 @@ describe("date range cache helpers", () => {
     expect(resolvePresetDateRange({ preset: "7d", now, dayWindowMode: "lookback" }).from).toBe(
       new Date("2026-06-12T00:00:00").toISOString(),
     );
+  });
+
+  it("rejects reversed custom date ranges without emitting API bounds", () => {
+    expect(resolvePresetDateRange({
+      preset: "custom",
+      customFrom: "2026-06-20",
+      customTo: "2026-06-12",
+    })).toEqual({
+      from: "",
+      to: "",
+      customReady: false,
+    });
   });
 });

--- a/ui/src/lib/date-range-cache.ts
+++ b/ui/src/lib/date-range-cache.ts
@@ -1,9 +1,24 @@
-export type SlidingDatePreset = "7d" | "15d" | "30d" | "mtd" | "ytd" | "all" | "custom";
+export type SlidingDatePreset = "24h" | "7d" | "15d" | "30d" | "mtd" | "ytd" | "all" | "custom";
 
 export function floorDateToMinuteIso(date: Date): string {
   const floored = new Date(date);
   floored.setSeconds(0, 0);
   return floored.toISOString();
+}
+
+function localDateInputValue(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+export function defaultCustomDateRange(now = new Date()): { from: string; to: string } {
+  const from = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 6);
+  return {
+    from: localDateInputValue(from),
+    to: localDateInputValue(now),
+  };
 }
 
 export function resolvePresetDateRange({
@@ -22,10 +37,16 @@ export function resolvePresetDateRange({
   if (preset === "custom") {
     const fromDate = customFrom ? new Date(`${customFrom}T00:00:00`) : null;
     const toDate = customTo ? new Date(`${customTo}T23:59:59.999`) : null;
+    const valid =
+      !!fromDate
+      && !!toDate
+      && Number.isFinite(fromDate.getTime())
+      && Number.isFinite(toDate.getTime())
+      && fromDate <= toDate;
     return {
-      from: fromDate ? fromDate.toISOString() : "",
-      to: toDate ? toDate.toISOString() : "",
-      customReady: !!customFrom && !!customTo,
+      from: valid ? fromDate.toISOString() : "",
+      to: valid ? toDate.toISOString() : "",
+      customReady: valid,
     };
   }
 
@@ -34,6 +55,13 @@ export function resolvePresetDateRange({
   }
 
   const to = floorDateToMinuteIso(now);
+  if (preset === "24h") {
+    return {
+      from: new Date(new Date(to).getTime() - 24 * 60 * 60 * 1000).toISOString(),
+      to,
+      customReady: true,
+    };
+  }
   if (preset === "mtd") {
     return {
       from: new Date(now.getFullYear(), now.getMonth(), 1).toISOString(),

--- a/ui/src/lib/queryKeys.ts
+++ b/ui/src/lib/queryKeys.ts
@@ -214,8 +214,15 @@ export const queryKeys = {
   activity: (orgId: string, filtersKey: string = "all") => ["activity", orgId, filtersKey] as const,
   costs: (orgId: string, from?: string, to?: string) =>
     ["costs", orgId, from, to] as const,
-  costTrend: (orgId: string, from?: string, to?: string, scopeKind: string = "all", scopeId: string = "") =>
-    ["costs", "trend", orgId, from, to, scopeKind, scopeId] as const,
+  costTrend: (
+    orgId: string,
+    from?: string,
+    to?: string,
+    granularity: string = "day",
+    scopeKind: string = "all",
+    scopeId: string = "",
+  ) =>
+    ["costs", "trend", orgId, from, to, granularity, scopeKind, scopeId] as const,
   usageByProvider: (orgId: string, from?: string, to?: string) =>
     ["usage-by-provider", orgId, from, to] as const,
   usageByBiller: (orgId: string, from?: string, to?: string) =>

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -260,10 +260,10 @@ export function AgentDetail() {
       resolvedCompanyId ?? "__none__",
       from,
       to,
-      "agent",
+      "day", "agent",
       resolvedAgentId ?? routeAgentRef,
     ),
-    queryFn: () => costsApi.trend(resolvedCompanyId!, from, to, { agentId: resolvedAgentId! }),
+    queryFn: () => costsApi.trend(resolvedCompanyId!, from, to, "day", { agentId: resolvedAgentId! }),
     enabled: Boolean(resolvedCompanyId) && Boolean(resolvedAgentId) && needsDashboardData && (datePreset !== "custom" || customReady),
     placeholderData: keepPreviousData,
   });

--- a/ui/src/pages/Costs.distribution.tsx
+++ b/ui/src/pages/Costs.distribution.tsx
@@ -1,0 +1,170 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { cn, formatCents, formatTokens } from "@/lib/utils";
+import { useMemo, useState } from "react";
+
+type DistributionMetric = "tokens" | "cost";
+
+export type DistributionDatum = {
+  id: string;
+  label: string;
+  tokens: number;
+  costCents: number;
+};
+
+type DistributionItem = DistributionDatum & {
+  color: string;
+  value: number;
+  percentage: number;
+};
+
+const distributionPalette = [
+  "#2563eb",
+  "#06b6d4",
+  "#10b981",
+  "#f59e0b",
+  "#8b5cf6",
+  "#e11d48",
+];
+
+export function buildDistributionItems(
+  rows: DistributionDatum[],
+  metric: DistributionMetric,
+  visibleLimit = 5,
+): DistributionItem[] {
+  const valueFor = (row: DistributionDatum) => metric === "tokens" ? row.tokens : row.costCents;
+  const sorted = rows
+    .filter((row) => valueFor(row) > 0)
+    .slice()
+    .sort((a, b) => valueFor(b) - valueFor(a));
+  const total = sorted.reduce((sum, row) => sum + valueFor(row), 0);
+  const visible = sorted.length > visibleLimit + 1 ? sorted.slice(0, visibleLimit) : sorted;
+  const hidden = sorted.length > visibleLimit + 1 ? sorted.slice(visibleLimit) : [];
+  const grouped: DistributionDatum[] = hidden.length > 0
+    ? [
+        ...visible,
+        {
+          id: "other",
+          label: `Other (${hidden.length})`,
+          tokens: hidden.reduce((sum, row) => sum + row.tokens, 0),
+          costCents: hidden.reduce((sum, row) => sum + row.costCents, 0),
+        },
+      ]
+    : visible;
+
+  return grouped.map((row, index) => {
+    const value = valueFor(row);
+    return {
+      ...row,
+      value,
+      percentage: total > 0 ? (value / total) * 100 : 0,
+      color: distributionPalette[index % distributionPalette.length]!,
+    };
+  });
+}
+
+function distributionGradient(items: DistributionItem[]): string {
+  const visualWeights = items.map((item) => Math.max(item.percentage, 0.5));
+  const visualTotal = visualWeights.reduce((sum, value) => sum + value, 0);
+  let cursor = 0;
+  const stops = items.map((item, index) => {
+    const start = cursor;
+    cursor += visualTotal > 0 ? (visualWeights[index]! / visualTotal) * 100 : 0;
+    return `${item.color} ${start.toFixed(2)}% ${cursor.toFixed(2)}%`;
+  });
+  return `conic-gradient(${stops.join(", ")})`;
+}
+
+export function DistributionPanel({
+  title,
+  description,
+  rows,
+}: {
+  title: string;
+  description: string;
+  rows: DistributionDatum[];
+}) {
+  const [metric, setMetric] = useState<DistributionMetric>("tokens");
+  const items = useMemo(() => buildDistributionItems(rows, metric), [metric, rows]);
+  const total = items.reduce((sum, item) => sum + item.value, 0);
+  const accessibleSummary = items
+    .map((item) => `${item.label} ${item.percentage.toFixed(1)}%`)
+    .join(", ");
+
+  return (
+    <Card data-testid={`distribution-${title.toLowerCase().replace(/\s+/g, "-")}`}>
+      <CardHeader className="gap-3 px-5 pb-2 pt-5">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <CardTitle className="text-base">{title}</CardTitle>
+            <CardDescription className="mt-1">{description}</CardDescription>
+          </div>
+          <div
+            className="flex rounded-[calc(var(--radius-sm)-1px)] border border-border p-0.5"
+            role="group"
+            aria-label={`${title} metric`}
+          >
+            {(["tokens", "cost"] as const).map((value) => (
+              <button
+                key={value}
+                type="button"
+                aria-pressed={metric === value}
+                onClick={() => setMetric(value)}
+                className={cn(
+                  "rounded-[calc(var(--radius-sm)-2px)] px-2.5 py-1 text-xs font-medium transition-colors",
+                  metric === value
+                    ? "bg-muted text-foreground"
+                    : "text-muted-foreground hover:text-foreground",
+                )}
+              >
+                {value === "tokens" ? "Token" : "Cost"}
+              </button>
+            ))}
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className="px-5 pb-5 pt-2">
+        {items.length === 0 ? (
+          <div className="flex min-h-52 items-center justify-center rounded-[calc(var(--radius-sm)-1px)] border border-dashed border-border text-sm text-muted-foreground">
+            No usage in this period.
+          </div>
+        ) : (
+          <div className="grid items-center gap-5 sm:grid-cols-[minmax(9rem,0.8fr)_minmax(0,1.2fr)]">
+            <div
+              role="img"
+              aria-label={`${title}: ${accessibleSummary}`}
+              className="relative mx-auto aspect-square w-full max-w-44 rounded-full"
+              style={{ background: distributionGradient(items) }}
+            >
+              <div className="absolute inset-[23%] flex flex-col items-center justify-center rounded-full bg-card px-2 text-center shadow-[0_0_0_1px_hsl(var(--border))]">
+                <span className="max-w-full truncate text-lg font-semibold tabular-nums">
+                  {metric === "tokens" ? formatTokens(total) : formatCents(total)}
+                </span>
+                <span className="text-[11px] text-muted-foreground">
+                  {metric === "tokens" ? "Total tokens" : "Estimated cost"}
+                </span>
+              </div>
+            </div>
+            <div className="min-w-0 space-y-2.5">
+              {items.map((item) => (
+                <div key={item.id} className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3 text-sm">
+                  <div className="flex min-w-0 items-center gap-2">
+                    <span className="h-2.5 w-2.5 shrink-0 rounded-[2px]" style={{ backgroundColor: item.color }} />
+                    <span className="truncate" title={item.label}>{item.label}</span>
+                  </div>
+                  <div className="text-right tabular-nums">
+                    <div className="font-medium">
+                      {metric === "tokens" ? formatTokens(item.value) : formatCents(item.value)}
+                    </div>
+                    <div className="text-xs text-muted-foreground">
+                      {item.percentage < 0.1 ? "<0.1%" : `${item.percentage.toFixed(1)}%`}
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/ui/src/pages/Costs.test.tsx
+++ b/ui/src/pages/Costs.test.tsx
@@ -4,6 +4,7 @@ import type { CostByAgent, CostByProject, CostTrendPoint } from "@rudderhq/share
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 import { CostTrendChart, calculateCostTrendInitialScrollLeft } from "./Costs";
+import { buildDistributionItems } from "./Costs.distribution";
 
 describe("CostTrendChart", () => {
   it("exposes daily cost data on each trend bar", () => {
@@ -52,6 +53,31 @@ describe("CostTrendChart", () => {
     expect(html).toContain(
       'aria-label="Jun 13, 2026: 300.8M tokens (19.2M uncached input, 280.4M cached, 1.2M output), $2.30 estimated spend, 138 events"',
     );
+  });
+
+  it("renders hourly buckets with a complete local-time tooltip", () => {
+    const rows: CostTrendPoint[] = [{
+      date: "2026-06-19T01:00:00.000Z",
+      costCents: 125,
+      inputTokens: 900,
+      cachedInputTokens: 300,
+      outputTokens: 100,
+      totalTokens: 1_000,
+      eventCount: 2,
+    }];
+
+    const html = renderToStaticMarkup(
+      <CostTrendChart
+        rows={rows}
+        from="2026-06-19T01:00:00.000Z"
+        to="2026-06-19T01:59:59.999Z"
+        granularity="hour"
+      />,
+    );
+
+    expect(html).toContain("Hourly token volume");
+    expect(html).toContain("1.0K tokens");
+    expect(html).toContain("$1.25 estimated spend");
   });
 
   it("renders all agent trend series when the agent filter is selected", () => {
@@ -161,7 +187,7 @@ describe("CostTrendChart", () => {
       targetDayIndex: 24,
       scrollWidth: 1_052,
       clientWidth: 360,
-    })).toBe(534);
+    })).toBe(537);
   });
 
   it("keeps the trend chart at the left edge when the target is already visible", () => {
@@ -178,5 +204,34 @@ describe("CostTrendChart", () => {
       scrollWidth: 360,
       clientWidth: 360,
     })).toBe(0);
+  });
+});
+
+describe("buildDistributionItems", () => {
+  it("groups long tails into Other while preserving the selected metric total", () => {
+    const rows = Array.from({ length: 8 }, (_, index) => ({
+      id: `agent-${index}`,
+      label: `Agent ${index}`,
+      tokens: 800 - index * 50,
+      costCents: 80 - index * 5,
+    }));
+
+    const items = buildDistributionItems(rows, "tokens");
+
+    expect(items).toHaveLength(6);
+    expect(items.at(-1)?.label).toBe("Other (3)");
+    expect(items.reduce((sum, item) => sum + item.value, 0)).toBe(
+      rows.reduce((sum, row) => sum + row.tokens, 0),
+    );
+  });
+
+  it("keeps extremely small shares visible in accessible legend data", () => {
+    const items = buildDistributionItems([
+      { id: "large", label: "Large", tokens: 999_999, costCents: 100 },
+      { id: "tiny", label: "Tiny", tokens: 1, costCents: 1 },
+    ], "tokens");
+
+    expect(items[1]?.percentage).toBeGreaterThan(0);
+    expect(items[1]?.label).toBe("Tiny");
   });
 });

--- a/ui/src/pages/Costs.tsx
+++ b/ui/src/pages/Costs.tsx
@@ -7,20 +7,19 @@ import {
   summarizeTokenUsage,
   type BudgetPolicySummary,
   type CostByAgent,
-  type CostByAgentModel,
   type CostByBiller,
   type CostByProject,
   type CostByProviderModel,
+  type CostTrendGranularity,
   type CostTrendPoint,
   type CostWindowSpendRow,
   type QuotaWindow,
 } from "@rudderhq/shared";
 import { keepPreviousData, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { ArrowDownLeft, ArrowUpRight, ChevronDown, ChevronRight, Coins, DollarSign, ReceiptText } from "lucide-react";
+import { ArrowDownLeft, ArrowUpRight, Clock, Coins, Database, DollarSign, ReceiptText } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState, type ComponentType, type CSSProperties } from "react";
 import { budgetsApi } from "../api/budgets";
 import { costsApi } from "../api/costs";
-import { AgentIdentity } from "../components/AgentAvatar";
 import { BillerSpendCard } from "../components/BillerSpendCard";
 import { BudgetIncidentCard } from "../components/BudgetIncidentCard";
 import { BudgetPolicyCard } from "../components/BudgetPolicyCard";
@@ -30,14 +29,14 @@ import { FinanceKindCard } from "../components/FinanceKindCard";
 import { PageSkeleton } from "../components/PageSkeleton";
 import { PageTabBar } from "../components/PageTabBar";
 import { ProviderQuotaCard } from "../components/ProviderQuotaCard";
-import { StatusBadge } from "../components/StatusBadge";
 import { useBreadcrumbs } from "../context/BreadcrumbContext";
 import { useDialog } from "../context/DialogContext";
 import { useOrganization } from "../context/OrganizationContext";
 import { PRESET_KEYS, PRESET_LABELS, useDateRange } from "../hooks/useDateRange";
 import { useScrollbarActivityRef } from "../hooks/useScrollbarActivityRef";
 import { queryKeys } from "../lib/queryKeys";
-import { billingTypeDisplayName, cn, formatCents, formatTokens, providerDisplayName } from "../lib/utils";
+import { cn, formatCents, formatTokens, providerDisplayName } from "../lib/utils";
+import { DistributionPanel, type DistributionDatum } from "./Costs.distribution";
 
 const NO_ORGANIZATION = "__none__";
 
@@ -114,10 +113,13 @@ function MetricTile({
   icon: ComponentType<{ className?: string }>;
 }) {
   return (
-    <div className="rounded-[calc(var(--radius-sm)-1px)] border border-border p-4">
+    <div
+      className="rounded-[calc(var(--radius-sm)-1px)] border border-border p-4"
+      data-testid={`cost-metric-${label.toLowerCase().replace(/\s+/g, "-")}`}
+    >
       <div className="flex items-center justify-between gap-3">
         <div className="min-w-0">
-          <div className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">{label}</div>
+          <div className="text-xs font-medium text-muted-foreground">{label}</div>
           <div className="mt-2 text-2xl font-semibold tabular-nums">{value}</div>
           <div className="mt-1 text-xs leading-5 text-muted-foreground">{subtitle}</div>
         </div>
@@ -137,13 +139,31 @@ function utcDayKey(value: string | Date): string {
   return `${year}-${month}-${day}`;
 }
 
+function utcHourKey(value: string | Date): string {
+  const date = new Date(value);
+  date.setUTCMinutes(0, 0, 0);
+  return date.toISOString();
+}
+
 function dayLabel(value: string): string {
   const date = new Date(`${value}T12:00:00Z`);
   return `${date.getUTCMonth() + 1}/${date.getUTCDate()}`;
 }
 
-function fullDayLabel(value: string): string {
-  return new Date(`${value}T12:00:00Z`).toLocaleDateString("en-US", {
+function hourLabel(value: string): string {
+  return new Date(value).toLocaleTimeString(undefined, {
+    hour: "numeric",
+  });
+}
+
+function fullBucketLabel(value: string, granularity: CostTrendGranularity): string {
+  if (granularity === "hour") {
+    return new Date(value).toLocaleString(undefined, {
+      dateStyle: "medium",
+      timeStyle: "short",
+    });
+  }
+  return new Date(`${value}T12:00:00Z`).toLocaleDateString(undefined, {
     month: "short",
     day: "numeric",
     year: "numeric",
@@ -163,26 +183,39 @@ function emptyTrendPoint(date: string): CostTrendPoint {
   };
 }
 
-function buildTrendSeries(rows: CostTrendPoint[], from?: string, to?: string): CostTrendPoint[] {
+function buildTrendSeries(
+  rows: CostTrendPoint[],
+  from?: string,
+  to?: string,
+  granularity: CostTrendGranularity = "day",
+): CostTrendPoint[] {
   if (!from || !to) return rows;
 
   const start = new Date(from);
   const end = new Date(to);
   if (!Number.isFinite(start.getTime()) || !Number.isFinite(end.getTime()) || start > end) return rows;
 
-  const startUtc = Date.UTC(start.getUTCFullYear(), start.getUTCMonth(), start.getUTCDate());
-  const endUtc = Date.UTC(end.getUTCFullYear(), end.getUTCMonth(), end.getUTCDate());
-  const dayCount = Math.floor((endUtc - startUtc) / 86_400_000) + 1;
-  if (dayCount <= 0 || dayCount > 62) return rows;
+  const bucketMs = granularity === "hour" ? 3_600_000 : 86_400_000;
+  const startUtc = granularity === "hour"
+    ? Date.UTC(start.getUTCFullYear(), start.getUTCMonth(), start.getUTCDate(), start.getUTCHours())
+    : Date.UTC(start.getUTCFullYear(), start.getUTCMonth(), start.getUTCDate());
+  const endUtc = granularity === "hour"
+    ? Date.UTC(end.getUTCFullYear(), end.getUTCMonth(), end.getUTCDate(), end.getUTCHours())
+    : Date.UTC(end.getUTCFullYear(), end.getUTCMonth(), end.getUTCDate());
+  const bucketCount = Math.floor((endUtc - startUtc) / bucketMs) + 1;
+  if (bucketCount <= 0 || bucketCount > (granularity === "hour" ? 49 : 62)) return rows;
 
   const rowsByDate = new Map(rows.map((row) => [row.date, row]));
-  return Array.from({ length: dayCount }, (_, index) => {
-    const date = utcDayKey(new Date(startUtc + index * 86_400_000));
+  return Array.from({ length: bucketCount }, (_, index) => {
+    const date = granularity === "hour"
+      ? utcHourKey(new Date(startUtc + index * bucketMs))
+      : utcDayKey(new Date(startUtc + index * bucketMs));
     return rowsByDate.get(date) ?? emptyTrendPoint(date);
   });
 }
 
-function shouldShowDayLabel(index: number, count: number): boolean {
+function shouldShowBucketLabel(index: number, count: number, granularity: CostTrendGranularity): boolean {
+  if (granularity === "hour") return index % 4 === 0 || index === count - 1;
   if (count <= 10) return true;
   return index === 0 || index === count - 1 || index === Math.floor((count - 1) / 2);
 }
@@ -196,7 +229,7 @@ export function calculateCostTrendInitialScrollLeft({
   targetDayIndex,
   scrollWidth,
   clientWidth,
-  axisWidth = 32,
+  axisWidth = 48,
   trailingPadding = 12,
 }: {
   dayCount: number;
@@ -250,7 +283,7 @@ function CostTrendScaleLabels({ ticks }: { ticks: CostTrendScaleTick[] }) {
       {ticks.map((tick) => (
         <span
           key={`${tick.value}:${tick.label}`}
-          className="absolute right-0 translate-y-1/2 text-[9px] leading-none text-muted-foreground/50 tabular-nums"
+          className="absolute right-1 translate-y-1/2 text-[11px] font-medium leading-none text-muted-foreground tabular-nums"
           style={{ bottom: `${tick.position * 100}%` }}
         >
           {tick.label}
@@ -305,6 +338,7 @@ export function CostTrendChart({
   rows,
   from,
   to,
+  granularity = "day",
   agentSeries = [],
   agentOptions = [],
   projectOptions = [],
@@ -317,6 +351,7 @@ export function CostTrendChart({
   rows: CostTrendPoint[];
   from?: string;
   to?: string;
+  granularity?: CostTrendGranularity;
   agentSeries?: AgentTrendSeries[];
   agentOptions?: CostByAgent[];
   projectOptions?: CostByProject[];
@@ -326,10 +361,10 @@ export function CostTrendChart({
   onProjectChange?: (projectId: string) => void;
   isLoading?: boolean;
 }) {
-  const series = buildTrendSeries(rows, from, to);
+  const series = buildTrendSeries(rows, from, to, granularity);
   const comparisonSeries = agentSeries.map((entry) => ({
     ...entry,
-    rows: buildTrendSeries(entry.rows, from, to),
+    rows: buildTrendSeries(entry.rows, from, to, granularity),
   }));
   const comparisonDays = comparisonSeries[0]?.rows.map((row) => row.date) ?? series.map((row) => row.date);
   const comparisonRowsByAgent = new Map(
@@ -404,9 +439,10 @@ export function CostTrendChart({
     color: agentTrendPalette[index % agentTrendPalette.length]!,
     label: trendAgentLabel(entry.agent),
   }));
+  const cadenceLabel = granularity === "hour" ? "Hourly" : "Daily";
   const chartSubtitle = isAgentComparison
-    ? "Daily token usage grouped by agent, with estimated spend in tooltips."
-    : "Daily token volume and estimated spend in the selected period.";
+    ? `${cadenceLabel} token usage grouped by agent, with estimated spend in tooltips.`
+    : `${cadenceLabel} token volume and estimated spend in the selected period.`;
 
   return (
     <div className="space-y-4 rounded-lg border border-border p-4" data-testid="cost-trend-chart">
@@ -477,7 +513,7 @@ export function CostTrendChart({
             <div className="dashboard-chart-motion space-y-3">
               <div ref={setChartScrollElement} className="scrollbar-auto-hide overflow-x-auto pb-1" data-testid="cost-trend-chart-scroll">
                 <div style={{ minWidth: chartMinWidth }}>
-                  <div className="grid grid-cols-[2rem_minmax(0,1fr)] gap-1.5">
+                  <div className="grid grid-cols-[3rem_minmax(0,1fr)] gap-2 pt-3">
                     <CostTrendScaleLabels ticks={scaleTicks} />
                     <div className="relative h-44 min-w-0">
                       <CostTrendGridLines ticks={scaleTicks} />
@@ -490,7 +526,7 @@ export function CostTrendChart({
                               });
                               const dayTotalTokens = dayRows.reduce((sum, entry) => sum + entry.row.totalTokens, 0);
                               const dayTotalCost = dayRows.reduce((sum, entry) => sum + entry.row.costCents, 0);
-                              const dateLabel = fullDayLabel(day);
+                              const dateLabel = fullBucketLabel(day, granularity);
                               const accessibleLabel = `${dateLabel}: ${dayRows.map((entry) => `${trendAgentLabel(entry.agent)} ${formatTrendTokenCount(entry.row.totalTokens)} tokens, ${formatCents(entry.row.costCents)}`).join("; ")}`;
                               return (
                                 <Tooltip key={day}>
@@ -554,7 +590,7 @@ export function CostTrendChart({
                           : series.map((row, index) => {
                               const usage = summarizeTokenUsage(row);
                               const tokenHeight = (usage.totalTokens / maxTokens) * 100;
-                              const dateLabel = fullDayLabel(row.date);
+                              const dateLabel = fullBucketLabel(row.date, granularity);
                               const accessibleLabel = `${dateLabel}: ${formatTrendTokenCount(usage.totalTokens)} tokens (${formatTrendTokenCount(usage.uncachedInputTokens)} uncached input, ${formatTrendTokenCount(usage.cachedInputTokens)} cached, ${formatTrendTokenCount(usage.outputTokens)} output), ${formatCents(row.costCents)} estimated spend, ${formatExactCount(row.eventCount)} events`;
                               return (
                                 <Tooltip key={row.date}>
@@ -621,13 +657,15 @@ export function CostTrendChart({
                       </div>
                     </div>
                   </div>
-                  <div className="grid grid-cols-[2rem_minmax(0,1fr)] gap-1.5">
+                  <div className="grid grid-cols-[3rem_minmax(0,1fr)] gap-2">
                     <div aria-hidden="true" />
                     <div className="mt-1.5 flex gap-[3px]">
                       {(isAgentComparison ? comparisonDays : series.map((row) => row.date)).map((day, index, days) => (
                         <div key={day} className="flex-1 text-center">
-                          {shouldShowDayLabel(index, days.length) ? (
-                            <span className="text-[9px] text-muted-foreground tabular-nums">{dayLabel(day)}</span>
+                          {shouldShowBucketLabel(index, days.length, granularity) ? (
+                            <span className="text-[10px] text-muted-foreground tabular-nums">
+                              {granularity === "hour" ? hourLabel(day) : dayLabel(day)}
+                            </span>
                           ) : null}
                         </div>
                       ))}
@@ -642,6 +680,16 @@ export function CostTrendChart({
       </div>
     </div>
   );
+}
+
+function formatDuration(milliseconds: number): string {
+  const totalMinutes = Math.max(0, Math.round(milliseconds / 60_000));
+  const days = Math.floor(totalMinutes / 1_440);
+  const hours = Math.floor((totalMinutes % 1_440) / 60);
+  const minutes = totalMinutes % 60;
+  if (days > 0) return `${days}d ${hours}h`;
+  if (hours > 0) return `${hours}h ${minutes}m`;
+  return `${minutes}m`;
 }
 
 function FinanceSummaryCard({
@@ -717,6 +765,8 @@ export function Costs() {
     from,
     to,
     customReady,
+    customError,
+    trendGranularity,
   } = useDateRange();
 
   useEffect(() => {
@@ -802,13 +852,12 @@ export function Costs() {
   const { data: spendData, isLoading: spendLoading, error: spendError } = useQuery({
     queryKey: queryKeys.costs(orgId, from || undefined, to || undefined),
     queryFn: async () => {
-      const [summary, byAgent, byProject, byAgentModel] = await Promise.all([
+      const [summary, byAgent, byProject] = await Promise.all([
         costsApi.summary(orgId, from || undefined, to || undefined),
         costsApi.byAgent(orgId, from || undefined, to || undefined),
         costsApi.byProject(orgId, from || undefined, to || undefined),
-        costsApi.byAgentModel(orgId, from || undefined, to || undefined),
       ]);
-      return { summary, byAgent, byProject, byAgentModel };
+      return { summary, byAgent, byProject };
     },
     enabled: !!selectedOrganizationId && customReady,
     placeholderData: keepPreviousData,
@@ -828,36 +877,9 @@ export function Costs() {
       ]);
       return { summary, byBiller, byKind };
     },
-    enabled: !!selectedOrganizationId && customReady,
+    enabled: !!selectedOrganizationId && customReady && mainTab === "finance",
     placeholderData: keepPreviousData,
   });
-
-  const [expandedAgents, setExpandedAgents] = useState<Set<string>>(new Set());
-  useEffect(() => {
-    setExpandedAgents(new Set());
-  }, [orgId, from, to]);
-
-  function toggleAgent(agentId: string) {
-    setExpandedAgents((prev) => {
-      const next = new Set(prev);
-      if (next.has(agentId)) next.delete(agentId);
-      else next.add(agentId);
-      return next;
-    });
-  }
-
-  const agentModelRows = useMemo(() => {
-    const map = new Map<string, CostByAgentModel[]>();
-    for (const row of spendData?.byAgentModel ?? []) {
-      const rows = map.get(row.agentId) ?? [];
-      rows.push(row);
-      map.set(row.agentId, rows);
-    }
-    for (const [agentId, rows] of map) {
-      map.set(agentId, rows.slice().sort((a, b) => b.costCents - a.costCents));
-    }
-    return map;
-  }, [spendData?.byAgentModel]);
 
   const trendAgentOptions = useMemo(
     () => (spendData?.byAgent ?? []).filter((row) => hasTokenUsage(row) || row.costCents > 0),
@@ -886,6 +908,7 @@ export function Costs() {
       orgId,
       from || undefined,
       to || undefined,
+      trendGranularity,
       effectiveTrendFilterKind,
       trendFilterId,
     ),
@@ -894,6 +917,7 @@ export function Costs() {
         orgId,
         from || undefined,
         to || undefined,
+        trendGranularity,
         effectiveTrendFilterKind === "project"
             ? { projectId: trendFilterId }
             : undefined,
@@ -909,13 +933,20 @@ export function Costs() {
       orgId,
       from || undefined,
       to || undefined,
+      trendGranularity,
       trendAgentOptions.map((row) => row.agentId).join(","),
     ],
     queryFn: async () => {
       const rows = await Promise.all(
         trendAgentOptions.map(async (agent) => ({
           agent,
-          rows: await costsApi.trend(orgId, from || undefined, to || undefined, { agentId: agent.agentId }),
+          rows: await costsApi.trend(
+            orgId,
+            from || undefined,
+            to || undefined,
+            trendGranularity,
+            { agentId: agent.agentId },
+          ),
         })),
       );
       return rows;
@@ -1150,11 +1181,24 @@ export function Costs() {
     ];
   }, [byBiller]);
 
-  const inferenceTokenTotal =
-    (spendData?.byAgent ?? []).reduce(
-      (sum, row) => sum + summarizeTokenUsage(row).totalTokens,
-      0,
-    );
+  const agentDistributionRows = useMemo<DistributionDatum[]>(
+    () => (spendData?.byAgent ?? []).map((row) => ({
+      id: row.agentId,
+      label: row.agentName ?? row.agentId,
+      tokens: summarizeTokenUsage(row).totalTokens,
+      costCents: row.costCents,
+    })),
+    [spendData?.byAgent],
+  );
+  const projectDistributionRows = useMemo<DistributionDatum[]>(
+    () => (spendData?.byProject ?? []).map((row) => ({
+      id: row.projectId ?? "unattributed",
+      label: row.projectName ?? "Unattributed",
+      tokens: summarizeTokenUsage(row).totalTokens,
+      costCents: row.costCents,
+    })),
+    [spendData?.byProject],
+  );
 
   const budgetPolicies = budgetData?.policies ?? [];
   const activeBudgetIncidents = budgetData?.activeIncidents ?? [];
@@ -1169,8 +1213,8 @@ export function Costs() {
   }
 
   const showCustomPrompt = preset === "custom" && !customReady;
-  const showOverviewLoading = (spendLoading || financeLoading) && customReady;
-  const overviewError = spendError ?? financeError ?? (effectiveTrendFilterKind === "agent" ? agentTrendError : trendError);
+  const showOverviewLoading = spendLoading && customReady;
+  const overviewError = spendError ?? (effectiveTrendFilterKind === "agent" ? agentTrendError : trendError);
 
   return (
     <div className="space-y-6">
@@ -1179,7 +1223,7 @@ export function Costs() {
             <div>
                 <h1 className="text-3xl font-semibold tracking-tight">Costs</h1>
                 <p className="mt-2 max-w-2xl text-sm leading-6 text-muted-foreground">
-                  Inference spend, platform fees, credits, and live quota windows.
+                  Analyze inference usage, runtime activity, attribution, and spend.
                 </p>
             </div>
 
@@ -1198,57 +1242,54 @@ export function Costs() {
           </div>
 
           {preset === "custom" ? (
-            <div className="flex flex-wrap items-center gap-2 rounded-[calc(var(--radius-sm)-1px)] border border-border p-3">
-              <input
-                type="date"
-                value={customFrom}
-                onChange={(event) => setCustomFrom(event.target.value)}
-                className="h-9 rounded-md border border-input bg-background px-3 text-sm text-foreground"
-              />
-              <span className="text-sm text-muted-foreground">to</span>
-              <input
-                type="date"
-                value={customTo}
-                onChange={(event) => setCustomTo(event.target.value)}
-                className="h-9 rounded-md border border-input bg-background px-3 text-sm text-foreground"
-              />
+            <div className="rounded-[calc(var(--radius-sm)-1px)] border border-border p-3">
+              <div className="flex flex-wrap items-center gap-2">
+                <input
+                  type="date"
+                  aria-label="Custom start date"
+                  aria-invalid={customError ? true : undefined}
+                  value={customFrom}
+                  onChange={(event) => setCustomFrom(event.target.value)}
+                  className="h-9 rounded-md border border-input bg-background px-3 text-sm text-foreground"
+                />
+                <span className="text-sm text-muted-foreground">to</span>
+                <input
+                  type="date"
+                  aria-label="Custom end date"
+                  aria-invalid={customError ? true : undefined}
+                  value={customTo}
+                  onChange={(event) => setCustomTo(event.target.value)}
+                  className="h-9 rounded-md border border-input bg-background px-3 text-sm text-foreground"
+                />
+              </div>
+              {customError ? <p className="mt-2 text-xs text-destructive">{customError}</p> : null}
             </div>
           ) : null}
 
           <div className="grid gap-3 lg:grid-cols-4">
             <MetricTile
-              label="Inference spend"
+              label="Estimated cost"
               value={formatCents(spendData?.summary.spendCents ?? 0)}
-              subtitle={`${formatTokens(inferenceTokenTotal)} tokens across request-scoped events`}
+              subtitle="Inference spend in the selected range"
               icon={DollarSign}
             />
             <MetricTile
-              label="Budget"
-              value={activeBudgetIncidents.length > 0 ? String(activeBudgetIncidents.length) : (
-                spendData?.summary.budgetCents && spendData.summary.budgetCents > 0
-                  ? `${spendData.summary.utilizationPercent}%`
-                  : "Open"
-              )}
-              subtitle={
-                activeBudgetIncidents.length > 0
-                  ? `${budgetData?.pausedAgentCount ?? 0} agents paused · ${budgetData?.pausedProjectCount ?? 0} projects paused`
-                  : spendData?.summary.budgetCents && spendData.summary.budgetCents > 0
-                    ? `${formatCents(spendData.summary.spendCents)} of ${formatCents(spendData.summary.budgetCents)}`
-                    : "No monthly cap configured"
-              }
+              label="Total tokens"
+              value={formatTokens(spendData?.summary.totalTokens ?? 0)}
+              subtitle="Input and output tokens"
               icon={Coins}
             />
             <MetricTile
-              label="Finance net"
-              value={formatCents(financeData?.summary.netCents ?? 0)}
-              subtitle={`${formatCents(financeData?.summary.debitCents ?? 0)} debits · ${formatCents(financeData?.summary.creditCents ?? 0)} credits`}
-              icon={ReceiptText}
+              label="Cached tokens"
+              value={formatTokens(spendData?.summary.cachedInputTokens ?? 0)}
+              subtitle="Cached input tokens"
+              icon={Database}
             />
             <MetricTile
-              label="Finance events"
-              value={String(financeData?.summary.eventCount ?? 0)}
-              subtitle={`${formatCents(financeData?.summary.estimatedDebitCents ?? 0)} estimated in range`}
-              icon={ArrowUpRight}
+              label="Active duration"
+              value={formatDuration(spendData?.summary.activeDurationMs ?? 0)}
+              subtitle="Cumulative agent-runtime time"
+              icon={Clock}
             />
           </div>
       </div>
@@ -1299,6 +1340,7 @@ export function Costs() {
                 rows={trendData ?? []}
                 from={from || undefined}
                 to={to || undefined}
+                granularity={trendGranularity}
                 agentSeries={agentTrendData ?? []}
                 agentOptions={trendAgentOptions}
                 projectOptions={trendProjectOptions}
@@ -1315,106 +1357,18 @@ export function Costs() {
                 isLoading={effectiveTrendFilterKind === "agent" ? agentTrendLoading : trendLoading}
               />
 
-              <FinanceSummaryCard
-                debitCents={financeData?.summary.debitCents ?? 0}
-                creditCents={financeData?.summary.creditCents ?? 0}
-                netCents={financeData?.summary.netCents ?? 0}
-                estimatedDebitCents={financeData?.summary.estimatedDebitCents ?? 0}
-                eventCount={financeData?.summary.eventCount ?? 0}
-              />
-
-              <Card>
-                <CardHeader className="px-5 pt-5 pb-2">
-                  <CardTitle className="text-base">By agent</CardTitle>
-                  <CardDescription>What each agent consumed in the selected period.</CardDescription>
-                </CardHeader>
-                <CardContent className="space-y-2 px-5 pb-5 pt-2">
-                  {(spendData?.byAgent.length ?? 0) === 0 ? (
-                    <p className="text-sm text-muted-foreground">No cost events yet.</p>
-                  ) : (
-                    spendData?.byAgent.map((row) => {
-                      const modelRows = agentModelRows.get(row.agentId) ?? [];
-                      const isExpanded = expandedAgents.has(row.agentId);
-                      const hasBreakdown = modelRows.length > 0;
-                      return (
-                        <div key={row.agentId} className="rounded-[calc(var(--radius-sm)-1px)] border border-border px-4 py-3">
-                          <div
-                            className={cn("flex items-start justify-between gap-3", hasBreakdown ? "cursor-pointer select-none" : "")}
-                            onClick={() => hasBreakdown && toggleAgent(row.agentId)}
-                          >
-                            <div className="flex min-w-0 items-center gap-2">
-                              {hasBreakdown ? (
-                                isExpanded
-                                  ? <ChevronDown className="h-3 w-3 shrink-0 text-muted-foreground" />
-                                  : <ChevronRight className="h-3 w-3 shrink-0 text-muted-foreground" />
-                              ) : (
-                                <span className="h-3 w-3 shrink-0" />
-                              )}
-                              <AgentIdentity
-                                name={row.agentName ?? row.agentId}
-                                icon={row.agentIcon}
-                                role={row.agentRole}
-                                size="sm"
-                              />
-                              {row.agentStatus === "terminated" ? <StatusBadge status="terminated" /> : null}
-                            </div>
-                            <div className="text-right text-sm tabular-nums">
-                              <div className="font-medium">{formatCents(row.costCents)}</div>
-                              <div className="text-xs text-muted-foreground">
-                                in {formatTokens(summarizeTokenUsage(row).promptTokens)} · out {formatTokens(row.outputTokens)}
-                              </div>
-                              {(row.apiRunCount > 0 || row.subscriptionRunCount > 0) ? (
-                                <div className="text-xs text-muted-foreground">
-                                  {row.apiRunCount > 0 ? `${row.apiRunCount} api` : "0 api"}
-                                  {" · "}
-                                  {row.subscriptionRunCount > 0
-                                    ? `${row.subscriptionRunCount} subscription`
-                                    : "0 subscription"}
-                                </div>
-                              ) : null}
-                            </div>
-                          </div>
-
-                          {isExpanded && modelRows.length > 0 ? (
-                            <div className="mt-3 space-y-2 border-l border-border pl-4">
-                              {modelRows.map((modelRow) => {
-                                const sharePct = row.costCents > 0 ? Math.round((modelRow.costCents / row.costCents) * 100) : 0;
-                                const modelTokenSummary = summarizeTokenUsage(modelRow);
-                                return (
-                                  <div
-                                    key={`${modelRow.provider}:${modelRow.model}:${modelRow.billingType}`}
-                                    className="flex items-start justify-between gap-3 text-xs"
-                                  >
-                                    <div className="min-w-0">
-                                      <div className="truncate font-medium text-foreground">
-                                        {providerDisplayName(modelRow.provider)}
-                                        <span className="mx-1 text-border">/</span>
-                                        <span className="font-mono">{modelRow.model}</span>
-                                      </div>
-                                      <div className="truncate text-muted-foreground">
-                                        {providerDisplayName(modelRow.biller)} · {billingTypeDisplayName(modelRow.billingType)}
-                                      </div>
-                                    </div>
-                                    <div className="text-right tabular-nums">
-                                      <div className="font-medium">
-                                        {formatCents(modelRow.costCents)}
-                                        <span className="ml-1 font-normal text-muted-foreground">({sharePct}%)</span>
-                                      </div>
-                                      <div className="text-muted-foreground">
-                                        {formatTokens(modelTokenSummary.totalTokens)} tok
-                                      </div>
-                                    </div>
-                                  </div>
-                                );
-                              })}
-                            </div>
-                          ) : null}
-                        </div>
-                      );
-                    })
-                  )}
-                </CardContent>
-              </Card>
+              <div className="grid gap-4 xl:grid-cols-2">
+                <DistributionPanel
+                  title="Agent distribution"
+                  description="Usage attributed to each agent."
+                  rows={agentDistributionRows}
+                />
+                <DistributionPanel
+                  title="Project distribution"
+                  description="Usage by project, including unattributed events."
+                  rows={projectDistributionRows}
+                />
+              </div>
             </>
           )}
         </TabsContent>


### PR DESCRIPTION
## Summary

- add a rolling Last 24 Hours range with explicit UTC-hour aggregation and local-time labels
- replace Overview ledger cards with estimated cost, total tokens, cached tokens, and clipped cumulative active duration
- add responsive Agent and Project Token/Cost donut distributions, including deterministic attribution, Unattributed, and Other
- default Custom to the latest seven local calendar days, keep Finance lazy to its tab, and align BUDGET.ENFORCEMENT.001

## Validation

- focused Vitest: 29 passed
- PostgreSQL cost rollups: 9 passed
- Playwright cost trend: 3 passed
- server and UI typechecks passed
- UI production build passed
- lint and changed-import lint passed
- architecture audit: no comparison regressions
- product logic: 79 contracts valid
- independent reviewer and verifier: no remaining blockers

## Repository-wide test note

The full pnpm test:run completed with 5,392 passing, 729 skipped, and 58 failures from host workspace environment pollution, shared PostgreSQL exhaustion, unrelated timeouts, and current-main route drift. Every changed focused suite listed above passed independently.

## Visual verification

Verified the actual Costs page in Chromium at desktop and 390px viewport widths. Screenshots are attached to the Rudder issue handoff.