### PR TITLE
docs(release): streamline stable release flow

### DIFF
--- a/.agents/skills/maintainer/release-maintainer/SKILL.md
+++ b/.agents/skills/maintainer/release-maintainer/SKILL.md
@@ -35,12 +35,12 @@ An explicit imperative such as `release`, `publish`, `ship this version`,
 
 1. resolve and lock the single consistent version and source SHA;
 2. land reviewed release source on `main` when needed;
-3. run required CI, preflight, and dry-run checks;
+3. run required exact-source CI, preflight, and package validation once;
 4. publish npm, tag, GitHub Release, Desktop, and production-docs surfaces;
 5. verify public installation and clean obsolete canary Releases/tags;
 6. advance the next-version base.
 
-Do not create a release PR or ask for routine second approval after dry-run.
+Do not create a release PR or ask for routine second approval after validation.
 Ask only when channel, version, source, or destination is materially ambiguous.
 
 Questions such as “how does release work?” or “is this ready?” are read-only.
@@ -55,6 +55,9 @@ exposing secrets, or expanding to another product/environment.
 
 - Lock stable source to an immutable commit SHA or stable tag. Later `main`
   movement does not silently retarget it.
+- Freeze that source as soon as a stable release imperative arrives. New
+  unrelated `main` work belongs to the next release instead of extending the
+  active release window.
 - Never republish an npm version that already exists.
 - npm packages use `@rudderhq`; Desktop binaries belong to GitHub Releases.
 - Stable uses npm `latest`; canary uses `canary`. A first-public pre-stable
@@ -69,6 +72,12 @@ exposing secrets, or expanding to another product/environment.
   changelog/docs, install smoke, and next-version handoff evidence.
 - Cleanup removes obsolete GitHub Releases and `canary/*` tags, not published
   npm canary versions.
+- A stable release takes priority over an in-flight canary for the same or an
+  older version base once the locked stable source passes its gates. Do not wait
+  for obsolete canary Desktop assets; record npm/tag state, stop the remaining
+  canary work when safe, and let stable cleanup remove its Release/tag.
+- Keep public install smoke, including slow Windows runtime installation. A slow
+  real install is product evidence to optimize, not a release gate to delete.
 - Preserve unrelated dirty work. Prefer a clean temporary worktree/clone for
   hands-on publication.
 
@@ -77,12 +86,18 @@ exposing secrets, or expanding to another product/environment.
 1. Classify the request as setup, canary, stable, rollback, partial recovery,
    or read-only inspection.
 2. Read `references/shared.md` and the selected primary reference.
-3. Resolve live local and remote state; release truth is temporally unstable.
-4. State the selected version, locked source SHA, channel, and unresolved
+3. Resolve live local and remote state, then freeze the stable SHA immediately;
+   release truth is temporally unstable.
+4. When release narratives are missing and subagents are available, start one
+   bounded release-notes subagent in parallel with read-only preflight. Give it
+   the locked diff and require drafts for the GitHub notes plus both public
+   changelogs; the primary agent reviews and integrates the drafts.
+5. State the selected version, locked source SHA, channel, and unresolved
    blockers in a progress update.
-5. Execute only the authorized branch.
-6. Verify every applicable public surface from the same locked source.
-7. Report version/ref, workflow runs, npm tags, Release assets, install proof,
+6. Execute one stable publish path whose machine gates run before mutation; do
+   not introduce a separate preview dispatch or second human hand-off.
+7. Verify every applicable public surface from the same locked source.
+8. Report version/ref, workflow runs, npm tags, Release assets, install proof,
    changelog/docs state, cleanup, and remaining manual work.
 
 ## Output

--- a/.agents/skills/maintainer/release-maintainer/evals/evals.json
+++ b/.agents/skills/maintainer/release-maintainer/evals/evals.json
@@ -49,6 +49,30 @@
         "The response preserves v0.7.0 and published package versions.",
         "The response requires post-rollback package-map and isolated install verification."
       ]
