### PR TITLE
fix: restore Linux packaged CLI launch baseline

### DIFF
--- a/desktop/scripts/verify-browser-bundle.mjs
+++ b/desktop/scripts/verify-browser-bundle.mjs
@@ -29,13 +29,7 @@ function packagedExecutableForServerPackage(serverPackageDir) {
 
 export function packagedCliArgs(platform, args) {
   if (platform !== "linux") return args;
-  return [
-    "--no-sandbox",
-    "--headless",
-    "--disable-gpu",
-    "--disable-dev-shm-usage",
-    ...args,
-  ];
+  return ["--no-sandbox", ...args];
 }
 
 export async function verifyBrowserBundle(options) {

--- a/desktop/scripts/verify-browser-bundle.test.mjs
+++ b/desktop/scripts/verify-browser-bundle.test.mjs
@@ -2,12 +2,9 @@ import { describe, expect, it } from "vitest";
 import { packagedCliArgs } from "./verify-browser-bundle.mjs";
 
 describe("packaged Browser bundle verifier", () => {
-  it("runs the Linux Electron CLI handshake without GPU or shared-memory requirements", () => {
+  it("runs the Linux Electron CLI handshake in the Xvfb display session", () => {
     expect(packagedCliArgs("linux", ["--desktop-cli", "mcp-server"])).toEqual([
       "--no-sandbox",
-      "--headless",
-      "--disable-gpu",
-      "--disable-dev-shm-usage",
       "--desktop-cli",
       "mcp-server",
     ]);


### PR DESCRIPTION
## Summary
- restore the Linux packaged Electron CLI verifier to the known-good Xvfb launch arguments
- keep the isolated D-Bus session added on main
- remove headless/GPU flags that caused the canary.4 MCP handshake to hang

## Validation
- pnpm exec vitest run desktop/scripts/verify-browser-bundle.test.mjs desktop/src/cli-link.test.ts desktop/src/desktop-cli-runner.test.ts
- pnpm --filter @rudderhq/desktop typecheck
- pnpm lint
- git diff --check