### PR TITLE
docs: contract local account upgrade compatibility

### DIFF
--- a/doc/product/domains/collaboration/chat-messenger-im.md
+++ b/doc/product/domains/collaboration/chat-messenger-im.md
@@ -56,6 +56,8 @@ related_code:
   - server/src/services/chat-steer-messages.ts
   - server/src/services/side-chats.ts
   - server/src/services/messenger.ts
+  - server/src/services/legacy-operator-state.ts
+  - server/src/services/local-account-auth.ts
   - server/src/services/organization-intelligence-profiles.ts
   - server/src/routes/integrations.ts
   - server/src/services/integrations/agent-integrations.ts
@@ -91,6 +93,7 @@ related_code:
   - ui/src/lib/chat-stream-state.ts
   - ui/src/pages/ProjectDetail.tsx
   - ui/src/lib/messenger-thread-organization.ts
+  - ui/src/lib/messenger-preferences.ts
   - ui/src/pages/Chat.messages.tsx
   - ui/src/components/MarkdownEditor.tsx
   - ui/src/components/transcript/RunTranscriptView.chat.tsx
@@ -115,6 +118,7 @@ related_tests:
   - server/src/__tests__/chat-work-manifest.test.ts
   - server/src/__tests__/chat-assistant.test.ts
   - server/src/__tests__/messenger-service.test.ts
+  - server/src/__tests__/local-account-auth.test.ts
   - server/src/__tests__/product-intelligence.test.ts
   - server/src/__tests__/organization-intelligence-profiles.test.ts
   - ui/src/components/MessengerContextSidebar.actions.test.tsx
@@ -155,6 +159,7 @@ related_tests:
   - packages/shared/src/website-icons.test.ts
   - tests/e2e/markdown-website-link-rendering.spec.ts
   - tests/e2e/messenger-contract.spec.ts
+  - tests/e2e/local-account-upgrade.spec.ts
   - tests/e2e/messenger-hover-preview.spec.ts
   - tests/e2e/chat-streaming.spec.ts
   - tests/e2e/chat-edit-stream-layout.spec.ts
@@ -3261,6 +3266,10 @@ Invariants:
 - Messenger must cite or route to owning domain contracts; it must not redefine
   issue, approval, run, or automation state.
 - Unread/attention counts must be organization-scoped and user-scoped.
+- When a local installation changes from the legacy `local-board` principal to
+  an account UUID, its acknowledged read progress must be reconciled under
+  `ORG.LOCAL.ACCOUNT.UPGRADE.001`; identity upgrade must not turn historical
+  acknowledged work into fresh unread attention.
 - Seeded onboarding issue threads must remain read for the seeded operator
   until later issue activity occurs after the seed read marker.
 - A Saved View must not have unread state, unread count, attention state,
@@ -3503,6 +3512,10 @@ Invariants:
   shows a title-generation motion state on the group header.
 - Manual group title regeneration failure must not mutate the existing group
   title.
+- Local account claim and already-claimed repair must preserve custom groups,
+  membership, group pin state, and supported device-local ordering under
+  `ORG.LOCAL.ACCOUNT.UPGRADE.001`. Repeating recovery must not duplicate groups
+  or overwrite newer account-era ordering.
 
 Evidence:
 
@@ -3817,6 +3830,11 @@ Side.
 - Restart, renderer crash, explicit tab close, and Browser reset may create a
   new `webContentsId`. Cold recovery promises only the last eligible URL and
   profile, not history, form state, scroll, POST state, or in-page memory.
+- Local account claim and already-claimed repair must preserve Saved View
+  identity, membership, and placement under `ORG.LOCAL.ACCOUNT.UPGRADE.001`.
+  When a target Saved View already exists, recovery must map legacy receipts to
+  its actual target placement instead of duplicating it or restoring stale
+  placement.
 
 ### Drift Boundaries
 

--- a/doc/product/domains/organizations-and-goals/README.md
+++ b/doc/product/domains/organizations-and-goals/README.md
@@ -20,6 +20,8 @@ edit_policy: user_confirmed_only
 ## Owns
 
 - Organization mission and lifecycle as the top-level operating boundary.
