### PR TITLE
fix: preserve local account state across upgrades

### DIFF
--- a/desktop/src/identity-local-session.test.ts
+++ b/desktop/src/identity-local-session.test.ts
@@ -1,7 +1,9 @@
+import { generateKeyPairSync } from "node:crypto";
 import { createServer } from "node:http";
 import { describe, expect, it, vi } from "vitest";
 import {
   clearDesktopLocalSessionCookies,
+  establishDesktopOfflineLocalSession,
   establishDesktopLocalSession,
   revokeDesktopLocalSessions,
 } from "./identity-local-session.js";
@@ -100,5 +102,58 @@ describe("Desktop local account session", () => {
       installCookie,
     })).rejects.toThrow("exchange failed");
     expect(installCookie).not.toHaveBeenCalled();
+  });
+
+  it("repairs legacy state after establishing an Offline Grant session", async () => {
+    const deviceKeys = generateKeyPairSync("ed25519");
+    const fetch = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        userId: "user-1",
+        nextTrustedTimeMs: 1_800_000_000_000,
+      }), {
+        status: 200,
+        headers: {
+          "set-cookie": "better-auth.session_token=offline.signature; Path=/; HttpOnly; SameSite=Lax",
+        },
+      }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ status: "already_claimed" }), { status: 200 }));
+    const installCookie = vi.fn(async () => undefined);
+    const updateTrustedTime = vi.fn();
+
+    await establishDesktopOfflineLocalSession({
+      localApiUrl: "http://127.0.0.1:3100/api",
+      credential: {
+        version: 1,
+        issuer: "https://accounts.rudderhq.dev",
+        accountId: "account-1",
+        deviceId: "device-1",
+        installationId: "installation-1",
+        grant: "offline-grant",
+        expiresAtMs: 1_900_000_000_000,
+        keyId: "identity-key",
+        identityPublicKeySpki: "identity-public-key",
+        devicePrivateKeyPkcs8: deviceKeys.privateKey
+          .export({ format: "der", type: "pkcs8" }).toString("base64url"),
+        devicePublicKeySpki: deviceKeys.publicKey
+          .export({ format: "der", type: "spki" }).toString("base64url"),
+        trustedTimeMs: 1_700_000_000_000,
+        signOutEpoch: 0,
+      },
+      nowMs: 1_750_000_000_000,
+      fetch,
+      installCookie,
+      updateTrustedTime,
+    });
+
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(fetch.mock.calls[1]?.[0]).toEqual(new URL("http://127.0.0.1:3100/api/auth/local-claim"));
+    expect(fetch.mock.calls[1]?.[1]).toMatchObject({
+      method: "POST",
+      headers: {
+        cookie: "better-auth.session_token=offline.signature",
+        origin: "http://127.0.0.1:3100",
+      },
+    });
+    expect(updateTrustedTime).toHaveBeenCalledWith(1_800_000_000_000);
   });
 });

--- a/desktop/src/identity-local-session.test.ts
+++ b/desktop/src/identity-local-session.test.ts
@@ -3,8 +3,8 @@ import { createServer } from "node:http";
 import { describe, expect, it, vi } from "vitest";
 import {
   clearDesktopLocalSessionCookies,
-  establishDesktopOfflineLocalSession,
   establishDesktopLocalSession,
+  establishDesktopOfflineLocalSession,
   revokeDesktopLocalSessions,
 } from "./identity-local-session.js";
 

--- a/desktop/src/identity-local-session.ts
+++ b/desktop/src/identity-local-session.ts
@@ -114,7 +114,16 @@ export async function establishDesktopOfflineLocalSession(options: {
   }
   const setCookie = exchange.headers.get("set-cookie");
   if (!setCookie) throw new Error("Local Rudder server did not issue a session cookie");
-  await options.installCookie(parseSetCookie(setCookie, baseUrl));
+  const cookie = parseSetCookie(setCookie, baseUrl);
+  await options.installCookie(cookie);
+  const claim = await request(new URL("/api/auth/local-claim", baseUrl), {
+    method: "POST",
+    headers: {
+      cookie: `${cookie.name}=${encodeURIComponent(cookie.value)}`,
+      origin: baseUrl,
+    },
+  });
+  if (!claim.ok) throw new Error(`Local Rudder legacy claim failed (${claim.status})`);
   options.updateTrustedTime(Number(value.nextTrustedTimeMs));
 }
 

--- a/packages/db/src/client.test.ts
+++ b/packages/db/src/client.test.ts
@@ -555,6 +555,7 @@ describe("applyPendingMigrations", () => {
           "0124_petite_cargill.sql",
           "0125_ambiguous_winter_soldier.sql",
           "0126_flashy_sentinels.sql",
+          "0127_remove_project_budgets.sql",
         ],
         reason: "pending-migrations",
       });
@@ -701,6 +702,7 @@ describe("applyPendingMigrations", () => {
           "0124_petite_cargill.sql",
           "0125_ambiguous_winter_soldier.sql",
           "0126_flashy_sentinels.sql",
+          "0127_remove_project_budgets.sql",
         ],
         reason: "pending-migrations",
       });

--- a/server/src/__tests__/local-account-auth.test.ts
+++ b/server/src/__tests__/local-account-auth.test.ts
@@ -3,11 +3,22 @@ import {
   applyPendingMigrations,
   authSessions,
   authUsers,
+  chatConversations,
+  chatConversationUserStates,
   createDb,
   ensurePostgresDatabase,
   externalUserBindings,
   installationAccountBindings,
   instanceUserRoles,
+  issueFollows,
+  issueReadStates,
+  issues,
+  messengerCustomGroupEntries,
+  messengerCustomGroups,
+  messengerSavedViewMutations,
+  messengerSavedViews,
+  messengerThreadUserStates,
+  operatorProfiles,
   organizationMemberships,
   organizations,
   serverExchangeRedemptions,
@@ -104,6 +115,17 @@ describe("localAccountAuthService", () => {
     await db.execute(sql`drop trigger if exists fail_claim_activity on activity_log`);
     await db.execute(sql`drop function if exists fail_claim_activity()`);
     await db.delete(activityLog);
+    await db.delete(messengerSavedViewMutations);
+    await db.delete(messengerCustomGroupEntries);
+    await db.delete(messengerCustomGroups);
+    await db.delete(messengerSavedViews);
+    await db.delete(messengerThreadUserStates);
+    await db.delete(chatConversationUserStates);
+    await db.delete(issueFollows);
+    await db.delete(issueReadStates);
+    await db.delete(operatorProfiles);
+    await db.delete(chatConversations);
+    await db.delete(issues);
     await db.delete(organizationMemberships);
     await db.delete(installationAccountBindings);
     await db.delete(instanceUserRoles);
@@ -213,6 +235,345 @@ describe("localAccountAuthService", () => {
     })).rejects.toMatchObject({ status: 403 });
   });
 
