### PR TITLE
fix: unblock macOS account login startup

### DIFF
--- a/desktop/src/identity-client.test.ts
+++ b/desktop/src/identity-client.test.ts
@@ -34,6 +34,38 @@ describe("Desktop Identity client", () => {
     expect(clear).toHaveBeenCalledOnce();
   });
 
+  it("completes local sign-out when stale credential file cleanup fails", async () => {
+    const offlineSignOut = vi.fn(() => {
+      throw new Error("offline file is locked");
+    });
+    const clear = vi.fn(() => {
+      throw new Error("credential file is locked");
+    });
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const client = createDesktopIdentityClient({
+      identityOrigin: "https://accounts.rudderhq.dev",
+      installationId: "installation-1",
+      deviceName: "Test Mac",
+      vault: { read: vi.fn(() => null), write: vi.fn(), clear },
+      offlineGrantStore: {
+        prepareDeviceKey: vi.fn(() => null),
+        acceptGrant: vi.fn(),
+        signOut: offlineSignOut,
+      },
+      openExternal: vi.fn(),
+    });
+
+    await expect(client.signOut()).resolves.toBeUndefined();
+
+    expect(offlineSignOut).toHaveBeenCalledOnce();
+    expect(clear).toHaveBeenCalledOnce();
+    expect(warning).toHaveBeenCalledWith(
+      "[rudder-desktop] local account credentials could not be fully removed",
+      expect.objectContaining({ message: "offline file is locked" }),
+      expect.objectContaining({ message: "credential file is locked" }),
+    );
+  });
+
   it("rotates the encrypted refresh credential before listing device sessions", async () => {
     const stored = {
       version: 1 as const,

--- a/desktop/src/identity-client.ts
+++ b/desktop/src/identity-client.ts
@@ -417,9 +417,24 @@ export function createDesktopIdentityClient(options: DesktopIdentityClientOption
       } catch {
         // Signing out locally must remain available while Identity is offline.
       } finally {
-        options.offlineGrantStore?.signOut();
-        options.vault.clear();
         accessToken = null;
+        const cleanupErrors: unknown[] = [];
+        try {
+          options.offlineGrantStore?.signOut();
+        } catch (error) {
+          cleanupErrors.push(error);
+        }
+        try {
+          options.vault.clear();
+        } catch (error) {
+          cleanupErrors.push(error);
+        }
+        if (cleanupErrors.length > 0) {
+          console.warn(
+            "[rudder-desktop] local account credentials could not be fully removed",
+            ...cleanupErrors,
+          );
+        }
       }
     },
   };

--- a/desktop/src/identity-offline-grant.test.ts
+++ b/desktop/src/identity-offline-grant.test.ts
@@ -90,6 +90,7 @@ describe("Desktop Offline Grant store", () => {
 
   it("does not create or persist an Offline Grant on Linux basic_text", () => {
     const statePath = temporaryStatePath();
+    fs.writeFileSync(statePath, "stale encrypted state");
     const store = createDesktopOfflineGrantStore({
       safeStorage: fakeSafeStorage("basic_text"),
       platform: "linux",

--- a/desktop/src/identity-offline-grant.test.ts
+++ b/desktop/src/identity-offline-grant.test.ts
@@ -103,4 +103,25 @@ describe("Desktop Offline Grant store", () => {
     store.signOut();
     expect(fs.existsSync(statePath)).toBe(false);
   });
+
+  it("forgets a pending device key even when secure sign-out persistence fails", () => {
+    const storage = fakeSafeStorage();
+    const store = createDesktopOfflineGrantStore({
+      safeStorage: {
+        ...storage,
+        encryptString: () => {
+          throw new Error("secure store is locked");
+        },
+      },
+      platform: "win32",
+      statePath: temporaryStatePath(),
+      issuer: "https://accounts.rudderhq.dev",
+      installationId: "installation-1",
+    });
+    const firstKey = store.prepareDeviceKey()!.thumbprint;
+
+    expect(() => store.signOut()).toThrow("secure store is locked");
+
+    expect(store.prepareDeviceKey()!.thumbprint).not.toBe(firstKey);
+  });
 });

--- a/desktop/src/identity-offline-grant.ts
+++ b/desktop/src/identity-offline-grant.ts
@@ -222,24 +222,23 @@ export function createDesktopOfflineGrantStore(options: {
     },
 
     signOut(): void {
-      if (!available) {
-        // A fail-closed memory-only build may follow an older secure build.
-        // Remove stale encrypted state without decrypting it or touching the
-        // unavailable native secure-storage API.
-        try {
+      try {
+        if (!available) {
+          // A fail-closed memory-only build may follow an older secure build.
+          // Remove stale encrypted state without decrypting it or touching the
+          // unavailable native secure-storage API.
           fs.rmSync(options.statePath, { force: true });
-        } finally {
-          pendingDeviceKeys = null;
+          return;
         }
-        return;
+        const state = readState();
+        writeState({
+          version: 1,
+          signOutEpoch: state.signOutEpoch + 1,
+          credential: null,
+        });
+      } finally {
+        pendingDeviceKeys = null;
       }
-      const state = readState();
-      writeState({
-        version: 1,
-        signOutEpoch: state.signOutEpoch + 1,
-        credential: null,
-      });
-      pendingDeviceKeys = null;
     },
   };
 }

--- a/desktop/src/identity-offline-grant.ts
+++ b/desktop/src/identity-offline-grant.ts
@@ -226,8 +226,11 @@ export function createDesktopOfflineGrantStore(options: {
         // A fail-closed memory-only build may follow an older secure build.
         // Remove stale encrypted state without decrypting it or touching the
         // unavailable native secure-storage API.
-        fs.rmSync(options.statePath, { force: true });
-        pendingDeviceKeys = null;
+        try {
+          fs.rmSync(options.statePath, { force: true });
+        } finally {
+          pendingDeviceKeys = null;
+        }
         return;
       }
       const state = readState();

--- a/desktop/src/identity-offline-grant.ts
+++ b/desktop/src/identity-offline-grant.ts
@@ -222,7 +222,14 @@ export function createDesktopOfflineGrantStore(options: {
     },
 
     signOut(): void {
-      if (!available) return;
+      if (!available) {
+        // A fail-closed memory-only build may follow an older secure build.
+        // Remove stale encrypted state without decrypting it or touching the
+        // unavailable native secure-storage API.
+        fs.rmSync(options.statePath, { force: true });
+        pendingDeviceKeys = null;
+        return;
+      }
       const state = readState();
       writeState({
         version: 1,

--- a/desktop/src/identity-runtime.ts
+++ b/desktop/src/identity-runtime.ts
@@ -22,6 +22,7 @@ import {
   createDesktopOfflineGrantStore,
   type DesktopOfflineGrantCredential,
 } from "./identity-offline-grant.js";
+import { resolveDesktopIdentitySafeStorage } from "./identity-safe-storage-policy.js";
 import { createDesktopIdentitySessionStore } from "./identity-session-store.js";
 import { desktopAccountBypassAllowed } from "./identity-startup-policy.js";
 
@@ -95,8 +96,13 @@ export function createDesktopIdentityRuntime(options: {
     isPackaged: app.isPackaged,
     override: process.env.RUDDER_IDENTITY_ORIGIN,
   });
-  const credentialVault = createIdentityCredentialVault({
+  const safeStorage = resolveDesktopIdentitySafeStorage({
     safeStorage: options.safeStorage,
+    isPackaged: app.isPackaged,
+    platform: process.platform,
+  });
+  const credentialVault = createIdentityCredentialVault({
+    safeStorage,
     platform: process.platform,
     credentialPath: path.join(app.getPath("userData"), "identity", "device-credential.bin"),
   });
@@ -104,7 +110,7 @@ export function createDesktopIdentityRuntime(options: {
   const vault = createDesktopIdentitySessionStore(credentialVault);
   if (debug) console.info("[rudder-desktop] identity-runtime:create-offline-store");
   const offlineGrantStore = createDesktopOfflineGrantStore({
-    safeStorage: options.safeStorage,
+    safeStorage,
     platform: process.platform,
     statePath: path.join(app.getPath("userData"), "identity", "offline-grant.bin"),
     issuer: origin,

--- a/desktop/src/identity-safe-storage-policy.test.ts
+++ b/desktop/src/identity-safe-storage-policy.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from "vitest";
+import { identityCredentialVaultStatus } from "./identity-credential-vault.js";
+import { resolveDesktopIdentitySafeStorage } from "./identity-safe-storage-policy.js";
+
+function poisonSafeStorage() {
+  return {
+    isEncryptionAvailable: vi.fn(() => {
+      throw new Error("native safeStorage probe must not run");
+    }),
+    getSelectedStorageBackend: vi.fn(() => {
+      throw new Error("native safeStorage backend probe must not run");
+    }),
+    encryptString: vi.fn(() => {
+      throw new Error("native safeStorage encryption must not run");
+    }),
+    decryptString: vi.fn(() => {
+      throw new Error("native safeStorage decryption must not run");
+    }),
+  };
+}
+
+describe("Desktop Identity safe storage policy", () => {
+  it.each([false, true])(
+    "never touches native safeStorage on macOS (isPackaged=%s)",
+    (isPackaged) => {
+    const nativeStorage = poisonSafeStorage();
+    const selectedStorage = resolveDesktopIdentitySafeStorage({
+      safeStorage: nativeStorage,
+      isPackaged,
+      platform: "darwin",
+    });
+
+    expect(identityCredentialVaultStatus(selectedStorage, "darwin")).toEqual({
+      available: false,
+      backend: "mac_memory_only",
+      reason: "encryption_unavailable",
+    });
+    expect(nativeStorage.isEncryptionAvailable).not.toHaveBeenCalled();
+    expect(nativeStorage.getSelectedStorageBackend).not.toHaveBeenCalled();
+    expect(nativeStorage.encryptString).not.toHaveBeenCalled();
+    expect(nativeStorage.decryptString).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    { isPackaged: true, platform: "linux" as const },
+    { isPackaged: true, platform: "win32" as const },
+  ])("preserves native secure storage outside packaged macOS (%o)", (input) => {
+    const nativeStorage = poisonSafeStorage();
+    expect(resolveDesktopIdentitySafeStorage({
+      safeStorage: nativeStorage,
+      ...input,
+    })).toBe(nativeStorage);
+  });
+});

--- a/desktop/src/identity-safe-storage-policy.ts
+++ b/desktop/src/identity-safe-storage-policy.ts
@@ -1,0 +1,35 @@
+import type { IdentitySafeStorage } from "./identity-credential-vault.js";
+
+const macMemoryOnlyStorage: IdentitySafeStorage = {
+  isEncryptionAvailable: () => false,
+  getSelectedStorageBackend: () => "mac_memory_only",
+  encryptString: () => {
+    throw new Error("Packaged macOS secure credential persistence is disabled");
+  },
+  decryptString: () => {
+    throw new Error("Packaged macOS secure credential persistence is disabled");
+  },
+};
+
+/**
+ * Current macOS artifacts are intentionally built without a Developer ID.
+ * Electron safeStorage can synchronously open a blocking Keychain NSAlert in
+ * those ad-hoc signed bundles before Rudder creates its first window.
+ *
+ * Keep macOS fail-closed in both development and packaged validation: online
+ * sessions remain process-only and no credential or Offline Grant is written
+ * to disk. This also keeps local and CI verification independent of the
+ * operator's unlocked login Keychain. When signing and notarization are
+ * enabled, replace this with an immutable signed-build capability verified by
+ * the release workflow.
+ */
+export function resolveDesktopIdentitySafeStorage(options: {
+  safeStorage: IdentitySafeStorage;
+  isPackaged: boolean;
+  platform: NodeJS.Platform;
+}): IdentitySafeStorage {
+  if (options.platform === "darwin") {
+    return macMemoryOnlyStorage;
+  }
+  return options.safeStorage;
+}

--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -57,7 +57,6 @@ import {
   createDesktopIdentityRuntime,
   type DesktopLocalAccountAuth,
 } from "./identity-runtime.js";
-import { resolveDesktopIdentitySafeStorage } from "./identity-safe-storage-policy.js";
 import { registerLocalAppsIpcHandlers } from "./local-apps-ipc.js";
 import { createDesktopLocalAppsRuntime } from "./local-apps-main-runtime.js";
 import { previewLocalFile } from "./local-file-preview.js";
@@ -747,15 +746,10 @@ function initializeLocalApps(desktopInstallationId: string): void {
 
 function initializeDesktopIdentity(desktopInstallationId: string): void {
   if (desktopIdentityRuntime) return;
-  const identitySafeStorage = resolveDesktopIdentitySafeStorage({
-    safeStorage,
-    isPackaged: app.isPackaged,
-    platform: process.platform,
-  });
   desktopIdentityRuntime = createDesktopIdentityRuntime({
     installationId: desktopInstallationId,
     appName: APP_NAME,
-    safeStorage: identitySafeStorage,
+    safeStorage,
     getMainRenderer: getCurrentMainRenderer,
     getLocalApiUrl: () => serverHandle?.apiUrl ?? lastKnownAppUrl,
     onSignedIn: startLocalRudder,

--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -57,6 +57,7 @@ import {
   createDesktopIdentityRuntime,
   type DesktopLocalAccountAuth,
 } from "./identity-runtime.js";
+import { resolveDesktopIdentitySafeStorage } from "./identity-safe-storage-policy.js";
 import { registerLocalAppsIpcHandlers } from "./local-apps-ipc.js";
 import { createDesktopLocalAppsRuntime } from "./local-apps-main-runtime.js";
 import { previewLocalFile } from "./local-file-preview.js";
@@ -746,10 +747,15 @@ function initializeLocalApps(desktopInstallationId: string): void {
 
 function initializeDesktopIdentity(desktopInstallationId: string): void {
   if (desktopIdentityRuntime) return;
+  const identitySafeStorage = resolveDesktopIdentitySafeStorage({
+    safeStorage,
+    isPackaged: app.isPackaged,
+    platform: process.platform,
+  });
   desktopIdentityRuntime = createDesktopIdentityRuntime({
     installationId: desktopInstallationId,
     appName: APP_NAME,
-    safeStorage,
+    safeStorage: identitySafeStorage,
     getMainRenderer: getCurrentMainRenderer,
     getLocalApiUrl: () => serverHandle?.apiUrl ?? lastKnownAppUrl,
     onSignedIn: startLocalRudder,


### PR DESCRIPTION
## Summary
- keep macOS Rudder Account sessions process-only until Developer ID signing/notarization is configured
- avoid all native safeStorage probes that can block ad-hoc signed Canary startup before the first window
- remove stale encrypted Offline Grant state on sign-out in memory-only mode

## Verification
- targeted Desktop Identity tests: 25 passed
- Desktop typecheck passed
- repository lint passed
- full Desktop packaged UI smoke requires the local Mac to be unlocked; release artifact black-box verification will run after CI/release

## Product logic
No Product Logic Registry change: required login and session-revocation semantics are unchanged. The existing secure-storage-unavailable process-memory fallback is selected deliberately for current macOS artifacts.