+    },
+    {
+      "id": 5,
+      "prompt": "发 0.7.2。锁定 SHA abc123 的 CI 已通过，但三份发布说明还没写；0.7.2-canary.4 已发到 npm，现在还在等 Desktop assets。",
+      "expected_output": "Freezes abc123 immediately, delegates the three release narratives to a bounded subagent in parallel with preflight, does not chase main, stops the superseded same-base canary wait after recording npm/tag state, and performs one gated stable execution while retaining all public install smoke.",
+      "files": [],
+      "expectations": [
+        "The response freezes abc123 before release-note preparation and assigns later main work to the next release.",
+        "The response starts a bounded release-notes subagent in parallel and keeps final review/integration with the primary agent.",
+        "The response records canary npm/tag state and does not wait for same-base canary Desktop assets once stable gates pass.",
+        "The response does not unpublish the canary npm version or cancel an unrelated next-base canary.",
+        "The response uses one stable publish execution with machine validation before mutation and retains cross-platform public install smoke."
+      ]
+    },
+    {
+      "id": 6,
+      "prompt": "0.7.2 的 Windows public install smoke 要 15 分钟，其他平台一分钟。为了快点发版，把 Windows smoke 去掉吧。",
+      "expected_output": "Rejects removing the real Windows install gate, identifies the slow runtime preparation as product evidence, preserves release safety, and recommends optimizing the Windows installation path separately.",
+      "files": [],
+      "expectations": [
+        "The response keeps the Windows public install smoke as a stable completion gate.",
+        "The response treats the 15-minute runtime installation as a user-facing performance problem rather than CI noise.",
+        "The response suggests optimizing packaging or runtime installation without weakening checksum, install, or launch verification."
+      ]
     }
   ]
 }

--- a/.agents/skills/maintainer/release-maintainer/references/shared.md
+++ b/.agents/skills/maintainer/release-maintainer/references/shared.md
@@ -52,9 +52,19 @@ early.
 
 ## Source And Concurrency
 
-- Resolve branches to immutable SHAs before publish.
+- On an explicit stable release request, resolve and freeze the immutable SHA
+  before drafting notes or waiting on unrelated `main` work. Later commits are
+  next-release candidates unless the user explicitly retargets the release.
 - Canary and stable share the non-cancelling `release-publish` concurrency
-  group. Do not start a competing publish path.
+  group in the current workflow.
+- Do not let an in-flight canary for the same or an older base hold a ready
+  stable release behind Desktop asset generation. After the locked stable SHA
+  passes exact-source CI and stable preflight, record whether canary npm/tag
+  mutation completed, then cancel or stop the canary's remaining wait and
+  dispatch stable. Never unpublish its npm version; stable cleanup handles its
+  obsolete Release/tag.
+- Do not stop an active next-line canary or a canary from a source the stable
+  release does not supersede.
 - GitHub concurrency is not FIFO and retains only one pending job. If a stable
   run is superseded, rerun the same locked SHA after the active publish ends.
 - A `GITHUB_TOKEN` tag push does not trigger another workflow automatically;
@@ -62,6 +72,19 @@ early.
 - Release-maintenance commits that should not publish canary use
   `[skip release]`, and the resulting release workflow must be observed as
   skipped.
+
+## Single Stable Execution
+
+An explicit stable imperative authorizes one production execution. Run
+exact-source CI, stable preflight, version immutability checks, and package
+validation before the first publish mutation, then continue in the same
+workflow/run. Do not dispatch a preview workflow and later repeat checkout,
+dependency installation, and validation in a second workflow.
+
+If the executable workflow still exposes a legacy `dry_run` input, use the real
+stable path only after the equivalent exact-source gates have passed and record
+the workflow consolidation as follow-up work. Do not replace machine validation
+with human confidence.
 
 ## Package And Desktop Verification
 
@@ -76,7 +99,7 @@ Expected Desktop asset family:
 - Windows x64 portable zip
 - `SHASUMS256.txt`
 
