### PR TITLE
fix: provide session bus for Linux package checks

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -129,7 +129,9 @@ jobs:
           fi
 
           if [ "$(uname -s)" = "Linux" ]; then
-            xvfb-run --auto-servernum pnpm desktop:dist
+            command -v dbus-run-session
+            command -v xvfb-run
+            dbus-run-session -- xvfb-run --auto-servernum pnpm desktop:dist
           else
             pnpm desktop:dist
           fi

--- a/desktop/scripts/verify-browser-bundle.mjs
+++ b/desktop/scripts/verify-browser-bundle.mjs
@@ -38,12 +38,6 @@ export function packagedCliArgs(platform, args) {
   ];
 }
 
-export function packagedCliRuntimeEnv(platform, env) {
-  const runtimeEnv = { ...env };
-  if (platform === "linux") delete runtimeEnv.DBUS_SESSION_BUS_ADDRESS;
-  return runtimeEnv;
-}
-
 export async function verifyBrowserBundle(options) {
   const serverPackageDir = path.resolve(options.serverPackageDir);
   const cliEntry = path.resolve(options.cliEntry ?? path.join(serverPackageDir, "desktop-cli.js"));
@@ -142,13 +136,13 @@ export async function verifyBrowserBundle(options) {
         command: packagedExecutable,
         args: packagedCliArgs(process.platform, browserCommand.args),
       };
-      const packagedRuntimeEnv = packagedCliRuntimeEnv(process.platform, {
+      const packagedRuntimeEnv = {
         ...process.env,
         HOME: tempRoot,
         PATH: [staleBinDir, process.env.PATH].filter(Boolean).join(path.delimiter),
         RUDDER_BROWSER_ENABLED: "true",
         RUDDER_DESKTOP_DISABLE_CLI_LINK: "1",
-      });
+      };
       const coreResult = await preflightModule.preflightRudderMcpServer({
         command: packagedCommand,
         runtimeEnv: packagedRuntimeEnv,

--- a/desktop/scripts/verify-browser-bundle.test.mjs
+++ b/desktop/scripts/verify-browser-bundle.test.mjs
@@ -1,11 +1,8 @@
 import { describe, expect, it } from "vitest";
-import {
-  packagedCliArgs,
-  packagedCliRuntimeEnv,
-} from "./verify-browser-bundle.mjs";
+import { packagedCliArgs } from "./verify-browser-bundle.mjs";
 
 describe("packaged Browser bundle verifier", () => {
-  it("runs the Linux Electron CLI handshake without a display or inherited session bus", () => {
+  it("runs the Linux Electron CLI handshake without GPU or shared-memory requirements", () => {
     expect(packagedCliArgs("linux", ["--desktop-cli", "mcp-server"])).toEqual([
       "--no-sandbox",
       "--headless",
@@ -14,22 +11,11 @@ describe("packaged Browser bundle verifier", () => {
       "--desktop-cli",
       "mcp-server",
     ]);
-    expect(packagedCliRuntimeEnv("linux", {
-      DBUS_SESSION_BUS_ADDRESS: "/dev/null",
-      PATH: "/usr/bin",
-    })).toEqual({
-      PATH: "/usr/bin",
-    });
   });
 
-  it("preserves normal packaged CLI arguments and environment on desktop platforms", () => {
+  it("preserves normal packaged CLI arguments on desktop platforms", () => {
     const args = ["desktop-cli-runner.js", "mcp-server"];
-    const env = {
-      DBUS_SESSION_BUS_ADDRESS: "unix:path=/tmp/dbus",
-      PATH: "/usr/bin",
-    };
 
     expect(packagedCliArgs("darwin", args)).toBe(args);
-    expect(packagedCliRuntimeEnv("darwin", env)).toEqual(env);
   });
 });


### PR DESCRIPTION
Summary:
- run Linux Desktop packaging under a temporary D-Bus session in addition to the existing Xvfb server
- preserve that valid session address for the packaged Electron verifier
- retain headless and GPU-disabled verifier flags

Incident: canary.3 showed Xvfb and headless Chromium were insufficient because the packaged Electron CLI still had no valid session bus; the MCP handshake timed out with D-Bus address parsing errors. macOS arm64/x64 and Windows continued to pass.

Verification: 13 focused verifier/CLI tests, lint, Desktop typecheck, and diff checks passed.