### PR TITLE
feat: refine Rudder account login experience

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -170,6 +170,10 @@ jobs:
             trap - EXIT
           fi
 
+      - name: Smoke packaged account gate
+        if: matrix.platform == 'macos' && matrix.arch == 'arm64'
+        run: node desktop/scripts/smoke.mjs --mode=packaged --scenario=account-gate
+
       - name: Collect release asset
         id: collect
         run: |

--- a/identity/api/index.ts
+++ b/identity/api/index.ts
@@ -1,6 +1,7 @@
+import { waitUntil } from "@vercel/functions";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { identityHandler } from "../src/handler.js";
 
 export default async function handler(req: IncomingMessage, res: ServerResponse): Promise<void> {
-  await identityHandler(req, res);
+  await identityHandler(req, res, { backgroundTaskHandler: waitUntil });
 }

--- a/identity/package.json
+++ b/identity/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@rudderhq/identity-core": "workspace:*",
     "@rudderhq/identity-db": "workspace:*",
+    "@vercel/functions": "^2.2.13",
     "better-auth": "1.6.23",
     "drizzle-orm": "^0.45.2",
     "postgres": "^3.4.8"

--- a/identity/src/auth.ts
+++ b/identity/src/auth.ts
@@ -27,8 +27,9 @@ export function createIdentityAuth(input: {
   db: IdentityDb;
   config: IdentityConfig;
   mail: IdentityMailAdapter;
+  backgroundTaskHandler?: (promise: Promise<unknown>) => void;
 }) {
-  const { db, config, mail } = input;
+  const { backgroundTaskHandler, db, config, mail } = input;
   const securityEventMetadata = (request?: Request | null) => ({
     ...requestMetadata(request),
     ipHashKey: config.secret,
@@ -151,6 +152,9 @@ export function createIdentityAuth(input: {
       }),
     ],
     advanced: {
+      ...(backgroundTaskHandler
+        ? { backgroundTasks: { handler: backgroundTaskHandler } }
+        : {}),
       trustedProxyHeaders: true,
       ipAddress: {
         ipAddressHeaders: ["x-real-ip", "x-forwarded-for"],

--- a/identity/src/client-script.ts
+++ b/identity/src/client-script.ts
@@ -3,6 +3,10 @@ export const identityClientScript = String.raw`
   const status = document.querySelector("#auth-status");
   const otpForm = document.querySelector("#otp-form");
   const verifyForm = document.querySelector("#otp-verify-form");
+  const otpEmailTarget = document.querySelector("#otp-email");
+  const changeEmailButton = document.querySelector("#change-email");
+  const passwordModeToggle = document.querySelector("#password-mode-toggle");
+  const passwordPanel = document.querySelector("#password-panel");
   let otpEmail = "";
   let otpPurpose = "sign-in";
   const next = new URLSearchParams(location.search).get("next");
@@ -20,7 +24,14 @@ export const identityClientScript = String.raw`
 
   const message = (text, error = false) => {
     status.textContent = text;
-    status.style.color = error ? "#fca5a5" : "#a7f3d0";
+    if (status.dataset) status.dataset.state = error ? "error" : "success";
+    status.style.color = "";
+  };
+  const setBusy = (button, busy) => {
+    if (!button) return;
+    button.dataset.loading = busy ? "true" : "false";
+    button.setAttribute?.("aria-busy", busy ? "true" : "false");
+    button.disabled = busy;
   };
   const request = async (path, body) => {
     const response = await fetch(path, {
@@ -35,6 +46,8 @@ export const identityClientScript = String.raw`
 
   document.querySelectorAll("[data-social]").forEach((button) => {
     button.addEventListener("click", async () => {
+      if (button.disabled) return;
+      setBusy(button, true);
       try {
         message("Opening secure sign in…");
         const result = await request("/api/auth/sign-in/social", {
@@ -45,12 +58,17 @@ export const identityClientScript = String.raw`
         location.assign(result.url);
       } catch (error) {
         message(error.message || "Unable to sign in", true);
+        setBusy(button, false);
       }
     });
   });
 
   otpForm?.addEventListener("submit", async (event) => {
     event.preventDefault();
+    const submit = otpForm.querySelector('button[type="submit"]');
+    if (submit?.disabled) return;
+    setBusy(submit, true);
+    setBusy(passwordModeToggle, true);
     otpEmail = new FormData(otpForm).get("email").toString();
     otpPurpose = "sign-in";
     try {
@@ -58,15 +76,48 @@ export const identityClientScript = String.raw`
         email: otpEmail,
         type: "sign-in",
       });
-    } finally {
+      otpForm.hidden = true;
       verifyForm.hidden = false;
+      if (otpEmailTarget) otpEmailTarget.textContent = otpEmail;
       message("If this email can receive a code, it is on the way.");
       verifyForm.querySelector("input").focus();
+    } catch (error) {
+      message(error.message || "Unable to send a verification code.", true);
+    } finally {
+      setBusy(submit, false);
+      setBusy(passwordModeToggle, false);
     }
+  });
+
+  changeEmailButton?.addEventListener("click", () => {
+    verifyForm.hidden = true;
+    otpForm.hidden = false;
+    otpForm.querySelector('input[name="email"]').focus();
+    message("");
+  });
+
+  passwordModeToggle?.addEventListener("click", () => {
+    const passwordMode = passwordPanel.hidden;
+    passwordPanel.hidden = !passwordMode;
+    passwordModeToggle.setAttribute("aria-expanded", passwordMode ? "true" : "false");
+    otpForm.hidden = passwordMode;
+    verifyForm.hidden = true;
+    passwordModeToggle.textContent = passwordMode
+      ? "Use email code instead"
+      : "Use password instead";
+    if (passwordMode) {
+      passwordPanel.querySelector('input[name="email"]').focus();
+    } else {
+      otpForm.querySelector('input[name="email"]').focus();
+    }
+    message("");
   });
 
   verifyForm?.addEventListener("submit", async (event) => {
     event.preventDefault();
+    const submit = verifyForm.querySelector('button[type="submit"]');
+    if (submit?.disabled) return;
+    setBusy(submit, true);
     try {
       await request(
         otpPurpose === "email-verification"
@@ -80,11 +131,15 @@ export const identityClientScript = String.raw`
       location.assign(safeNext);
     } catch (error) {
       message(error.message || "The code is invalid or expired", true);
+      setBusy(submit, false);
     }
   });
 
   document.querySelector("#password-form")?.addEventListener("submit", async (event) => {
     event.preventDefault();
+    const submit = event.currentTarget.querySelector?.('button[type="submit"]');
+    if (submit?.disabled) return;
+    setBusy(submit, true);
     const data = new FormData(event.currentTarget);
     try {
       await request("/api/auth/sign-in/email", {
@@ -94,11 +149,15 @@ export const identityClientScript = String.raw`
       location.assign(safeNext);
     } catch {
       message("The email or password is incorrect.", true);
+      setBusy(submit, false);
     }
   });
 
   document.querySelector("#password-signup-form")?.addEventListener("submit", async (event) => {
     event.preventDefault();
+    const submit = event.currentTarget.querySelector('button[type="submit"]');
+    if (submit?.disabled) return;
+    setBusy(submit, true);
     const data = new FormData(event.currentTarget);
     try {
       await request("/api/auth/sign-up/email", {
@@ -108,10 +167,18 @@ export const identityClientScript = String.raw`
       });
       otpEmail = data.get("email").toString();
       otpPurpose = "email-verification";
+      otpForm.hidden = true;
+      passwordPanel.hidden = true;
+      passwordModeToggle.setAttribute("aria-expanded", "false");
+      passwordModeToggle.textContent = "Use password instead";
       verifyForm.hidden = false;
+      if (otpEmailTarget) otpEmailTarget.textContent = otpEmail;
       message("Check your email to verify this account.");
+      verifyForm.querySelector("input").focus();
     } catch {
       message("Check your email to continue. If the account exists, sign in instead.");
+    } finally {
+      setBusy(submit, false);
     }
   });
 
@@ -120,16 +187,26 @@ export const identityClientScript = String.raw`
   let resetEmail = "";
   forgotForm?.addEventListener("submit", async (event) => {
     event.preventDefault();
+    const submit = forgotForm.querySelector('button[type="submit"]');
+    if (submit?.disabled) return;
+    setBusy(submit, true);
     resetEmail = new FormData(forgotForm).get("email").toString();
     try {
       await request("/api/auth/email-otp/request-password-reset", { email: resetEmail });
+    } catch {
+      // Password recovery must not reveal whether an account or mailbox exists.
     } finally {
       resetForm.hidden = false;
       message("If this account exists, a reset code is on the way.");
+      resetForm.querySelector("input").focus();
+      setBusy(submit, false);
     }
   });
   resetForm?.addEventListener("submit", async (event) => {
     event.preventDefault();
+    const submit = resetForm.querySelector('button[type="submit"]');
+    if (submit?.disabled) return;
+    setBusy(submit, true);
     const data = new FormData(resetForm);
     try {
       await request("/api/auth/email-otp/reset-password", {
@@ -140,6 +217,8 @@ export const identityClientScript = String.raw`
       message("Password updated. You can sign in with it now.");
     } catch {
       message("The reset code is invalid or expired.", true);
+    } finally {
+      setBusy(submit, false);
     }
   });
 

