### PR TITLE
revert: restore Messenger latest activity ordering

### DIFF
--- a/server/src/__tests__/messenger-service.test.ts
+++ b/server/src/__tests__/messenger-service.test.ts
@@ -4656,7 +4656,7 @@ describe("messengerService and issue follows", () => {
     expect(secondPage.pageInfo).toEqual({ limit: 3, nextCursor: null, hasMore: false });
   });
 
-  it("promotes older unread and processing chats across Messenger summary pages", async () => {
+  it("keeps latest-activity pagination stable across unread and processing chats", async () => {
     const orgId = randomUUID();
     const userId = "board-user-attention-pagination";
     await db.insert(organizations).values({
@@ -4723,19 +4723,15 @@ describe("messengerService and issue follows", () => {
     });
 
     expect(firstPage.items.map((item) => item.threadKey)).toEqual([
-      `chat:${unreadConversationId}`,
-      `chat:${processingConversationId}`,
       `chat:${conversationIds[0]}`,
+      `chat:${conversationIds[1]}`,
+      `chat:${conversationIds[2]}`,
     ]);
-    expect(firstPage.items[0]).toMatchObject({ unreadCount: 1, needsAttention: true });
-    expect(firstPage.items[1]?.metadata).toMatchObject({ activeGenerationId: generationId });
+    expect(secondPage.items[1]?.metadata).toMatchObject({ activeGenerationId: generationId });
+    expect(secondPage.items[2]).toMatchObject({ unreadCount: 1, needsAttention: true });
     const allThreadKeys = [...firstPage.items, ...secondPage.items].map((item) => item.threadKey);
     expect(new Set(allThreadKeys).size).toBe(6);
-    expect(allThreadKeys).toEqual([
-      `chat:${unreadConversationId}`,
-      `chat:${processingConversationId}`,
-      ...conversationIds.slice(0, 4).map((id) => `chat:${id}`),
-    ]);
+    expect(allThreadKeys).toEqual(conversationIds.map((id) => `chat:${id}`));
   });
 
   it("keeps older pinned chats in the first Messenger thread summary page", async () => {

--- a/server/src/services/chats.attention-order.ts
+++ b/server/src/services/chats.attention-order.ts
@@ -1,15 +1,11 @@
 import type { Db } from "@rudderhq/db";
 import {
-  agentIntegrationChatBindings,
   approvals,
-  chatConversations,
-  chatConversationUserStates,
   chatGenerations,
   chatMessages,
 } from "@rudderhq/db";
-import { and, desc, eq, gt, inArray, isNull, sql } from "drizzle-orm";
+import { and, desc, eq, inArray, isNull } from "drizzle-orm";
 import { ACTIVE_CHAT_GENERATION_STATUSES } from "./chats.constants.js";
-import { visibleIncomingMessageSql } from "./chats.helpers.js";
 
 export async function listActiveChatGenerationIds(
   db: Db,
@@ -56,54 +52,4 @@ export async function listPendingChatProposalConversationIds(
     ))
     .groupBy(chatMessages.conversationId);
   return new Set(rows.map((row) => row.conversationId));
-}
-
-export function chatSummaryAttentionSql(orgId: string, userId?: string | null) {
-  const activityAtSql =
-    sql<Date>`coalesce(${chatConversations.lastMessageAt}, ${chatConversations.updatedAt})`;
-  const threadKeySql = sql<string>`'chat:' || ${chatConversations.id}`;
-  const hasActiveGenerationSql = sql<boolean>`exists (
-    select 1
-    from ${chatGenerations}
-    where ${chatGenerations.orgId} = ${orgId}
-      and ${chatGenerations.conversationId} = ${chatConversations.id}
-      and ${inArray(chatGenerations.status, ACTIVE_CHAT_GENERATION_STATUSES)}
-  )`;
-  const needsAttentionSql = userId
-    ? sql<boolean>`not exists (
-        select 1
-        from ${agentIntegrationChatBindings}
-        where ${agentIntegrationChatBindings.orgId} = ${orgId}
-          and ${agentIntegrationChatBindings.conversationId} = ${chatConversations.id}
-      ) and (
-        exists (
-          select 1
-          from ${chatMessages}
-          inner join ${chatConversationUserStates}
-            on ${chatConversationUserStates.orgId} = ${orgId}
-           and ${chatConversationUserStates.userId} = ${userId}
-           and ${chatConversationUserStates.conversationId} = ${chatMessages.conversationId}
-          where ${chatMessages.orgId} = ${orgId}
-            and ${chatMessages.conversationId} = ${chatConversations.id}
-            and ${isNull(chatMessages.supersededAt)}
-            and ${visibleIncomingMessageSql()}
-            and ${gt(chatMessages.createdAt, chatConversationUserStates.lastReadAt)}
-        )
-        or exists (
-          select 1
-          from ${chatMessages}
-          inner join ${approvals} on ${approvals.id} = ${chatMessages.approvalId}
-          where ${chatMessages.orgId} = ${orgId}
-            and ${chatMessages.conversationId} = ${chatConversations.id}
-            and ${isNull(chatMessages.supersededAt)}
-            and ${approvals.status} = 'pending'
-        )
-      )`
-    : sql<boolean>`false`;
-  const attentionRankSql = sql<number>`case
-    when ${needsAttentionSql} then 0
-    when ${hasActiveGenerationSql} then 1
-    else 2
-  end`;
-  return { activityAtSql, attentionRankSql, threadKeySql };
 }

--- a/server/src/services/chats.ts
+++ b/server/src/services/chats.ts
@@ -39,7 +39,6 @@ import {
 } from "./chat-queued-message-materialization.js";
 import { createChatAnnotationMessagePersistence } from "./chats.annotation-persistence.js";
 import {
-  chatSummaryAttentionSql,
   listActiveChatGenerationIds,
   listPendingChatProposalConversationIds,
 } from "./chats.attention-order.js";
@@ -3557,28 +3556,23 @@ export function chatService(db: Db) {
     ) {
       const status = options?.status ?? "active";
       const conditions = [eq(chatConversations.orgId, orgId)];
-      const { activityAtSql, attentionRankSql, threadKeySql } =
-        chatSummaryAttentionSql(orgId, userId);
+      const activityAtSql =
+        sql<Date>`coalesce(${chatConversations.lastMessageAt}, ${chatConversations.updatedAt})`;
+      const threadKeySql = sql<string>`'chat:' || ${chatConversations.id}`;
       if (status !== "all") {
         conditions.push(eq(chatConversations.status, status));
       }
       if (options?.after) {
         const afterActivityAt = options.after.activityAt.toISOString();
         conditions.push(sql<boolean>`(
-          ${attentionRankSql} > ${options.after.attentionRank}
+          ${activityAtSql} < ${afterActivityAt}
           OR (
-            ${attentionRankSql} = ${options.after.attentionRank}
+            ${activityAtSql} = ${afterActivityAt}
             AND (
-              ${activityAtSql} < ${afterActivityAt}
+              ${chatConversations.title} > ${options.after.title}
               OR (
-                ${activityAtSql} = ${afterActivityAt}
-                AND (
-                  ${chatConversations.title} > ${options.after.title}
-                  OR (
-                    ${chatConversations.title} = ${options.after.title}
-                    AND ${threadKeySql} > ${options.after.threadKey}
-                  )
-                )
+                ${chatConversations.title} = ${options.after.title}
+                AND ${threadKeySql} > ${options.after.threadKey}
               )
             )
           )
@@ -3598,7 +3592,7 @@ export function chatService(db: Db) {
         .select()
         .from(chatConversations)
         .where(and(...conditions))
-        .orderBy(asc(attentionRankSql), desc(activityAtSql), chatConversations.title, chatConversations.id)
+        .orderBy(desc(activityAtSql), chatConversations.title, chatConversations.id)
         .$dynamic();
       if (typeof options?.limit === "number" && Number.isFinite(options.limit)) {
         query = query.limit(Math.max(1, Math.floor(options.limit)));

--- a/server/src/services/chats.types.ts
+++ b/server/src/services/chats.types.ts
@@ -20,7 +20,6 @@ export type MessageHydrationRow = MessageRow & {
 };
 
 export type ConversationSummaryCursor = {
-  attentionRank: number;
   activityAt: Date;
   title: string;
   threadKey: string;

--- a/server/src/services/messenger-thread-summary-order.test.ts
+++ b/server/src/services/messenger-thread-summary-order.test.ts
@@ -1,0 +1,80 @@
+import type { MessengerThreadSummary } from "@rudderhq/shared";
+import { describe, expect, it } from "vitest";
+import {
+  comparePinnedThenLatest,
+  decodeThreadSummaryCursor,
+  encodeThreadSummaryCursor,
+  threadSummaryIsAfterCursor,
+} from "./messenger-thread-summary-order.js";
+
+function summary(
+  threadKey: string,
+  latestActivityAt: string,
+  overrides: Partial<MessengerThreadSummary> = {},
+) {
+  return {
+    threadKey,
+    kind: "chat",
+    title: threadKey,
+    preview: null,
+    subtitle: null,
+    href: `/messenger/${threadKey}`,
+    latestActivityAt: new Date(latestActivityAt),
+    lastReadAt: null,
+    unreadCount: 0,
+    needsAttention: false,
+    isPinned: false,
+    metadata: {},
+    ...overrides,
+  } as MessengerThreadSummary;
+}
+
+describe("Messenger thread summary ordering", () => {
+  it("keeps pinning first and otherwise ignores unread and processing state", () => {
+    const pinnedRead = summary("chat:pinned", "2026-07-29T08:00:00.000Z", {
+      isPinned: true,
+    });
+    const newestRead = summary("chat:newest", "2026-07-29T12:00:00.000Z");
+    const processing = summary("chat:processing", "2026-07-29T11:00:00.000Z", {
+      metadata: { activeGenerationId: "generation-1" },
+    });
+    const oldestUnread = summary("chat:unread", "2026-07-29T10:00:00.000Z", {
+      unreadCount: 1,
+      needsAttention: true,
+    });
+
+    expect(
+      [oldestUnread, processing, newestRead, pinnedRead]
+        .sort(comparePinnedThenLatest)
+        .map((item) => item.threadKey),
+    ).toEqual([
+      "chat:pinned",
+      "chat:newest",
+      "chat:processing",
+      "chat:unread",
+    ]);
+  });
+
+  it("uses latest activity cursor position regardless of attention state", () => {
+    const middleProcessing = summary("chat:processing", "2026-07-29T11:00:00.000Z", {
+      metadata: { activeGenerationId: "generation-1" },
+    });
+    const cursor = decodeThreadSummaryCursor(
+      encodeThreadSummaryCursor(middleProcessing),
+    );
+    const newerRead = summary("chat:newer", "2026-07-29T12:00:00.000Z");
+    const olderUnread = summary("chat:older", "2026-07-29T10:00:00.000Z", {
+      unreadCount: 1,
+      needsAttention: true,
+    });
+
+    expect(cursor).toEqual({
+      activityAt: "2026-07-29T11:00:00.000Z",
+      title: "chat:processing",
+      threadKey: "chat:processing",
+      isPinned: false,
+    });
+    expect(threadSummaryIsAfterCursor(newerRead, cursor)).toBe(false);
+    expect(threadSummaryIsAfterCursor(olderUnread, cursor)).toBe(true);
+  });
+});

--- a/server/src/services/messenger-thread-summary-order.ts
+++ b/server/src/services/messenger-thread-summary-order.ts
@@ -1,29 +1,15 @@
 import type { MessengerThreadSummary } from "@rudderhq/shared";
 
 export type ThreadSummaryCursor = {
-  attentionRank: number;
   activityAt: string;
   title: string;
   threadKey: string;
   isPinned: boolean;
 };
 
-export function threadSummaryAttentionRank(
-  summary: Pick<MessengerThreadSummary, "unreadCount" | "needsAttention" | "metadata">,
-) {
-  if (summary.unreadCount > 0 || summary.needsAttention) return 0;
-  if (
-    (typeof summary.metadata?.activeExecutionRunId === "string"
-      && summary.metadata.activeExecutionRunId.length > 0)
-    || (typeof summary.metadata?.activeGenerationId === "string"
-      && summary.metadata.activeGenerationId.length > 0)
-  ) return 1;
-  return 2;
-}
-
 type OrderableThreadSummary = Pick<
   MessengerThreadSummary,
-  "latestActivityAt" | "title" | "unreadCount" | "needsAttention" | "metadata"
+  "latestActivityAt" | "title"
 > & { threadKey?: string; isPinned?: boolean };
 
 export function comparePinnedThenLatest(
@@ -32,8 +18,6 @@ export function comparePinnedThenLatest(
 ) {
   const pinnedDiff = Number(Boolean(b.isPinned)) - Number(Boolean(a.isPinned));
   if (pinnedDiff !== 0) return pinnedDiff;
-  const attentionDiff = threadSummaryAttentionRank(a) - threadSummaryAttentionRank(b);
-  if (attentionDiff !== 0) return attentionDiff;
   const aTime = a.latestActivityAt?.getTime() ?? Number.NEGATIVE_INFINITY;
   const bTime = b.latestActivityAt?.getTime() ?? Number.NEGATIVE_INFINITY;
   if (aTime !== bTime) return bTime - aTime;
@@ -46,7 +30,6 @@ export function encodeThreadSummaryCursor(summary: MessengerThreadSummary) {
     ? new Date(summary.latestActivityAt)
     : new Date(0);
   const payload: ThreadSummaryCursor = {
-    attentionRank: threadSummaryAttentionRank(summary),
     activityAt: (Number.isNaN(activityAt.getTime()) ? new Date(0) : activityAt).toISOString(),
     title: summary.title,
     threadKey: summary.threadKey,
@@ -71,10 +54,6 @@ export function decodeThreadSummaryCursor(
       || decoded.threadKey.length === 0
     ) return null;
     return {
-      attentionRank: typeof decoded.attentionRank === "number"
-        && Number.isFinite(decoded.attentionRank)
-        ? decoded.attentionRank
-        : 2,
       activityAt: decoded.activityAt,
       title: decoded.title,
       threadKey: decoded.threadKey,
@@ -95,8 +74,5 @@ export function threadSummaryIsAfterCursor(
     title: cursor.title,
     threadKey: cursor.threadKey,
     isPinned: cursor.isPinned,
-    unreadCount: cursor.attentionRank === 0 ? 1 : 0,
-    needsAttention: cursor.attentionRank === 0,
-    metadata: cursor.attentionRank === 1 ? { activeGenerationId: "cursor" } : undefined,
   }) > 0;
 }

--- a/server/src/services/messenger.ts
+++ b/server/src/services/messenger.ts
@@ -2780,7 +2780,6 @@ export function messengerService(db: Db) {
     const syntheticAfterCursor = syntheticSummaries.filter((summary) => threadSummaryIsAfterCursor(summary, cursor));
     const chatAfter = cursor && !cursor.isPinned
       ? {
-        attentionRank: cursor.attentionRank,
         activityAt: new Date(cursor.activityAt),
         title: cursor.title,
         threadKey: cursor.threadKey,

--- a/tests/e2e/messenger-contract.spec.ts
+++ b/tests/e2e/messenger-contract.spec.ts
@@ -440,7 +440,7 @@ test.describe("Messenger unified threads contract", () => {
     ]);
   });
 
-  test("prioritizes unread, processing, and read messages within latest and project views", async ({ page }) => {
+  test("keeps latest activity order regardless of unread and processing state", async ({ page }) => {
     const sessionRes = await page.request.get("/api/auth/get-session");
     expect(sessionRes.ok()).toBe(true);
     const session = await sessionRes.json();
@@ -518,11 +518,11 @@ test.describe("Messenger unified threads contract", () => {
     const readTestId = threadTestId(`chat:${readChatId}`);
     await expect(page.getByTestId(unreadTestId)).toContainText("Oldest unread chat");
     await expect(page.getByTestId(processingTestId).getByLabel("Chat reply in progress")).toBeVisible();
-    await expectTestIdsInDomOrder(page, [unreadTestId, processingTestId, readTestId]);
+    await expectTestIdsInDomOrder(page, [readTestId, processingTestId, unreadTestId]);
 
     await page.getByTestId(unreadTestId).getByRole("link").click();
     await expect(page).toHaveURL(new RegExp(`/messenger/chat/${unreadChatId}`));
-    await expectTestIdsInDomOrder(page, [processingTestId, readTestId, unreadTestId]);
+    await expectTestIdsInDomOrder(page, [readTestId, processingTestId, unreadTestId]);
 
     await page.evaluate((orgId) => {
       window.localStorage.setItem("rudder.messengerThreadOrganizationByOrg", JSON.stringify({ [orgId]: "project" }));
@@ -531,8 +531,8 @@ test.describe("Messenger unified threads contract", () => {
     const projectSection = page.getByTestId(`messenger-thread-section-project-${projectId}`);
     await expect(projectSection).toBeVisible();
     await expectTestIdWithinSection(page, `messenger-thread-section-project-${projectId}`, processingTestId);
-    await expectTestIdsInDomOrder(page, [processingTestId, readTestId, unreadTestId]);
-    await page.screenshot({ path: "/tmp/rudder-messenger-attention-order-project.png", fullPage: true });
+    await expectTestIdsInDomOrder(page, [readTestId, processingTestId, unreadTestId]);
+    await page.screenshot({ path: "/tmp/rudder-messenger-latest-order-project.png", fullPage: true });
   });
 
   test("double-clicking primary rail Messenger cycles the sidebar through unread threads", async ({ page }) => {

--- a/ui/src/components/MessengerContextSidebar.test.tsx
+++ b/ui/src/components/MessengerContextSidebar.test.tsx
@@ -635,7 +635,7 @@ describe("MessengerContextSidebar", () => {
     );
   });
 
-  it("keeps attention order across historical manual rows while preserving Saved View slots", () => {
+  it("keeps historical manual rows and Saved View slots regardless of unread state", () => {
     chatList = [];
     localStorageValues["rudder.messengerThreadOrganizationByOrg"] = JSON.stringify({ "org-1": "custom" });
     localStorageValues["rudder.messengerDefaultThreadOrder:org-1:anonymous"] = JSON.stringify([
@@ -708,8 +708,8 @@ describe("MessengerContextSidebar", () => {
 
     const html = renderToStaticMarkup(<MessengerContextSidebar />);
 
-    expect(html.indexOf("Older unread chat")).toBeLessThan(html.indexOf("Saved attention slot"));
-    expect(html.indexOf("Saved attention slot")).toBeLessThan(html.indexOf("Newer read chat"));
+    expect(html.indexOf("Newer read chat")).toBeLessThan(html.indexOf("Saved attention slot"));
+    expect(html.indexOf("Saved attention slot")).toBeLessThan(html.indexOf("Older unread chat"));
   });
 
   it("keeps pinned grouped threads inside their custom group in persisted order", () => {

--- a/ui/src/components/MessengerContextSidebar.tsx
+++ b/ui/src/components/MessengerContextSidebar.tsx
@@ -101,7 +101,6 @@ import { messengerSavedViewRoute } from "@/lib/messenger-saved-views";
 import { messengerThreadKindLabel } from "@/lib/messenger-thread-labels";
 import {
   applyManualDirectoryOrder,
-  applyVisibleThreadAttentionOrder,
   chatConversationForThreadSummary,
   customGroupIdFromSectionKey,
   customGroupSectionKey,
@@ -2956,10 +2955,7 @@ export function MessengerContextSidebar() {
     const manuallyOrderedCustomEntries = customGroup?.entries
       .slice()
       .sort((left, right) => left.sortOrder - right.sortOrder) ?? [];
-    const orderedCustomEntries = applyVisibleThreadAttentionOrder(
-      manuallyOrderedCustomEntries,
-      visibleEntries,
-    );
+    const orderedCustomEntries = manuallyOrderedCustomEntries;
     const renderedEntryNodes = customGroup
       ? orderedCustomEntries.map((entry) => {
         if (isSavedViewCustomGroupEntry(entry)) {

--- a/ui/src/lib/messenger-query-cache.test.ts
+++ b/ui/src/lib/messenger-query-cache.test.ts
@@ -135,7 +135,7 @@ describe("upsertMessengerThreadSummaryQueries", () => {
     expect(pages?.[1]?.items.map((item) => item.threadKey)).toEqual([]);
   });
 
-  it("keeps optimistic cache merges aligned with unread, processing, and read priority", () => {
+  it("keeps optimistic cache merges ordered by pinning and latest activity", () => {
     const queryClient = new QueryClient();
     const orgId = "org-1";
     const newerRead = thread({
@@ -170,9 +170,9 @@ describe("upsertMessengerThreadSummaryQueries", () => {
       pages: Array<{ items: MessengerThreadSummary[] }>;
     }>(queryKeys.messenger.threadPages(orgId, false))?.pages[0]?.items;
     expect(items?.map((item) => item.threadKey)).toEqual([
-      "chat:unread",
-      "chat:processing",
       "chat:read",
+      "chat:processing",
+      "chat:unread",
     ]);
   });
 });

--- a/ui/src/lib/messenger-query-cache.ts
+++ b/ui/src/lib/messenger-query-cache.ts
@@ -23,7 +23,6 @@ function isThreadCustomGroupEntry(
 
 function encodeMessengerThreadSummaryCursor(summary: MessengerThreadSummary) {
   const payload = {
-    attentionRank: messengerThreadSummaryAttentionRank(summary),
     activityAt: new Date(summary.latestActivityAt ?? 0).toISOString(),
     title: summary.title,
     threadKey: summary.threadKey,
@@ -36,24 +35,10 @@ function encodeMessengerThreadSummaryCursor(summary: MessengerThreadSummary) {
   return base64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
 }
 
-function messengerThreadSummaryAttentionRank(summary: MessengerThreadSummary) {
-  if (summary.unreadCount > 0 || summary.needsAttention) return 0;
-  if (
-    (typeof summary.metadata?.activeExecutionRunId === "string" && summary.metadata.activeExecutionRunId.length > 0)
-    || (typeof summary.metadata?.activeGenerationId === "string" && summary.metadata.activeGenerationId.length > 0)
-  ) {
-    return 1;
-  }
-  return 2;
-}
-
 function compareMessengerThreadSummaries(a: MessengerThreadSummary, b: MessengerThreadSummary) {
   const aPinned = Boolean(a.isPinned);
   const bPinned = Boolean(b.isPinned);
   if (aPinned !== bPinned) return aPinned ? -1 : 1;
-  const attentionDiff =
-    messengerThreadSummaryAttentionRank(a) - messengerThreadSummaryAttentionRank(b);
-  if (attentionDiff !== 0) return attentionDiff;
   const aTime = a.latestActivityAt ? new Date(a.latestActivityAt).getTime() : Number.NEGATIVE_INFINITY;
   const bTime = b.latestActivityAt ? new Date(b.latestActivityAt).getTime() : Number.NEGATIVE_INFINITY;
   if (aTime !== bTime) return bTime - aTime;

--- a/ui/src/lib/messenger-thread-organization.test.ts
+++ b/ui/src/lib/messenger-thread-organization.test.ts
@@ -10,7 +10,6 @@ import {
   flattenThreadSectionEntries,
   flattenThreadSections,
   locallyReadThreadSummary,
-  messengerThreadAttentionRank,
   nextDefaultThreadOrderKeysAfterMove,
   organizeCustomThreadDirectory,
   organizeProjectThreadDirectory,
@@ -217,7 +216,7 @@ describe("messenger thread organization", () => {
     )).toEqual(["chat:hidden", "chat:c", "chat:a", "chat:b"]);
   });
 
-  it("orders unread or attention work before processing work and settled work", () => {
+  it("orders work by latest activity regardless of unread or processing state", () => {
     const entries = [
       entry("chat:new-read", {
         latestActivityAt: new Date("2026-07-17T08:05:00.000Z"),
@@ -244,16 +243,15 @@ describe("messenger thread organization", () => {
     ].sort(compareThreadEntries);
 
     expect(entries.map((item) => item.thread.threadKey)).toEqual([
-      "chat:older-unread",
-      "issue:attention-and-processing",
+      "chat:new-read",
       "issue:newer-processing",
       "chat:older-processing",
-      "chat:new-read",
+      "chat:older-unread",
+      "issue:attention-and-processing",
     ]);
-    expect(entries.map((item) => messengerThreadAttentionRank(item.thread))).toEqual([0, 0, 1, 1, 2]);
   });
 
-  it("keeps pinning above attention rank and manual order within each rank", () => {
+  it("keeps pinning above the persisted manual order", () => {
     const sections = organizeCustomThreadDirectory(
       [
         entry("chat:pinned-read", { isPinned: true }),
@@ -267,13 +265,13 @@ describe("messenger thread organization", () => {
 
     expect(flattenThreadSectionEntries(sections).map((item) => item.thread.threadKey)).toEqual([
       "chat:pinned-read",
+      "chat:read",
       "chat:unread",
       "chat:processing",
-      "chat:read",
     ]);
   });
 
-  it("applies attention rank within project and custom-group boundaries", () => {
+  it("uses latest activity in projects and preserves custom-group order", () => {
     const projectConversation = conversation("project", {
       contextLinks: [{
         entityType: "project",
@@ -282,14 +280,22 @@ describe("messenger thread organization", () => {
       } as ChatConversation["contextLinks"][number]],
     });
     const projectSections = organizeThreadEntries([
-      entry("chat:project-read", {}, projectConversation),
-      entry("chat:project-processing", { metadata: { isProcessing: true } }, projectConversation),
-      entry("chat:project-unread", { unreadCount: 1 }, projectConversation),
+      entry("chat:project-read", {
+        latestActivityAt: new Date("2026-07-17T08:03:00.000Z"),
+      }, projectConversation),
+      entry("chat:project-processing", {
+        latestActivityAt: new Date("2026-07-17T08:02:00.000Z"),
+        metadata: { isProcessing: true },
+      }, projectConversation),
+      entry("chat:project-unread", {
+        latestActivityAt: new Date("2026-07-17T08:01:00.000Z"),
+        unreadCount: 1,
+      }, projectConversation),
     ], "project", new Map(), new Map(), (kind) => kind);
     expect(projectSections[0]?.entries.map((item) => item.thread.threadKey)).toEqual([
-      "chat:project-unread",
-      "chat:project-processing",
       "chat:project-read",
+      "chat:project-processing",
+      "chat:project-unread",
     ]);
 
     const customSections = organizeProjectThreadDirectory([], [{
@@ -303,7 +309,7 @@ describe("messenger thread organization", () => {
       ],
     }], new Map());
     expect(customSections[0]?.childSections?.[0]?.entries.map((item) => item.thread.threadKey))
-      .toEqual(["chat:group-unread", "chat:group-processing", "chat:group-read"]);
+      .toEqual(["chat:group-read", "chat:group-processing", "chat:group-unread"]);
   });
 
   it("never moves an unpinned custom section ahead of a pinned section", () => {

--- a/ui/src/lib/messenger-thread-organization.ts
+++ b/ui/src/lib/messenger-thread-organization.ts
@@ -1,8 +1,6 @@
 import type {
   Agent,
   ChatConversation,
-  MessengerCustomGroupHydratedEntry,
-  MessengerCustomGroupHydratedThreadEntry,
   MessengerSavedView,
   MessengerThreadSummary,
   Project,
@@ -61,12 +59,7 @@ export function applyManualDirectoryOrder(
     ...manualItems,
     ...items.slice(firstManualIndex).filter((item) => !manualKeys.has(item.key)),
   ];
-  const attentionOrderedSections = items.filter((item) => item.kind === "section");
-  let nextSectionIndex = 0;
-  return manuallyOrderedItems.map((item) => {
-    if (item.kind !== "section") return item;
-    return attentionOrderedSections[nextSectionIndex++] ?? item;
-  });
+  return manuallyOrderedItems;
 }
 
 export function withLiveProcessingState(
@@ -79,26 +72,6 @@ export function withLiveProcessingState(
     ...thread,
     metadata: { ...thread.metadata, isProcessing: true },
   };
-}
-
-export function applyVisibleThreadAttentionOrder(
-  manuallyOrderedEntries: MessengerCustomGroupHydratedEntry[],
-  visibleEntries: OrganizedThreadEntry[],
-) {
-  const threadEntryByKey = new Map(
-    manuallyOrderedEntries
-      .filter((entry): entry is MessengerCustomGroupHydratedThreadEntry =>
-        entry.item.type === "thread")
-      .map((entry) => [entry.threadKey, entry]),
-  );
-  const attentionOrderedEntries = visibleEntries
-    .map((entry) => threadEntryByKey.get(entry.thread.threadKey) ?? null)
-    .filter((entry): entry is MessengerCustomGroupHydratedThreadEntry => Boolean(entry));
-  let nextVisibleThreadIndex = 0;
-  return manuallyOrderedEntries.map((entry) =>
-    entry.item.type === "thread"
-      ? attentionOrderedEntries[nextVisibleThreadIndex++] ?? entry
-      : entry);
 }
 
 export interface CustomThreadGroupLayoutInput {
@@ -468,35 +441,11 @@ function entryActivityTime(entry: OrganizedThreadEntry) {
   return value ? new Date(value).getTime() : Number.NEGATIVE_INFINITY;
 }
 
-export function messengerThreadAttentionRank(thread: MessengerThreadSummary) {
-  if (thread.unreadCount > 0 || thread.needsAttention) return 0;
-  if (
-    thread.metadata?.isProcessing === true
-    || (typeof thread.metadata?.activeExecutionRunId === "string" && thread.metadata.activeExecutionRunId.length > 0)
-    || (typeof thread.metadata?.activeGenerationId === "string" && thread.metadata.activeGenerationId.length > 0)
-  ) {
-    return 1;
-  }
-  return 2;
-}
-
 export function compareThreadEntries(a: OrganizedThreadEntry, b: OrganizedThreadEntry) {
   if (isPinnedEntry(a) !== isPinnedEntry(b)) return isPinnedEntry(a) ? -1 : 1;
-  const attentionDiff = messengerThreadAttentionRank(a.thread) - messengerThreadAttentionRank(b.thread);
-  if (attentionDiff !== 0) return attentionDiff;
   const timeDiff = entryActivityTime(b) - entryActivityTime(a);
   if (timeDiff !== 0) return timeDiff;
   return a.thread.title.localeCompare(b.thread.title);
-}
-
-function sortEntriesByAttentionPreservingOrder(entries: OrganizedThreadEntry[]) {
-  return entries
-    .map((entry, index) => ({ entry, index }))
-    .sort((a, b) => (
-      messengerThreadAttentionRank(a.entry.thread) - messengerThreadAttentionRank(b.entry.thread)
-      || a.index - b.index
-    ))
-    .map(({ entry }) => entry);
 }
 
 function sectionActivityTime(section: OrganizedThreadSection) {
@@ -506,17 +455,8 @@ function sectionActivityTime(section: OrganizedThreadSection) {
   );
 }
 
-function sectionAttentionRank(section: OrganizedThreadSection) {
-  return section.entries.reduce(
-    (rank, entry) => Math.min(rank, messengerThreadAttentionRank(entry.thread)),
-    2,
-  );
-}
-
 export function compareCustomLayoutSections(a: OrganizedThreadSection, b: OrganizedThreadSection) {
   if (Boolean(a.isPinned) !== Boolean(b.isPinned)) return a.isPinned ? -1 : 1;
-  const attentionDiff = sectionAttentionRank(a) - sectionAttentionRank(b);
-  if (attentionDiff !== 0) return attentionDiff;
   const timeDiff = sectionActivityTime(b) - sectionActivityTime(a);
   if (timeDiff !== 0) return timeDiff;
   return (a.label ?? a.entries[0]?.thread.title ?? a.key)
@@ -550,15 +490,9 @@ export function sortCustomLayoutSections(
   if (orderedSectionKeys.length === 0) return sections;
   const pinnedSections = sections.filter((section) => section.isPinned);
   const unpinnedSections = sections.filter((section) => !section.isPinned);
-  const applyOrderWithinAttentionRanks = (domainSections: OrganizedThreadSection[]) => (
-    [0, 1, 2].flatMap((rank) => applyManualCustomLayoutOrder(
-      domainSections.filter((section) => sectionAttentionRank(section) === rank),
-      orderedSectionKeys,
-    ))
-  );
   return [
-    ...applyOrderWithinAttentionRanks(pinnedSections),
-    ...applyOrderWithinAttentionRanks(unpinnedSections),
+    ...applyManualCustomLayoutOrder(pinnedSections, orderedSectionKeys),
+    ...applyManualCustomLayoutOrder(unpinnedSections, orderedSectionKeys),
   ];
 }
 
@@ -596,9 +530,7 @@ export function organizeCustomThreadDirectory(
     label: group.name,
     icon: group.icon,
     isPinned: group.pinned,
-    entries: sortEntriesByAttentionPreservingOrder(
-      group.entries.map((entry) => ({ ...entry, customGroupId: group.id })),
-    ),
+    entries: group.entries.map((entry) => ({ ...entry, customGroupId: group.id })),
   }) satisfies OrganizedThreadSection);
   const ungroupedEntries = looseEntries
     .filter((entry) => !groupedThreadKeys.has(entry.thread.threadKey))
@@ -608,16 +540,12 @@ export function organizeCustomThreadDirectory(
     ...groupSections.flatMap((section) => section.entries),
     ...ungroupedEntries,
   ]);
-  const orderedPinnedLooseEntries = [0, 1, 2].flatMap((rank) => applyManualCustomEntryOrder(
+  const pinnedLooseEntries = applyManualCustomEntryOrder(
     allEntries
-      .filter((entry) =>
-        isPinnedEntry(entry)
-        && entry.customGroupId === null
-        && messengerThreadAttentionRank(entry.thread) === rank,
-      )
+      .filter((entry) => isPinnedEntry(entry) && entry.customGroupId === null)
       .sort(compareThreadEntries),
     orderedSectionKeys,
-  ));
+  );
   const looseSections = ungroupedEntries
     .filter((entry) => !isPinnedEntry(entry))
     .map((entry) => ({
@@ -633,11 +561,11 @@ export function organizeCustomThreadDirectory(
   );
   const pinnedChildSections = [
     ...topLevelSections.filter((section) => section.isPinned),
-    ...(orderedPinnedLooseEntries.length > 0
+    ...(pinnedLooseEntries.length > 0
       ? [{
         key: "custom:pinned:loose",
         label: null,
-        entries: orderedPinnedLooseEntries,
+        entries: pinnedLooseEntries,
       } satisfies OrganizedThreadSection]
       : []),
   ];
@@ -666,15 +594,13 @@ export function organizeProjectThreadDirectory(
     label: group.name,
     icon: group.icon,
     isPinned: group.pinned,
-    entries: sortEntriesByAttentionPreservingOrder(
-      group.entries
-        .filter((entry) => {
-          if (groupedThreadKeys.has(entry.thread.threadKey)) return false;
-          groupedThreadKeys.add(entry.thread.threadKey);
-          return true;
-        })
-        .map((entry) => ({ ...entry, customGroupId: group.id })),
-    ),
+    entries: group.entries
+      .filter((entry) => {
+        if (groupedThreadKeys.has(entry.thread.threadKey)) return false;
+        groupedThreadKeys.add(entry.thread.threadKey);
+        return true;
+      })
+      .map((entry) => ({ ...entry, customGroupId: group.id })),
   }) satisfies OrganizedThreadSection);
   const ungroupedEntries = dedupeOrganizedThreadEntriesByKey(looseEntries)
     .filter((entry) => !groupedThreadKeys.has(entry.thread.threadKey))


### PR DESCRIPTION
Summary:
- remove unread/processing/read priority sorting
- restore pinned-first, then latest-activity ordering across Latest and Project views
- preserve custom manual ordering and processing indicators

Validation:
- 72 targeted UI tests passed
- 2 server ordering unit tests passed
- server and UI typechecks passed
- UI production build passed
- real local Playwright acceptance passed for Latest, Project, read transitions, processing indicator, and pinned boundary

Note: the DB-backed messenger-service test could not initialize its temporary PostgreSQL cluster in this shared host; equivalent cursor behavior is covered by the new isolated server unit test and the real local E2E.