### PR TITLE
fix: normalize packaged desktop identity exports

### DIFF
--- a/desktop/scripts/after-pack.mjs
+++ b/desktop/scripts/after-pack.mjs
@@ -26,7 +26,10 @@ async function rewriteInternalPackageManifest(packageDir, { includeTypes = true 
 
   const raw = await fs.readFile(manifestPath, "utf8");
   const manifest = JSON.parse(raw);
-  if (!manifest.name?.startsWith?.("@rudderhq/")) return;
+  if (
+    !manifest.name?.startsWith?.("@rudderhq/")
+    && !manifest.name?.startsWith?.("@rudder/")
+  ) return;
   if (!manifest.publishConfig) return;
 
   const nextManifest = {
@@ -214,7 +217,10 @@ export default async function afterPack(context) {
     ? path.join(context.appOutDir, "Rudder.app", "Contents", "Resources")
     : path.join(context.appOutDir, "resources");
   const appNodeModulesDir = path.join(resourcesDir, "app", "node_modules");
-  const rudderPackagesDir = path.join(appNodeModulesDir, "@rudder");
+  const appRudderPackagesDirs = [
+    path.join(appNodeModulesDir, "@rudderhq"),
+    path.join(appNodeModulesDir, "@rudder"),
+  ];
   const packagedServerRudderPackagesDirs = [
     path.join(resourcesDir, "server-package", "node_modules", "@rudderhq"),
     path.join(resourcesDir, "server-package", "node_modules", "@rudder"),
@@ -237,12 +243,13 @@ export default async function afterPack(context) {
     );
   }
 
-  if (!(await exists(rudderPackagesDir))) return;
-
-  const entries = await fs.readdir(rudderPackagesDir, { withFileTypes: true });
-  await Promise.all(
-    entries
-      .filter((entry) => entry.isDirectory() || entry.isSymbolicLink())
-      .map((entry) => rewriteInternalPackageManifest(path.join(rudderPackagesDir, entry.name))),
-  );
+  for (const appRudderPackagesDir of appRudderPackagesDirs) {
+    if (!(await exists(appRudderPackagesDir))) continue;
+    const entries = await fs.readdir(appRudderPackagesDir, { withFileTypes: true });
+    await Promise.all(
+      entries
+        .filter((entry) => entry.isDirectory() || entry.isSymbolicLink())
+        .map((entry) => rewriteInternalPackageManifest(path.join(appRudderPackagesDir, entry.name))),
+    );
+  }
 }

--- a/desktop/scripts/after-pack.test.mjs
+++ b/desktop/scripts/after-pack.test.mjs
@@ -1,4 +1,5 @@
 import {
+  linkSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -18,8 +19,69 @@ afterEach(() => {
   }
 });
 
-describe("Desktop afterPack server manifest normalization", () => {
-  it("does not restore declarations removed from the production server package", async () => {
+describe("Desktop afterPack internal package manifest normalization", () => {
+  it.each([
+    { electronPlatformName: "darwin", packageScope: "@rudderhq" },
+    { electronPlatformName: "darwin", packageScope: "@rudder" },
+    { electronPlatformName: "linux", packageScope: "@rudderhq" },
+  ])(
+    "uses compiled exports for $electronPlatformName app dependencies in the $packageScope scope",
+    async ({ electronPlatformName, packageScope }) => {
+      const projectDir = mkdtempSync(path.join(tmpdir(), "rudder-after-pack-"));
+      tempRoots.push(projectDir);
+      const appOutDir = path.join(projectDir, "release", "unpacked");
+      const resourcesDir = electronPlatformName === "darwin"
+        ? path.join(appOutDir, "Rudder.app", "Contents", "Resources")
+        : path.join(appOutDir, "resources");
+      const packageDir = path.join(
+        resourcesDir,
+        "app",
+        "node_modules",
+        packageScope,
+        "identity-core",
+      );
+      mkdirSync(path.join(packageDir, "dist"), { recursive: true });
+      writeFileSync(path.join(packageDir, "dist", "index.js"), "export {};\n");
+      const sourceManifestPath = path.join(projectDir, "workspace-package.json");
+      writeFileSync(sourceManifestPath, `${JSON.stringify({
+        name: `${packageScope}/identity-core`,
+        version: "1.0.0",
+        exports: {
+          ".": "./src/index.ts",
+        },
+        publishConfig: {
+          exports: {
+            ".": {
+              types: "./dist/index.d.ts",
+              import: "./dist/index.js",
+            },
+          },
+          main: "./dist/index.js",
+          types: "./dist/index.d.ts",
+        },
+      }, null, 2)}\n`);
+      linkSync(sourceManifestPath, path.join(packageDir, "package.json"));
+
+      await afterPack({
+        appDir: projectDir,
+        electronPlatformName,
+        appOutDir,
+        packager: { projectDir },
+      });
+
+      const manifest = JSON.parse(readFileSync(path.join(packageDir, "package.json"), "utf8"));
+      expect(manifest.main).toBe("./dist/index.js");
+      expect(manifest.types).toBe("./dist/index.d.ts");
+      expect(manifest.exports["."].import).toBe("./dist/index.js");
+      expect(manifest.exports["."].default).toBe("./dist/index.js");
+      expect(JSON.parse(readFileSync(sourceManifestPath, "utf8")).exports["."])
+        .toBe("./src/index.ts");
+    },
+  );
+
+  it.each(["@rudderhq", "@rudder"])(
+    "does not restore declarations removed from the production server package in the %s scope",
+    async (packageScope) => {
     const projectDir = mkdtempSync(path.join(tmpdir(), "rudder-after-pack-"));
     tempRoots.push(projectDir);
     const packageDir = path.join(
@@ -27,13 +89,13 @@ describe("Desktop afterPack server manifest normalization", () => {
       ".packaged",
       "server-package",
       "node_modules",
-      "@rudderhq",
+      packageScope,
       "shared",
     );
     mkdirSync(path.join(packageDir, "dist"), { recursive: true });
     writeFileSync(path.join(packageDir, "dist", "index.js"), "export {};\n");
     writeFileSync(path.join(packageDir, "package.json"), `${JSON.stringify({
-      name: "@rudderhq/shared",
+      name: `${packageScope}/shared`,
       version: "1.0.0",
       publishConfig: {
         exports: {
@@ -63,7 +125,7 @@ describe("Desktop afterPack server manifest normalization", () => {
       "Resources",
       "server-package",
       "node_modules",
-      "@rudderhq",
+      packageScope,
       "shared",
       "package.json",
     ), "utf8"));
@@ -71,5 +133,6 @@ describe("Desktop afterPack server manifest normalization", () => {
     expect(manifest.exports["."].types).toBeUndefined();
     expect(manifest.exports["."].import).toBe("./dist/index.js");
     expect(manifest.exports["."].default).toBe("./dist/index.js");
-  });
+    },
+  );
 });


### PR DESCRIPTION
## Summary
- normalize packaged app manifests for both @rudderhq and legacy @rudder scopes
- ensure TypeScript development exports are replaced with compiled dist entry points
- add macOS/Linux regression coverage, including hard-linked manifests

## Verification
- focused after-pack tests: 5 passed
- desktop distribution build: passed
- packaged startup-recovery smoke: passed
- black-box reproduction against the failing canary.8 bundle: baseline crash reproduced; patched app reached bootstrap ready and displayed the login screen
- independent review: approved
- independent verifier: passed

## Known unrelated workspace failures
The main dirty workspace currently has pre-existing App Builder/Local Apps and broader test-suite failures. The clean branch contains only this two-file packaging fix.