+- Local installation account claims and compatibility-preserving operator-state
+  recovery across identity upgrades.
 - Goal hierarchy, status, owner, and dependency protection.
 - Project identity, project-goal links, lead agent, status, and grouping of
   chats/issues/resources/workspaces.
@@ -41,6 +43,9 @@ edit_policy: user_confirmed_only
 - `ORG.SETTINGS.001`: settings persist instance/operator/organization behavior
   without crossing scopes.
 - `ORG.ONBOARDING.001`: onboarding guides a fresh user to a real work surface.
+- `ORG.LOCAL.ACCOUNT.UPGRADE.001`: local account claim and repair preserve
+  scoped operator state, Messenger organization, and downgrade-readable legacy
+  data across Desktop upgrades.
 - `ORG.PORTABILITY.001`: export/import moves the explicitly supported
   organization configuration and work records with previewable, scoped
   mutations.

--- a/doc/product/domains/organizations-and-goals/settings-onboarding-portability.md
+++ b/doc/product/domains/organizations-and-goals/settings-onboarding-portability.md
@@ -7,6 +7,7 @@ contract_ids:
   - ORG.IDENTITY.001
   - ORG.SETTINGS.001
   - ORG.ONBOARDING.001
+  - ORG.LOCAL.ACCOUNT.UPGRADE.001
   - ORG.DESKTOP.UPDATE.001
   - ORG.DESKTOP.RELEASE.NOTES.001
   - ORG.PORTABILITY.001
@@ -18,6 +19,7 @@ related_code:
   - desktop/src/browser-profile.ts
   - desktop/src/desktop-quit-flow.ts
   - desktop/src/desktop-update-flow.ts
+  - desktop/src/identity-local-session.ts
   - desktop/src/main.ts
   - desktop/src/post-update-reload.ts
   - desktop/src/release-notes.ts
@@ -27,6 +29,8 @@ related_code:
   - server/src/routes/instance-settings.ts
   - server/src/routes/onboarding.ts
   - server/src/services/instance-settings.ts
+  - server/src/services/legacy-operator-state.ts
+  - server/src/services/local-account-auth.ts
   - server/src/services/orgs.ts
   - server/src/services/operator-profile.ts
   - server/src/services/organization-intelligence-profiles.ts
@@ -37,6 +41,7 @@ related_code:
   - ui/src/App.tsx
   - ui/src/lib/organization-routes.ts
   - ui/src/lib/organization-page-memory.ts
+  - ui/src/lib/messenger-preferences.ts
   - ui/src/hooks/useOrganizationPageMemory.ts
   - ui/src/components/Layout.tsx
   - ui/src/components/MobileBottomNav.tsx
@@ -73,10 +78,12 @@ related_tests:
   - desktop/src/browser-profile.test.ts
   - desktop/src/desktop-quit-flow.test.ts
   - desktop/src/desktop-update-flow.test.ts
+  - desktop/src/identity-local-session.test.ts
   - desktop/src/release-notes.test.ts
   - desktop/src/post-update-reload.test.ts
   - server/src/__tests__/instance-settings-service.test.ts
   - server/src/__tests__/instance-settings-routes.test.ts
+  - server/src/__tests__/local-account-auth.test.ts
   - server/src/__tests__/operator-profile-service.test.ts
   - server/src/__tests__/orgs-service.test.ts
   - server/src/__tests__/organization-intelligence-profiles.test.ts
@@ -103,6 +110,7 @@ related_tests:
   - ui/src/components/DesktopUpdatePromptBridge.test.tsx
   - ui/src/components/DesktopUpdateStatusCard.test.tsx
   - tests/e2e/desktop-update-prompt.spec.ts
+  - tests/e2e/local-account-upgrade.spec.ts
   - tests/e2e/onboarding.spec.ts
   - tests/e2e/organization-issue-key.spec.ts
   - tests/e2e/settings-appearance.spec.ts
@@ -484,6 +492,225 @@ Evidence:
   instruction text behavior.
 - Known gap: release-smoke onboarding evidence still belongs to release/Desktop
   validation, not this product contract alone.
