### PR TITLE
feat: send GitHub issue notifications as Feishu cards

### DIFF
--- a/.github/scripts/notify-feishu-issue.mjs
+++ b/.github/scripts/notify-feishu-issue.mjs
@@ -3,6 +3,10 @@ import fs from "node:fs/promises";
 import { pathToFileURL } from "node:url";
 
 const MAX_BODY_LENGTH = 800;
+const MAX_LABEL_LENGTH = 40;
+const MAX_LABELS = 8;
+const MAX_PAYLOAD_BYTES = 20 * 1024;
+const MAX_TITLE_LENGTH = 256;
 
 export function createSignature(secret, timestamp) {
   return crypto
@@ -16,46 +20,156 @@ function normalizeText(value) {
     .replace(/\r\n/g, "\n")
     .replace(/[ \t]+/g, " ")
     .replace(/\n{3,}/g, "\n\n")
-    .replaceAll("<", "＜")
-    .replaceAll(">", "＞")
     .trim();
 }
 
-export function formatIssueNotification(event, repository) {
+function truncateText(value, maxLength) {
+  const characters = Array.from(value);
+  return characters.length > maxLength
+    ? `${characters.slice(0, maxLength - 1).join("")}…`
+    : value;
+}
+
+function validateIssueUrl(value) {
+  let url;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error("GitHub issue URL is invalid");
+  }
+
+  const isIssuePath = /^\/[^/]+\/[^/]+\/issues\/\d+\/?$/.test(url.pathname);
+  if (
+    url.protocol !== "https:" ||
+    url.hostname !== "github.com" ||
+    !isIssuePath
+  ) {
+    throw new Error("GitHub issue URL must be an HTTPS github.com issue URL");
+  }
+
+  return url.href;
+}
+
+function buildCard({ bodyElements, repository, title }) {
+  return {
+    schema: "2.0",
+    config: {
+      update_multi: true,
+      style: {
+        text_size: {
+          normal_v2: {
+            default: "normal",
+            pc: "normal",
+            mobile: "heading",
+          },
+        },
+      },
+    },
+    body: {
+      direction: "vertical",
+      padding: "12px 12px 12px 12px",
+      elements: bodyElements,
+    },
+    header: {
+      title: {
+        tag: "plain_text",
+        content: title,
+      },
+      subtitle: {
+        tag: "plain_text",
+        content: normalizeText(repository),
+      },
+      template: "blue",
+      padding: "12px 12px 12px 12px",
+    },
+  };
+}
+
+export function buildIssueCard(event, repository) {
   const issue = event.issue;
   if (!issue) {
-    return `Rudder dev GitHub Actions 手动测试成功。\nRepository: ${repository}`;
+    return buildCard({
+      repository,
+      title: "✅ GitHub Actions 手动测试",
+      bodyElements: [
+        {
+          tag: "plain_text",
+          content: "Rudder dev 通知通道正常。",
+          text_align: "left",
+          text_size: "normal_v2",
+        },
+      ],
+    });
   }
 
   const labels = (issue.labels ?? [])
     .map((label) => (typeof label === "string" ? label : label?.name))
     .filter(Boolean);
-  const safeLabels = labels.map(normalizeText);
-  const body = normalizeText(issue.body || "No description provided.");
-  const excerpt =
-    body.length > MAX_BODY_LENGTH
-      ? `${body.slice(0, MAX_BODY_LENGTH - 1)}…`
-      : body;
+  const safeLabels = labels
+    .slice(0, MAX_LABELS)
+    .map((label) => truncateText(normalizeText(label), MAX_LABEL_LENGTH));
+  if (labels.length > MAX_LABELS) {
+    safeLabels.push(`另有 ${labels.length - MAX_LABELS} 个`);
+  }
+  const excerpt = truncateText(
+    normalizeText(issue.body || "未提供描述。"),
+    MAX_BODY_LENGTH,
+  );
+  const safeTitle = truncateText(normalizeText(issue.title), MAX_TITLE_LENGTH);
+  const issueUrl = validateIssueUrl(issue.html_url);
 
-  return [
-    "🐞 New GitHub Issue",
-    `Repository: ${repository}`,
-    `Issue: #${issue.number} ${normalizeText(issue.title)}`,
-    `Opened by: @${issue.user?.login ?? "unknown"}`,
-    safeLabels.length > 0 ? `Labels: ${safeLabels.join(", ")}` : null,
-    "",
-    excerpt,
-    "",
-    issue.html_url,
-  ]
-    .filter((line) => line !== null)
-    .join("\n");
+  return buildCard({
+    repository,
+    title: "🐞 新 GitHub Issue",
+    bodyElements: [
+      {
+        tag: "plain_text",
+        content: `#${issue.number} ${safeTitle}`,
+        text_align: "left",
+        text_size: "normal_v2",
+      },
+      {
+        tag: "plain_text",
+        content: [
+          `提交人：@${issue.user?.login ?? "unknown"}`,
+          `标签：${safeLabels.length > 0 ? safeLabels.join(" · ") : "无"}`,
+        ].join("\n"),
+        text_align: "left",
+        text_size: "normal_v2",
+      },
+      {
+        tag: "plain_text",
+        content: excerpt,
+        text_align: "left",
+        text_size: "normal_v2",
+      },
+      {
+        tag: "button",
+        text: {
+          tag: "plain_text",
+          content: "在 GitHub 查看 Issue",
+        },
+        type: "primary",
+        width: "default",
+        size: "medium",
+        behaviors: [
+          {
+            type: "open_url",
+            default_url: issueUrl,
+            pc_url: "",
+            ios_url: "",
+            android_url: "",
+          },
+        ],
+      },
+    ],
+  });
 }
 
 export async function sendFeishuNotification({
   webhookUrl,
   secret,
-  text,
+  card,
   timestamp = Math.floor(Date.now() / 1000).toString(),
   fetchImpl = fetch,
 }) {
@@ -63,15 +177,21 @@ export async function sendFeishuNotification({
     throw new Error("Feishu notification secrets are not configured");
   }
 
+  const payload = {
+    timestamp,
+    sign: createSignature(secret, timestamp),
+    msg_type: "interactive",
+    card,
+  };
+  const payloadSize = new TextEncoder().encode(JSON.stringify(payload)).length;
+  if (payloadSize > MAX_PAYLOAD_BYTES) {
+    throw new Error("Feishu notification payload exceeds 20 KB");
+  }
+
   const response = await fetchImpl(webhookUrl, {
     method: "POST",
     headers: { "content-type": "application/json" },
-    body: JSON.stringify({
-      timestamp,
-      sign: createSignature(secret, timestamp),
-      msg_type: "text",
-      content: { text },
-    }),
+    body: JSON.stringify(payload),
     signal: AbortSignal.timeout(15_000),
   });
 
@@ -82,8 +202,10 @@ export async function sendFeishuNotification({
     throw new Error(`Feishu returned a non-JSON response (${response.status})`);
   }
 
-  const code = result.code ?? result.StatusCode ?? null;
-  if (!response.ok || (code !== null && code !== 0)) {
+  const code = Object.hasOwn(result, "code")
+    ? result.code
+    : result.StatusCode;
+  if (!response.ok || code !== 0) {
     const message = result.msg ?? result.StatusMessage ?? "unknown error";
     throw new Error(`Feishu notification failed (${response.status}): ${message}`);
   }
@@ -95,12 +217,12 @@ async function main() {
   const event = JSON.parse(
     await fs.readFile(process.env.GITHUB_EVENT_PATH, "utf8"),
   );
-  const text = formatIssueNotification(event, process.env.GITHUB_REPOSITORY);
+  const card = buildIssueCard(event, process.env.GITHUB_REPOSITORY);
 
   await sendFeishuNotification({
     webhookUrl: process.env.FEISHU_WEBHOOK_URL,
     secret: process.env.FEISHU_BOT_SECRET,
-    text,
+    card,
   });
 
   console.log("Feishu issue notification sent successfully");

--- a/scripts/runtime-notify-feishu-issue.test.mjs
+++ b/scripts/runtime-notify-feishu-issue.test.mjs
@@ -9,8 +9,8 @@ import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
 
 import {
+  buildIssueCard,
   createSignature,
-  formatIssueNotification,
   sendFeishuNotification,
 } from "../.github/scripts/notify-feishu-issue.mjs";
 
@@ -63,8 +63,8 @@ function runNotificationScript(env) {
 }
 
 describe("GitHub issue to Feishu notification", () => {
-  it("formats useful issue details and bounds long bodies", () => {
-    const text = formatIssueNotification(
+  it("builds a bounded issue card with a GitHub button", () => {
+    const card = buildIssueCard(
       {
         issue: {
           number: 42,
@@ -77,12 +77,45 @@ describe("GitHub issue to Feishu notification", () => {
       },
       "acme/rudder",
     );
+    const [title, metadata, body, button] = card.body.elements;
 
-    expect(text).toContain("#42 Broken installer");
-    expect(text).toContain("Opened by: @octocat");
-    expect(text).toContain("Labels: bug, desktop");
-    expect(text).toContain("https://github.com/acme/rudder/issues/42");
-    expect(text.length).toBeLessThan(1_100);
+    expect(card).toMatchObject({
+      schema: "2.0",
+      config: {
+        style: {
+          text_size: {
+            normal_v2: {
+              default: "normal",
+              pc: "normal",
+              mobile: "heading",
+            },
+          },
+        },
+      },
+      header: {
+        title: { tag: "plain_text", content: "🐞 新 GitHub Issue" },
+        subtitle: { tag: "plain_text", content: "acme/rudder" },
+        template: "blue",
+      },
+    });
+    expect(title).toMatchObject({
+      tag: "plain_text",
+      content: "#42 Broken installer",
+    });
+    expect(metadata.content).toContain("提交人：@octocat");
+    expect(metadata.content).toContain("标签：bug · desktop");
+    expect(body.content.length).toBeLessThan(900);
+    expect(button).toMatchObject({
+      tag: "button",
+      text: { tag: "plain_text", content: "在 GitHub 查看 Issue" },
+      type: "primary",
+      behaviors: [
+        {
+          type: "open_url",
+          default_url: "https://github.com/acme/rudder/issues/42",
+        },
+      ],
+    });
   });
 
   it("uses the Feishu timestamp-plus-secret signing contract", () => {
@@ -97,7 +130,7 @@ describe("GitHub issue to Feishu notification", () => {
   });
 
   it("neutralizes Feishu mention markup from untrusted issue text", () => {
-    const text = formatIssueNotification(
+    const card = buildIssueCard(
       {
         issue: {
           number: 43,
@@ -110,10 +143,88 @@ describe("GitHub issue to Feishu notification", () => {
       },
       "acme/rudder",
     );
+    const plainText = card.body.elements
+      .filter((element) => element.tag === "plain_text")
+      .map((element) => element.content)
+      .join("\n");
 
-    expect(text).not.toContain("<at");
-    expect(text).toContain('＜at user_id="all"＞Everyone＜/at＞');
-    expect(text).toContain('＜at user_id="ou_known"＞Target＜/at＞');
+    expect(plainText).toContain('<at user_id="all">Everyone</at>');
+    expect(plainText).toContain('<at user_id="ou_known">Target</at>');
+    expect(
+      card.body.elements
+        .filter((element) => element.tag !== "button")
+        .every((element) => element.tag === "plain_text"),
+    ).toBe(true);
+  });
+
+  it("preserves Markdown-like source text without interpreting it", () => {
+    const card = buildIssueCard(
+      {
+        issue: {
+          number: 45,
+          title: "Normal**\n\n[Open securely](https://evil.example)\n\n**",
+          body: "![trusted image](https://evil.example/image.png)",
+          html_url: "https://github.com/acme/rudder/issues/45",
+          user: { login: "reporter" },
+          labels: [{ name: "[security](https://evil.example)" }],
+        },
+      },
+      "acme/rudder",
+    );
+    const [title, metadata, body] = card.body.elements;
+
+    expect(title).toEqual(
+      expect.objectContaining({
+        tag: "plain_text",
+        content: "#45 Normal**\n\n[Open securely](https://evil.example)\n\n**",
+      }),
+    );
+    expect(metadata).toEqual(
+      expect.objectContaining({
+        tag: "plain_text",
+        content: expect.stringContaining(
+          "标签：[security](https://evil.example)",
+        ),
+      }),
+    );
+    expect(body).toEqual(
+      expect.objectContaining({
+        tag: "plain_text",
+        content: "![trusted image](https://evil.example/image.png)",
+      }),
+    );
+  });
+
+  it("builds a manual test card without a navigation button", () => {
+    const card = buildIssueCard({}, "acme/rudder");
+
+    expect(card.header.title.content).toBe("✅ GitHub Actions 手动测试");
+    expect(card.header.subtitle.content).toBe("acme/rudder");
+    expect(card.body.elements).toEqual([
+      expect.objectContaining({
+        tag: "plain_text",
+        content: "Rudder dev 通知通道正常。",
+      }),
+    ]);
+    expect(card.body.elements.some((element) => element.tag === "button")).toBe(
+      false,
+    );
+  });
+
+  it("rejects non-GitHub and non-HTTPS issue links", () => {
+    const event = {
+      issue: {
+        number: 44,
+        title: "Unsafe link",
+        body: "Do not render this button.",
+        html_url: "https://example.com/acme/rudder/issues/44",
+        user: { login: "reporter" },
+      },
+    };
+
+    expect(() => buildIssueCard(event, "acme/rudder")).toThrow(
+      "GitHub issue URL must be an HTTPS github.com issue URL",
+    );
   });
 
   it("runs the workflow script end to end and sends a signed payload", async () => {
@@ -164,8 +275,20 @@ describe("GitHub issue to Feishu notification", () => {
         stderr: "",
         stdout: "Feishu issue notification sent successfully\n",
       });
-      expect(receivedBody.msg_type).toBe("text");
-      expect(receivedBody.content.text).toContain("#7 Notification regression");
+      expect(receivedBody.msg_type).toBe("interactive");
+      expect(receivedBody.card.schema).toBe("2.0");
+      expect(receivedBody.card.body.elements[0].content).toContain(
+        "#7 Notification regression",
+      );
+      expect(receivedBody.card.body.elements[3]).toMatchObject({
+        tag: "button",
+        behaviors: [
+          {
+            type: "open_url",
+            default_url: "https://github.com/acme/rudder/issues/7",
+          },
+        ],
+      });
       expect(receivedBody.sign).toBe(
         createSignature("integration-secret", receivedBody.timestamp),
       );
@@ -174,12 +297,69 @@ describe("GitHub issue to Feishu notification", () => {
     }
   });
 
+  it("bounds a production-shaped high-volume issue below the webhook limit", async () => {
+    let payloadBody;
+    const card = buildIssueCard(
+      {
+        issue: {
+          number: 46,
+          title: "😀".repeat(256),
+          body: "😀".repeat(800),
+          html_url: "https://github.com/acme/rudder/issues/46",
+          user: { login: "reporter" },
+          labels: Array.from({ length: 100 }, (_, index) => ({
+            name: `${index}-${"😀".repeat(50)}`,
+          })),
+        },
+      },
+      "acme/rudder",
+    );
+
+    await sendFeishuNotification({
+      webhookUrl: "https://example.invalid/hook",
+      secret: "secret",
+      card,
+      timestamp: "1785080000",
+      fetchImpl: async (_url, options) => {
+        payloadBody = options.body;
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ code: 0, msg: "success" }),
+        };
+      },
+    });
+
+    expect(new TextEncoder().encode(payloadBody).length).toBeLessThanOrEqual(
+      20 * 1024,
+    );
+    const labelsLine = JSON.parse(payloadBody).card.body.elements[1].content;
+    expect(labelsLine).toContain("另有 92 个");
+  });
+
+  it("uses a Chinese fallback for an empty issue body", () => {
+    const card = buildIssueCard(
+      {
+        issue: {
+          number: 47,
+          title: "No body",
+          body: "",
+          html_url: "https://github.com/acme/rudder/issues/47",
+          user: { login: "reporter" },
+        },
+      },
+      "acme/rudder",
+    );
+
+    expect(card.body.elements[2].content).toContain("未提供描述。");
+  });
+
   it("fails closed when Feishu rejects a notification", async () => {
     await expect(
       sendFeishuNotification({
         webhookUrl: "https://example.invalid/hook",
         secret: "secret",
-        text: "test",
+        card: buildIssueCard({}, "acme/rudder"),
         timestamp: "1785080000",
         fetchImpl: async () => ({
           ok: true,
@@ -188,5 +368,21 @@ describe("GitHub issue to Feishu notification", () => {
         }),
       }),
     ).rejects.toThrow("sign match fail");
+  });
+
+  it("fails closed when Feishu omits an explicit success code", async () => {
+    await expect(
+      sendFeishuNotification({
+        webhookUrl: "https://example.invalid/hook",
+        secret: "secret",
+        card: buildIssueCard({}, "acme/rudder"),
+        timestamp: "1785080000",
+        fetchImpl: async () => ({
+          ok: true,
+          status: 200,
+          json: async () => ({}),
+        }),
+      }),
+    ).rejects.toThrow("unknown error");
   });
 });


### PR DESCRIPTION
## Summary
- replace plain-text GitHub Issue notifications with Feishu JSON 2.0 interactive cards
- show repository, issue title, author, labels, and an 800-character excerpt
- add a validated HTTPS GitHub Issue button while keeping manual test cards button-free
- preserve signing, timeout, Feishu response checks, and render untrusted fields as plain text

## Verification
- `pnpm exec vitest run scripts/runtime-notify-feishu-issue.test.mjs` — 11/11 passed
- `pnpm lint` — passed
- `pnpm -r typecheck` — passed
- `pnpm build` — passed
- `pnpm test:run` — existing unrelated failures: 589 files passed, 54 failed; the notification suite passed in the full run

## Risk
Low and isolated to the repository notification script. No secrets, robot settings, workflow triggers, database schema, or Product Logic Registry files changed.