### PR TITLE
fix(docs): register App Builder navigation

### DIFF
--- a/scripts/docs-content-map.yml
+++ b/scripts/docs-content-map.yml
@@ -133,6 +133,23 @@
       "metadata_enforcement": "strict"
     },
     {
+      "id": "app-builder",
+      "kind": "concept",
+      "user_job": "Turn a workflow request into a verified full-stack App that runs on this device.",
+      "status": "active",
+      "files": {"en": "docs/concepts/app-builder.mdx", "zh": "docs/zh/concepts/app-builder.mdx"},
+      "urls": {"en": "/concepts/app-builder", "zh": "/zh/concepts/app-builder"},
+      "anchors": {"en": ["describe-the-workflow-not-the-stack", "enable-sites-then-start-from-apps", "the-app-owns-its-data", "development-data-recovery", "machine-resident-not-cloud-hosted"], "zh": ["描述业务不用选择技术栈", "启用-sites然后从-apps-开始", "app-自己管理数据", "开发数据恢复", "在用户设备运行不提供云端版本"]},
+      "composes": ["workspaces"],
+      "source_docs": ["doc/product/domains/execution/app-builder.md", "doc/product/domains/execution/desktop-local-apps.md", "doc/product/domains/library-and-context/resources-library-workspaces.md"],
+      "llms": true,
+      "pairing_exception": null,
+      "aliases": [],
+      "example_ids": [],
+      "contracts": {"primary": ["APP.BUILDER.001"], "supporting": []},
+      "metadata_enforcement": "strict"
+    },
+    {
       "id": "built-in-browser",
       "kind": "concept",
       "user_job": "Understand local browser sessions and agent-control boundaries.",

--- a/scripts/postprocess-docs-export.test.mjs
+++ b/scripts/postprocess-docs-export.test.mjs
@@ -245,8 +245,10 @@ test("staging and production workflows postprocess exported docs", () => {
 
 test("static acceptance checks cover every canonical route and generated active alias", () => {
   const checks = staticVerificationChecks();
-  assert.equal(checks.canonical.length, 66);
+  assert.equal(checks.canonical.length, 68);
   assert.ok(checks.aliases.length > 27);
+  assert.ok(checks.canonical.some((entry) => entry.route === "/concepts/app-builder"));
+  assert.ok(checks.canonical.some((entry) => entry.route === "/zh/concepts/app-builder"));
   assert.ok(checks.canonical.some((entry) => entry.route === "/benchmarks/gdpval-harness"));
   assert.ok(checks.canonical.some((entry) => entry.route === "/zh/benchmarks/gdpval-harness"));
   assert.deepEqual(


### PR DESCRIPTION
## Summary
- register the existing App Builder pages in the docs content manifest
- cover both localized routes in static acceptance checks

## Verification
- `node --test scripts/docs-content-map.test.mjs scripts/postprocess-docs-export.test.mjs`