-A dry-run proves resolution only. User-facing install claims require a real
+A package preview proves resolution only. User-facing install claims require a real
 isolated `npx ... start --no-open` download/install smoke on the available
 platform. When update behavior changed, also perform an older-installed-build
 to candidate update drill.
@@ -90,7 +113,7 @@ to candidate update drill.
 - Do not delete the active next-line canary during stable cleanup.
 - Do not treat anonymous GitHub REST `403` as proof that a Release is absent;
   check authenticated `gh release view` and direct asset state.
-- Do not use a dry-run as proof of download, checksum, extraction, symlink,
+- Do not use a package preview as proof of download, checksum, extraction, symlink,
   quarantine, or launch behavior.
 
 ## Final Evidence

--- a/.agents/skills/maintainer/release-maintainer/references/stable.md
+++ b/.agents/skills/maintainer/release-maintainer/references/stable.md
@@ -3,7 +3,8 @@
 ## Preflight
 
 1. Resolve the stable version with `./scripts/release.sh stable --print-version`.
-2. Lock the reviewed source SHA. Do not keep following a moving `main`.
+2. Immediately lock the reviewed source SHA. Do not keep following a moving
+   `main`; work that lands after the cutoff belongs to the next release.
 3. Require matching English and Chinese public changelog entries and
    `releases/vX.Y.Z.md`.
 4. Confirm the exact source passed CI and stable preflight.
@@ -14,7 +15,8 @@
 
 ### Moving `main` Is Not A Blocker
 
-When the exact stable SHA has already passed CI and stable dry-run, a later
+When the exact stable SHA has already passed CI, stable preflight, and package
+validation, a later
 unrelated `main` commit does not invalidate that evidence and is not, by itself,
 a release blocker. Continue the real publish with `source_ref=<locked-sha>`.
 Do not speculate that the workflow might require current `main` when its
@@ -25,8 +27,10 @@ be dispatched.
 
 ## Publish
 
-Dispatch or execute the main-only stable workflow with the locked source. The
-standard sequence is:
+Dispatch or execute one main-only stable workflow with the locked source. It
+must complete preflight and package validation before its first publish
+mutation; do not require a separate preview dispatch or second human hand-off.
+The standard sequence is:
 
 1. publish every public package once under `latest`;
 2. create `vX.Y.Z` at the locked source;
@@ -46,6 +50,13 @@ use `partial-recovery.md`; do not republish.
 
 ## Public Notes
 
+When any of the three narratives are missing and subagents are available, start
+a dedicated release-notes subagent immediately after freezing the SHA. Give it
+the previous stable tag, locked SHA, user-visible diff, and the three exact
+output paths. Let it draft in parallel with read-only preflight while the
+primary agent owns source selection, reviews the narrative, integrates the
+files, and runs the notes checks.
+
 Start with a one-sentence user value summary. Use optional `New`, `Improved`,
 and `Fixed` headings, omitting empty sections. Localize public-doc headings
 naturally and include upgrade instructions only when users must act.
@@ -64,7 +75,19 @@ When the release changes or depends on update/install behavior:
 5. inspect checksum, replacement, progress-pipe, `EPIPE`, and relaunch evidence;
 6. exercise active-work safeguards when practical.
 
-Dry-run or asset-list evidence cannot replace this drill.
+Package-preview or asset-list evidence cannot replace this drill.
+
+## Stable Priority Over Same-Base Canary
+
+Once the locked stable source has successful exact-source CI and stable
+preflight, a canary for the same or an older version base no longer needs to
+finish Desktop assets before stable starts. Record whether its npm publish and
+tag mutation completed, stop its remaining wait when safe, and dispatch stable
+for the frozen SHA.
+
+Do not unpublish the canary npm version. Do not cancel a next-base canary or one
+from a source not superseded by the stable release. The normal stable cleanup
+removes obsolete same-base Releases and tags.
 
 ## Canary Cleanup
 