--- a/identity/src/handler.ts
+++ b/identity/src/handler.ts
@@ -161,7 +161,11 @@ function nonNegativeSafeInteger(body: Record<string, unknown>, key: string): num
   return Number(value);
 }
 
-export async function identityHandler(req: IncomingMessage, res: ServerResponse): Promise<void> {
+export async function identityHandler(
+  req: IncomingMessage,
+  res: ServerResponse,
+  options?: { backgroundTaskHandler?: (promise: Promise<unknown>) => void },
+): Promise<void> {
   const publicBaseUrl = process.env.IDENTITY_BASE_URL ?? "http://127.0.0.1";
   const url = new URL(req.url ?? "/", publicBaseUrl);
 
@@ -191,7 +195,7 @@ export async function identityHandler(req: IncomingMessage, res: ServerResponse)
 
   // Static legal and bootstrap pages above intentionally remain deployable
   // before production OAuth and database credentials exist.
-  const runtime = getIdentityRuntime();
+  const runtime = getIdentityRuntime(options);
 
   if (req.method === "GET" && url.pathname === "/account") {
     const session = await runtime.auth.api.getSession({ headers: nodeHeaders(req) });

--- a/identity/src/identity.e2e.test.ts
+++ b/identity/src/identity.e2e.test.ts
@@ -35,6 +35,7 @@ describe("Rudder Identity HTTP journey", () => {
   let httpServer: Server | undefined;
   let tempDirectory: string;
   let baseUrl: string;
+  const backgroundTasks = new Set<Promise<unknown>>();
 
   async function availablePort(): Promise<number> {
     const probe = createServer();
@@ -70,6 +71,7 @@ describe("Rudder Identity HTTP journey", () => {
   }
 
   async function capturedMailbox() {
+    await Promise.all(backgroundTasks);
     return await (await fetch(`${baseUrl}/api/dev/mailbox`, {
       headers: { authorization: `Bearer ${CAPTURE_MAILBOX_SECRET}` },
     })).json() as {
@@ -105,7 +107,13 @@ describe("Rudder Identity HTTP journey", () => {
     await migrationConnection.close();
 
     const server = createServer((req, res) => {
-      void identityHandler(req, res).catch(() => {
+      void identityHandler(req, res, {
+        backgroundTaskHandler: (promise) => {
+          let tracked: Promise<unknown>;
+          tracked = promise.finally(() => backgroundTasks.delete(tracked));
+          backgroundTasks.add(tracked);
+        },
+      }).catch(() => {
         res.statusCode = 500;
         res.end(JSON.stringify({ error: "internal_server_error" }));
       });
@@ -334,6 +342,36 @@ describe("Rudder Identity HTTP journey", () => {
     });
     expect(existingReset.status).toBe(unknownReset.status);
     expect(await existingReset.json()).toEqual(await unknownReset.json());
+  });
+
+  it("keeps password recovery identical when mail delivery is slow and fails", async () => {
+    const runtime = getIdentityRuntime();
+    const originalSend = runtime.mail.send.bind(runtime.mail);
+    runtime.mail.send = async () => {
+      await new Promise((resolve) => setTimeout(resolve, 500));
+      throw new Error("injected mail transport failure");
+    };
+    try {
+      const startedAt = Date.now();
+      const [existingReset, unknownReset] = await Promise.all([
+        post("/api/auth/email-otp/request-password-reset", {
+          email: "password-e2e@example.com",
+        }),
+        post("/api/auth/email-otp/request-password-reset", {
+          email: `unknown-mail-failure-${randomUUID()}@example.com`,
+        }),
+      ]);
+      const responseTimeMs = Date.now() - startedAt;
+
+      expect(existingReset.status).toBe(200);
+      expect(unknownReset.status).toBe(200);
+      expect(await existingReset.json()).toEqual({ success: true });
+      expect(await unknownReset.json()).toEqual({ success: true });
+      expect(responseTimeMs).toBeLessThan(400);
+      await Promise.all(backgroundTasks);
+    } finally {
+      runtime.mail.send = originalSend;
+    }
   });
 
   it("converges concurrent verified Google and GitHub identities on one account", async () => {

--- a/identity/src/pages.test.ts
+++ b/identity/src/pages.test.ts
@@ -12,6 +12,12 @@ describe("Identity public pages", () => {
     expect(html).toContain("Sign in with password");
     expect(html).toContain("Create account with password");
     expect(html).toContain("Reset password");
+    expect(html).toContain('class="auth-card"');
+    expect(html).toContain("Welcome to Rudder");
+    expect(html).toContain("Signing in connects your identity and devices");
+    expect(html).toContain('id="change-email"');
+    expect(html).toContain("[hidden] { display: none !important; }");
+    expect(html).not.toContain("background-image");
     expect(html).not.toContain("font-family: Inter");
   });
 
@@ -66,6 +72,69 @@ describe("Identity public pages", () => {
     expect(passwordHandler).toBeTypeOf("function");
     await passwordHandler!({ preventDefault() {}, currentTarget: {} });
     expect(assigned).toBe("/");
+  });
+
+  it("keeps the email step visible when sending a code fails", async () => {
+    let otpHandler: ((event: { preventDefault(): void }) => Promise<void>) | undefined;
+    const status = { textContent: "", dataset: {} as Record<string, string>, style: { color: "" } };
+    const submit = {
+      dataset: {} as Record<string, string>,
+      disabled: false,
+      setAttribute() {},
+    };
+    const emailInput = { focus() {} };
+    const otpInput = { focus() {} };
+    const otpForm = {
+      hidden: false,
+      addEventListener: (
+        _name: string,
+        handler: (event: { preventDefault(): void }) => Promise<void>,
+      ) => {
+        otpHandler = handler;
+      },
+      querySelector: (selector: string) =>
+        selector === 'button[type="submit"]' ? submit : emailInput,
+    };
+    const verifyForm = {
+      hidden: true,
+      querySelector: () => otpInput,
+      addEventListener() {},
+    };
+    runInNewContext(identityClientScript, {
+      URL,
+      URLSearchParams,
+      location: {
+        origin: "https://accounts.rudderhq.dev",
+        search: "",
+        assign() {},
+      },
+      document: {
+        querySelector: (selector: string) => {
+          if (selector === "#auth-status") return status;
+          if (selector === "#otp-form") return otpForm;
+          if (selector === "#otp-verify-form") return verifyForm;
+          return null;
+        },
+        querySelectorAll: () => [],
+      },
+      FormData: class {
+        get() {
+          return "owner@example.com";
+        }
+      },
+      fetch: async () => ({
+        ok: false,
+        json: async () => ({ message: "Mail transport unavailable" }),
+      }),
+    });
+
+    expect(otpHandler).toBeTypeOf("function");
+    await otpHandler!({ preventDefault() {} });
+    expect(otpForm.hidden).toBe(false);
+    expect(verifyForm.hidden).toBe(true);
+    expect(submit.disabled).toBe(false);
+    expect(status.dataset.state).toBe("error");
+    expect(status.textContent).toBe("Mail transport unavailable");
   });
 
   it("publishes the Local privacy boundary and deletion contact", () => {

--- a/identity/src/pages.ts
+++ b/identity/src/pages.ts
@@ -9,7 +9,7 @@ function escapeHtml(value: string): string {
     .replaceAll("'", "&#039;");
 }
 
-function page(title: string, body: string): string {
+function page(title: string, body: string, layout: "document" | "auth" = "document"): string {
   return `<!doctype html>
 <html lang="en">
 <head>
@@ -17,68 +17,211 @@ function page(title: string, body: string): string {
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>${escapeHtml(title)} · Rudder Account</title>
   <style>
-    :root { color-scheme: light dark; font-family: Geist, Avenir, ui-sans-serif, system-ui, sans-serif; }
-    body { margin: 0; background: #0b0c0f; color: #f5f5f4; }
-    main { max-width: 720px; margin: 0 auto; padding: 72px 24px 96px; }
-    a { color: #a7f3d0; } h1 { font-size: 2.5rem; letter-spacing: -.04em; }
-    h2 { margin-top: 2rem; } p, li { color: #d6d3d1; line-height: 1.65; }
-    nav { display: flex; gap: 20px; margin-top: 40px; }
-    .eyebrow { color: #a7f3d0; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; }
-    section { display: grid; gap: 12px; margin-top: 32px; padding: 24px; border: 1px solid #292524; border-radius: 16px; }
-    form { display: grid; gap: 12px; } label { display: grid; gap: 6px; }
-    input, button { box-sizing: border-box; width: 100%; padding: 12px 14px; border: 1px solid #44403c; border-radius: 9px; font: inherit; }
-    button { cursor: pointer; font-weight: 700; } button:disabled { cursor: not-allowed; opacity: .45; }
+    :root {
+      color-scheme: light dark;
+      font-family: Geist, "Avenir Next", ui-sans-serif, system-ui, -apple-system, sans-serif;
+      --page: #f1f0ec;
+      --surface: #fbfaf7;
+      --surface-raised: #ffffff;
+      --surface-muted: #f3f2ee;
+      --text: #20211f;
+      --muted: #676963;
+      --faint: #92958d;
+      --line: #deddd7;
+      --line-strong: #cbc9c1;
+      --primary: #20211f;
+      --primary-text: #fbfaf7;
+      --focus: #2f7d5a;
+      --positive: #256f4d;
+      --negative: #b33a35;
+      --shadow: rgba(54, 52, 45, .11);
+    }
+    * { box-sizing: border-box; }
+    body { margin: 0; min-width: 320px; background: var(--page); color: var(--text); }
+    main { max-width: 760px; margin: 0 auto; padding: 72px 24px 96px; }
+    a { color: inherit; text-underline-offset: 3px; }
+    h1 { margin: 16px 0; font-size: clamp(2rem, 5vw, 2.75rem); letter-spacing: -.045em; line-height: 1.04; }
+    h2 { margin-top: 2rem; }
+    p, li { color: var(--muted); line-height: 1.65; }
+    nav { display: flex; flex-wrap: wrap; gap: 20px; margin-top: 40px; }
+    .eyebrow { color: var(--positive); font-size: .78rem; font-weight: 750; letter-spacing: .1em; text-transform: uppercase; }
+    section { display: grid; gap: 12px; margin-top: 32px; padding: 24px; border: 1px solid var(--line); border-radius: 16px; background: color-mix(in srgb, var(--surface) 78%, transparent); }
+    form { display: grid; gap: 14px; }
+    label { display: grid; gap: 7px; color: var(--text); font-size: .82rem; font-weight: 650; }
+    input, button { box-sizing: border-box; width: 100%; min-height: 46px; padding: 11px 13px; border: 1px solid var(--line-strong); border-radius: 10px; font: inherit; }
+    input { background: var(--surface-raised); color: var(--text); outline: none; }
+    input::placeholder { color: var(--faint); }
+    input:focus-visible, button:focus-visible, summary:focus-visible, a:focus-visible {
+      outline: 3px solid color-mix(in srgb, var(--focus) 32%, transparent);
+      outline-offset: 2px;
+    }
+    button { cursor: pointer; background: var(--surface-raised); color: var(--text); font-weight: 700; transition: transform 140ms ease, border-color 140ms ease, background 140ms ease; }
+    button:hover:not(:disabled) { border-color: var(--text); }
+    button:active:not(:disabled) { transform: translateY(1px); }
+    button:disabled { cursor: not-allowed; opacity: .48; }
+    button[data-loading="true"] { cursor: progress; opacity: .68; }
+    .auth-page { min-height: 100dvh; display: grid; place-items: center; padding: 48px 20px; }
+    .auth-page main { width: 100%; max-width: 440px; margin: 0; padding: 0; }
+    .auth-card {
+      display: block;
+      width: 100%;
+      margin: 0;
+      padding: 34px;
+      border: 1px solid color-mix(in srgb, var(--line) 86%, transparent);
+      border-radius: 22px;
+      background: var(--surface);
+      box-shadow: 0 24px 64px -36px var(--shadow), 0 8px 24px -18px var(--shadow);
+    }
+    .brand-mark {
+      display: grid;
+      width: 44px;
+      height: 44px;
+      margin: 0 auto 20px;
+      place-items: center;
+      border: 1px solid var(--line-strong);
+      border-radius: 12px;
+      background: var(--primary);
+      color: var(--primary-text);
+      box-shadow: inset 0 1px 0 color-mix(in srgb, white 14%, transparent);
+    }
+    .brand-mark svg { width: 29px; height: 29px; }
+    .auth-heading { margin: 0; text-align: center; font-size: 1.72rem; letter-spacing: -.035em; line-height: 1.15; }
+    .auth-intro { max-width: 34ch; margin: 10px auto 26px; text-align: center; color: var(--muted); font-size: .92rem; line-height: 1.55; }
+    .social-stack { display: grid; gap: 10px; }
+    .social-button { position: relative; display: grid; grid-template-columns: 22px 1fr 22px; align-items: center; background: var(--surface-raised); }
+    .social-button svg { width: 18px; height: 18px; }
+    .social-button span { grid-column: 2; }
+    .divider { display: grid; grid-template-columns: 1fr auto 1fr; gap: 12px; align-items: center; margin: 22px 0; color: var(--faint); font-size: .68rem; font-weight: 780; letter-spacing: .12em; text-transform: uppercase; }
+    .divider::before, .divider::after { content: ""; height: 1px; background: var(--line); }
+    .primary-button { border-color: var(--primary); background: var(--primary); color: var(--primary-text); }
+    .primary-button:hover:not(:disabled) { background: color-mix(in srgb, var(--primary) 91%, white); }
+    .auth-form + .auth-form { margin-top: 14px; }
+    .otp-form { margin-top: 16px; padding-top: 16px; border-top: 1px solid var(--line); }
+    .step-context { display: flex; align-items: center; justify-content: space-between; gap: 12px; color: var(--muted); font-size: .78rem; }
+    .step-context strong { color: var(--text); font-weight: 680; }
+    .text-button { width: auto; min-height: 0; padding: 0; border: 0; border-radius: 0; background: transparent; color: var(--muted); font-size: .76rem; text-decoration: underline; text-underline-offset: 3px; }
+    .text-button:hover:not(:disabled) { border-color: transparent; color: var(--text); }
+    .mode-toggle { display: block; width: fit-content; min-height: 0; margin: 18px auto 0; padding: 0; border: 0; border-radius: 0; background: transparent; color: var(--muted); font-size: .82rem; font-weight: 680; }
+    .mode-toggle::after { content: " →"; }
+    .mode-toggle:hover:not(:disabled) { border-color: transparent; color: var(--text); }
+    .password-panel { margin-top: 18px; }
+    .password-section { display: grid; gap: 14px; padding-top: 18px; border-top: 1px solid var(--line); }
+    .password-section + .password-section { margin-top: 18px; }
+    .password-section h2 { margin: 0; font-size: .9rem; letter-spacing: -.01em; }
+    .password-section p { margin: -6px 0 0; font-size: .78rem; line-height: 1.5; }
+    .secondary-disclosure > summary { color: var(--muted); cursor: pointer; font-size: .8rem; font-weight: 650; }
+    .secondary-disclosure form { margin-top: 14px; }
+    .auth-status { min-height: 20px; margin: 16px 0 0; text-align: center; font-size: .8rem; line-height: 1.45; }
+    .auth-status[data-state="error"] { color: var(--negative); }
+    .auth-status[data-state="success"] { color: var(--positive); }
+    .auth-privacy { margin: 22px auto 0; text-align: center; color: var(--faint); font-size: .74rem; line-height: 1.5; }
+    .auth-legal { display: flex; justify-content: center; gap: 18px; margin-top: 12px; color: var(--muted); font-size: .75rem; }
+    [hidden] { display: none !important; }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --page: #171816;
+        --surface: #20211f;
+        --surface-raised: #272825;
+        --surface-muted: #242522;
+        --text: #f1f0eb;
+        --muted: #b1b3ac;
+        --faint: #858880;
+        --line: #363833;
+        --line-strong: #474a43;
+        --primary: #f1f0eb;
+        --primary-text: #1d1e1b;
+        --focus: #70b58f;
+        --positive: #8dc9a7;
+        --negative: #f08c85;
+        --shadow: rgba(0, 0, 0, .42);
+      }
+    }
+    @media (max-width: 520px) {
+      .auth-page { padding: 20px 14px; align-items: start; }
+      .auth-card { padding: 28px 22px; border-radius: 18px; }
+    }
+    @media (prefers-reduced-motion: reduce) {
+      button { transition: none; }
+    }
   </style>
 </head>
-<body><main>${body}</main></body>
+<body class="${layout === "auth" ? "auth-page" : "document-page"}"><main>${body}</main></body>
 </html>`;
 }
 
 export function homePage(providers: { google: boolean; github: boolean }): string {
   return page(
     "Sign in",
-    `<p class="eyebrow">Rudder Account</p>
-     <h1>Your identity for Rudder.</h1>
-     <p>Sign in securely from Rudder Desktop. Your Local Workspace content stays on your device and is not uploaded just because you sign in.</p>
-     <section aria-labelledby="sign-in-heading">
-       <h2 id="sign-in-heading">Sign in</h2>
-       <button type="button" data-social="google"${providers.google ? "" : " disabled"}>Continue with Google</button>
-       <button type="button" data-social="github"${providers.github ? "" : " disabled"}>Continue with GitHub</button>
-       <form id="otp-form">
-         <label>Email <input required type="email" name="email" autocomplete="email"></label>
-         <button type="submit">Continue with email code</button>
+    `<section class="auth-card" aria-labelledby="sign-in-heading">
+       <div class="brand-mark" aria-hidden="true">
+         <svg viewBox="0 0 64 64" role="img">
+           <path fill="var(--primary-text)" d="M32 3a29 29 0 1 0 29 29A29 29 0 0 0 32 3Zm0 6a23 23 0 0 1 22.4 17.8l-6 1.6A17 17 0 0 0 18.5 43l-5.3 3.2A23 23 0 0 1 32 9Z"/>
+           <path fill="var(--primary)" d="m17 42 33-14-16 28 1.4-15.2Z"/>
+         </svg>
+       </div>
+       <h1 class="auth-heading" id="sign-in-heading">Welcome to Rudder</h1>
+       <p class="auth-intro">Sign in to connect this device. Your Local Workspace stays on your machine.</p>
+       <div class="social-stack" role="group" aria-label="Social sign in">
+         <button class="social-button" type="button" data-social="google"${providers.google ? "" : " disabled"}>
+           <svg viewBox="0 0 24 24" aria-hidden="true"><path fill="#4285F4" d="M21.6 12.23c0-.71-.06-1.4-.19-2.07H12v3.92h5.38a4.6 4.6 0 0 1-2 3.02v2.55h3.24c1.9-1.75 2.98-4.33 2.98-7.42Z"/><path fill="#34A853" d="M12 22c2.7 0 4.98-.9 6.63-2.43l-3.24-2.54c-.9.6-2.05.96-3.39.96-2.61 0-4.82-1.76-5.61-4.13H3.05v2.62A10 10 0 0 0 12 22Z"/><path fill="#FBBC05" d="M6.39 13.86A6 6 0 0 1 6.08 12c0-.65.11-1.28.31-1.86V7.52H3.05A10 10 0 0 0 2 12c0 1.61.38 3.14 1.05 4.48l3.34-2.62Z"/><path fill="#EA4335" d="M12 6.01c1.47 0 2.79.5 3.83 1.5l2.87-2.87A9.65 9.65 0 0 0 12 2a10 10 0 0 0-8.95 5.52l3.34 2.62C7.18 7.77 9.39 6.01 12 6.01Z"/></svg>
+           <span>Continue with Google</span>
+         </button>
+         <button class="social-button" type="button" data-social="github"${providers.github ? "" : " disabled"}>
+           <svg viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M12 2a10 10 0 0 0-3.16 19.49c.5.09.68-.22.68-.48l-.01-1.87c-2.78.6-3.37-1.18-3.37-1.18-.45-1.16-1.11-1.47-1.11-1.47-.91-.62.07-.61.07-.61 1 .07 1.54 1.03 1.54 1.03.9 1.53 2.35 1.09 2.92.83.09-.65.35-1.09.64-1.34-2.22-.25-4.56-1.11-4.56-4.94 0-1.09.39-1.98 1.03-2.68-.1-.25-.45-1.27.1-2.64 0 0 .84-.27 2.75 1.02A9.57 9.57 0 0 1 12 6.82c.85 0 1.7.11 2.5.34 1.91-1.29 2.75-1.02 2.75-1.02.55 1.37.2 2.39.1 2.64.64.7 1.03 1.59 1.03 2.68 0 3.84-2.34 4.68-4.57 4.93.36.31.68.92.68 1.86l-.01 2.76c0 .27.18.58.69.48A10 10 0 0 0 12 2Z"/></svg>
+           <span>Continue with GitHub</span>
+         </button>
+       </div>
+       <div class="divider">or continue with email</div>
+       <form class="auth-form" id="otp-form">
+         <label>Email address <input required type="email" name="email" autocomplete="email" placeholder="you@example.com"></label>
+         <button class="primary-button" type="submit">Continue with email code</button>
        </form>
-       <form id="otp-verify-form" hidden>
-         <label>6-digit code <input required name="otp" inputmode="numeric" autocomplete="one-time-code" pattern="[0-9]{6}"></label>
-         <button type="submit">Verify code</button>
+       <form class="auth-form otp-form" id="otp-verify-form" hidden>
+         <div class="step-context">
+           <span>Code sent to <strong id="otp-email"></strong></span>
+           <button class="text-button" id="change-email" type="button">Change email</button>
+         </div>
+         <label>Verification code <input required name="otp" inputmode="numeric" autocomplete="one-time-code" pattern="[0-9]{6}" maxlength="6" placeholder="000000"></label>
+         <button class="primary-button" type="submit">Verify and continue</button>
        </form>
-       <details>
-         <summary>Use password instead</summary>
-         <form id="password-form">
-           <label>Email <input required type="email" name="email" autocomplete="email"></label>
-           <label>Password <input required type="password" name="password" minlength="8" maxlength="128" autocomplete="current-password"></label>
-           <button type="submit">Sign in with password</button>
-         </form>
-         <form id="password-signup-form">
-           <label>Name <input required name="name" autocomplete="name"></label>
-           <label>Email <input required type="email" name="email" autocomplete="email"></label>
-           <label>Password <input required type="password" name="password" minlength="8" maxlength="128" autocomplete="new-password"></label>
-           <button type="submit">Create account with password</button>
-         </form>
-         <form id="forgot-password-form">
-           <label>Email <input required type="email" name="email" autocomplete="email"></label>
-           <button type="submit">Forgot password</button>
-         </form>
-         <form id="reset-password-form" hidden>
-           <label>6-digit reset code <input required name="otp" inputmode="numeric" autocomplete="one-time-code" pattern="[0-9]{6}"></label>
-           <label>New password <input required type="password" name="password" minlength="8" maxlength="128" autocomplete="new-password"></label>
-           <button type="submit">Reset password</button>
-         </form>
-       </details>
-       <p id="auth-status" role="status" aria-live="polite"></p>
+       <button class="mode-toggle" id="password-mode-toggle" type="button" aria-controls="password-panel" aria-expanded="false">Use password instead</button>
+       <div class="password-panel" id="password-panel" hidden>
+         <div class="password-section">
+           <h2>Password sign in</h2>
+           <form class="auth-form" id="password-form">
+             <label>Email address <input required type="email" name="email" autocomplete="email"></label>
+             <label>Password <input required type="password" name="password" minlength="8" maxlength="128" autocomplete="current-password"></label>
+             <button class="primary-button" type="submit">Sign in with password</button>
+           </form>
+           <details class="secondary-disclosure">
+             <summary>Create a password account</summary>
+             <form class="auth-form" id="password-signup-form">
+               <label>Name <input required name="name" autocomplete="name"></label>
+               <label>Email address <input required type="email" name="email" autocomplete="email"></label>
+               <label>Password <input required type="password" name="password" minlength="8" maxlength="128" autocomplete="new-password"></label>
+               <button type="submit">Create account with password</button>
+             </form>
+           </details>
+           <details class="secondary-disclosure">
+             <summary>Forgot password?</summary>
+             <form class="auth-form" id="forgot-password-form">
+               <label>Email address <input required type="email" name="email" autocomplete="email"></label>
+               <button type="submit">Send reset code</button>
+             </form>
+             <form class="auth-form otp-form" id="reset-password-form" hidden>
+               <label>Reset code <input required name="otp" inputmode="numeric" autocomplete="one-time-code" pattern="[0-9]{6}" maxlength="6"></label>
+               <label>New password <input required type="password" name="password" minlength="8" maxlength="128" autocomplete="new-password"></label>
+               <button class="primary-button" type="submit">Reset password</button>
+             </form>
+           </details>
+         </div>
+       </div>
+       <p class="auth-status" id="auth-status" role="status" aria-live="polite"></p>
+       <p class="auth-privacy">Signing in connects your identity and devices. It does not upload Local Workspace content.</p>
+       <nav class="auth-legal"><a href="/privacy">Privacy</a><a href="/terms">Terms</a></nav>
      </section>
-     <nav><a href="/privacy">Privacy</a><a href="/terms">Terms</a></nav>
-     <script src="/identity.js" defer></script>`,
+     <script src="/identity.js?v=20260730-login-card" defer></script>`,
+    "auth",
   );
 }
 

--- a/identity/src/runtime.ts
+++ b/identity/src/runtime.ts
@@ -24,7 +24,9 @@ export type IdentityRuntime = {
 
 let singleton: IdentityRuntime | undefined;
 
-export function getIdentityRuntime(): IdentityRuntime {
+export function getIdentityRuntime(options?: {
+  backgroundTaskHandler?: (promise: Promise<unknown>) => void;
+}): IdentityRuntime {
   if (singleton) return singleton;
   const config = readIdentityConfig();
   const connection = createIdentityDb(config.databaseUrl);
@@ -57,7 +59,12 @@ export function getIdentityRuntime(): IdentityRuntime {
     mail,
     capturedMail,
     offlineGrantSigning,
-    auth: createIdentityAuth({ db: connection.db, config, mail }),
+    auth: createIdentityAuth({
+      db: connection.db,
+      config,
+      mail,
+      backgroundTaskHandler: options?.backgroundTaskHandler,
+    }),
   };
   return singleton;
 }

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "smoke:openclaw-docker-ui": "./scripts/smoke/openclaw-docker-ui.sh",
     "smoke:openclaw-sse-standalone": "./scripts/smoke/openclaw-sse-standalone.sh",
     "test:e2e": "npx playwright test --config tests/e2e/playwright.config.ts",
+    "test:identity-ui": "playwright test --config tests/identity-ui/playwright.config.ts",
     "test:e2e:headed": "npx playwright test --config tests/e2e/playwright.config.ts --headed",
     "test:docs-search": "playwright test --config tests/docs-search/playwright.config.ts",
     "perf:workflows": "node cli/node_modules/tsx/dist/cli.mjs scripts/perf/workflow-baseline.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -145,6 +145,9 @@ importers:
       '@rudderhq/identity-db':
         specifier: workspace:*
         version: link:../packages/identity-db
+      '@vercel/functions':
+        specifier: ^2.2.13
+        version: 2.2.13(@aws-sdk/credential-provider-web-identity@3.972.24)
       better-auth:
         specifier: 1.6.23
         version: 1.6.23(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(kysely@0.29.3)(pg@8.20.0)(postgres@3.4.8))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@3.2.7(@types/debug@4.1.13)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.32.0)(tsx@4.21.0))(vue@3.5.34(typescript@5.9.3))
@@ -4187,6 +4190,19 @@ packages:
   '@upsetjs/venn.js@2.0.0':
     resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
 
+  '@vercel/functions@2.2.13':
+    resolution: {integrity: sha512-14ArBSIIcOBx9nrEgaJb4Bw+en1gl6eSoJWh8qjifLl5G3E4dRXCFOT8HP+w66vb9Wqyd1lAQBrmRhRwOj9X9A==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      '@aws-sdk/credential-provider-web-identity': '*'
+    peerDependenciesMeta:
+      '@aws-sdk/credential-provider-web-identity':
+        optional: true
+
+  '@vercel/oidc@2.0.2':
+    resolution: {integrity: sha512-59PBFx3T+k5hLTEWa3ggiMpGRz1OVvl9eN8SUai+A43IsqiOuAe7qPBf+cray/Fj6mkgnxm/D7IAtjc8zSHi7g==}
+    engines: {node: '>= 18'}
+
   '@vitejs/plugin-react@4.7.0':
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -6604,11 +6620,6 @@ packages:
   plist@3.1.0:
     resolution: {integrity: sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==}
     engines: {node: '>=10.4.0'}
-
-  pnpm@9.15.4:
-    resolution: {integrity: sha512-stwg4vxys+GISEWbNzWaMgZGY+VielHkx0ssKd2OjgSRSDw6u0B4nP1Xi/Ni+2uoJhsF8Dh9dnku1uI+o7G2oA==}
-    engines: {node: '>=18.12'}
-    hasBin: true
 
   points-on-curve@0.2.0:
     resolution: {integrity: sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==}
@@ -11777,6 +11788,17 @@ snapshots:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
 
+  '@vercel/functions@2.2.13(@aws-sdk/credential-provider-web-identity@3.972.24)':
+    dependencies:
+      '@vercel/oidc': 2.0.2
+    optionalDependencies:
+      '@aws-sdk/credential-provider-web-identity': 3.972.24
+
+  '@vercel/oidc@2.0.2':
+    dependencies:
+      '@types/ms': 2.1.0
+      ms: 2.1.3
+
   '@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))':
     dependencies:
       '@babel/core': 7.29.0
@@ -14690,8 +14712,6 @@ snapshots:
       '@xmldom/xmldom': 0.8.11
       base64-js: 1.5.1
       xmlbuilder: 15.1.1
-
-  pnpm@9.15.4: {}
 
   points-on-curve@0.2.0: {}
 

--- a/scripts/release-workflow-contract.test.mjs
+++ b/scripts/release-workflow-contract.test.mjs
@@ -106,6 +106,20 @@ describe("release workflow latency contracts", () => {
     expect(releaseWorkflow).toContain('-f source_ref="$tag"');
   });
 
+  it("opens the packaged macOS account gate before publishing Desktop artifacts", () => {
+    expect(desktopWorkflow).toContain("matrix.platform == 'macos' && matrix.arch == 'arm64'");
+    expect(desktopWorkflow).toContain(
+      "node desktop/scripts/smoke.mjs --mode=packaged --scenario=account-gate",
+    );
+
+    const smokeIndex = desktopWorkflow.indexOf(
+      "node desktop/scripts/smoke.mjs --mode=packaged --scenario=account-gate",
+    );
+    const collectIndex = desktopWorkflow.indexOf("node scripts/collect-desktop-release-assets.mjs");
+    expect(smokeIndex).toBeGreaterThan(-1);
+    expect(collectIndex).toBeGreaterThan(smokeIndex);
+  });
+
   it("does not rebuild after the local verification gate already built the workspace", () => {
     expect(releaseScript).toContain("workspace_built=true");
     expect(releaseScript).toContain("Reusing workspace build from verification gate");

--- a/tests/identity-ui/identity-login.spec.ts
+++ b/tests/identity-ui/identity-login.spec.ts
@@ -1,0 +1,235 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Rudder Account login UI", () => {
+  test("shows one focused login task at a time and remains responsive", async ({ page }) => {
+    await page.goto("/");
+
+    await expect(page.getByRole("heading", { name: "Welcome to Rudder" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Continue with Google" })).toBeEnabled();
+    await expect(page.getByRole("button", { name: "Continue with GitHub" })).toBeEnabled();
+    await expect(page.locator("#otp-form")).toBeVisible();
+    await expect(page.locator("#otp-verify-form")).toBeHidden();
+    await expect(page.locator("#password-panel")).toBeHidden();
+    await expect(page.locator("#reset-password-form")).toBeHidden();
+
+    const passwordMode = page.locator("#password-mode-toggle");
+    await passwordMode.click();
+    await expect(passwordMode).toHaveAttribute("aria-expanded", "true");
+    await expect(page.locator("#otp-form")).toBeHidden();
+    await expect(page.locator("#password-panel")).toBeVisible();
+    await expect(page.locator('#password-form input[name="email"]')).toBeFocused();
+
+    await passwordMode.click();
+    await expect(passwordMode).toHaveAttribute("aria-expanded", "false");
+    await expect(page.locator("#otp-form")).toBeVisible();
+    await expect(page.locator("#password-panel")).toBeHidden();
+    await expect(page.locator('#otp-form input[name="email"]')).toBeFocused();
+
+    await page.setViewportSize({ width: 390, height: 844 });
+    const dimensions = await page.evaluate(() => ({
+      viewport: window.innerWidth,
+      document: document.documentElement.scrollWidth,
+      card: document.querySelector(".auth-card")?.getBoundingClientRect().width ?? 0,
+    }));
+    expect(dimensions.document).toBe(dimensions.viewport);
+    expect(dimensions.card).toBeLessThanOrEqual(dimensions.viewport);
+  });
+
+  test("switches to the verification step once and supports changing email", async ({ page }) => {
+    let sendCount = 0;
+    await page.route("**/api/auth/email-otp/send-verification-otp", async (route) => {
+      sendCount += 1;
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: "{}",
+      });
+    });
+    await page.goto("/");
+
+    await page.locator("#otp-form").getByLabel("Email address").fill("login-ui@rudderhq.dev");
+    const continueButton = page.getByRole("button", { name: "Continue with email code" });
+    const passwordMode = page.locator("#password-mode-toggle");
+    const submitPromise = continueButton.dblclick();
+    await expect(passwordMode).toBeDisabled();
+    await submitPromise;
+
+    await expect(page.locator("#otp-form")).toBeHidden();
+    await expect(page.locator("#otp-verify-form")).toBeVisible();
+    await expect(page.locator("#otp-email")).toHaveText("login-ui@rudderhq.dev");
+    expect(sendCount).toBe(1);
+
+    await page.getByRole("button", { name: "Change email" }).click();
+    await expect(page.locator("#otp-form")).toBeVisible();
+    await expect(page.locator("#otp-verify-form")).toBeHidden();
+    await expect(page.locator('#otp-form input[name="email"]')).toBeFocused();
+  });
+
+  test("keeps email entry recoverable when code delivery fails", async ({ page }) => {
+    await page.route("**/api/auth/email-otp/send-verification-otp", (route) =>
+      route.fulfill({
+        status: 503,
+        contentType: "application/json",
+        body: JSON.stringify({ message: "Mail transport unavailable" }),
+      }));
+    await page.goto("/");
+
+    await page.locator("#otp-form").getByLabel("Email address").fill("delivery-test@rudderhq.dev");
+    await page.getByRole("button", { name: "Continue with email code" }).click();
+
+    await expect(page.locator("#otp-form")).toBeVisible();
+    await expect(page.locator("#otp-verify-form")).toBeHidden();
+    await expect(page.getByRole("status")).toHaveText("Mail transport unavailable");
+    await expect(page.getByRole("status")).toHaveAttribute("data-state", "error");
+    await expect(page.getByRole("button", { name: "Continue with email code" })).toBeEnabled();
+  });
+
+  test("verifies an email code and rejects an unsafe next redirect", async ({ page }) => {
+    let verificationBody: { email?: string; otp?: string } = {};
+    await page.route("**/api/auth/email-otp/send-verification-otp", (route) =>
+      route.fulfill({ status: 200, contentType: "application/json", body: "{}" }));
+    await page.route("**/api/auth/sign-in/email-otp", async (route) => {
+      verificationBody = route.request().postDataJSON();
+      await route.fulfill({ status: 200, contentType: "application/json", body: "{}" });
+    });
+    await page.goto("/?next=https://evil.example/collect");
+
+    await page.locator("#otp-form").getByLabel("Email address").fill("owner@rudderhq.dev");
+    await page.getByRole("button", { name: "Continue with email code" }).click();
+    await page.locator("#otp-verify-form").getByLabel("Verification code").fill("123456");
+    await page.getByRole("button", { name: "Verify and continue" }).click();
+
+    await expect(page).toHaveURL("/");
+    expect(verificationBody).toEqual({ email: "owner@rudderhq.dev", otp: "123456" });
+  });
+
+  test("keeps an invalid email code recoverable", async ({ page }) => {
+    await page.route("**/api/auth/email-otp/send-verification-otp", (route) =>
+      route.fulfill({ status: 200, contentType: "application/json", body: "{}" }));
+    await page.route("**/api/auth/sign-in/email-otp", (route) =>
+      route.fulfill({
+        status: 401,
+        contentType: "application/json",
+        body: JSON.stringify({ message: "The code is invalid or expired" }),
+      }));
+    await page.goto("/");
+
+    await page.locator("#otp-form").getByLabel("Email address").fill("owner@rudderhq.dev");
+    await page.getByRole("button", { name: "Continue with email code" }).click();
+    await page.locator("#otp-verify-form").getByLabel("Verification code").fill("000000");
+    await page.getByRole("button", { name: "Verify and continue" }).click();
+
+    await expect(page.locator("#otp-verify-form")).toBeVisible();
+    await expect(page.getByRole("status")).toHaveAttribute("data-state", "error");
+    await expect(page.getByRole("button", { name: "Verify and continue" })).toBeEnabled();
+  });
+
+  test("signs in with a password from the mutually exclusive password mode", async ({ page }) => {
+    let signInBody: { email?: string; password?: string } = {};
+    await page.route("**/api/auth/sign-in/email", async (route) => {
+      signInBody = route.request().postDataJSON();
+      await route.fulfill({ status: 200, contentType: "application/json", body: "{}" });
+    });
+    await page.goto("/");
+    await page.locator("#password-mode-toggle").click();
+
+    await page.locator("#password-form").getByLabel("Email address").fill("owner@rudderhq.dev");
+    await page.locator("#password-form").getByLabel("Password").fill("correct horse battery");
+    await page.getByRole("button", { name: "Sign in with password" }).click();
+
+    await expect(page).toHaveURL("/");
+    expect(signInBody).toEqual({
+      email: "owner@rudderhq.dev",
+      password: "correct horse battery",
+    });
+  });
+
+  test("moves password registration into the single email verification step", async ({ page }) => {
+    await page.route("**/api/auth/sign-up/email", (route) =>
+      route.fulfill({ status: 200, contentType: "application/json", body: "{}" }));
+    await page.goto("/");
+    await page.locator("#password-mode-toggle").click();
+    await page.getByText("Create a password account").click();
+
+    const signup = page.locator("#password-signup-form");
+    await signup.getByLabel("Name").fill("Rudder Owner");
+    await signup.getByLabel("Email address").fill("new-owner@rudderhq.dev");
+    await signup.getByLabel("Password").fill("correct horse battery");
+    await signup.getByRole("button", { name: "Create account with password" }).click();
+
+    await expect(page.locator("#password-panel")).toBeHidden();
+    await expect(page.locator("#otp-verify-form")).toBeVisible();
+    await expect(page.locator("#otp-email")).toHaveText("new-owner@rudderhq.dev");
+    await expect(page.locator("#otp-verify-form").getByLabel("Verification code")).toBeFocused();
+  });
+
+  for (const responseStatus of [200, 503]) {
+    test(`keeps password recovery account-private after a ${responseStatus} response`, async ({ page }) => {
+      await page.route("**/api/auth/email-otp/request-password-reset", (route) =>
+        route.fulfill({
+          status: responseStatus,
+          contentType: "application/json",
+          body: responseStatus === 200 ? "{}" : JSON.stringify({ message: "Mail transport unavailable" }),
+        }));
+      await page.goto("/");
+      await page.locator("#password-mode-toggle").click();
+      await page.getByText("Forgot password?").click();
+
+      const forgot = page.locator("#forgot-password-form");
+      await forgot.getByLabel("Email address").fill("private@rudderhq.dev");
+      await forgot.getByRole("button", { name: "Send reset code" }).click();
+
+      await expect(page.locator("#reset-password-form")).toBeVisible();
+      await expect(page.getByRole("status")).toHaveText(
+        "If this account exists, a reset code is on the way.",
+      );
+      await expect(page.getByRole("status")).toHaveAttribute("data-state", "success");
+      await expect(page.locator("#reset-password-form").getByLabel("Reset code")).toBeFocused();
+    });
+  }
+
+  test("submits a reset code and leaves an invalid attempt recoverable", async ({ page }) => {
+    await page.route("**/api/auth/email-otp/request-password-reset", (route) =>
+      route.fulfill({ status: 200, contentType: "application/json", body: "{}" }));
+    await page.route("**/api/auth/email-otp/reset-password", (route) =>
+      route.fulfill({ status: 401, contentType: "application/json", body: "{}" }));
+    await page.goto("/");
+    await page.locator("#password-mode-toggle").click();
+    await page.getByText("Forgot password?").click();
+    await page.locator("#forgot-password-form").getByLabel("Email address").fill("owner@rudderhq.dev");
+    await page.getByRole("button", { name: "Send reset code" }).click();
+
+    const reset = page.locator("#reset-password-form");
+    await reset.getByLabel("Reset code").fill("000000");
+    await reset.getByLabel("New password").fill("replacement password");
+    await reset.getByRole("button", { name: "Reset password" }).click();
+
+    await expect(reset).toBeVisible();
+    await expect(page.getByRole("status")).toHaveText("The reset code is invalid or expired.");
+    await expect(reset.getByRole("button", { name: "Reset password" })).toBeEnabled();
+  });
+
+  for (const provider of ["Google", "GitHub"] as const) {
+    test(`starts ${provider} OAuth from the visible provider control`, async ({ page }) => {
+      let requestProvider = "";
+      await page.route("**/api/auth/sign-in/social", async (route) => {
+        const body = route.request().postDataJSON() as { provider?: string };
+        requestProvider = body.provider ?? "";
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            url: `http://127.0.0.1:3211/?oauth=${requestProvider}`,
+          }),
+        });
+      });
+      await page.goto("/");
+
+      await page.getByRole("button", { name: `Continue with ${provider}` }).click();
+
+      await expect(page).toHaveURL(`/?oauth=${provider.toLowerCase()}`);
+      expect(requestProvider).toBe(provider.toLowerCase());
+    });
+  }
+});

--- a/tests/identity-ui/playwright.config.ts
+++ b/tests/identity-ui/playwright.config.ts
@@ -1,0 +1,38 @@
+import { defineConfig } from "@playwright/test";
+
+const port = 3211;
+const baseURL = `http://127.0.0.1:${port}`;
+
+export default defineConfig({
+  testDir: ".",
+  testMatch: "**/*.spec.ts",
+  timeout: 30_000,
+  retries: 0,
+  use: {
+    baseURL,
+    headless: true,
+    screenshot: "only-on-failure",
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { browserName: "chromium" },
+    },
+  ],
+  webServer: {
+    command: [
+      `IDENTITY_BASE_URL=${baseURL}`,
+      "IDENTITY_GOOGLE_CLIENT_ID=identity-ui-google-fixture",
+      "IDENTITY_GITHUB_CLIENT_ID=identity-ui-github-fixture",
+      "pnpm --filter @rudderhq/identity dev",
+    ].join(" "),
+    url: baseURL,
+    reuseExistingServer: false,
+    timeout: 30_000,
+    stdout: "pipe",
+    stderr: "pipe",
+  },
+  outputDir: "./test-results",
+  reporter: [["list"]],
+});


### PR DESCRIPTION
## Summary
- redesign Rudder Account sign-in as a compact centered card on the default Rudder background
- keep Google, GitHub, email OTP, and password flows mutually exclusive and accessible
- prevent password-recovery account enumeration with Vercel background email delivery
- normalize packaged @rudderhq manifests and block Desktop releases unless the packaged account gate opens
- add browser E2E coverage for OAuth entry, OTP, password signup/sign-in/reset, unsafe redirects, and mobile layout

## Verification
- Identity tests: 32/32
- Identity UI Playwright: 12/12
- after-pack + release workflow contract: 10/10
- lint, recursive typecheck, build, product-logic check: pass
- packaged macOS account gate: independent PASS in 3.662s
- independent reviewer: PASS

## Full-suite note
The parallel full test run passed 6490 tests and exposed 13 unrelated/resource-contention failures. Serial rerun recovered 12; one pre-existing Feishu chat mixed-patch assertion remains unrelated to these files.

No doc/product/** files were modified.