### PR TITLE
fix: remove approval comment panel

### DIFF
--- a/tests/e2e/messenger-contract.spec.ts
+++ b/tests/e2e/messenger-contract.spec.ts
@@ -3112,7 +3112,7 @@ test.describe("Messenger unified threads contract", () => {
     }).toContain(labels[0].id);
   });
 
-  test("keeps approval decision note in the modal review flow and scrolls long approval threads", async ({ page }, testInfo) => {
+  test("keeps approval decisions in the modal review flow without a separate comments surface", async ({ page }, testInfo) => {
     const organization = await createOrganization(page, `Messenger-Approval-Modal-${Date.now()}`);
 
     const approvalRes = await page.request.post(`/api/orgs/${organization.id}/approvals`, {
@@ -3147,31 +3147,15 @@ test.describe("Messenger unified threads contract", () => {
     await page.goto(`/${organization.issuePrefix}/messenger/approvals/${approval.id}`, { waitUntil: "commit" });
 
     const dialog = page.getByTestId("approval-detail-dialog");
-    const scrollArea = page.getByTestId("approval-detail-scroll-area");
 
     await expect(dialog).toBeVisible({ timeout: 15_000 });
     await expect(page.getByTestId("approval-decision-note")).toBeVisible();
     await expect(dialog.getByRole("button", { name: "See full request" })).toHaveCount(0);
-
-    const scrollMetrics = await scrollArea.evaluate((node) => ({
-      scrollHeight: node.scrollHeight,
-      clientHeight: node.clientHeight,
-    }));
-    expect(scrollMetrics.scrollHeight).toBeGreaterThan(scrollMetrics.clientHeight);
-
-    await scrollArea.evaluate((node) => {
-      node.scrollTo({ top: node.scrollHeight, behavior: "auto" });
-    });
-
-    await expect.poll(async () => {
-      return await scrollArea.evaluate((node) => node.scrollTop);
-    }).toBeGreaterThan(0);
-
-    await expect(page.getByPlaceholder("Add a comment...")).toBeVisible();
-
-    await scrollArea.evaluate((node) => {
-      node.scrollTo({ top: 0, behavior: "auto" });
-    });
+    await expect(dialog.getByText("Comments (10)")).toHaveCount(0);
+    await expect(dialog.getByText("Scrollable approval comment 1", { exact: false })).toHaveCount(0);
+    await expect(dialog.getByPlaceholder("Add a comment...")).toHaveCount(0);
+    await expect(dialog).toBeInViewport();
+    await expect(dialog.getByRole("button", { name: "Request changes" })).toBeInViewport();
     await expect(page.getByTestId("approval-decision-note")).toBeVisible();
 
     await page.getByTestId("approval-decision-note").fill("Please tighten the execution scope before resubmitting.");

--- a/ui/src/components/ApprovalDetailDialog.tsx
+++ b/ui/src/components/ApprovalDetailDialog.tsx
@@ -15,12 +15,8 @@ import {
 import { Textarea } from "@/components/ui/textarea";
 import { useDialog } from "@/context/DialogContext";
 import { useOrganization } from "@/context/OrganizationContext";
-import { useOperatorDisplayName } from "@/hooks/useOperatorDisplayName";
-import { resolveBoardActorLabel } from "@/lib/activity-actors";
 import { queryKeys } from "@/lib/queryKeys";
 import { Link, useNavigate, useSearchParams } from "@/lib/router";
-import { formatDateTime } from "@/lib/utils";
-import type { ApprovalComment } from "@rudderhq/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { CheckCircle2, Sparkles } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
@@ -36,8 +32,6 @@ import {
   defaultTypeIcon,
   typeIcon,
 } from "./ApprovalPayload";
-import { Identity } from "./Identity";
-import { MarkdownBody } from "./MarkdownBody";
 import { StatusBadge } from "./StatusBadge";
 
 interface ApprovalDetailDialogProps {
@@ -57,10 +51,8 @@ export function ApprovalDetailDialog({
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const [decisionNote, setDecisionNote] = useState("");
-  const [commentBody, setCommentBody] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [selectedChatIssueLabelIds, setSelectedChatIssueLabelIds] = useState<string[]>([]);
-  const operatorDisplayName = useOperatorDisplayName();
 
   const { data: approval, isLoading } = useQuery({
     queryKey: queryKeys.approvals.detail(approvalId ?? "__none__"),
@@ -68,12 +60,6 @@ export function ApprovalDetailDialog({
     enabled: Boolean(approvalId && open),
   });
   const resolvedOrgId = approval?.orgId ?? selectedOrganizationId;
-
-  const { data: comments } = useQuery({
-    queryKey: queryKeys.approvals.comments(approvalId ?? "__none__"),
-    queryFn: () => approvalsApi.listComments(approvalId!),
-    enabled: Boolean(approvalId && open),
-  });
 
   const { data: linkedIssues } = useQuery({
     queryKey: queryKeys.approvals.issues(approvalId ?? "__none__"),
@@ -121,7 +107,6 @@ export function ApprovalDetailDialog({
 
   useEffect(() => {
     setDecisionNote("");
-    setCommentBody("");
     setError(null);
     setSelectedChatIssueLabelIds([]);
   }, [approvalId]);
@@ -143,7 +128,6 @@ export function ApprovalDetailDialog({
   const refresh = () => {
     if (!approvalId) return;
     queryClient.invalidateQueries({ queryKey: queryKeys.approvals.detail(approvalId) });
-    queryClient.invalidateQueries({ queryKey: queryKeys.approvals.comments(approvalId) });
     queryClient.invalidateQueries({ queryKey: queryKeys.approvals.issues(approvalId) });
     if (approval?.orgId) {
       queryClient.invalidateQueries({ queryKey: queryKeys.approvals.list(approval.orgId) });
@@ -201,16 +185,6 @@ export function ApprovalDetailDialog({
       refresh();
     },
     onError: (err) => setError(err instanceof Error ? err.message : "Resubmit failed"),
-  });
-
-  const addCommentMutation = useMutation({
-    mutationFn: () => approvalsApi.addComment(approvalId!, commentBody.trim()),
-    onSuccess: () => {
-      setCommentBody("");
-      setError(null);
-      refresh();
-    },
-    onError: (err) => setError(err instanceof Error ? err.message : "Comment failed"),
   });
 
   const deleteAgentMutation = useMutation({
@@ -488,52 +462,6 @@ export function ApprovalDetailDialog({
                   </div>
                 </ApprovalPanel>
 
-                <ApprovalPanel className="space-y-3">
-                  <h3 className="text-sm font-medium">Comments ({comments?.length ?? 0})</h3>
-                  <div className="space-y-2">
-                    {(comments ?? []).map((comment: ApprovalComment) => (
-                      <ApprovalInset key={comment.id} className="p-3">
-                        <div className="mb-1 flex items-center justify-between">
-                          {comment.authorAgentId ? (
-                            <Link to={`/agents/${comment.authorAgentId}`} className="hover:underline">
-                              <AgentIdentity
-                                name={agentById.get(comment.authorAgentId)?.name ?? comment.authorAgentId.slice(0, 8)}
-                                icon={agentById.get(comment.authorAgentId)?.icon}
-                                role={agentById.get(comment.authorAgentId)?.role}
-                                size="sm"
-                              />
-                            </Link>
-                          ) : (
-                            <Identity
-                              name={resolveBoardActorLabel("user", comment.authorUserId, currentBoardUserId, operatorDisplayName)}
-                              size="sm"
-                            />
-                          )}
-                          <span className="text-xs text-muted-foreground">
-                            {formatDateTime(comment.createdAt)}
-                          </span>
-                        </div>
-                        <MarkdownBody className="text-sm">{comment.body}</MarkdownBody>
-                      </ApprovalInset>
-                    ))}
-                  </div>
-                  <Textarea
-                    value={commentBody}
-                    onChange={(event) => setCommentBody(event.target.value)}
-                    placeholder="Add a comment..."
-                    rows={3}
-                    className="min-h-[132px] rounded-[calc(var(--radius-sm)-1px)] border-border/80 bg-background/70"
-                  />
-                  <div className="flex justify-end">
-                    <Button
-                      size="sm"
-                      onClick={() => addCommentMutation.mutate()}
-                      disabled={!commentBody.trim() || addCommentMutation.isPending}
-                    >
-                      {addCommentMutation.isPending ? "Posting…" : "Comment"}
-                    </Button>
-                  </div>
-                </ApprovalPanel>
               </div>
             )}
           </div>


### PR DESCRIPTION
## Summary
- remove the Comments section from the Approval detail dialog
- stop fetching and posting approval comments from that dialog
- keep Decision note and approval actions unchanged
- add E2E coverage proving stored comments stay hidden

## Verification
- pnpm --filter @rudderhq/ui typecheck
- pnpm product-logic:check
- pnpm build
- focused Messenger approval E2E (passed in two independent real-runtime runs)
- independent code review and black-box acceptance verification

## Notes
- The approval comment API and stored data remain intact; this change only removes the modal UI surface.
- Global pnpm lint remains blocked by pre-existing import-order findings in packages/shared/src/website-icons.test.ts and ui/src/pages/Chat.side-panel.tsx.