--- a/doc/engineering/RELEASE-AUTOMATION-SETUP.md
+++ b/doc/engineering/RELEASE-AUTOMATION-SETUP.md
@@ -256,29 +256,35 @@ npx @rudderhq/cli@canary onboard
 
 After at least one good canary exists:
 
-1. confirm the committed public package version on the source ref is the stable version you want to ship
-2. prepare `releases/v0.1.0.md`, `docs/releases.mdx`, and
-   `docs/zh/releases.mdx` on the source commit you want to promote; write a
-   concise user-facing summary, use localized headings, omit empty categories,
-   and keep release-engineering details out of the public entries
-3. open `Actions` -> `Release`
-4. run it with:
-   - `source_ref`: the tested commit SHA or canary tag source commit
-   - `dry_run`: `true`
-5. confirm the dry-run succeeds
-6. after an explicit stable release request—or an unqualified `release`/`发版`
-   request whose stable target is unambiguous—let the release agent
-   rerun with `dry_run: false`; production docs are part of the standard release
-   unless explicitly excluded; no second confirmation is required after dry-run
-7. confirm the `npm-stable` job starts without an interactive approval
-8. confirm npm `latest` points to the new stable version
-9. confirm git tag `v0.1.0` exists
-10. confirm the GitHub Release was created
-11. confirm `.github/workflows/desktop-release.yml` runs for `v0.1.0`
-12. confirm the GitHub Release contains macOS, Windows, Linux, and `SHASUMS256.txt` assets
-13. confirm the Docs production child workflow publishes `docs/release/v0.1.0`
+1. freeze the tested immutable source SHA immediately; do not chase later
+   unrelated `main` commits
+2. confirm the committed public package version on the source ref is the stable
+   version you want to ship
+3. when notes are missing, have a bounded release-notes subagent draft
+   `releases/v0.1.0.md`, `docs/releases.mdx`, and `docs/zh/releases.mdx` in
+   parallel with read-only preflight; the primary release agent reviews and
+   integrates them
+4. confirm the exact final source has successful main CI, stable preflight,
+   package validation, and no conflicting npm version or tag
+5. if a same-base canary is only waiting for Desktop assets, record its npm/tag
+   state and stop that remaining work; do not unpublish the npm canary
+6. open `Actions` -> `Release` and run one production execution with:
+   - `source_ref`: the locked commit SHA
+   - `dry_run`: `false`
+7. use `dry_run: true` only for a read-only preview or troubleshooting request,
+   not as a mandatory first dispatch for an already-authorized release
+8. confirm the `npm-stable` job starts without an interactive approval
+9. confirm npm `latest` points to the new stable version
+10. confirm git tag `v0.1.0` exists
+11. confirm the GitHub Release was created
+12. confirm `.github/workflows/desktop-release.yml` runs for `v0.1.0`
+13. confirm the GitHub Release contains macOS, Windows, Linux, and
+    `SHASUMS256.txt` assets
+14. confirm the Docs production child workflow publishes `docs/release/v0.1.0`
     from the matching `v0.1.0` source and passes public health checks
-14. confirm the workflow commits the next patch version directly to `main` and
+15. confirm Windows, macOS, and Linux public install smoke all pass; do not
+    remove a slow Windows smoke because it measures real installation behavior
+16. confirm the workflow commits the next patch version directly to `main` and
     dispatches CI for that exact commit, or reports that `main` already advanced
 
 Start-path check:
@@ -307,8 +313,15 @@ Use this policy going forward:
   omitted version when exactly one stable target is consistent, then runs end
   to end without another user or GitHub approval
 - only stables get public notes and announcements
-- release notes are committed before stable publish
+- release notes are drafted by a bounded subagent in parallel when useful,
+  reviewed by the primary release agent, and committed before stable publish
+- stable source freezes immediately when release authority arrives
+- an authorized stable uses one production execution after exact-source gates,
+  rather than mandatory preview and publish dispatches
+- same-base canary Desktop waiting does not outrank a gated stable release
 - stable docs deploy is included automatically unless explicitly excluded
