### PR TITLE
fix: publish identity core with server releases

### DIFF
--- a/packages/identity-core/package.json
+++ b/packages/identity-core/package.json
@@ -1,15 +1,34 @@
 {
   "name": "@rudderhq/identity-core",
-  "version": "0.0.0",
-  "private": true,
+  "version": "0.6.6",
+  "license": "SEE LICENSE IN LICENSE",
+  "homepage": "https://github.com/Undertone0809/rudder",
+  "bugs": {
+    "url": "https://github.com/Undertone0809/rudder/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Undertone0809/rudder",
+    "directory": "packages/identity-core"
+  },
   "type": "module",
   "exports": {
-    ".": {
-      "development": "./src/index.ts",
-      "types": "./src/index.ts",
-      "default": "./dist/index.js"
-    }
+    ".": "./src/index.ts"
   },
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts"
+  },
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsc",
     "clean": "rm -rf dist",

--- a/scripts/release-package-map.mjs
+++ b/scripts/release-package-map.mjs
@@ -6,7 +6,7 @@ import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(__dirname, "..");
-const roots = ["packages", "server", "ui", "cli"];
+const roots = ["packages", "server", "ui", "cli", "desktop", "identity"];
 
 function readJson(filePath) {
   return JSON.parse(readFileSync(filePath, "utf8"));

--- a/scripts/release-package-map.mjs
+++ b/scripts/release-package-map.mjs
@@ -16,7 +16,7 @@ function writeJson(filePath, value) {
   writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
 }
 
-function discoverPublicPackages() {
+function discoverWorkspacePackages() {
   const packages = [];
 
   function walk(relDir) {
@@ -26,15 +26,13 @@ function discoverPublicPackages() {
     const pkgPath = join(absDir, "package.json");
     if (existsSync(pkgPath)) {
       const pkg = readJson(pkgPath);
-      if (!pkg.private) {
-        packages.push({
-          dir: relDir,
-          pkgPath,
-          name: pkg.name,
-          version: pkg.version,
-          pkg,
-        });
-      }
+      packages.push({
+        dir: relDir,
+        pkgPath,
+        name: pkg.name,
+        version: pkg.version,
+        pkg,
+      });
       return;
     }
 
@@ -50,6 +48,34 @@ function discoverPublicPackages() {
   }
 
   return packages;
+}
+
+function discoverPublicPackages() {
+  const workspacePackages = discoverWorkspacePackages();
+  const privatePackageNames = new Set(
+    workspacePackages.filter((pkg) => pkg.pkg.private).map((pkg) => pkg.name),
+  );
+  const publicPackages = workspacePackages.filter((pkg) => !pkg.pkg.private);
+
+  for (const pkg of publicPackages) {
+    const dependencySections = [
+      pkg.pkg.dependencies ?? {},
+      pkg.pkg.optionalDependencies ?? {},
+      pkg.pkg.peerDependencies ?? {},
+    ];
+
+    for (const deps of dependencySections) {
+      for (const depName of Object.keys(deps)) {
+        if (privatePackageNames.has(depName)) {
+          throw new Error(
+            `public package ${pkg.name} depends on private workspace package ${depName}`,
+          );
+        }
+      }
+    }
+  }
+
+  return publicPackages;
 }
 
 function sortTopologically(packages) {

--- a/scripts/release-package-map.test.mjs
+++ b/scripts/release-package-map.test.mjs
@@ -48,6 +48,24 @@ function createPackageMapRepo() {
   return { repo, packagePath };
 }
 
+function addPrivateWorkspaceDependency(repo, packagePath) {
+  const privatePackageDir = join(repo, "packages", "identity-core");
+  mkdirSync(privatePackageDir, { recursive: true });
+  writeJson(join(privatePackageDir, "package.json"), {
+    name: "@rudderhq/identity-core",
+    version: "0.0.0",
+    private: true,
+  });
+
+  const pkg = readJson(packagePath);
+  writeJson(packagePath, {
+    ...pkg,
+    dependencies: {
+      "@rudderhq/identity-core": "workspace:*",
+    },
+  });
+}
+
 function runPackageMap(repo, args) {
   return spawnSync("node", ["scripts/release-package-map.mjs", ...args], {
     cwd: repo,
@@ -62,6 +80,18 @@ afterEach(() => {
 });
 
 describe("release package map", () => {
+  it("rejects public packages that depend on private workspace packages", () => {
+    const { repo, packagePath } = createPackageMapRepo();
+    addPrivateWorkspaceDependency(repo, packagePath);
+
+    const result = runPackageMap(repo, ["list"]);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      "public package @rudderhq/shared depends on private workspace package @rudderhq/identity-core",
+    );
+  });
+
   it("refuses publish manifest rewrites unless release automation opts in", () => {
     const { repo, packagePath } = createPackageMapRepo();
     const before = readFileSync(packagePath, "utf8");

--- a/scripts/release-package-map.test.mjs
+++ b/scripts/release-package-map.test.mjs
@@ -49,10 +49,10 @@ function createPackageMapRepo() {
 }
 
 function addPrivateWorkspaceDependency(repo, packagePath) {
-  const privatePackageDir = join(repo, "packages", "identity-core");
+  const privatePackageDir = join(repo, "identity");
   mkdirSync(privatePackageDir, { recursive: true });
   writeJson(join(privatePackageDir, "package.json"), {
-    name: "@rudderhq/identity-core",
+    name: "@rudderhq/identity",
     version: "0.0.0",
     private: true,
   });
@@ -61,9 +61,23 @@ function addPrivateWorkspaceDependency(repo, packagePath) {
   writeJson(packagePath, {
     ...pkg,
     dependencies: {
-      "@rudderhq/identity-core": "workspace:*",
+      "@rudderhq/identity": "workspace:*",
     },
   });
+}
+
+function addPublicServerDependency(repo) {
+  const serverDir = join(repo, "server");
+  mkdirSync(serverDir, { recursive: true });
+  const serverPackagePath = join(serverDir, "package.json");
+  writeJson(serverPackagePath, {
+    name: "@rudderhq/server",
+    version: "0.2.10",
+    dependencies: {
+      "@rudderhq/shared": "workspace:*",
+    },
+  });
+  return serverPackagePath;
 }
 
 function runPackageMap(repo, args) {
@@ -88,8 +102,24 @@ describe("release package map", () => {
 
     expect(result.status).toBe(1);
     expect(result.stderr).toContain(
-      "public package @rudderhq/shared depends on private workspace package @rudderhq/identity-core",
+      "public package @rudderhq/shared depends on private workspace package @rudderhq/identity",
     );
+  });
+
+  it("rewrites public workspace dependencies to the exact publish version", () => {
+    const { repo } = createPackageMapRepo();
+    const serverPackagePath = addPublicServerDependency(repo);
+
+    const result = runPackageMap(repo, [
+      "set-publish-version",
+      "0.2.11-canary.2",
+      "--allow-source-mutation",
+    ]);
+    const manifest = readJson(serverPackagePath);
+
+    expect(result.status).toBe(0);
+    expect(manifest.version).toBe("0.2.11-canary.2");
+    expect(manifest.dependencies["@rudderhq/shared"]).toBe("0.2.11-canary.2");
   });
 
   it("refuses publish manifest rewrites unless release automation opts in", () => {


### PR DESCRIPTION
Summary:
- publish the identity-core package as part of the public package graph
- rewrite the server dependency to the immutable release version
- reject public packages that depend on private workspace packages

Incident: 0.6.6-canary.1 built Desktop assets successfully but public install smoke failed on Linux, Windows, and macOS because the published server retained a workspace dependency on private Identity Core.

Verification: focused release tests, Identity Core build, lint, workspace typecheck, Product Logic check, and frozen-lockfile install passed.