+
+## ORG.LOCAL.ACCOUNT.UPGRADE.001
+
+### Contract Summary
+
+Claiming an existing trusted local Rudder installation into a Rudder Account
+must preserve the operator's scoped work state across the identity change from
+the legacy `local-board` principal to the account user UUID. Recovery runs for
+online and offline Desktop sessions, is safe to repeat, and retains the legacy
+source records so an automatic version rollback can still read them.
+
+### Intent / User Job
+
+- An operator can install a new Desktop or Canary version, sign in or resume
+  offline, and continue from the same Messenger attention state, groups, Saved
+  Views, ordering, issue state, and profile instead of receiving a seemingly
+  fresh account.
+- A repaired installation can run the same claim again without duplicating
+  state or undoing newer account-era changes.
+- If the new build rolls back, the older build can still use the legacy state
+  that existed before the account claim.
+
+### Why / Design Reasoning
+
+- Operator-scoped records use the authenticated user id. Changing the local
+  principal without an explicit compatibility boundary makes durable data
+  appear deleted even though it remains in the same database.
+- Recomputing unread state from content is not recovery: it can turn years of
+  acknowledged messages into `99+` attention and cannot reconstruct manual
+  groups, Saved View placement, or device-local ordering.
+- Moving or deleting the legacy rows would make rollback unsafe. A
+  copy-and-reconcile migration is therefore preferred over destructive
+  ownership transfer.
+- Account-era edits may already exist when a Canary is repaired. Recovery must
+  merge monotonically or choose the newest authoritative state instead of
+  blindly replacing the target namespace.
+
+### Actors / Objects / State
+
+- The Desktop shell establishes either an online server-exchange session or a
+  valid offline-grant session, then invokes the authenticated local-installation
+  claim.
+- The legacy principal is `local-board`; older browser-only preference keys may
+  also use `anonymous`. The target principal is the authenticated account user
+  UUID bound to the installation.
+- Server-owned recovery includes active organization membership scope,
+  Messenger custom groups and entries, Saved Views and mutation receipts,
+  Messenger and Chat read/pin state, issue read state and follows, and the
+  operator profile.
+- Device-local recovery includes project order, Messenger project-group order,
+  Agent/Kind thread-group order, default thread order, and hidden-issue
+  watermarks stored under a user-specific local preference key.
+- `installation.legacy_operator_state_copied` activity records are durable
+  receipts for organization-scoped server recovery.
+
+### Entry Points / Inputs
+
+- First account claim for an installation that still has active
+  `local-board` organization memberships.
+- A repeated claim for an already-bound installation, including a repair after
+  a partially compatible Canary already changed membership ownership.
+- Desktop online session establishment and Desktop offline-grant session
+  establishment.
+- First rendered Messenger preference read under the authenticated account user
+  UUID.
+
+### Product Logic Flow
+
+1. Desktop authenticates the local account session online or offline and then
+   calls the local installation claim before treating identity setup as
+   complete.
+2. The server verifies that the installation binding and authenticated external
+   identity resolve to the same local account user. A different account cannot
+   claim or repair the installation.
+3. In one claim transaction, Rudder scopes recovery to organizations where the
+   legacy or target user has an active membership. First claim transfers the
+   active organization and instance role boundary to the account user; an
+   already-claimed installation still runs reconciliation.
+4. Rudder copies missing legacy groups, entries, Saved Views, mutation receipts,
+   follows, read state, pin state, and profile fields into the target namespace.
+   Stable deterministic ids and conflict-aware mapping make the operation
+   repeatable.
+5. Read progress takes the greatest known read timestamp. A pin/unpin conflict
+   takes the value with the newest update timestamp. Existing target Saved View
+   identity and actual target placement win over a stale legacy receipt.
+   Existing non-empty target profile fields and preference keys are preserved.
+6. The browser preference layer copies each supported, valid legacy
+   `local-board` or `anonymous` key only when the account-specific destination
+   key is absent. Invalid JSON is ignored and unavailable storage does not
+   invalidate successful server recovery.
+7. Rudder retains all legacy source rows and keys. Repeating the claim
+   reconciles any missing compatible state and emits at most one recovery
+   receipt per installation, organization, and target user.
+8. Messenger renders from the recovered target namespace, so acknowledged work,
+   custom grouping, Saved View placement, and manual order survive reload.
+
+### Decision Table
+
+| Case | Conditions | Product result | Must not happen | Evidence |
+| --- | --- | --- | --- | --- |
+| First claim | Active legacy organization belongs to `local-board` and installation is unclaimed | Bind the account and copy scoped operator state transactionally | Present a clean Messenger or delete legacy state | Auth service tests and upgrade E2E |
+| Already claimed repair | Installation already belongs to the same account but legacy state remains | Reconcile the same compatibility copy again, idempotently | Return early before repair or duplicate groups/Saved Views | Auth service tests |
+| Read-state conflict | Legacy and target both have read markers | Keep the greatest read progress | Reset to an older marker and create false unread debt | Auth service tests and upgrade E2E |
+| Pin-state conflict | Legacy and target pin values differ | Keep the value from the newest state update | Re-pin something the account later unpinned | Auth service tests |
+| Saved View identity conflict | Target already has the same mutation, instance, or resource | Reuse target identity and record its actual placement | Duplicate the Saved View or restore a stale legacy group receipt | Auth service tests |
+| Local preference conflict | Valid target key already exists | Preserve target value | Overwrite account-era ordering with legacy order | Messenger preference tests |
+| Invalid or unavailable local storage | Legacy value is invalid JSON or storage rejects access | Skip that device-local key; retain server recovery | Crash Messenger or discard server-owned state | Messenger preference tests |
+| Different account | Installation binding or external identity does not match | Reject the claim without changing ownership or operator state | Copy one operator's state into another account | Auth service tests |
+| Automatic rollback | A newer claim completed and an older build starts | Legacy source rows and keys remain available | Require a destructive reverse migration | Auth service and preference tests |
+
+### Actor-Visible Input
+
+- The operator supplies normal online sign-in or an already-issued offline
+  credential; there is no separate manual data-migration workflow.
+- Messenger continues to expose the same organization and normal thread/group
+  controls after the account session is established.
+
+### Operator-Visible Output
+
+- The Messenger badge reflects genuinely unread work rather than every
+  historical message.
+- Existing Custom Groups, grouped members, Saved Views, loose/group placement,
+  pin state, ordering, hidden issue watermarks, follows, and operator profile
+  remain available after update and reload.
+- A claim failure is surfaced as an identity/setup failure. Rudder must not
+  silently continue into a new-looking empty state and imply that recovery
+  succeeded.
+
+### Persisted Evidence
+
+- Target-user rows preserve recovered operator state in their owning tables.
+- The original `local-board` rows and legacy local preference keys remain
+  intact for downgrade compatibility.
+- One `installation.legacy_operator_state_copied` activity receipt per scoped
+  organization records the installation, target actor, prior principal, and
+  copy-preserving compatibility mode.
+
+### Canonical Scenarios
+
+1. Upgrade a long-lived local Messenger:
+   - Trigger: Claim an already-used installation with 105 historical Chat
+     messages acknowledged and one genuinely unread Chat.
+   - Expected state/action: Copy the legacy read marker and directory state to
+     the account user.
+   - Visible output: Messenger shows one unread item, the original group, and
+     its Saved View before and after reload.
+   - Evidence: `tests/e2e/local-account-upgrade.spec.ts`.
+2. Repair an already-claimed Canary:
+   - Trigger: Reopen an installation whose membership was already moved but
+     whose legacy operator rows were not copied.
+   - Expected state/action: The repeated claim reconciles missing state and
+     leaves a single receipt and stable target records.
+   - Visible output: Restored Messenger state without duplicate groups or
+     Saved Views.
+   - Evidence: `server/src/__tests__/local-account-auth.test.ts`.
+3. Preserve newer account edits:
+   - Trigger: Target read/pin/profile/Saved View or local ordering state
+     conflicts with legacy state.
+   - Expected state/action: Use monotonic read progress, newest pin state,
+     target placement, and existing target preference values.
+   - Visible output: Recovery does not undo the operator's newer organization.
+   - Evidence: auth service and Messenger preference tests.
+4. Resume offline:
+   - Trigger: Desktop creates a valid local session from an offline grant.
+   - Expected state/action: Desktop still invokes the same local claim before
+     completing session setup.
+   - Visible output: Offline startup uses the recovered account namespace.
+   - Evidence: `desktop/src/identity-local-session.test.ts`.
+
+### Invariants / Non-Goals
+
+- Recovery is scoped to active memberships for the legacy or target user and
+  must never cross organization or account boundaries.
+- First claim and already-claimed repair use the same reconciliation behavior.
+  Online and offline Desktop session paths both invoke it.
+- Recovery must be idempotent, source-preserving, and conflict-aware.
+- Read progress cannot move backward. A newer unpin must not be overwritten by
+  an older legacy pin.
+- Existing target Saved View identity and actual target placement must not be
+  replaced by a stale legacy mutation receipt.
+- Valid account-specific local preferences must not be overwritten. Invalid
+  legacy preference payloads must not be copied.
+- This contract does not promise cross-device synchronization for
+  local-storage ordering or hidden-watermark preferences; it preserves them on
+  the upgraded local profile.
+- This contract does not authorize one Rudder Account to adopt another
+  account's installation or data.
+
+### Drift Boundaries
+
+- Changing the local principal namespace, claim ordering, recovered table set,
+  conflict rules, rollback retention, online/offline parity, activity receipt,
+  or device-local preference set requires updating this contract.
+- Deterministic-id hashing, batching, internal helper boundaries, and exact
+  response shapes may change without a contract update when the visible and
+  persisted compatibility behavior remains equivalent.
+
+### Traceability
+
+Related code:
+
+- `desktop/src/identity-local-session.ts`
+- `server/src/services/local-account-auth.ts`
+- `server/src/services/legacy-operator-state.ts`
+- `ui/src/lib/messenger-preferences.ts`
+
+Related tests:
+
+- `desktop/src/identity-local-session.test.ts`
+- `server/src/__tests__/local-account-auth.test.ts`
+- `ui/src/lib/messenger-preferences.test.ts`
+- `tests/e2e/local-account-upgrade.spec.ts`
+- `tests/e2e/messenger-contract.spec.ts`
+
+Related contracts:
+
+- `MESSENGER.ATTENTION.001`
+- `MESSENGER.CUSTOM.GROUPS.001`
+- `MESSENGER.SAVED.VIEWS.001`
 
 ## ORG.DESKTOP.UPDATE.001
 