+  it("copies legacy Messenger state, preserves read progress, and repairs an existing claim once", async () => {
+    const svc = service();
+    const { userId } = await svc.redeem("fixture-exchange-code");
+    const [org] = await db.insert(organizations).values({
+      name: "Owned",
+      urlKey: "owned-state",
+      issuePrefix: "OWN",
+    }).returning();
+    await db.insert(instanceUserRoles).values({ userId: "local-board", role: "instance_admin" });
+    await db.insert(organizationMemberships).values({
+      orgId: org!.id,
+      principalType: "user",
+      principalId: "local-board",
+      status: "active",
+      membershipRole: "owner",
+    });
+    const [group] = await db.insert(messengerCustomGroups).values({
+      orgId: org!.id,
+      userId: "local-board",
+      name: "My ordered group",
+      sortOrder: 7,
+      collapsed: true,
+      pinnedAt: new Date("2026-07-20T00:00:00.000Z"),
+    }).returning();
+    await db.insert(messengerCustomGroupEntries).values({
+      orgId: org!.id,
+      userId: "local-board",
+      groupId: group!.id,
+      threadKey: "chat:fixture",
+      sortOrder: 3,
+    });
+    const [savedView] = await db.insert(messengerSavedViews).values({
+      orgId: org!.id,
+      userId: "local-board",
+      targetKind: "browser",
+      targetPayload: {
+        kind: "browser",
+        tabId: "tab-1",
+        url: "https://example.com",
+        viewInstanceId: "view-instance-1",
+      },
+      resourceKey: "browser:https://example.com",
+      instanceId: "view-instance-1",
+      canonicalResourceKey: "browser:https://example.com",
+      title: "Example",
+      sortOrder: 4,
+    }).returning();
+    await db.insert(messengerSavedViewMutations).values({
+      orgId: org!.id,
+      userId: "local-board",
+      clientMutationId: randomUUID(),
+      savedViewId: savedView!.id,
+      groupId: group!.id,
+      requestFingerprint: "fixture",
+    });
+    const [conversation] = await db.insert(chatConversations).values({
+      orgId: org!.id,
+      title: "Unread regression fixture",
+    }).returning();
+    const legacyReadAt = new Date("2026-07-29T12:00:00.000Z");
+    const targetReadAt = new Date("2026-07-28T12:00:00.000Z");
+    await db.insert(chatConversationUserStates).values([
+      {
+        orgId: org!.id,
+        conversationId: conversation!.id,
+        userId: "local-board",
+        lastReadAt: legacyReadAt,
+        pinnedAt: legacyReadAt,
+        updatedAt: legacyReadAt,
+      },
+      {
+        orgId: org!.id,
+        conversationId: conversation!.id,
+        userId,
+        lastReadAt: targetReadAt,
+        updatedAt: targetReadAt,
+      },
+    ]);
+    await db.insert(messengerThreadUserStates).values([
+      {
+        orgId: org!.id,
+        userId: "local-board",
+        threadKey: "system:failed-runs",
+        lastReadAt: legacyReadAt,
+        pinnedAt: legacyReadAt,
+        updatedAt: legacyReadAt,
+      },
+      {
+        orgId: org!.id,
+        userId,
+        threadKey: "system:failed-runs",
+        lastReadAt: targetReadAt,
+        updatedAt: new Date("2026-07-30T12:00:00.000Z"),
+      },
+    ]);
+    const [issue] = await db.insert(issues).values({
+      orgId: org!.id,
+      title: "Issue state fixture",
+    }).returning();
+    await db.insert(issueReadStates).values({
+      orgId: org!.id,
+      issueId: issue!.id,
+      userId: "local-board",
+      lastReadAt: legacyReadAt,
+    });
+    await db.insert(issueFollows).values({
+      orgId: org!.id,
+      issueId: issue!.id,
+      userId: "local-board",
+    });
+    await db.insert(operatorProfiles).values({
+      userId: "local-board",
+      nickname: "Legacy operator",
+      preferences: { messenger: "compact" },
+    });
+
+    await svc.claimLegacyInstallation({
+      installationId: "installation-1",
+      issuer: claims.issuer,
+      subject: claims.subject,
+      localUserId: userId,
+    });
+    const targetGroups = await db.select().from(messengerCustomGroups)
+      .where(eq(messengerCustomGroups.userId, userId));
+    expect(targetGroups).toMatchObject([{
+      name: "My ordered group",
+      sortOrder: 7,
+      collapsed: true,
+    }]);
+    const targetEntries = await db.select().from(messengerCustomGroupEntries)
+      .where(eq(messengerCustomGroupEntries.userId, userId));
+    expect(targetEntries).toMatchObject([{
+      groupId: targetGroups[0]!.id,
+      threadKey: "chat:fixture",
+      sortOrder: 3,
+    }]);
+    expect(await db.select().from(messengerSavedViews)
+      .where(eq(messengerSavedViews.userId, userId))).toHaveLength(1);
+    expect(await db.select().from(messengerSavedViewMutations)
+      .where(eq(messengerSavedViewMutations.userId, userId))).toHaveLength(1);
+    expect(await db.select().from(issueFollows)
+      .where(eq(issueFollows.userId, userId))).toHaveLength(1);
+    expect(await db.select().from(operatorProfiles)
+      .where(eq(operatorProfiles.userId, userId))).toMatchObject([{
+      nickname: "Legacy operator",
+      preferences: { messenger: "compact" },
+    }]);
+    const [chatState] = await db.select().from(chatConversationUserStates)
+      .where(eq(chatConversationUserStates.userId, userId));
+    expect(chatState!.lastReadAt).toEqual(legacyReadAt);
+    expect(chatState!.pinnedAt).toEqual(legacyReadAt);
+    const [threadState] = await db.select().from(messengerThreadUserStates)
+      .where(eq(messengerThreadUserStates.userId, userId));
+    expect(threadState!.lastReadAt).toEqual(legacyReadAt);
+    expect(threadState!.pinnedAt).toBeNull();
+
+    const beforeRepairCounts = {
+      groups: targetGroups.length,
+      entries: targetEntries.length,
+      activities: (await db.select().from(activityLog)
+        .where(eq(activityLog.action, "installation.legacy_operator_state_copied"))).length,
+    };
+    const repair = await svc.claimLegacyInstallation({
+      installationId: "installation-1",
+      issuer: claims.issuer,
+      subject: claims.subject,
+      localUserId: userId,
+    });
+    expect(repair.status).toBe("already_claimed");
+    expect(await db.select().from(messengerCustomGroups)
+      .where(eq(messengerCustomGroups.userId, userId))).toHaveLength(beforeRepairCounts.groups);
+    expect(await db.select().from(messengerCustomGroupEntries)
+      .where(eq(messengerCustomGroupEntries.userId, userId))).toHaveLength(beforeRepairCounts.entries);
+    expect(await db.select().from(activityLog)
+      .where(eq(activityLog.action, "installation.legacy_operator_state_copied")))
+      .toHaveLength(beforeRepairCounts.activities);
+    expect(await db.select().from(messengerCustomGroups)
+      .where(eq(messengerCustomGroups.userId, "local-board"))).toHaveLength(1);
+  });
+
+  it("repairs personalization omitted by an already-recorded Canary installation claim", async () => {
+    const svc = service();
+    const { userId } = await svc.redeem("fixture-exchange-code");
+    const [org] = await db.insert(organizations).values({
+      name: "Canary repair",
+      urlKey: "canary-repair",
+      issuePrefix: "CNR",
+    }).returning();
+    await db.insert(organizationMemberships).values([
+      {
+        orgId: org!.id,
+        principalType: "user",
+        principalId: "local-board",
+        status: "revoked",
+        membershipRole: "owner",
+      },
+      {
+        orgId: org!.id,
+        principalType: "user",
+        principalId: userId,
+        status: "active",
+        membershipRole: "owner",
+      },
+    ]);
+    await db.insert(installationAccountBindings).values({
+      installationId: "installation-1",
+      issuer: claims.issuer,
+      subject: claims.subject,
+      localUserId: userId,
+    });
+    await db.insert(messengerThreadUserStates).values({
+      orgId: org!.id,
+      userId: "local-board",
+      threadKey: "system:failed-runs",
+      lastReadAt: new Date("2026-07-29T12:00:00.000Z"),
+    });
+
+    const repaired = await svc.claimLegacyInstallation({
+      installationId: "installation-1",
+      issuer: claims.issuer,
+      subject: claims.subject,
+      localUserId: userId,
+    });
+
+    expect(repaired).toMatchObject({
+      status: "already_claimed",
+      localUserId: userId,
+      orgIds: [org!.id],
+    });
+    expect(await db.select().from(messengerThreadUserStates)
+      .where(eq(messengerThreadUserStates.userId, userId))).toHaveLength(1);
+    expect(await db.select().from(activityLog)
+      .where(eq(activityLog.action, "installation.legacy_operator_state_copied"))).toHaveLength(1);
+
+    await db.insert(messengerThreadUserStates).values({
+      orgId: org!.id,
+      userId: "local-board",
+      threadKey: "system:approvals",
+      lastReadAt: new Date("2026-07-30T12:00:00.000Z"),
+    });
+    await svc.claimLegacyInstallation({
+      installationId: "installation-1",
+      issuer: claims.issuer,
+      subject: claims.subject,
+      localUserId: userId,
+    });
+    expect(await db.select().from(messengerThreadUserStates)
+      .where(eq(messengerThreadUserStates.userId, userId))).toHaveLength(2);
+    expect(await db.select().from(activityLog)
+      .where(eq(activityLog.action, "installation.legacy_operator_state_copied"))).toHaveLength(1);
+  });
+
+  it("maps a legacy Saved View receipt to the target account's existing placement", async () => {
+    const svc = service();
+    const { userId } = await svc.redeem("fixture-exchange-code");
+    const [org] = await db.insert(organizations).values({
+      name: "Saved View conflict",
+      urlKey: "saved-view-conflict",
+      issuePrefix: "SVC",
+    }).returning();
+    await db.insert(organizationMemberships).values({
+      orgId: org!.id,
+      principalType: "user",
+      principalId: "local-board",
+      status: "active",
+      membershipRole: "owner",
+    });
+    const [legacyGroup, targetGroup] = await db.insert(messengerCustomGroups).values([
+      { orgId: org!.id, userId: "local-board", name: "Legacy placement" },
+      { orgId: org!.id, userId, name: "Account placement" },
+    ]).returning();
+    const targetPayload = {
+      kind: "browser" as const,
+      tabId: "tab-conflict",
+      url: "https://example.com/conflict",
+      viewInstanceId: "view-conflict",
+    };
+    const [legacyView, targetView] = await db.insert(messengerSavedViews).values([
+      {
+        orgId: org!.id,
+        userId: "local-board",
+        targetKind: "browser",
+        targetPayload,
+        resourceKey: "browser:https://example.com/conflict",
+        instanceId: "view-conflict",
+        canonicalResourceKey: "browser:https://example.com/conflict",
+        title: "Legacy",
+      },
+      {
+        orgId: org!.id,
+        userId,
+        targetKind: "browser",
+        targetPayload,
+        resourceKey: "browser:https://example.com/conflict",
+        instanceId: "view-conflict",
+        canonicalResourceKey: "browser:https://example.com/conflict",
+        title: "Account",
+      },
+    ]).returning();
+    await db.insert(messengerCustomGroupEntries).values([
+      {
+        orgId: org!.id,
+        userId: "local-board",
+        groupId: legacyGroup!.id,
+        threadKey: `saved-view:${legacyView!.id}`,
+      },
+      {
+        orgId: org!.id,
+        userId,
+        groupId: targetGroup!.id,
+        threadKey: `saved-view:${targetView!.id}`,
+      },
+    ]);
+    await db.insert(messengerSavedViewMutations).values({
+      orgId: org!.id,
+      userId: "local-board",
+      clientMutationId: randomUUID(),
+      savedViewId: legacyView!.id,
+      groupId: legacyGroup!.id,
+      requestFingerprint: "saved-view-conflict",
+    });
+
+    await svc.claimLegacyInstallation({
+      installationId: "installation-1",
+      issuer: claims.issuer,
+      subject: claims.subject,
+      localUserId: userId,
+    });
+
+    const [receipt] = await db.select().from(messengerSavedViewMutations)
+      .where(eq(messengerSavedViewMutations.userId, userId));
+    expect(receipt).toMatchObject({
+      savedViewId: targetView!.id,
+      groupId: targetGroup!.id,
+    });
+    expect(await db.select().from(messengerCustomGroupEntries)
+      .where(eq(messengerCustomGroupEntries.userId, userId))).toHaveLength(1);
+  });
+
   it("rolls back the installation binding, roles, and memberships when claim audit fails", async () => {
     const svc = service();
     const { userId } = await svc.redeem("fixture-exchange-code");
@@ -256,6 +617,35 @@ describe("localAccountAuthService", () => {
 
   it("runs the HTTP exchange, session gate, replay defense, and legacy claim end to end", async () => {
     service();
+    const [upgradeOrg] = await db.insert(organizations).values({
+      name: "HTTP upgrade fixture",
+      urlKey: "http-upgrade-fixture",
+      issuePrefix: "HUF",
+    }).returning();
+    await db.insert(organizationMemberships).values({
+      orgId: upgradeOrg!.id,
+      principalType: "user",
+      principalId: "local-board",
+      status: "active",
+      membershipRole: "owner",
+    });
+    await db.insert(messengerCustomGroups).values({
+      orgId: upgradeOrg!.id,
+      userId: "local-board",
+      name: "HTTP restored group",
+      sortOrder: 5,
+    });
+    const [upgradeConversation] = await db.insert(chatConversations).values({
+      orgId: upgradeOrg!.id,
+      title: "HTTP unread fixture",
+    }).returning();
+    const upgradeReadAt = new Date("2026-07-29T12:00:00.000Z");
+    await db.insert(chatConversationUserStates).values({
+      orgId: upgradeOrg!.id,
+      conversationId: upgradeConversation!.id,
+      userId: "local-board",
+      lastReadAt: upgradeReadAt,
+    });
     const exchangePolicy = {
       expectedIssuer: "https://accounts.rudderhq.dev",
       audience: "rudder-installation:test",
@@ -297,10 +687,21 @@ describe("localAccountAuthService", () => {
     expect((await request(app)
       .post("/api/auth/local-claim")
       .set("Cookie", cookie!)).status).toBe(403);
-    expect((await request(app)
+    const claimed = await request(app)
       .post("/api/auth/local-claim")
       .set("Cookie", cookie!)
-      .set("Origin", "http://127.0.0.1:3100")).status).toBe(200);
+      .set("Origin", "http://127.0.0.1:3100");
+    expect(claimed.status).toBe(200);
+    const targetUserId = exchanged.body.userId as string;
+    expect(await db.select().from(messengerCustomGroups)
+      .where(eq(messengerCustomGroups.userId, targetUserId))).toMatchObject([{
+      name: "HTTP restored group",
+      sortOrder: 5,
+    }]);
+    expect(await db.select().from(chatConversationUserStates)
+      .where(eq(chatConversationUserStates.userId, targetUserId))).toMatchObject([{
+      lastReadAt: upgradeReadAt,
+    }]);
     claims.jti = "exchange-2";
     const secondExchange = await request(app)
       .post("/api/auth/local-exchange")

--- a/server/src/services/legacy-operator-state.ts
+++ b/server/src/services/legacy-operator-state.ts
@@ -1,0 +1,312 @@
+import type { Db } from "@rudderhq/db";
+import {
+  activityLog,
+  chatConversationUserStates,
+  issueFollows,
+  issueReadStates,
+  messengerCustomGroupEntries,
+  messengerCustomGroups,
+  messengerSavedViewMutations,
+  messengerSavedViews,
+  messengerThreadUserStates,
+  operatorProfiles,
+  organizationMemberships,
+} from "@rudderhq/db";
+import { and, eq, or, sql, type SQLWrapper } from "drizzle-orm";
+import { createHash } from "node:crypto";
+
+const LEGACY_BOARD_USER_ID = "local-board";
+const LEGACY_STATE_COPIED_ACTION = "installation.legacy_operator_state_copied";
+
+type Transaction = Parameters<Parameters<Db["transaction"]>[0]>[0];
+
+function deterministicUuid(sourceId: string, targetUserId: string) {
+  const hex = createHash("md5")
+    .update(`${sourceId}:${targetUserId}`)
+    .digest("hex");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
+function chunks<T>(values: T[], size = 250): T[][] {
+  const result: T[][] = [];
+  for (let index = 0; index < values.length; index += size) {
+    result.push(values.slice(index, index + size));
+  }
+  return result;
+}
+
+export async function copyLegacyOperatorState(
+  tx: Transaction,
+  input: {
+    installationId: string;
+    targetUserId: string;
+  },
+) {
+  const scopedMemberships = await tx
+    .select({ orgId: organizationMemberships.orgId })
+    .from(organizationMemberships)
+    .where(and(
+      eq(organizationMemberships.principalType, "user"),
+      eq(organizationMemberships.status, "active"),
+      or(
+        eq(organizationMemberships.principalId, LEGACY_BOARD_USER_ID),
+        eq(organizationMemberships.principalId, input.targetUserId),
+      ),
+    ));
+  const orgIds = Array.from(new Set(scopedMemberships.map((row) => row.orgId)));
+  if (orgIds.length === 0) return { status: "no_scoped_organizations" as const, orgIds };
+  const inScope = (orgId: SQLWrapper) =>
+    sql`${orgId} in (${sql.join(orgIds.map((orgId) => sql`${orgId}`), sql`, `)})`;
+
+  const legacyGroups = await tx
+    .select()
+    .from(messengerCustomGroups)
+    .where(and(eq(messengerCustomGroups.userId, LEGACY_BOARD_USER_ID), inScope(messengerCustomGroups.orgId)));
+  const groupIdMap = new Map(
+    legacyGroups.map((group) => [
+      group.id,
+      deterministicUuid(group.id, input.targetUserId),
+    ]),
+  );
+  if (legacyGroups.length > 0) {
+    await tx.insert(messengerCustomGroups).values(legacyGroups.map((group) => ({
+      ...group,
+      id: groupIdMap.get(group.id)!,
+      userId: input.targetUserId,
+    }))).onConflictDoNothing();
+  }
+
+  const legacySavedViews = await tx
+    .select()
+    .from(messengerSavedViews)
+    .where(and(eq(messengerSavedViews.userId, LEGACY_BOARD_USER_ID), inScope(messengerSavedViews.orgId)));
+  const targetSavedViews = await tx
+    .select()
+    .from(messengerSavedViews)
+    .where(and(eq(messengerSavedViews.userId, input.targetUserId), inScope(messengerSavedViews.orgId)));
+  const targetByResource = new Map(targetSavedViews.map((view) => [`${view.orgId}:${view.resourceKey}`, view]));
+  const targetByInstance = new Map(targetSavedViews.map((view) => [`${view.orgId}:${view.instanceId}`, view]));
+  const targetByMutation = new Map(
+    targetSavedViews
+      .filter((view) => view.clientMutationId)
+      .map((view) => [`${view.orgId}:${view.clientMutationId}`, view]),
+  );
+  const savedViewIdMap = new Map<string, string>();
+  for (const view of legacySavedViews) {
+    const target =
+      (view.clientMutationId ? targetByMutation.get(`${view.orgId}:${view.clientMutationId}`) : undefined)
+      ?? targetByInstance.get(`${view.orgId}:${view.instanceId}`)
+      ?? targetByResource.get(`${view.orgId}:${view.resourceKey}`);
+    const targetId = target?.id ?? deterministicUuid(view.id, input.targetUserId);
+    savedViewIdMap.set(view.id, targetId);
+    if (target) continue;
+    await tx.insert(messengerSavedViews).values({
+      ...view,
+      id: targetId,
+      userId: input.targetUserId,
+    }).onConflictDoNothing();
+  }
+
+  const legacyEntries = await tx
+    .select()
+    .from(messengerCustomGroupEntries)
+    .where(and(
+      eq(messengerCustomGroupEntries.userId, LEGACY_BOARD_USER_ID),
+      inScope(messengerCustomGroupEntries.orgId),
+    ));
+  if (legacyEntries.length > 0) {
+    await tx.insert(messengerCustomGroupEntries).values(legacyEntries.flatMap((entry) => {
+      const groupId = groupIdMap.get(entry.groupId);
+      if (!groupId) return [];
+      const savedViewMatch = /^saved-view:(.+)$/.exec(entry.threadKey);
+      const mappedSavedViewId = savedViewMatch ? savedViewIdMap.get(savedViewMatch[1]!) : undefined;
+      return [{
+        ...entry,
+        id: deterministicUuid(entry.id, input.targetUserId),
+        userId: input.targetUserId,
+        groupId,
+        threadKey: mappedSavedViewId ? `saved-view:${mappedSavedViewId}` : entry.threadKey,
+      }];
+    })).onConflictDoNothing();
+  }
+
+  const targetEntries = await tx
+    .select()
+    .from(messengerCustomGroupEntries)
+    .where(and(
+      eq(messengerCustomGroupEntries.userId, input.targetUserId),
+      inScope(messengerCustomGroupEntries.orgId),
+    ));
+  const targetEntryByThreadKey = new Map(
+    targetEntries.map((entry) => [`${entry.orgId}:${entry.threadKey}`, entry]),
+  );
+  const legacyMutations = await tx
+    .select()
+    .from(messengerSavedViewMutations)
+    .where(and(
+      eq(messengerSavedViewMutations.userId, LEGACY_BOARD_USER_ID),
+      inScope(messengerSavedViewMutations.orgId),
+    ));
+  const mappedMutations = legacyMutations.flatMap((mutation) => {
+    const savedViewId = savedViewIdMap.get(mutation.savedViewId);
+    if (!savedViewId) return [];
+    const placement = targetEntryByThreadKey.get(`${mutation.orgId}:saved-view:${savedViewId}`);
+    return [{
+      ...mutation,
+      id: deterministicUuid(mutation.id, input.targetUserId),
+      userId: input.targetUserId,
+      savedViewId,
+      groupId: placement?.groupId ?? null,
+    }];
+  });
+  if (mappedMutations.length > 0) {
+    await tx.insert(messengerSavedViewMutations).values(mappedMutations).onConflictDoNothing();
+  }
+
+  const legacyThreadStates = await tx
+    .select()
+    .from(messengerThreadUserStates)
+    .where(and(
+      eq(messengerThreadUserStates.userId, LEGACY_BOARD_USER_ID),
+      inScope(messengerThreadUserStates.orgId),
+    ));
+  for (const batch of chunks(legacyThreadStates)) {
+    await tx.insert(messengerThreadUserStates).values(batch.map((state) => ({
+      ...state,
+      id: deterministicUuid(state.id, input.targetUserId),
+      userId: input.targetUserId,
+    }))).onConflictDoUpdate({
+      target: [
+        messengerThreadUserStates.orgId,
+        messengerThreadUserStates.threadKey,
+        messengerThreadUserStates.userId,
+      ],
+      set: {
+        lastReadAt: sql`greatest(${messengerThreadUserStates.lastReadAt}, excluded.last_read_at)`,
+        pinnedAt: sql`case
+          when excluded.updated_at > ${messengerThreadUserStates.updatedAt}
+            then excluded.pinned_at
+          else ${messengerThreadUserStates.pinnedAt}
+        end`,
+        updatedAt: sql`greatest(${messengerThreadUserStates.updatedAt}, excluded.updated_at)`,
+      },
+    });
+  }
+
+  const legacyChatStates = await tx
+    .select()
+    .from(chatConversationUserStates)
+    .where(and(
+      eq(chatConversationUserStates.userId, LEGACY_BOARD_USER_ID),
+      inScope(chatConversationUserStates.orgId),
+    ));
+  for (const batch of chunks(legacyChatStates)) {
+    await tx.insert(chatConversationUserStates).values(batch.map((state) => ({
+      ...state,
+      id: deterministicUuid(state.id, input.targetUserId),
+      userId: input.targetUserId,
+    }))).onConflictDoUpdate({
+      target: [
+        chatConversationUserStates.orgId,
+        chatConversationUserStates.conversationId,
+        chatConversationUserStates.userId,
+      ],
+      set: {
+        lastReadAt: sql`greatest(${chatConversationUserStates.lastReadAt}, excluded.last_read_at)`,
+        pinnedAt: sql`case
+          when excluded.updated_at > ${chatConversationUserStates.updatedAt}
+            then excluded.pinned_at
+          else ${chatConversationUserStates.pinnedAt}
+        end`,
+        updatedAt: sql`greatest(${chatConversationUserStates.updatedAt}, excluded.updated_at)`,
+      },
+    });
+  }
+
+  const legacyIssueReadStates = await tx
+    .select()
+    .from(issueReadStates)
+    .where(and(eq(issueReadStates.userId, LEGACY_BOARD_USER_ID), inScope(issueReadStates.orgId)));
+  for (const batch of chunks(legacyIssueReadStates)) {
+    await tx.insert(issueReadStates).values(batch.map((state) => ({
+      ...state,
+      id: deterministicUuid(state.id, input.targetUserId),
+      userId: input.targetUserId,
+    }))).onConflictDoUpdate({
+      target: [issueReadStates.orgId, issueReadStates.issueId, issueReadStates.userId],
+      set: {
+        lastReadAt: sql`greatest(${issueReadStates.lastReadAt}, excluded.last_read_at)`,
+        updatedAt: sql`greatest(${issueReadStates.updatedAt}, excluded.updated_at)`,
+      },
+    });
+  }
+
+  const legacyIssueFollows = await tx
+    .select()
+    .from(issueFollows)
+    .where(and(eq(issueFollows.userId, LEGACY_BOARD_USER_ID), inScope(issueFollows.orgId)));
+  if (legacyIssueFollows.length > 0) {
+    await tx.insert(issueFollows).values(legacyIssueFollows.map((follow) => ({
+      ...follow,
+      id: deterministicUuid(follow.id, input.targetUserId),
+      userId: input.targetUserId,
+    }))).onConflictDoNothing();
+  }
+
+  const legacyProfile = await tx
+    .select()
+    .from(operatorProfiles)
+    .where(eq(operatorProfiles.userId, LEGACY_BOARD_USER_ID))
+    .then((rows) => rows[0] ?? null);
+  if (legacyProfile) {
+    const targetProfile = await tx
+      .select()
+      .from(operatorProfiles)
+      .where(eq(operatorProfiles.userId, input.targetUserId))
+      .then((rows) => rows[0] ?? null);
+    if (targetProfile) {
+      await tx.update(operatorProfiles).set({
+        nickname: targetProfile.nickname ?? legacyProfile.nickname,
+        moreAboutYou: targetProfile.moreAboutYou ?? legacyProfile.moreAboutYou,
+        preferences: { ...legacyProfile.preferences, ...targetProfile.preferences },
+        updatedAt: targetProfile.updatedAt > legacyProfile.updatedAt
+          ? targetProfile.updatedAt
+          : legacyProfile.updatedAt,
+      }).where(eq(operatorProfiles.userId, input.targetUserId));
+    } else {
+      await tx.insert(operatorProfiles).values({
+        ...legacyProfile,
+        userId: input.targetUserId,
+      });
+    }
+  }
+
+  const existingReceiptOrgIds = new Set(
+    (await tx
+      .select({ orgId: activityLog.orgId })
+      .from(activityLog)
+      .where(and(
+        eq(activityLog.actorType, "user"),
+        eq(activityLog.actorId, input.targetUserId),
+        eq(activityLog.action, LEGACY_STATE_COPIED_ACTION),
+        eq(activityLog.entityType, "installation"),
+        eq(activityLog.entityId, input.installationId),
+      )))
+      .map((row) => row.orgId),
+  );
+  const receiptOrgIds = orgIds.filter((orgId) => !existingReceiptOrgIds.has(orgId));
+  if (receiptOrgIds.length > 0) await tx.insert(activityLog).values(receiptOrgIds.map((orgId) => ({
+    orgId,
+    actorType: "user" as const,
+    actorId: input.targetUserId,
+    action: LEGACY_STATE_COPIED_ACTION,
+    entityType: "installation",
+    entityId: input.installationId,
+    details: {
+      priorPrincipalId: LEGACY_BOARD_USER_ID,
+      compatibilityMode: "copy_preserving_legacy",
+    },
+  })));
+
+  return { status: receiptOrgIds.length > 0 ? "copied" as const : "reconciled" as const, orgIds };
+}

--- a/server/src/services/local-account-auth.ts
+++ b/server/src/services/local-account-auth.ts
@@ -25,6 +25,7 @@ import {
 } from "node:crypto";
 import type { IncomingHttpHeaders } from "node:http";
 import { conflict, forbidden, unauthorized } from "../errors.js";
+import { copyLegacyOperatorState } from "./legacy-operator-state.js";
 
 const LOCAL_BOARD_USER_ID = "local-board";
 const LOCAL_SESSION_TTL_MS = 30 * 24 * 60 * 60 * 1000;
@@ -501,9 +502,6 @@ export function localAccountAuthService(db: Db, policy: LocalAccountExchangePoli
       ) {
         throw forbidden("This Rudder installation is already claimed by another account");
       }
-      if (existing) {
-        return { status: "already_claimed" as const, localUserId: existing.localUserId, orgIds: [] as string[] };
-      }
 
       const externalBinding = await tx
         .select({ localUserId: externalUserBindings.localUserId })
@@ -517,6 +515,18 @@ export function localAccountAuthService(db: Db, policy: LocalAccountExchangePoli
         )
         .then((rows) => rows[0] ?? null);
       if (!externalBinding) throw forbidden("The local user does not match the authenticated Rudder Account");
+
+      if (existing) {
+        const copied = await copyLegacyOperatorState(tx, {
+          installationId: input.installationId,
+          targetUserId: input.localUserId,
+        });
+        return {
+          status: "already_claimed" as const,
+          localUserId: existing.localUserId,
+          orgIds: copied.orgIds,
+        };
+      }
 
       const legacyMemberships = await tx
         .select()
@@ -589,6 +599,11 @@ export function localAccountAuthService(db: Db, policy: LocalAccountExchangePoli
           },
         });
       }
+
+      await copyLegacyOperatorState(tx, {
+        installationId: input.installationId,
+        targetUserId: input.localUserId,
+      });
 
       return {
         status: "claimed" as const,

--- a/tests/e2e/local-account-upgrade.spec.ts
+++ b/tests/e2e/local-account-upgrade.spec.ts
@@ -1,0 +1,291 @@
+import { expect, test } from "@playwright/test";
+import fs from "node:fs";
+import { createServer } from "node:http";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import { eq } from "../../packages/db/node_modules/drizzle-orm/index.js";
+import {
+  chatConversationUserStates,
+  chatConversations,
+  chatMessages,
+  createDb,
+  installationAccountBindings,
+  messengerCustomGroupEntries,
+  messengerCustomGroups,
+  messengerSavedViews,
+  organizationMemberships,
+  organizations,
+} from "../../packages/db/src/index.ts";
+import { startServer } from "../../server/src/index.ts";
+
+async function availablePort() {
+  return new Promise<number>((resolve, reject) => {
+    const listener = net.createServer();
+    listener.unref();
+    listener.on("error", reject);
+    listener.listen(0, "127.0.0.1", () => {
+      const address = listener.address();
+      if (!address || typeof address === "string") {
+        reject(new Error("Could not allocate a local E2E port"));
+        return;
+      }
+      listener.close((error) => error ? reject(error) : resolve(address.port));
+    });
+  });
+}
+
+test("repairs an already-claimed Canary workspace before Messenger renders", async ({ page }) => {
+  test.setTimeout(120_000);
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "rudder-account-upgrade-e2e-"));
+  const instanceId = "account-upgrade";
+  const instanceRoot = path.join(homeDir, "instances", instanceId);
+  const configPath = path.join(instanceRoot, "config.json");
+  const [appPort, dbPort, identityPort] = await Promise.all([
+    availablePort(),
+    availablePort(),
+    availablePort(),
+  ]);
+  fs.mkdirSync(instanceRoot, { recursive: true });
+  fs.writeFileSync(configPath, JSON.stringify({
+    $meta: {
+      version: 1,
+      updatedAt: "2026-07-30T00:00:00.000Z",
+      source: "test",
+    },
+    database: {
+      mode: "embedded-postgres",
+      embeddedPostgresDataDir: path.join(instanceRoot, "db"),
+      embeddedPostgresPort: dbPort,
+      backup: {
+        enabled: false,
+        intervalMinutes: 60,
+        retentionDays: 1,
+        dir: path.join(instanceRoot, "data/backups"),
+      },
+    },
+    logging: { mode: "file", logDir: path.join(instanceRoot, "logs") },
+    server: { deploymentMode: "local_trusted", host: "127.0.0.1", port: appPort },
+    auth: { baseUrlMode: "auto" },
+    storage: {
+      provider: "local_disk",
+      localDisk: { baseDir: path.join(instanceRoot, "data/storage") },
+    },
+    secrets: {
+      provider: "local_encrypted",
+      strictMode: false,
+      localEncrypted: { keyFilePath: path.join(instanceRoot, "secrets/master.key") },
+    },
+  }, null, 2));
+
+  const issuer = `http://127.0.0.1:${identityPort}`;
+  const identityServer = createServer((_req, response) => {
+    response.writeHead(200, { "content-type": "application/json" });
+    response.end(JSON.stringify({
+      issuer,
+      subject: "account-upgrade-user",
+      audience: `rudder-installation:${instanceId}`,
+      installationId: instanceId,
+      jti: "upgrade-exchange-jti",
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      email: "upgrade@example.com",
+      name: "Upgrade Operator",
+    }));
+  });
+  await new Promise<void>((resolve) => identityServer.listen(identityPort, "127.0.0.1", resolve));
+
+  const envKeys = [
+    "RUDDER_HOME",
+    "RUDDER_CONFIG",
+    "RUDDER_INSTANCE_ID",
+    "RUDDER_LOCAL_ENV",
+    "RUDDER_UI_DEV_MIDDLEWARE",
+  ] as const;
+  const priorEnv = Object.fromEntries(envKeys.map((key) => [key, process.env[key]]));
+  process.env.RUDDER_HOME = homeDir;
+  process.env.RUDDER_CONFIG = configPath;
+  process.env.RUDDER_INSTANCE_ID = instanceId;
+  process.env.RUDDER_LOCAL_ENV = "e2e-account-upgrade";
+  process.env.RUDDER_UI_DEV_MIDDLEWARE = "true";
+
+  const started = await startServer({
+    runtimeOwnerKind: "cli",
+    localAccountAuth: {
+      identityOrigin: issuer,
+      audience: `rudder-installation:${instanceId}`,
+      sessionSecret: "account-upgrade-e2e-session-secret",
+      secureCookie: false,
+    },
+    runtimeOverrides: {
+      host: "127.0.0.1",
+      port: appPort,
+      deploymentMode: "local_trusted",
+      serveUi: true,
+      uiDevMiddleware: true,
+      heartbeatSchedulerEnabled: false,
+      databaseBackupEnabled: false,
+    },
+  });
+  const db = createDb(started.databaseUrl);
+
+  try {
+    const [org] = await db.insert(organizations).values({
+      name: "Recovered workspace",
+      urlKey: "recovered-workspace",
+      issuePrefix: "RCV",
+    }).returning();
+    const [readConversation, unreadConversation] = await db.insert(chatConversations).values([
+      {
+        orgId: org!.id,
+        title: "Previously read history",
+        lastMessageAt: new Date("2026-07-29T12:00:00.000Z"),
+      },
+      {
+        orgId: org!.id,
+        title: "One genuinely unread chat",
+        lastMessageAt: new Date("2026-07-30T12:00:00.000Z"),
+      },
+    ]).returning();
+    await db.insert(chatMessages).values([
+      ...Array.from({ length: 105 }, (_, index) => ({
+        orgId: org!.id,
+        conversationId: readConversation!.id,
+        role: "assistant",
+        body: `Historical message ${index + 1}`,
+        createdAt: new Date(Date.parse("2026-07-29T10:00:00.000Z") + index * 30_000),
+      })),
+      {
+        orgId: org!.id,
+        conversationId: unreadConversation!.id,
+        role: "assistant",
+        body: "Actually unread",
+        createdAt: new Date("2026-07-30T12:00:00.000Z"),
+      },
+    ]);
+    await db.insert(organizationMemberships).values({
+      orgId: org!.id,
+      principalType: "user",
+      principalId: "local-board",
+      status: "active",
+      membershipRole: "owner",
+    });
+    await db.insert(chatConversationUserStates).values([
+      {
+        orgId: org!.id,
+        conversationId: readConversation!.id,
+        userId: "local-board",
+        lastReadAt: new Date("2026-07-29T13:00:00.000Z"),
+      },
+      {
+        orgId: org!.id,
+        conversationId: unreadConversation!.id,
+        userId: "local-board",
+        lastReadAt: new Date("2026-07-30T11:00:00.000Z"),
+      },
+    ]);
+    const [group] = await db.insert(messengerCustomGroups).values({
+      orgId: org!.id,
+      userId: "local-board",
+      name: "Recovered priority",
+      sortOrder: 0,
+      pinnedAt: new Date("2026-07-29T13:00:00.000Z"),
+    }).returning();
+    const [savedView] = await db.insert(messengerSavedViews).values({
+      orgId: org!.id,
+      userId: "local-board",
+      targetKind: "browser",
+      targetPayload: {
+        kind: "browser",
+        tabId: "upgrade-tab",
+        url: "https://example.com/recovered",
+        viewInstanceId: "upgrade-view",
+      },
+      resourceKey: "browser:https://example.com/recovered",
+      instanceId: "upgrade-view",
+      canonicalResourceKey: "browser:https://example.com/recovered",
+      title: "Recovered saved view",
+      sortOrder: 1,
+    }).returning();
+    await db.insert(messengerCustomGroupEntries).values([
+      {
+        orgId: org!.id,
+        userId: "local-board",
+        groupId: group!.id,
+        threadKey: `chat:${readConversation!.id}`,
+        sortOrder: 0,
+      },
+      {
+        orgId: org!.id,
+        userId: "local-board",
+        groupId: group!.id,
+        threadKey: `saved-view:${savedView!.id}`,
+        sortOrder: 1,
+      },
+    ]);
+
+    const exchange = await page.request.post(`${started.apiUrl}/api/auth/local-exchange`, {
+      data: { exchangeCode: "canary-upgrade-exchange" },
+    });
+    expect(exchange.ok()).toBe(true);
+    const exchangeBody = await exchange.json() as { userId: string };
+    const cookieHeader = exchange.headers()["set-cookie"];
+    expect(cookieHeader).toBeTruthy();
+    await db.insert(installationAccountBindings).values({
+      installationId: instanceId,
+      issuer,
+      subject: "account-upgrade-user",
+      localUserId: exchangeBody.userId,
+    });
+    await db.update(organizationMemberships).set({
+      status: "revoked",
+      updatedAt: new Date(),
+    }).where(eq(organizationMemberships.principalId, "local-board"));
+    await db.insert(organizationMemberships).values({
+      orgId: org!.id,
+      principalType: "user",
+      principalId: exchangeBody.userId,
+      status: "active",
+      membershipRole: "owner",
+    });
+
+    const claim = await page.request.post(`${started.apiUrl}/api/auth/local-claim`, {
+      headers: {
+        cookie: cookieHeader!.split(";")[0]!,
+        origin: started.apiUrl,
+      },
+    });
+    expect(claim.ok()).toBe(true);
+    const [cookiePair] = cookieHeader!.split(";");
+    const cookieSeparator = cookiePair!.indexOf("=");
+    await page.context().addCookies([{
+      name: cookiePair!.slice(0, cookieSeparator),
+      value: decodeURIComponent(cookiePair!.slice(cookieSeparator + 1)),
+      url: started.apiUrl,
+      httpOnly: true,
+      sameSite: "Lax",
+    }]);
+
+    await page.goto(`${started.apiUrl}/${org!.issuePrefix}/messenger`);
+    await expect(page.getByRole("link", { name: "1 Messenger" })).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Recovered priority", exact: true }),
+    ).toBeVisible();
+    await expect(page.getByRole("link", { name: /Recovered saved view/ })).toBeVisible();
+    await expect(page.getByRole("link", { name: /Previously read history/ })).toBeVisible();
+    await page.reload();
+    await expect(page.getByRole("link", { name: "1 Messenger" })).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Recovered priority", exact: true }),
+    ).toBeVisible();
+  } finally {
+    await db.$client.end({ timeout: 5 }).catch(() => undefined);
+    await started.stop();
+    await new Promise<void>((resolve) => identityServer.close(() => resolve()));
+    for (const key of envKeys) {
+      const value = priorEnv[key];
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
+});

--- a/tests/e2e/messenger-contract.spec.ts
+++ b/tests/e2e/messenger-contract.spec.ts
@@ -210,6 +210,51 @@ async function scrollMessengerUntilTestId(page: Page, testId: string) {
 }
 
 test.describe("Messenger unified threads contract", () => {
+  test("keeps legacy Messenger ordering preferences when the session switches to an account UUID", async ({ page }) => {
+    const organization = await createOrganization(page, `Messenger-Account-Preference-${Date.now()}`);
+    const accountUserId = randomUUID();
+    await page.route("**/api/auth/get-session", async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({
+          session: { id: "account-session", userId: accountUserId },
+          user: { id: accountUserId, email: "operator@example.com", name: "Operator" },
+        }),
+      });
+    });
+    await page.addInitScript(({ orgId }) => {
+      window.localStorage.setItem(
+        `rudder.projectOrder:${orgId}:local-board`,
+        JSON.stringify(["project-2", "project-1"]),
+      );
+      window.localStorage.setItem(
+        `rudder.messengerThreadGroupOrder:kind:${orgId}:anonymous`,
+        JSON.stringify(["kind:issue", "kind:chat"]),
+      );
+      window.localStorage.setItem(
+        `rudder.messengerDefaultThreadOrder:${orgId}:local-board`,
+        JSON.stringify(["system:failed-runs", "system:approvals"]),
+      );
+    }, { orgId: organization.id });
+
+    await page.goto(`/${organization.issuePrefix}/messenger`);
+    await expect(page.getByRole("heading", { name: "Messenger" })).toBeVisible();
+    await expect.poll(async () => page.evaluate(({ orgId, userId }) => ({
+      projects: window.localStorage.getItem(`rudder.projectOrder:${orgId}:${userId}`),
+      kinds: window.localStorage.getItem(`rudder.messengerThreadGroupOrder:kind:${orgId}:${userId}`),
+      defaults: window.localStorage.getItem(`rudder.messengerDefaultThreadOrder:${orgId}:${userId}`),
+    }), { orgId: organization.id, userId: accountUserId })).toEqual({
+      projects: JSON.stringify(["project-2", "project-1"]),
+      kinds: JSON.stringify(["kind:issue", "kind:chat"]),
+      defaults: JSON.stringify(["system:failed-runs", "system:approvals"]),
+    });
+    await page.reload();
+    await expect.poll(async () => page.evaluate(({ orgId, userId }) =>
+      window.localStorage.getItem(`rudder.messengerDefaultThreadOrder:${orgId}:${userId}`),
+    { orgId: organization.id, userId: accountUserId }))
+      .toBe(JSON.stringify(["system:failed-runs", "system:approvals"]));
+  });
+
   test("loads additional chat sessions in the Messenger sidebar without fetching every thread up front", async ({ page }) => {
     const organization = await createOrganization(page, `Messenger-Paged-Sessions-${Date.now()}`);
     const baseTime = Date.parse("2026-05-15T12:00:00.000Z");

--- a/ui/src/components/MessengerContextSidebar.tsx
+++ b/ui/src/components/MessengerContextSidebar.tsx
@@ -52,9 +52,7 @@ import { Popover, PopoverAnchor, PopoverContent } from "@/components/ui/popover"
 import { VirtualizedActivityTimeline } from "@/components/VirtualizedActivityTimeline";
 import { useChatGenerationActions, useChatGenerations } from "@/context/ChatGenerationContext";
 import { useDialog } from "@/context/DialogContext";
-import {
-  useMainWorkbench,
-} from "@/context/MainWorkbenchContext";
+import { useMainWorkbench } from "@/context/MainWorkbenchContext";
 import { useOrganization } from "@/context/OrganizationContext";
 import { useOptionalSavedViewPromotion } from "@/context/SavedViewPromotionContext";
 import { useSidebar } from "@/context/SidebarContext";
@@ -65,7 +63,6 @@ import { isFeishuBackedConversation } from "@/lib/chat-source";
 import { displayChatTitle } from "@/lib/chat-title";
 import { rememberMessengerPath } from "@/lib/messenger-memory";
 import {
-  copyLegacyMessengerLocalPreferences,
   DEFAULT_THREAD_ORGANIZATION_RULE,
   getHiddenIssueThreadsStorageKey,
   getMessengerDefaultThreadOrderStorageKey,
@@ -79,6 +76,7 @@ import {
   readStringList,
   readThreadDensity,
   readThreadOrganizationRule,
+  useRecoveredMessengerPreferenceUserId,
   writeCollapsedThreadGroups,
   writeHiddenIssueThreadWatermarks,
   writeSplitIssueNotifications,
@@ -858,11 +856,7 @@ export function MessengerContextSidebar() {
     queryKey: queryKeys.auth.session,
     queryFn: () => authApi.getSession(),
   });
-  const currentUserId = sessionQuery.data?.user?.id ?? sessionQuery.data?.session?.userId ?? null;
-  useEffect(() => {
-    if (!model.selectedOrganizationId || !currentUserId) return;
-    copyLegacyMessengerLocalPreferences(model.selectedOrganizationId, currentUserId);
-  }, [currentUserId, model.selectedOrganizationId]);
+  const currentUserId = useRecoveredMessengerPreferenceUserId(model.selectedOrganizationId, sessionQuery.data);
   const projectOrderStorageKey = useMemo(() => {
     if (!model.selectedOrganizationId) return null;
     return getProjectOrderStorageKey(model.selectedOrganizationId, currentUserId);

--- a/ui/src/components/MessengerContextSidebar.tsx
+++ b/ui/src/components/MessengerContextSidebar.tsx
@@ -65,6 +65,7 @@ import { isFeishuBackedConversation } from "@/lib/chat-source";
 import { displayChatTitle } from "@/lib/chat-title";
 import { rememberMessengerPath } from "@/lib/messenger-memory";
 import {
+  copyLegacyMessengerLocalPreferences,
   DEFAULT_THREAD_ORGANIZATION_RULE,
   getHiddenIssueThreadsStorageKey,
   getMessengerDefaultThreadOrderStorageKey,
@@ -858,6 +859,10 @@ export function MessengerContextSidebar() {
     queryFn: () => authApi.getSession(),
   });
   const currentUserId = sessionQuery.data?.user?.id ?? sessionQuery.data?.session?.userId ?? null;
+  useEffect(() => {
+    if (!model.selectedOrganizationId || !currentUserId) return;
+    copyLegacyMessengerLocalPreferences(model.selectedOrganizationId, currentUserId);
+  }, [currentUserId, model.selectedOrganizationId]);
   const projectOrderStorageKey = useMemo(() => {
     if (!model.selectedOrganizationId) return null;
     return getProjectOrderStorageKey(model.selectedOrganizationId, currentUserId);

--- a/ui/src/lib/messenger-preferences.test.ts
+++ b/ui/src/lib/messenger-preferences.test.ts
@@ -2,6 +2,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  copyLegacyMessengerLocalPreferences,
   getHiddenIssueThreadsStorageKey,
   getMessengerDefaultThreadOrderStorageKey,
   getMessengerThreadGroupOrderStorageKey,
@@ -85,6 +86,49 @@ describe("messenger preferences", () => {
 
     values.order = JSON.stringify(["chat:3", 4, null]);
     expect(readStringList("order")).toEqual(["chat:3"]);
+  });
+
+  it("copies legacy account-scoped ordering without overwriting account-era preferences", () => {
+    values["rudder.projectOrder:org-1:local-board"] = JSON.stringify(["project-2", "project-1"]);
+    values["rudder.messengerProjectGroupOrder:org-1:anonymous"] = JSON.stringify(["project:2"]);
+    values["rudder.messengerThreadGroupOrder:kind:org-1:local-board"] = JSON.stringify(["kind:issue"]);
+    values["rudder.messengerDefaultThreadOrder:org-1:local-board"] = JSON.stringify(["chat:old"]);
+    values["rudder.messengerDefaultThreadOrder:org-1:account-1"] = JSON.stringify(["chat:new"]);
+    values["rudder.messengerHiddenIssueThreads:org-1:anonymous"] = JSON.stringify({
+      "issue:1": "2026-07-29T00:00:00.000Z",
+    });
+
+    const copied = copyLegacyMessengerLocalPreferences("org-1", "account-1");
+
+    expect(copied).toContain("rudder.projectOrder:org-1:account-1");
+    expect(values["rudder.projectOrder:org-1:account-1"]).toBe(
+      values["rudder.projectOrder:org-1:local-board"],
+    );
+    expect(values["rudder.messengerProjectGroupOrder:org-1:account-1"]).toBe(
+      values["rudder.messengerProjectGroupOrder:org-1:anonymous"],
+    );
+    expect(values["rudder.messengerThreadGroupOrder:kind:org-1:account-1"]).toBe(
+      values["rudder.messengerThreadGroupOrder:kind:org-1:local-board"],
+    );
+    expect(values["rudder.messengerDefaultThreadOrder:org-1:account-1"]).toBe(
+      JSON.stringify(["chat:new"]),
+    );
+    expect(values["rudder.messengerHiddenIssueThreads:org-1:account-1"]).toBe(
+      values["rudder.messengerHiddenIssueThreads:org-1:anonymous"],
+    );
+
+    expect(copyLegacyMessengerLocalPreferences("org-1", "account-1")).toEqual([]);
+  });
+
+  it("ignores malformed legacy preference payloads", () => {
+    values["rudder.projectOrder:org-1:local-board"] = "{";
+    values["rudder.messengerHiddenIssueThreads:org-1:anonymous"] = JSON.stringify({
+      "issue:1": 42,
+    });
+
+    expect(copyLegacyMessengerLocalPreferences("org-1", "account-1")).toEqual([]);
+    expect(values["rudder.projectOrder:org-1:account-1"]).toBeUndefined();
+    expect(values["rudder.messengerHiddenIssueThreads:org-1:account-1"]).toBeUndefined();
   });
 
   it("keeps collapsed groups scoped by organization and grouping rule", () => {

--- a/ui/src/lib/messenger-preferences.ts
+++ b/ui/src/lib/messenger-preferences.ts
@@ -11,6 +11,8 @@ const MESSENGER_THREAD_GROUP_ORDER_STORAGE_PREFIX = "rudder.messengerThreadGroup
 // Legacy key retained so existing local tab layouts survive the Arc-style top-level layout.
 const MESSENGER_DEFAULT_THREAD_ORDER_STORAGE_PREFIX = "rudder.messengerDefaultThreadOrder";
 const HIDDEN_ISSUE_THREADS_STORAGE_PREFIX = "rudder.messengerHiddenIssueThreads";
+const PROJECT_ORDER_STORAGE_PREFIX = "rudder.projectOrder";
+const LEGACY_MESSENGER_USER_IDS = ["local-board", "anonymous"] as const;
 
 export const DEFAULT_THREAD_ORGANIZATION_RULE: ThreadOrganizationRule = "latest";
 export const DEFAULT_THREAD_DENSITY: MessengerThreadDensity = "compact";
@@ -140,6 +142,68 @@ function normalizeStringList(value: unknown): string[] {
 function messengerUserStorageId(userId: string | null | undefined) {
   const trimmed = userId?.trim();
   return trimmed || "anonymous";
+}
+
+function isValidStringListJson(raw: string) {
+  try {
+    return Array.isArray(JSON.parse(raw))
+      && (JSON.parse(raw) as unknown[]).every((item) => typeof item === "string");
+  } catch {
+    return false;
+  }
+}
+
+function isValidWatermarkJson(raw: string) {
+  try {
+    const value = JSON.parse(raw) as unknown;
+    return Boolean(value)
+      && typeof value === "object"
+      && !Array.isArray(value)
+      && Object.values(value as Record<string, unknown>).every((item) => typeof item === "string");
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Account sign-in changes the local preference namespace from the trusted
+ * `local-board`/anonymous identity to the account UUID. Copying only when the
+ * destination is absent preserves account-era edits and keeps the legacy keys
+ * available to an older app after an automatic rollback.
+ */
+export function copyLegacyMessengerLocalPreferences(
+  orgId: string,
+  targetUserId: string | null | undefined,
+  storage: Pick<Storage, "getItem" | "setItem"> = window.localStorage,
+) {
+  const targetId = messengerUserStorageId(targetUserId);
+  if (targetId === "anonymous" || targetId === "local-board") return [];
+
+  const copied: string[] = [];
+  const specs = [
+    { prefix: PROJECT_ORDER_STORAGE_PREFIX, suffix: `${orgId}`, valid: isValidStringListJson },
+    { prefix: MESSENGER_PROJECT_GROUP_ORDER_STORAGE_PREFIX, suffix: `${orgId}`, valid: isValidStringListJson },
+    { prefix: MESSENGER_THREAD_GROUP_ORDER_STORAGE_PREFIX, suffix: `agent:${orgId}`, valid: isValidStringListJson },
+    { prefix: MESSENGER_THREAD_GROUP_ORDER_STORAGE_PREFIX, suffix: `kind:${orgId}`, valid: isValidStringListJson },
+    { prefix: MESSENGER_DEFAULT_THREAD_ORDER_STORAGE_PREFIX, suffix: `${orgId}`, valid: isValidStringListJson },
+    { prefix: HIDDEN_ISSUE_THREADS_STORAGE_PREFIX, suffix: `${orgId}`, valid: isValidWatermarkJson },
+  ];
+  for (const spec of specs) {
+    const targetKey = `${spec.prefix}:${spec.suffix}:${targetId}`;
+    if (storage.getItem(targetKey) !== null) continue;
+    for (const legacyId of LEGACY_MESSENGER_USER_IDS) {
+      const source = storage.getItem(`${spec.prefix}:${spec.suffix}:${legacyId}`);
+      if (source === null || !spec.valid(source)) continue;
+      try {
+        storage.setItem(targetKey, source);
+        copied.push(targetKey);
+      } catch {
+        // The server-side state recovery remains usable when storage is restricted.
+      }
+      break;
+    }
+  }
+  return copied;
 }
 
 export function getMessengerProjectGroupOrderStorageKey(

--- a/ui/src/lib/messenger-preferences.ts
+++ b/ui/src/lib/messenger-preferences.ts
@@ -1,3 +1,5 @@
+import { useEffect } from "react";
+
 export type ThreadOrganizationRule = "latest" | "project" | "agent" | "kind" | "attention" | "custom";
 export type MessengerThreadDensity = "comfortable" | "compact";
 
@@ -204,6 +206,21 @@ export function copyLegacyMessengerLocalPreferences(
     }
   }
   return copied;
+}
+
+export function useRecoveredMessengerPreferenceUserId(
+  orgId: string | null | undefined,
+  session: {
+    user?: { id?: string | null } | null;
+    session?: { userId?: string | null } | null;
+  } | null | undefined,
+) {
+  const userId = session?.user?.id ?? session?.session?.userId ?? null;
+  useEffect(() => {
+    if (!orgId || !userId) return;
+    copyLegacyMessengerLocalPreferences(orgId, userId);
+  }, [orgId, userId]);
+  return userId;
 }
 
 export function getMessengerProjectGroupOrderStorageKey(


### PR DESCRIPTION
## Summary
- reconcile legacy local-board Messenger and operator state into the claimed local account
- repair already-claimed Canary installations on every local claim without deleting downgrade-compatible source rows
- copy legacy Messenger local preferences before rendering
- claim legacy state for offline Desktop sessions too
- keep Identity Core runtime exports on compiled JavaScript through the current main baseline

## Verification
- reviewer: PASS
- independent verifier: PASS
- pnpm lint: PASS
- pnpm -r typecheck: PASS
- pnpm --workspace-concurrency=1 -r build: PASS
- targeted Vitest: 24/24 PASS
- Identity Core manifest: 1/1 PASS
- real local-account upgrade Playwright E2E: 1/1 PASS
- pnpm desktop:dist + server-package verification: PASS
- dev startup-recovery smoke: PASS
- packaged account-gate smoke: PASS

Full pnpm test:run completed with 6630 passing and 23 failures across 19 unrelated/concurrency-sensitive files; all changed-area tests pass. Full desktop:verify passed startup recovery, App Builder, clean/restart/browser/settings flows, then hit an unrelated Local Apps catalog locator timeout.

## Data safety
Migration is additive and idempotent. Legacy local-board rows remain available for downgrade compatibility; read watermarks use the newest timestamp and pin conflicts use the newest update.