### PR TITLE
fix: disable GPU in Linux packaged verifier

### DIFF
--- a/desktop/scripts/verify-browser-bundle.mjs
+++ b/desktop/scripts/verify-browser-bundle.mjs
@@ -29,7 +29,7 @@ function packagedExecutableForServerPackage(serverPackageDir) {
 
 export function packagedCliArgs(platform, args) {
   if (platform !== "linux") return args;
-  return ["--no-sandbox", ...args];
+  return ["--no-sandbox", "--disable-gpu", ...args];
 }
 
 export async function verifyBrowserBundle(options) {

--- a/desktop/scripts/verify-browser-bundle.test.mjs
+++ b/desktop/scripts/verify-browser-bundle.test.mjs
@@ -5,6 +5,7 @@ describe("packaged Browser bundle verifier", () => {
   it("runs the Linux Electron CLI handshake in the Xvfb display session", () => {
     expect(packagedCliArgs("linux", ["--desktop-cli", "mcp-server"])).toEqual([
       "--no-sandbox",
+      "--disable-gpu",
       "--desktop-cli",
       "mcp-server",
     ]);


### PR DESCRIPTION
## Summary
- disable Electron GPU only for the Linux packaged CLI verifier
- retain the isolated D-Bus session, Xvfb display, and non-headless launch
- address the explicit GPU-process initialization failure observed in canary.5

## Evidence
- canary.5 Linux job 90721133945 reported GPU initialization failure immediately before MCP handshake timeout
- canary.4 with headless+disable-gpu had no GPU error, so this change isolates the GPU fix without reintroducing headless

## Validation
- pnpm exec vitest run desktop/scripts/verify-browser-bundle.test.mjs desktop/src/cli-link.test.ts desktop/src/desktop-cli-runner.test.ts
- pnpm --filter @rudderhq/desktop typecheck
- pnpm lint
- git diff --check
- independent reviewer PASS