--- a/doc/product/registry.yml
+++ b/doc/product/registry.yml
@@ -1620,6 +1620,8 @@ contracts:
       - doc/product/domains/collaboration/chat-messenger-im.md
     related_code:
       - server/src/routes/onboarding.ts
+      - server/src/services/legacy-operator-state.ts
+      - server/src/services/local-account-auth.ts
       - server/src/services/messenger.ts
       - server/src/services/messenger-run-origin.ts
       - server/src/routes/sidebar-badges.ts
@@ -1629,6 +1631,7 @@ contracts:
       - server/src/__tests__/messenger-service.test.ts
       - server/src/__tests__/sidebar-badges-service.test.ts
       - tests/e2e/messenger-contract.spec.ts
+      - tests/e2e/local-account-upgrade.spec.ts
       - tests/e2e/onboarding.spec.ts
     related_plans:
       - doc/plans/2026-06-21-product-logic-registry.md
@@ -1650,6 +1653,8 @@ contracts:
       - doc/product/domains/collaboration/chat-messenger-im.md
     related_code:
       - server/src/routes/onboarding.ts
+      - server/src/services/legacy-operator-state.ts
+      - server/src/services/local-account-auth.ts
       - server/src/services/messenger.ts
       - ui/src/components/MessengerContextSidebar.tsx
       - ui/src/components/messenger/MessengerCustomGroupVisuals.tsx