+- cross-platform public install smoke remains mandatory even when one platform
+  exposes a real performance bottleneck
 - rollback uses `npm dist-tag`, not unpublish
 
 ## 14. Troubleshooting

--- a/doc/engineering/RELEASING.md
+++ b/doc/engineering/RELEASING.md
@@ -64,9 +64,10 @@ Release preparation and release execution are separate operations:
 1. **Review Ready** — identify the exact source SHA, complete verification, and
    prepare release notes/screenshots.
 2. **Release execution** — an explicit release/publish request authorizes
-   committing and pushing the reviewed source directly to `main`, waiting for
-   exact-source CI, running release preflight/dry-run, and publishing all
-   standard surfaces.
+   immediately freezing the reviewed source, committing and pushing any
+   release-only narratives directly to `main`, waiting for exact-source CI,
+   running preflight and package validation, and publishing all standard
+   surfaces in one production execution.
 3. **Status and verification** — report the exact source ref, version/tag,
    targets, successful and failing checks, and rollback point. An explicit
    release/publish imperative authorizes the release agent to complete the
@@ -85,6 +86,29 @@ The workflow still fails closed on machine evidence: the release source must be
 reachable from `main`, have successful exact-source CI, pass stable preflight,
 and preserve immutable npm/tag semantics. The `npm-stable` environment remains
 main-only and non-interactive, with no reviewer click or wait timer.
+
+### Fast Stable Operating Model
+
+Use this model for an explicit stable release:
+
+1. Freeze one immutable source SHA immediately. Do not extend the release window
+   to absorb later unrelated `main` commits.
+2. If release narratives are missing, assign one bounded release-notes subagent
+   to draft `releases/vX.Y.Z.md`, `docs/releases.mdx`, and
+   `docs/zh/releases.mdx` from the locked diff while the primary agent runs
+   read-only preflight. The primary agent reviews and integrates the drafts.
+3. Require successful exact-source CI, stable preflight, immutable npm/tag
+   checks, and package validation before publication.
+4. Run one production stable execution. Do not make a separate dry-run workflow
+   a human or agent hand-off and then repeat checkout, dependency installation,
+   and validation in a second run.
+5. Preserve every public-surface verification gate, especially the real
+   Windows/macOS/Linux install smoke.
+
+The workflow still exposes `dry_run` for read-only preview requests and
+troubleshooting. For an already-authorized release whose equivalent machine
+gates passed, use the production path directly; `dry_run: true` is not a
+mandatory first dispatch.
 
 Only an explicit production-release instruction authorizes proceeding. Once it
 exists and the reviewed source, resolved target, checks, known failures, and
@@ -154,11 +178,17 @@ The release workflow dispatches the Desktop workflow explicitly after pushing th
 canary tag. Do not rely on a tag push made by `GITHUB_TOKEN` to trigger another
 workflow.
 
-Canary and stable publication use the same non-cancelling concurrency group, so
-their npm/Desktop orchestration cannot run at the same time. GitHub retains at
-most one pending job per group rather than a FIFO queue. If a pending manual
-stable is superseded by a newer pending run, rerun the same locked stable SHA
-after the active publication finishes; do not silently retarget it.
+Canary and stable publication currently use the same non-cancelling concurrency
+group. An explicit stable release takes priority over an in-flight canary for
+the same or an older version base after the locked stable source passes
+exact-source CI and preflight. Record whether canary npm/tag mutation completed,
+then stop its remaining Desktop wait and dispatch stable; do not unpublish the
+canary npm version. Never stop an active next-base canary or a canary whose
+source is not superseded by the stable release.
+
+GitHub retains at most one pending job per group rather than a FIFO queue. If a
+pending manual stable is superseded, rerun the same locked stable SHA; do not
+silently retarget it.
 
 Users install canaries with:
 
@@ -179,22 +209,27 @@ Inputs:
 - `source_ref`
   - commit SHA, branch, or tag
 - `dry_run`
-  - preview only when true
+  - optional read-only preview when true; an authorized stable release normally
+    uses `false` after equivalent exact-source gates pass
 
 Before running stable:
 
