### PR TITLE
fix(ui): restore chat header glass

### DIFF
--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -1392,6 +1392,10 @@
     background: var(--desktop-content-surface-light);
   }
 
+  .chat-desktop-toolbar-clearance {
+    height: 2.75rem;
+  }
+
   .chat-load-error-offset {
     margin-top: 1.5rem;
   }
@@ -1408,6 +1412,53 @@
 
   .chat-messages-scroll-content {
     padding-top: 1rem;
+  }
+
+  @media (min-width: 768px) {
+    html.desktop-shell-macos [data-testid="chat-main-workspace-card"]:has(> [data-testid="chat-desktop-toolbar-clearance"]) {
+      isolation: isolate;
+    }
+
+    html.desktop-shell-macos [data-testid="chat-main-workspace-card"] .chat-messages-scroll-content {
+      padding-top: calc(2.75rem + 1rem);
+    }
+
+    html.desktop-shell-macos [data-testid="chat-main-workspace-card"]:has(> [data-testid="chat-desktop-toolbar-clearance"]) > [data-testid="chat-load-error"] {
+      margin-top: calc(2.75rem + 1.5rem);
+    }
+
+    html.desktop-shell-macos [data-testid="chat-main-workspace-card"]:has(> [data-testid="chat-desktop-toolbar-clearance"]) > [data-testid="chat-conversation-loading-state"] {
+      padding-top: calc(2.75rem + 1rem);
+    }
+
+    html.desktop-shell-macos [data-testid="chat-main-workspace-card"] > [data-testid="chat-desktop-toolbar-clearance"] {
+      position: absolute;
+      inset: 0 0 auto;
+      z-index: 20;
+      height: 2.75rem;
+      overflow: hidden;
+      border-bottom: 1px solid color-mix(in oklab, var(--desktop-content-border-light) 42%, transparent);
+      border-top-left-radius: max(0px, calc(var(--desktop-workspace-radius) - 1px));
+      border-top-right-radius: max(0px, calc(var(--desktop-workspace-radius) - 1px));
+      background: color-mix(in oklab, var(--desktop-content-surface-light) 26%, transparent);
+      box-shadow:
+        inset 0 1px 0 rgb(255 255 255 / 0.58),
+        inset 1px 0 0 rgb(255 255 255 / 0.16),
+        inset -1px 0 0 rgb(255 255 255 / 0.1);
+      -webkit-backdrop-filter: blur(18px) saturate(128%);
+      backdrop-filter: blur(18px) saturate(128%);
+    }
+
+    html.dark.desktop-shell-macos [data-testid="chat-main-workspace-card"] > [data-testid="chat-desktop-toolbar-clearance"] {
+      border-bottom-color: color-mix(in oklab, var(--desktop-content-border-dark) 36%, transparent);
+      background: color-mix(in oklab, var(--desktop-content-surface-dark) 24%, transparent);
+      box-shadow:
+        inset 0 1px 0 rgb(255 255 255 / 0.12),
+        inset 1px 0 0 rgb(255 255 255 / 0.05),
+        inset -1px 0 0 rgb(255 255 255 / 0.04);
+      -webkit-backdrop-filter: blur(18px) saturate(132%);
+      backdrop-filter: blur(18px) saturate(132%);
+    }
   }
 
   .workspace-column-resizer {

--- a/ui/src/lib/index-css.test.ts
+++ b/ui/src/lib/index-css.test.ts
@@ -413,7 +413,7 @@ describe("index.css motion rules", () => {
     expect(lightDesktopBackdrop).toContain("backdrop-filter: blur(38px) saturate(122%)");
   });
 
-  it("keeps macOS desktop glass on the app backdrop without adding a workspace wash", () => {
+  it("keeps macOS desktop glass on the app backdrop and active Chat header without adding a workspace wash", () => {
     const lightDesktopBackdrop = cssBlock("html.desktop-shell-macos .app-shell-backdrop");
     const darkDesktopBackdrop = cssBlock("html.dark.desktop-shell-macos .app-shell-backdrop");
     const lightPrimaryRail = cssBlock("html.desktop-shell-macos .primary-rail-shell");
@@ -421,7 +421,16 @@ describe("index.css motion rules", () => {
     const darkWorkspaceShell = cssBlock("html.dark.desktop-shell-macos .workspace-shell");
     const lightDesktopWorkspaceCards = cssBlock("html.desktop-shell-macos :is(.workspace-context-card, .workspace-main-card)");
     const darkDesktopWorkspaceCards = cssBlock("html.dark.desktop-shell-macos :is(.workspace-context-card, .workspace-main-card)");
-    const chatMessages = cssBlock(".chat-messages-scroll-content");
+    const activeChatCardSelector = 'html.desktop-shell-macos [data-testid="chat-main-workspace-card"]:has(> [data-testid="chat-desktop-toolbar-clearance"])';
+    const chatHeaderSelector = 'html.desktop-shell-macos [data-testid="chat-main-workspace-card"] > [data-testid="chat-desktop-toolbar-clearance"]';
+    const darkChatHeaderSelector = 'html.dark.desktop-shell-macos [data-testid="chat-main-workspace-card"] > [data-testid="chat-desktop-toolbar-clearance"]';
+    const activeChatCard = cssBlock(activeChatCardSelector);
+    const lightChatHeader = cssBlock(chatHeaderSelector);
+    const darkChatHeader = cssBlock(darkChatHeaderSelector);
+    const chatMessages = cssBlock('html.desktop-shell-macos [data-testid="chat-main-workspace-card"] .chat-messages-scroll-content');
+    const chatLoadError = cssBlock(`${activeChatCardSelector} > [data-testid="chat-load-error"]`);
+    const chatLoadingState = cssBlock(`${activeChatCardSelector} > [data-testid="chat-conversation-loading-state"]`);
+    const chatToolbarClearance = cssBlock(".chat-desktop-toolbar-clearance");
     const chatLoadErrorOffset = cssBlock(".chat-load-error-offset");
     const chatLoadingOffset = cssBlock(".chat-conversation-loading-offset");
 
@@ -437,11 +446,19 @@ describe("index.css motion rules", () => {
     expect(darkDesktopWorkspaceCards).toContain("background: var(--desktop-content-surface-dark)");
     expect(lightDesktopWorkspaceCards).not.toContain("backdrop-filter");
     expect(darkDesktopWorkspaceCards).not.toContain("backdrop-filter");
-    expect(chatMessages).toContain("padding-top: 1rem");
+    expect(activeChatCard).toContain("isolation: isolate");
+    expect(activeChatCard).not.toContain("linear-gradient");
+    expect(chatToolbarClearance).toContain("height: 2.75rem");
+    expect(lightChatHeader).toContain("position: absolute");
+    expect(lightChatHeader).toContain("height: 2.75rem");
+    expect(lightChatHeader).toContain("backdrop-filter: blur(18px) saturate(128%)");
+    expect(darkChatHeader).toContain("backdrop-filter: blur(18px) saturate(132%)");
+    expect(chatMessages).toContain("padding-top: calc(2.75rem + 1rem)");
+    expect(chatLoadError).toContain("margin-top: calc(2.75rem + 1.5rem)");
+    expect(chatLoadingState).toContain("padding-top: calc(2.75rem + 1rem)");
     expect(chatLoadErrorOffset).toContain("margin-top: 1.5rem");
     expect(chatLoadingOffset).toContain("padding-top: 1rem");
     expect(chatLoadingOffset).toContain("padding-bottom: 1rem");
-    expect(indexCss).not.toContain("chat-desktop-toolbar-clearance");
     expect(indexCss).not.toContain("html.desktop-shell-macos :is(.workspace-context-header, .workspace-main-header)");
   });
 


### PR DESCRIPTION
## Summary
- restore the macOS Desktop Chat header glass layer
- keep messages, loading state, and load errors clear of the 44px header
- add regression coverage for light and dark glass styling

## Verification
- pnpm exec vitest run ui/src/lib/index-css.test.ts --project @rudderhq/ui
- RUDDER_E2E_USE_EXISTING_SERVER=1 RUDDER_E2E_BASE_URL=http://127.0.0.1:3100 pnpm exec playwright test --config tests/e2e/playwright.config.ts tests/e2e/chat-sidebar-layout.spec.ts --grep "keeps chat load errors inside the main workspace card"
- pnpm -r typecheck
- pnpm build
- pnpm product-logic:check

## Notes
- Full repository lint is currently blocked by unrelated import ordering in ui/src/components/side-panel/SideChatPanelView.tsx.
