### PR TITLE
fix: package identity core for Vercel

### DIFF
--- a/identity/package.json
+++ b/identity/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "pnpm --filter @rudderhq/identity-core build && pnpm --filter @rudderhq/identity-db build",
+    "build": "pnpm --filter @rudderhq/identity-core build && pnpm --filter @rudderhq/identity-db build && node scripts/prepare-vercel-workspace.mjs",
     "clean": "rm -rf dist",
     "dev": "tsx src/dev.ts",
     "start": "node dist/src/dev.js",

--- a/identity/scripts/prepare-vercel-workspace.mjs
+++ b/identity/scripts/prepare-vercel-workspace.mjs
@@ -1,0 +1,48 @@
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+function addDefaultExportCondition(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return;
+
+  for (const entry of Object.values(value)) {
+    if (entry && typeof entry === "object" && !Array.isArray(entry)) {
+      if (entry.import && !entry.default) entry.default = entry.import;
+      addDefaultExportCondition(entry);
+    }
+  }
+}
+
+export function createDeploymentManifest(manifest) {
+  if (!manifest.publishConfig) {
+    throw new Error(`${manifest.name ?? "workspace package"} is missing publishConfig`);
+  }
+
+  const next = structuredClone(manifest);
+  if (manifest.publishConfig.exports) {
+    next.exports = structuredClone(manifest.publishConfig.exports);
+    addDefaultExportCondition(next.exports);
+  }
+  if (manifest.publishConfig.main) next.main = manifest.publishConfig.main;
+  if (manifest.publishConfig.types) next.types = manifest.publishConfig.types;
+  return next;
+}
+
+export async function prepareVercelWorkspace({
+  env = process.env,
+  packagePath = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "../../packages/identity-core/package.json",
+  ),
+} = {}) {
+  if (env.VERCEL !== "1") return false;
+
+  const manifest = JSON.parse(await readFile(packagePath, "utf8"));
+  const deploymentManifest = createDeploymentManifest(manifest);
+  await writeFile(packagePath, `${JSON.stringify(deploymentManifest, null, 2)}\n`, "utf8");
+  return true;
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  await prepareVercelWorkspace();
+}

--- a/identity/scripts/prepare-vercel-workspace.test.mjs
+++ b/identity/scripts/prepare-vercel-workspace.test.mjs
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  createDeploymentManifest,
+  prepareVercelWorkspace,
+} from "./prepare-vercel-workspace.mjs";
+
+const sourceManifest = {
+  name: "@rudderhq/identity-core",
+  exports: { ".": "./src/index.ts" },
+  publishConfig: {
+    exports: {
+      ".": {
+        types: "./dist/index.d.ts",
+        import: "./dist/index.js",
+      },
+    },
+    main: "./dist/index.js",
+    types: "./dist/index.d.ts",
+  },
+};
+
+test("creates a Node-compatible deployment manifest from publishConfig", () => {
+  const manifest = createDeploymentManifest(sourceManifest);
+
+  assert.deepEqual(manifest.exports, {
+    ".": {
+      types: "./dist/index.d.ts",
+      import: "./dist/index.js",
+      default: "./dist/index.js",
+    },
+  });
+  assert.equal(manifest.main, "./dist/index.js");
+  assert.equal(manifest.types, "./dist/index.d.ts");
+  assert.deepEqual(sourceManifest.exports, { ".": "./src/index.ts" });
+});
+
+test("only rewrites the workspace manifest inside Vercel", async () => {
+  const directory = await mkdtemp(path.join(tmpdir(), "rudder-vercel-workspace-"));
+  const packagePath = path.join(directory, "package.json");
+  await writeFile(packagePath, `${JSON.stringify(sourceManifest)}\n`);
+
+  assert.equal(await prepareVercelWorkspace({ env: {}, packagePath }), false);
+  assert.deepEqual(JSON.parse(await readFile(packagePath, "utf8")), sourceManifest);
+
+  assert.equal(await prepareVercelWorkspace({ env: { VERCEL: "1" }, packagePath }), true);
+  const manifest = JSON.parse(await readFile(packagePath, "utf8"));
+  assert.equal(manifest.exports["."].default, "./dist/index.js");
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6624,6 +6624,11 @@ packages:
     resolution: {integrity: sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==}
     engines: {node: '>=10.4.0'}
 
+  pnpm@9.15.4:
+    resolution: {integrity: sha512-stwg4vxys+GISEWbNzWaMgZGY+VielHkx0ssKd2OjgSRSDw6u0B4nP1Xi/Ni+2uoJhsF8Dh9dnku1uI+o7G2oA==}
+    engines: {node: '>=18.12'}
+    hasBin: true
+
   points-on-curve@0.2.0:
     resolution: {integrity: sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==}
 
@@ -14715,6 +14720,8 @@ snapshots:
       '@xmldom/xmldom': 0.8.11
       base64-js: 1.5.1
       xmlbuilder: 15.1.1
+
+  pnpm@9.15.4: {}
 
   points-on-curve@0.2.0: {}
 


### PR DESCRIPTION
## Summary\n- rewrite the identity-core workspace manifest to its built publish shape during Vercel builds only\n- keep local development manifests untouched\n- add focused regression tests\n\n## Production incident\nThe new Identity deployment built successfully but returned 500 because the serverless bundle resolved @rudderhq/identity-core to src/index.ts, which is not included in the Vercel function bundle.\n\n## Verification\n- node --test identity/scripts/prepare-vercel-workspace.test.mjs\n- pnpm --filter @rudderhq/identity build\n- pnpm --filter @rudderhq/identity typecheck\n- git diff --check