@@ -1661,6 +1666,7 @@ contracts:
       - ui/src/pages/Messenger.tsx
     related_tests:
       - server/src/__tests__/messenger-service.test.ts
+      - server/src/__tests__/local-account-auth.test.ts
       - ui/src/components/MessengerContextSidebar.test.tsx
       - ui/src/components/MessengerContextSidebar.actions.test.tsx
       - ui/src/components/messenger/MessengerSavedViewRow.test.tsx
@@ -1669,6 +1675,7 @@ contracts:
       - ui/src/lib/messenger-preferences.test.ts
       - ui/src/lib/messenger-thread-organization.test.ts
       - tests/e2e/messenger-contract.spec.ts
+      - tests/e2e/local-account-upgrade.spec.ts
       - tests/e2e/messenger-saved-views.spec.ts
       - tests/e2e/onboarding.spec.ts
     related_plans:
@@ -1689,6 +1696,8 @@ contracts:
       - packages/shared/src/validators/chat.ts
       - packages/shared/src/validators/messenger.ts
       - server/src/routes/messenger.ts
+      - server/src/services/legacy-operator-state.ts
+      - server/src/services/local-account-auth.ts
       - server/src/services/messenger.ts
       - server/src/services/messenger-saved-views.ts
       - ui/src/api/messenger.ts
