### PR TITLE
feat: move Messenger members out of groups

### DIFF
--- a/doc/product/domains/collaboration/chat-messenger-im.md
+++ b/doc/product/domains/collaboration/chat-messenger-im.md
@@ -3127,6 +3127,8 @@ Why:
 - Group membership must not make a thread feel like a second-class item. A
   grouped row is still the same Messenger item for navigation, unread state,
   pin ordering, and attention semantics.
+- Operators must be able to remove one grouped Chat, Issue, or Saved View
+  without dismantling the group or changing any sibling member.
 
 Product model:
 
@@ -3218,11 +3220,13 @@ Flow:
 10. Saved View group order and Main Workbench tab order are independent.
     Reordering or moving a Messenger row does not move, close, focus, or
     reassign the corresponding Main tab or live runtime.
-11. Removing a Saved View's group membership, choosing `Move to Messenger
-    sidebar`, or separating/deleting its group returns the Saved View to the
-    loose directory without deleting it. A loose Saved View can then be
-    reordered, moved into an existing group, or merged with an eligible loose
-    Chat or Issue through the same pointer and keyboard placement model.
+11. Every grouped Chat, Issue, and Saved View row exposes `Move out of group`
+    from its `Move to group` menu. The action removes only that selected
+    member's operator-scoped membership, returns it to the loose directory,
+    and leaves the group plus all sibling members intact. It does not delete or
+    mutate the owning Chat, Issue, or Saved View. A loose member can then be
+    reordered, moved into an existing group, or merged with another eligible
+    loose Chat or Issue through the same pointer and keyboard placement model.
 
 Invariants:
 
@@ -3267,6 +3271,9 @@ Invariants:
 - Removing a thread-backed item or Saved View from a group returns it to the
   loose Messenger directory. Thread-backed items retain existing read/unread
   and attention state; Saved Views retain their non-thread identity.
+- `Move out of group` is a per-member operation for grouped Chat, Issue, and
+  Saved View rows. It must not delete the custom group, remove sibling
+  memberships, or delete the selected owning-domain object.
 - A mixed group may contain both thread-backed members and Saved Views. Saved
   View rows preserve their Saved View route, target kind, title, and manual
   order, but must not inherit unread badges, attention state, mark-read actions,

--- a/doc/product/registry.yml
+++ b/doc/product/registry.yml
@@ -1586,6 +1586,7 @@ contracts:
       - ui/src/components/MessengerContextSidebar.test.tsx
       - ui/src/components/MessengerContextSidebar.actions.test.tsx
       - ui/src/components/messenger/MessengerSavedViewRow.test.tsx
+      - ui/src/components/messenger/MessengerThreadListViews.test.tsx
       - ui/src/context/MainWorkbenchContext.test.tsx
       - ui/src/lib/messenger-preferences.test.ts
       - ui/src/lib/messenger-thread-organization.test.ts

--- a/tests/e2e/messenger-contract.spec.ts
+++ b/tests/e2e/messenger-contract.spec.ts
@@ -1568,6 +1568,138 @@ test.describe("Messenger unified threads contract", () => {
     }).toBeGreaterThanOrEqual(2);
   });
 
+  test("moves one Chat, Issue, or Saved View out of a group without removing the group or siblings", async ({ page }) => {
+    const organization = await createConfiguredOrganization(page, `Messenger-Move-Out-${Date.now()}`);
+    const chatRes = await page.request.post(`/api/orgs/${organization.id}/chats`, {
+      data: {
+        title: "Grouped move-out chat",
+        summary: "Only this Chat membership should be removed.",
+        initialMessage: { body: "Keep the Chat while moving it out of the group." },
+        issueCreationMode: "manual_approval",
+        planMode: false,
+      },
+    });
+    expect(chatRes.ok()).toBe(true);
+    const chat = await chatRes.json() as { id: string };
+
+    const issueRes = await page.request.post(`/api/orgs/${organization.id}/issues`, {
+      data: {
+        title: "Grouped move-out issue",
+        description: "Only this Issue membership should be removed.",
+        status: "todo",
+        priority: "medium",
+      },
+    });
+    expect(issueRes.ok()).toBe(true);
+    const issue = await issueRes.json() as { id: string };
+
+    const groupRes = await page.request.post(`/api/orgs/${organization.id}/messenger/groups`, {
+      data: { name: "Move-out proof", icon: "folder::blue" },
+    });
+    expect(groupRes.ok()).toBe(true);
+    const group = await groupRes.json() as { id: string };
+    for (const itemKey of [`chat:${chat.id}`, `issue:${issue.id}`]) {
+      const assignRes = await page.request.post(
+        `/api/orgs/${organization.id}/messenger/groups/${group.id}/entries`,
+        { data: { itemKey } },
+      );
+      expect(assignRes.ok()).toBe(true);
+    }
+
+    const savedViewRes = await page.request.post(`/api/orgs/${organization.id}/messenger/saved-views/keep`, {
+      data: {
+        title: "Grouped move-out reference",
+        target: {
+          kind: "browser",
+          tabId: `move-out-${randomUUID()}`,
+          url: "https://example.com/move-out-proof",
+          viewInstanceId: `move-out-${randomUUID()}`,
+        },
+        clientMutationId: randomUUID(),
+        placement: { kind: "group", groupId: group.id },
+      },
+    });
+    expect(savedViewRes.ok()).toBe(true);
+    const savedView = (await savedViewRes.json() as { savedView: { id: string } }).savedView;
+
+    await page.goto("/");
+    await page.evaluate((orgId) => {
+      window.localStorage.setItem("rudder.selectedOrganizationId", orgId);
+      window.localStorage.setItem("rudder.messengerThreadOrganizationByOrg", JSON.stringify({ [orgId]: "latest" }));
+      window.localStorage.setItem("rudder.messengerSplitIssueNotificationsByOrg", JSON.stringify({ [orgId]: true }));
+    }, organization.id);
+    await page.goto(`/${organization.issuePrefix}/messenger`, { waitUntil: "commit" });
+
+    const groupSectionId = `messenger-thread-section-custom-group-${group.id}`;
+    const chatRowId = threadTestId(`chat:${chat.id}`);
+    const issueRowId = threadTestId(`issue:${issue.id}`);
+    const savedViewRow = page.locator(`[data-messenger-saved-view-id="${savedView.id}"]`);
+    const groupSection = page.getByTestId(groupSectionId);
+    const groupedSavedViewRow = groupSection.locator(`[data-messenger-saved-view-id="${savedView.id}"]`);
+    await expect(groupSection).toContainText("Move-out proof", { timeout: 15_000 });
+    await expectTestIdWithinSection(page, groupSectionId, chatRowId);
+    await expectTestIdWithinSection(page, groupSectionId, issueRowId);
+    await expect(groupedSavedViewRow).toBeVisible();
+
+    const moveOutFromOpenMenu = async () => {
+      await page.getByRole("menuitem", { name: "Move to group", exact: true }).hover();
+      await page.getByRole("menuitem", { name: "Move out of group", exact: true }).click();
+    };
+    const expectMemberships = async (expectedItemKeys: string[]) => {
+      await expect.poll(async () => {
+        const groupsRes = await page.request.get(`/api/orgs/${organization.id}/messenger/groups`);
+        expect(groupsRes.ok()).toBe(true);
+        const payload = await groupsRes.json() as {
+          groups: Array<{ id: string; entries: Array<{ itemKey: string; threadKey: string | null }> }>;
+        };
+        const persistedGroup = payload.groups.find((candidate) => candidate.id === group.id);
+        return persistedGroup?.entries.map((entry) => entry.itemKey ?? entry.threadKey).sort() ?? null;
+      }).toEqual(expectedItemKeys.slice().sort());
+      await expect(groupSection).toBeVisible();
+    };
+
+    const chatMoveResponse = page.waitForResponse((response) =>
+      response.url().includes(`/api/orgs/${organization.id}/messenger/groups/entries/`)
+      && response.request().method() === "DELETE",
+    );
+    await page.getByTestId(chatRowId).hover();
+    await page.getByTestId(chatRowId).getByRole("button", { name: "Chat actions" }).click();
+    await moveOutFromOpenMenu();
+    expect((await chatMoveResponse).ok()).toBe(true);
+    await expectMemberships([`issue:${issue.id}`, `saved-view:${savedView.id}`]);
+    await expect(groupSection.getByTestId(chatRowId)).toHaveCount(0);
+    await expect(page.getByTestId(chatRowId)).toBeVisible();
+    await expectTestIdWithinSection(page, groupSectionId, issueRowId);
+    await expect(groupedSavedViewRow).toBeVisible();
+
+    const issueMoveResponse = page.waitForResponse((response) =>
+      response.url().includes(`/api/orgs/${organization.id}/messenger/groups/entries/`)
+      && response.request().method() === "DELETE",
+    );
+    await page.getByTestId(issueRowId).hover();
+    await page.getByTestId(issueRowId).getByRole("button", { name: "Thread actions" }).click();
+    await moveOutFromOpenMenu();
+    expect((await issueMoveResponse).ok()).toBe(true);
+    await expectMemberships([`saved-view:${savedView.id}`]);
+    await expect(groupSection.getByTestId(issueRowId)).toHaveCount(0);
+    await expect(page.getByTestId(issueRowId)).toBeVisible();
+    await expect(groupedSavedViewRow).toBeVisible();
+
+    const savedViewMoveResponse = page.waitForResponse((response) =>
+      response.url().includes(`/api/orgs/${organization.id}/messenger/groups/entries/`)
+      && response.request().method() === "DELETE",
+    );
+    await savedViewRow.hover();
+    await savedViewRow.getByRole("button", { name: "Saved View actions for Grouped move-out reference" }).click();
+    await moveOutFromOpenMenu();
+    expect((await savedViewMoveResponse).ok()).toBe(true);
+    await expectMemberships([]);
+    await expect(groupedSavedViewRow).toHaveCount(0);
+    await expect(savedViewRow).toBeVisible();
+    await expect(page.getByTestId(chatRowId)).toBeVisible();
+    await expect(page.getByTestId(issueRowId)).toBeVisible();
+  });
+
   test("groups aggregate issue and synthetic Messenger rows through the same group contract", async ({ page }) => {
     const organization = await createConfiguredOrganization(page, `Messenger-Nonchat-Groups-${Date.now()}`);
 

--- a/ui/src/components/MessengerContextSidebar.actions.test.tsx
+++ b/ui/src/components/MessengerContextSidebar.actions.test.tsx
@@ -4219,7 +4219,7 @@ describe("MessengerContextSidebar chat actions", () => {
     });
   });
 
-  it("releases a grouped Saved View loose and keeps group separation available", async () => {
+  it("moves one grouped Saved View out without removing its group", async () => {
     installLocalStorage({
       "rudder.messengerThreadOrganizationByOrg": JSON.stringify({ "org-1": "custom" }),
     });
@@ -4229,7 +4229,7 @@ describe("MessengerContextSidebar chat actions", () => {
     const { container } = renderSidebar();
 
     const moveLoose = Array.from(container.querySelectorAll("button"))
-      .find((button) => button.textContent?.includes("Move to Messenger sidebar"));
+      .find((button) => button.textContent?.includes("Move out of group"));
     expect(moveLoose).toBeTruthy();
     await act(async () => {
       moveLoose?.click();

--- a/ui/src/components/MessengerContextSidebar.tsx
+++ b/ui/src/components/MessengerContextSidebar.tsx
@@ -2915,7 +2915,7 @@ export function MessengerContextSidebar() {
               entry={entry}
               groups={customGroups}
               onMove={requestMoveSavedView}
-              onMoveToSidebar={requestReleaseSavedView}
+              onMoveOutOfGroup={requestReleaseSavedView}
               onRemove={requestRemoveSavedView}
               placementPending={placementPending}
             />
@@ -2936,7 +2936,7 @@ export function MessengerContextSidebar() {
                   entry={entry}
                   groups={customGroups}
                   onMove={requestMoveSavedView}
-                  onMoveToSidebar={requestReleaseSavedView}
+                  onMoveOutOfGroup={requestReleaseSavedView}
                   onRemove={requestRemoveSavedView}
                   placementPending={placementPending}
                 />

--- a/ui/src/components/messenger/MessengerSavedViewRow.test.tsx
+++ b/ui/src/components/messenger/MessengerSavedViewRow.test.tsx
@@ -97,14 +97,14 @@ function renderRow({
   entry = savedViewEntry(),
   groups = [],
   onMove = vi.fn(),
-  onMoveToSidebar = vi.fn(),
+  onMoveOutOfGroup = vi.fn(),
 }: {
   active?: boolean;
   currentGroupId?: string | null;
   entry?: MessengerCustomGroupHydratedSavedViewEntry;
   groups?: Array<{ id: string; name: string }>;
   onMove?: ReturnType<typeof vi.fn>;
-  onMoveToSidebar?: ReturnType<typeof vi.fn>;
+  onMoveOutOfGroup?: ReturnType<typeof vi.fn>;
 } = {}) {
   host = document.createElement("div");
   document.body.appendChild(host);
@@ -129,7 +129,7 @@ function renderRow({
         entry={entry}
         groups={groups as never}
         onMove={onMove}
-        onMoveToSidebar={onMoveToSidebar}
+        onMoveOutOfGroup={onMoveOutOfGroup}
         onRemove={vi.fn()}
       />,
     );
@@ -263,7 +263,7 @@ describe("MessengerSavedViewRow", () => {
 
   it("renders loose and grouped placement actions without inventing group membership", () => {
     const onMove = vi.fn();
-    const onMoveToSidebar = vi.fn();
+    const onMoveOutOfGroup = vi.fn();
     const groups = [
       { id: "group-a", name: "Launch" },
       { id: "group-b", name: "Review" },
@@ -273,13 +273,13 @@ describe("MessengerSavedViewRow", () => {
       currentGroupId: null,
       groups,
       onMove,
-      onMoveToSidebar,
+      onMoveOutOfGroup,
     });
 
     expect(host!.textContent).toContain("Move to group");
     expect(host!.textContent).toContain("Launch");
     expect(host!.textContent).toContain("Review");
-    expect(host!.textContent).not.toContain("Move to Messenger sidebar");
+    expect(host!.textContent).not.toContain("Move out of group");
     act(() => {
       Array.from(host!.querySelectorAll("button"))
         .find((button) => button.textContent === "Launch")
@@ -295,15 +295,15 @@ describe("MessengerSavedViewRow", () => {
       currentGroupId: "group-a",
       groups,
       onMove,
-      onMoveToSidebar,
+      onMoveOutOfGroup,
     });
 
     expect(host!.textContent).not.toContain(">Launch<");
     expect(host!.textContent).toContain("Review");
     const moveLooseButton = Array.from(host!.querySelectorAll("button"))
-      .find((button) => button.textContent?.includes("Move to Messenger sidebar"));
+      .find((button) => button.textContent?.includes("Move out of group"));
     expect(moveLooseButton).toBeTruthy();
     act(() => moveLooseButton?.click());
-    expect(onMoveToSidebar).toHaveBeenCalledWith("saved-view:saved-a");
+    expect(onMoveOutOfGroup).toHaveBeenCalledWith("saved-view:saved-a");
   });
 });

--- a/ui/src/components/messenger/MessengerSavedViewRow.tsx
+++ b/ui/src/components/messenger/MessengerSavedViewRow.tsx
@@ -180,7 +180,7 @@ export function MessengerSavedViewRow({
   savedView: looseSavedView,
   groups,
   onMove,
-  onMoveToSidebar,
+  onMoveOutOfGroup,
   onRemove,
   placementPending = false,
 }: {
@@ -194,7 +194,7 @@ export function MessengerSavedViewRow({
   savedView?: MessengerSavedView;
   groups: MessengerCustomGroupWithEntries[];
   onMove: (groupId: string, itemKey: string) => void;
-  onMoveToSidebar?: (itemKey: string) => void;
+  onMoveOutOfGroup?: (itemKey: string) => void;
   onRemove: (savedViewId: string) => void;
   placementPending?: boolean;
 }) {
@@ -272,11 +272,17 @@ export function MessengerSavedViewRow({
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end" className="surface-overlay text-foreground">
           <DropdownMenuSub>
-            <DropdownMenuSubTrigger disabled={otherGroups.length === 0}>
+            <DropdownMenuSubTrigger disabled={otherGroups.length === 0 && !currentGroupId}>
               <FolderInput className="h-4 w-4" />
               Move to group
             </DropdownMenuSubTrigger>
             <DropdownMenuSubContent className="surface-overlay text-foreground">
+              {currentGroupId && onMoveOutOfGroup ? (
+                <DropdownMenuItem onClick={() => onMoveOutOfGroup(resolvedItemKey)}>
+                  <Folder className="h-4 w-4" />
+                  Move out of group
+                </DropdownMenuItem>
+              ) : null}
               {otherGroups.map((group) => (
                 <DropdownMenuItem key={group.id} onClick={() => onMove(group.id, resolvedItemKey)}>
                   {group.name}
@@ -284,12 +290,6 @@ export function MessengerSavedViewRow({
               ))}
             </DropdownMenuSubContent>
           </DropdownMenuSub>
-          {currentGroupId && onMoveToSidebar ? (
-            <DropdownMenuItem onClick={() => onMoveToSidebar(resolvedItemKey)}>
-              <FolderInput className="h-4 w-4" />
-              Move to Messenger sidebar
-            </DropdownMenuItem>
-          ) : null}
           <DropdownMenuItem
             className="text-destructive focus:text-destructive"
             onClick={() => onRemove(savedView.id)}


### PR DESCRIPTION
## Summary
- expose Move out of group for grouped Saved Views alongside existing Chat and Issue actions
- remove only the selected membership while preserving the group, siblings, and owning object
- update MESSENGER.CUSTOM.GROUPS.001 and add real Chromium E2E coverage

## Validation
- pnpm lint
- pnpm -r typecheck
- pnpm build
- pnpm product-logic:check
- targeted Vitest coverage for Saved View rows, sidebar actions, and thread-list views
- real Chromium E2E for Chat, Issue, and Saved View move-out behavior

Full pnpm test:run was attempted in the shared high-concurrency workspace; 5780 tests passed and 129 unrelated tests failed, predominantly existing 5s timeouts and worker/database teardown errors. All task-specific tests passed.