### PR TITLE
fix: run Linux package verification headlessly

### DIFF
--- a/desktop/scripts/verify-browser-bundle.mjs
+++ b/desktop/scripts/verify-browser-bundle.mjs
@@ -27,6 +27,23 @@ function packagedExecutableForServerPackage(serverPackageDir) {
   return path.resolve(resourcesDir, "..", "Rudder");
 }
 
+export function packagedCliArgs(platform, args) {
+  if (platform !== "linux") return args;
+  return [
+    "--no-sandbox",
+    "--headless",
+    "--disable-gpu",
+    "--disable-dev-shm-usage",
+    ...args,
+  ];
+}
+
+export function packagedCliRuntimeEnv(platform, env) {
+  const runtimeEnv = { ...env };
+  if (platform === "linux") delete runtimeEnv.DBUS_SESSION_BUS_ADDRESS;
+  return runtimeEnv;
+}
+
 export async function verifyBrowserBundle(options) {
   const serverPackageDir = path.resolve(options.serverPackageDir);
   const cliEntry = path.resolve(options.cliEntry ?? path.join(serverPackageDir, "desktop-cli.js"));
@@ -118,22 +135,23 @@ export async function verifyBrowserBundle(options) {
       const packagedCommand = {
         ...command,
         command: packagedExecutable,
-        args: process.platform === "linux" ? ["--no-sandbox", ...command.args] : command.args,
+        args: packagedCliArgs(process.platform, command.args),
       };
       const packagedBrowserCommand = {
         ...browserCommand,
         command: packagedExecutable,
-        args: process.platform === "linux" ? ["--no-sandbox", ...browserCommand.args] : browserCommand.args,
+        args: packagedCliArgs(process.platform, browserCommand.args),
       };
+      const packagedRuntimeEnv = packagedCliRuntimeEnv(process.platform, {
+        ...process.env,
+        HOME: tempRoot,
+        PATH: [staleBinDir, process.env.PATH].filter(Boolean).join(path.delimiter),
+        RUDDER_BROWSER_ENABLED: "true",
+        RUDDER_DESKTOP_DISABLE_CLI_LINK: "1",
+      });
       const coreResult = await preflightModule.preflightRudderMcpServer({
         command: packagedCommand,
-        runtimeEnv: {
-          ...process.env,
-          HOME: tempRoot,
-          PATH: [staleBinDir, process.env.PATH].filter(Boolean).join(path.delimiter),
-          RUDDER_BROWSER_ENABLED: "true",
-          RUDDER_DESKTOP_DISABLE_CLI_LINK: "1",
-        },
+        runtimeEnv: packagedRuntimeEnv,
         browserEnabled: false,
         timeoutMs: 15_000,
       });
@@ -144,13 +162,7 @@ export async function verifyBrowserBundle(options) {
       }
       const result = await preflightModule.preflightRudderBrowserMcpServer({
         command: packagedBrowserCommand,
-        runtimeEnv: {
-          ...process.env,
-          HOME: tempRoot,
-          PATH: [staleBinDir, process.env.PATH].filter(Boolean).join(path.delimiter),
-          RUDDER_BROWSER_ENABLED: "true",
-          RUDDER_DESKTOP_DISABLE_CLI_LINK: "1",
-        },
+        runtimeEnv: packagedRuntimeEnv,
         timeoutMs: 15_000,
       });
       if (!result.browserAvailable) {

--- a/desktop/scripts/verify-browser-bundle.test.mjs
+++ b/desktop/scripts/verify-browser-bundle.test.mjs
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import {
+  packagedCliArgs,
+  packagedCliRuntimeEnv,
+} from "./verify-browser-bundle.mjs";
+
+describe("packaged Browser bundle verifier", () => {
+  it("runs the Linux Electron CLI handshake without a display or inherited session bus", () => {
+    expect(packagedCliArgs("linux", ["--desktop-cli", "mcp-server"])).toEqual([
+      "--no-sandbox",
+      "--headless",
+      "--disable-gpu",
+      "--disable-dev-shm-usage",
+      "--desktop-cli",
+      "mcp-server",
+    ]);
+    expect(packagedCliRuntimeEnv("linux", {
+      DBUS_SESSION_BUS_ADDRESS: "/dev/null",
+      PATH: "/usr/bin",
+    })).toEqual({
+      PATH: "/usr/bin",
+    });
+  });
+
+  it("preserves normal packaged CLI arguments and environment on desktop platforms", () => {
+    const args = ["desktop-cli-runner.js", "mcp-server"];
+    const env = {
+      DBUS_SESSION_BUS_ADDRESS: "unix:path=/tmp/dbus",
+      PATH: "/usr/bin",
+    };
+
+    expect(packagedCliArgs("darwin", args)).toBe(args);
+    expect(packagedCliRuntimeEnv("darwin", env)).toEqual(env);
+  });
+});


### PR DESCRIPTION
Summary:
- launch the packaged Linux Electron CLI verifier in headless GPU-disabled mode
- remove an invalid inherited D-Bus session address from the verification child
- cover Linux and normal desktop argument/environment behavior

Incident: the 0.6.6-canary.2 Linux AppImage built and passed package integrity checks, but its post-build MCP handshake timed out twice while Chromium failed to initialize GPU and D-Bus on the headless runner. macOS arm64/x64 and Windows builds passed.

Verification: focused verifier tests, lint, Desktop typecheck, and diff checks passed.