@@ -1710,6 +1719,7 @@ contracts:
     related_tests:
       - packages/shared/src/validators/messenger.test.ts
       - server/src/__tests__/messenger-routes.test.ts
+      - server/src/__tests__/local-account-auth.test.ts
       - server/src/__tests__/messenger-service.test.ts
       - ui/src/components/MessengerContextSidebar.test.tsx
       - ui/src/components/MessengerContextSidebar.actions.test.tsx
@@ -1725,6 +1735,7 @@ contracts:
       - ui/src/pages/Messenger.test.tsx
       - ui/src/pages/MessengerSavedViewWorkspace.test.tsx
       - tests/e2e/messenger-contract.spec.ts
+      - tests/e2e/local-account-upgrade.spec.ts
       - tests/e2e/chat-side-panel.spec.ts
       - tests/e2e/messenger-saved-views.spec.ts
       - tests/e2e/messenger-local-apps.spec.ts
@@ -2222,6 +2233,24 @@ contracts:
     related_plans:
       - doc/plans/2026-05-08-onboarding-getting-started-dashboard.md
       - doc/plans/2026-07-22-getting-started-onboarding-issues-simplification.md
+  ORG.LOCAL.ACCOUNT.UPGRADE.001:
+    owner: product
+    domain: organizations-and-goals
+    status: active
+    spec_depth: logic_contract
+    docs:
+      - doc/product/domains/organizations-and-goals/settings-onboarding-portability.md
+    related_code:
+      - desktop/src/identity-local-session.ts
+      - server/src/services/local-account-auth.ts
+      - server/src/services/legacy-operator-state.ts
+      - ui/src/lib/messenger-preferences.ts
+    related_tests:
+      - desktop/src/identity-local-session.test.ts
+      - server/src/__tests__/local-account-auth.test.ts
+      - ui/src/lib/messenger-preferences.test.ts
+      - tests/e2e/local-account-upgrade.spec.ts
+      - tests/e2e/messenger-contract.spec.ts
   ORG.DESKTOP.UPDATE.001:
     owner: product
     domain: organizations-and-goals


### PR DESCRIPTION
## Summary
- add ORG.LOCAL.ACCOUNT.UPGRADE.001 for local-account claim and repair compatibility
- protect Messenger unread state, custom groups, Saved Views, and device-local ordering across identity upgrades
- require idempotent, conflict-aware, source-preserving recovery for downgrade safety
- link the merged implementation and upgrade E2E in the Product Logic Registry

## Validation
- pnpm product-logic:check
- pnpm product-logic:test
- git diff --check
- independent reviewer: PASS
- independent verifier: PASS

## Product Logic Alignment
- changed doc/product/** with explicit user authorization
- added ORG.LOCAL.ACCOUNT.UPGRADE.001
- aligned MESSENGER.ATTENTION.001, MESSENGER.CUSTOM.GROUPS.001, and MESSENGER.SAVED.VIEWS.001
- implementation evidence: merged commit 84ef212f1815f528d19fe8241a25f97b392bdf81