-1. pick the canary commit or tag you trust
-2. confirm the committed public package version is the stable version you want to ship
-3. create or update `releases/vX.Y.Z.md`, `docs/releases.mdx`, and
-   `docs/zh/releases.mdx` on that source ref
-4. confirm that exact source commit has a successful `CI` run
-5. run the workflow with `dry_run: true`
-6. present the exact source ref, version, checks, targets, and rollback point as
-   a progress update; the existing release request remains the production and
-   standard docs authorization
-7. continue without another confirmation unless the user excluded
+1. freeze the tested canary commit or immutable SHA immediately
+2. confirm the committed public package version is the stable version you want
+   to ship
+3. if narratives are missing, start a bounded release-notes subagent in
+   parallel with read-only preflight; review and commit
+   `releases/vX.Y.Z.md`, `docs/releases.mdx`, and `docs/zh/releases.mdx`
+4. confirm that exact final source commit has successful `CI`, stable preflight,
+   package validation, and no existing immutable npm version/tag
+5. present the exact source ref, version, checks, targets, data impact, and
+   rollback point as a progress update
+6. if a same-base canary is only waiting for Desktop assets, record its npm/tag
+   state and stop the remaining wait; do not unpublish it
+7. run one production workflow with `dry_run: false`; the existing release
+   request remains the npm, GitHub, Desktop, and production-docs authorization
+8. continue without another confirmation unless the user excluded
    `docs.rudderhq.dev` or a genuinely ambiguous/nonstandard decision appears
-8. run the workflow with `dry_run: false`
 9. after stable and the docs deployment are both published, confirm the
    workflow committed the next-patch base directly to `main` and its explicitly
    dispatched CI succeeded
@@ -378,14 +413,20 @@ plumbing such as CI checks, source locking, branch history, workflow inputs,
 account approvals, deployment authorization, or maintainer-only cleanup.
 Put those details in engineering docs or the release closeout record.
 
-Recommended local generation flow:
+Recommended agent generation flow:
 
-```bash
-VERSION="$(./scripts/release.sh stable --print-version)"
-claude --print --output-format stream-json --verbose --dangerously-skip-permissions --model claude-opus-4-6 "Draft user-facing stable notes for v${VERSION}. Read doc/engineering/RELEASING.md, summarize only changes users can see or act on, add a one-sentence value summary, use New/Improved/Fixed only when non-empty, and keep CI, workflow, source-locking, approval, and deployment details out of public notes. Do not create a canary changelog."
-```
+1. Freeze the stable SHA and previous stable tag.
+2. Start one release-notes subagent with that exact diff and the three required
+   output paths. Ask it to draft only user-visible outcomes, localized
+   naturally, with no release plumbing.
+3. In parallel, keep the primary agent on version/tag/npm preflight and CI
+   evidence.
+4. Have the primary agent review factual coverage, integrate the three files,
+   and run stable preflight plus docs checks.
 
-The repo intentionally does not run this through GitHub Actions because:
+The subagent drafts narratives but does not select or retarget the release
+source, publish, or push independently. The repo intentionally does not generate
+notes through GitHub Actions because:
 
 - canaries are too frequent
 - stable notes are the only public narrative surface that needs LLM help


### PR DESCRIPTION
## Summary
- freeze the stable source immediately and keep later main work for the next release
- delegate release-note drafting to one bounded subagent in parallel with preflight
- document one gated production stable execution instead of mandatory preview plus publish dispatches
- let a gated stable supersede same-base canary Desktop waiting without unpublishing canary npm history
- preserve Windows, macOS, and Linux public install smoke as real product evidence
- add release-maintainer eval cases for same-base canary precedence and slow Windows install handling

## Validation
- release-maintainer quick validator
- `pnpm docs:structure:test` (52 passed)
- `pnpm product-logic:check` (79 contracts valid)

## Scope
Documentation, maintainer skill instructions, and skill eval definitions only. No release workflow implementation or product logic changes.