### PR TITLE
fix(desktop): authenticate update blocker checks

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -16,7 +16,7 @@
     "stage:app": "node scripts/stage-app.mjs",
     "stage:app-builder-toolchain": "node scripts/stage-app-builder-toolchain.mjs",
     "typecheck": "tsc --noEmit -p tsconfig.json",
-    "smoke": "node scripts/smoke.mjs && node scripts/app-builder-smoke.mjs",
+    "smoke": "node scripts/smoke.mjs && electron scripts/update-session-fetch-smoke.mjs && node scripts/app-builder-smoke.mjs",
     "smoke:app-builder": "pnpm build && node scripts/app-builder-smoke.mjs",
     "smoke:app-builder:packaged": "node scripts/app-builder-smoke.mjs --packaged"
   },

--- a/desktop/scripts/update-session-fetch-smoke.mjs
+++ b/desktop/scripts/update-session-fetch-smoke.mjs
@@ -1,0 +1,118 @@
+import { app, session } from "electron";
+import assert from "node:assert/strict";
+import { randomBytes } from "node:crypto";
+import { mkdtempSync, rmSync } from "node:fs";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { createDesktopQuitFlow } from "../dist/desktop-quit-flow.js";
+
+const sessionCookieName = "better-auth.session_token";
+const sessionCookieValue = randomBytes(24).toString("base64url");
+const userDataDir = mkdtempSync(path.join(os.tmpdir(), "rudder-update-session-smoke-"));
+app.setPath("userData", userDataDir);
+let server;
+let baseUrl;
+const watchdog = setTimeout(() => {
+  console.error("Desktop update session fetch smoke timed out.");
+  process.exit(1);
+}, 30_000);
+
+function json(response, status, body) {
+  response.writeHead(status, { "content-type": "application/json" });
+  response.end(JSON.stringify(body));
+}
+
+function hasSessionCookie(request) {
+  return (request.headers.cookie ?? "")
+    .split(";")
+    .map((part) => part.trim())
+    .includes(`${sessionCookieName}=${sessionCookieValue}`);
+}
+
+async function closeServer() {
+  if (!server) return;
+  await new Promise((resolve, reject) => {
+    server.close((error) => error ? reject(error) : resolve());
+  });
+}
+
+async function run() {
+  console.log("[update-session-smoke] waiting for Electron ready");
+  await app.whenReady();
+  console.log("[update-session-smoke] Electron ready");
+  const authenticatedPaths = [];
+  server = http.createServer((request, response) => {
+    if (!hasSessionCookie(request)) {
+      json(response, 401, { error: "Rudder Account session required", code: "account_session_required" });
+      return;
+    }
+    authenticatedPaths.push(request.url);
+    if (request.url === "/api/orgs") {
+      json(response, 200, [{ id: "org-smoke", name: "Update Session Smoke" }]);
+      return;
+    }
+    if (request.url === "/api/orgs/org-smoke/live-runs") {
+      json(response, 200, []);
+      return;
+    }
+    json(response, 404, { error: "Not found" });
+  });
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  assert.ok(address && typeof address !== "string");
+  baseUrl = `http://127.0.0.1:${address.port}`;
+  console.log("[update-session-smoke] fixture listening");
+
+  const anonymousResponse = await fetch(`${baseUrl}/api/orgs`, { credentials: "include" });
+  assert.equal(anonymousResponse.status, 401, "anonymous main-process fetch must reproduce the updater auth failure");
+  console.log("[update-session-smoke] anonymous request rejected");
+
+  await session.defaultSession.cookies.set({
+    url: baseUrl,
+    name: sessionCookieName,
+    value: sessionCookieValue,
+    httpOnly: true,
+  });
+  console.log("[update-session-smoke] session cookie installed");
+  const quitFlow = createDesktopQuitFlow({
+    appName: "Rudder",
+    getMainWindow: () => null,
+    setMainWindow: () => undefined,
+    getServerHandle: () => ({ apiUrl: baseUrl, runtime: { mode: "owned" } }),
+    fetchApi: (input, init) => session.defaultSession.fetch(input, init),
+    stopLocalRudder: async () => undefined,
+    destroyResidentTray: () => undefined,
+  });
+
+  assert.deepEqual(await quitFlow.listRunningRunsForUpdate(), {
+    totalRuns: 0,
+    organizations: [],
+    blockers: [],
+  });
+  assert.deepEqual(authenticatedPaths, ["/api/orgs", "/api/orgs/org-smoke/live-runs"]);
+  console.log("Desktop update session fetch smoke passed.");
+}
+
+async function finish() {
+  if (baseUrl) {
+    await session.defaultSession.cookies.remove(baseUrl, sessionCookieName).catch(() => undefined);
+  }
+  await closeServer().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+  clearTimeout(watchdog);
+  rmSync(userDataDir, { recursive: true, force: true });
+  app.quit();
+}
+
+void run()
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  })
+  .finally(finish);

--- a/desktop/src/desktop-quit-flow.test.ts
+++ b/desktop/src/desktop-quit-flow.test.ts
@@ -218,6 +218,42 @@ describe("desktop quit flow update handoff", () => {
     }
   });
 
+  it("uses the Electron session fetch with credentials for authenticated blocker inspection", async () => {
+    const fetchApi = vi.fn(async (url: string, init?: RequestInit) => {
+      const pathName = new URL(url).pathname;
+      expect(init?.credentials).toBe("include");
+      if (pathName === "/api/orgs") {
+        return jsonResponse([{ id: "org-auth", name: "Authenticated Org" }]);
+      }
+      if (pathName === "/api/orgs/org-auth/live-runs") {
+        return jsonResponse([]);
+      }
+      return new Response("not found", { status: 404, statusText: "Not Found" });
+    });
+    const globalFetch = vi.spyOn(globalThis, "fetch");
+    try {
+      const quitFlow = createDesktopQuitFlow({
+        appName: "Rudder",
+        getMainWindow: () => null,
+        setMainWindow: vi.fn(),
+        getServerHandle: () => ({ apiUrl: "http://127.0.0.1:3200", runtime: { mode: "owned" } }),
+        fetchApi,
+        stopLocalRudder: vi.fn(),
+        destroyResidentTray: vi.fn(),
+      });
+
+      await expect(quitFlow.listRunningRunsForUpdate()).resolves.toEqual({
+        totalRuns: 0,
+        organizations: [],
+        blockers: [],
+      });
+      expect(fetchApi).toHaveBeenCalledTimes(2);
+      expect(globalFetch).not.toHaveBeenCalled();
+    } finally {
+      globalFetch.mockRestore();
+    }
+  });
+
   it("allows update quit when only queued or terminal records remain", async () => {
     const stopLocalRudder = vi.fn(async () => undefined);
     const fetchMock = vi.fn(async (url: string) => {

--- a/desktop/src/desktop-quit-flow.ts
+++ b/desktop/src/desktop-quit-flow.ts
@@ -17,12 +17,14 @@ type DesktopUpdateBlocker = {
   organizationName: string;
 };
 type DesktopUpdateRunSummary = ActiveRunSummary & { blockers: DesktopUpdateBlocker[] };
+type DesktopApiFetch = (input: string, init?: RequestInit) => Promise<Response>;
 
 export function createDesktopQuitFlow(context: {
   appName: string;
   getMainWindow: () => BrowserWindow | null;
   setMainWindow: (value: BrowserWindow | null) => void;
   getServerHandle: () => { apiUrl: string; runtime: { mode: "owned" | "attached" } } | null;
+  fetchApi?: DesktopApiFetch;
   prepareForQuit?: () => Promise<void>;
   prepareLocalAppsForQuit?: () => Promise<void>;
   stopLocalRudder: () => Promise<void>;
@@ -47,9 +49,10 @@ export function createDesktopQuitFlow(context: {
       headers.set("Accept", "application/json");
     }
 
-    const response = await fetch(buildDesktopApiRequestUrl(apiBase, apiPath), {
+    const response = await (context.fetchApi ?? fetch)(buildDesktopApiRequestUrl(apiBase, apiPath), {
       ...init,
       headers,
+      credentials: "include",
     });
 
     if (!response.ok) {

--- a/desktop/src/desktop-update-flow.test.ts
+++ b/desktop/src/desktop-update-flow.test.ts
@@ -8,6 +8,7 @@ import {
 } from "./postgres-runtime.js";
 
 const spawnMock = vi.hoisted(() => vi.fn());
+const showMessageBoxMock = vi.hoisted(() => vi.fn());
 
 vi.mock("node:child_process", () => ({
   spawn: spawnMock,
@@ -22,7 +23,7 @@ vi.mock("electron", () => ({
   },
   BrowserWindow: vi.fn(),
   dialog: {
-    showMessageBox: vi.fn(),
+    showMessageBox: showMessageBoxMock,
   },
   shell: {
     openExternal: vi.fn(),
@@ -94,7 +95,7 @@ function createFlow(overrides: Partial<Parameters<typeof createDesktopUpdateFlow
     appName: "Rudder",
     getMainWindow: () => mainWindow,
     getServerHandle: () => ({ runtime: { version: "0.3.3" } }),
-    getBootState: () => ({ runtime: { localEnv: "prod_local", version: "0.3.3" } }),
+    getBootState: () => ({ stage: "ready", runtime: { localEnv: "prod_local", version: "0.3.3" } }),
     listRunningRunsForUpdate: async () => createRunSummary(),
     formatUpdateRunDetail: (summary) => summary.blockers
       .map((blocker) => `${blocker.organizationName}: ${blocker.agentName} (run ${blocker.runId})`)
@@ -109,7 +110,68 @@ function createFlow(overrides: Partial<Parameters<typeof createDesktopUpdateFlow
 describe("desktop update flow", () => {
   beforeEach(() => {
     spawnMock.mockReset();
+    showMessageBoxMock.mockReset();
     fs.rmSync("/tmp/rudder-desktop-test/post-update-reload.json", { force: true });
+  });
+
+  it("does not show the startup update notice before the local runtime is ready", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch");
+    try {
+      const { flow } = createFlow({ getServerHandle: () => null });
+
+      await flow.maybeShowStartupUpdateNotice();
+
+      expect(fetchMock).not.toHaveBeenCalled();
+    } finally {
+      fetchMock.mockRestore();
+    }
+  });
+
+  it("keeps manual and direct update entry points recoverable while signed out", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch");
+    try {
+      const { flow } = createFlow({ getServerHandle: () => null });
+
+      await flow.showManualUpdateCheckDialog();
+      await expect(flow.installUpdate("0.3.4")).resolves.toEqual({
+        status: "blocked",
+        message: "Sign in and wait for the Local Workspace to become ready, then start the update again.",
+      });
+
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(spawnMock).not.toHaveBeenCalled();
+      expect(showMessageBoxMock).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ message: "Sign in before checking for updates." }),
+      );
+    } finally {
+      fetchMock.mockRestore();
+    }
+  });
+
+  it("blocks update entry points until the account session is ready", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch");
+    try {
+      const { flow } = createFlow({
+        getServerHandle: () => ({ runtime: { version: "0.3.3" } }),
+        getBootState: () => ({ stage: "account_exchange" }),
+      });
+
+      await flow.showManualUpdateCheckDialog();
+      await expect(flow.installUpdate("0.3.4")).resolves.toEqual({
+        status: "blocked",
+        message: "Sign in and wait for the Local Workspace to become ready, then start the update again.",
+      });
+
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(spawnMock).not.toHaveBeenCalled();
+      expect(showMessageBoxMock).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ message: "Wait for the Local Workspace to become ready." }),
+      );
+    } finally {
+      fetchMock.mockRestore();
+    }
   });
 
   it("uses the Node-mode CLI runner for macOS update children", () => {

--- a/desktop/src/desktop-update-flow.ts
+++ b/desktop/src/desktop-update-flow.ts
@@ -116,6 +116,10 @@ export function createDesktopUpdateFlow(context: {
     version: string;
     promise: Promise<DesktopUpdateInstallResult>;
   } | null = null;
+
+  function isLocalRuntimeReadyForUpdate(): boolean {
+    return Boolean(context.getServerHandle()) && context.getBootState()?.stage === "ready";
+  }
   let startupUpdateNoticeShown = false;
 
   type DesktopUpdateInstallResult =
@@ -487,7 +491,7 @@ export function createDesktopUpdateFlow(context: {
   }
 
   async function maybeShowStartupUpdateNotice(): Promise<void> {
-    if (startupUpdateNoticeShown || !app.isPackaged) return;
+    if (startupUpdateNoticeShown || !app.isPackaged || !isLocalRuntimeReadyForUpdate()) return;
     startupUpdateNoticeShown = true;
 
     const result = await checkForUpdates();
@@ -498,6 +502,24 @@ export function createDesktopUpdateFlow(context: {
 
   async function showManualUpdateCheckDialog(): Promise<void> {
     context.showMainWindow();
+    if (!isLocalRuntimeReadyForUpdate()) {
+      const signedOut = !context.getServerHandle();
+      await showMessageBox({
+        type: "info",
+        title: context.appName,
+        buttons: ["OK"],
+        defaultId: 0,
+        cancelId: 0,
+        noLink: true,
+        message: signedOut
+          ? "Sign in before checking for updates."
+          : "Wait for the Local Workspace to become ready.",
+        detail: signedOut
+          ? "Rudder will start the Local Workspace after sign-in. Check for updates again when the workspace is ready."
+          : "The account session is still connecting. Check for updates again when startup finishes.",
+      });
+      return;
+    }
     const result = await checkForUpdates();
 
     if (result.status === "update-available") {
@@ -546,6 +568,12 @@ export function createDesktopUpdateFlow(context: {
       return {
         status: "unavailable",
         message: "The update check did not return a target version.",
+      };
+    }
+    if (!isLocalRuntimeReadyForUpdate()) {
+      return {
+        status: "blocked",
+        message: "Sign in and wait for the Local Workspace to become ready, then start the update again.",
       };
     }
 

--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -564,6 +564,7 @@ const desktopQuitFlow = createDesktopQuitFlow({
   getMainWindow: () => mainWindow,
   setMainWindow: (value) => { mainWindow = value; },
   getServerHandle: () => serverHandle,
+  fetchApi: (input, init) => session.defaultSession.fetch(input, init),
   prepareForQuit: async () => {
     await Promise.all([
       browserProfileController?.shutdown() ?? Promise.resolve(),
@@ -2034,6 +2035,7 @@ async function startLocalRudder(): Promise<void> {
       await openAppWindow(loadUrl);
       schedulePostUpdateRendererReloadIfNeeded();
       await captureDesktopWindowIfRequested();
+      void maybeShowStartupUpdateNotice();
     } catch (error) {
       console.error("[rudder-desktop] managed local server startup failed", error);
       const failure = createDesktopStartupFailureView({
@@ -2662,7 +2664,6 @@ async function bootstrap(): Promise<void> {
     console.info("[rudder-desktop] bootstrap:start-runtime");
   }
   await startLocalRudder();
-  void maybeShowStartupUpdateNotice();
   if (desktopDebugEnabled()) {
     console.info("[rudder-desktop] bootstrap:ready");
   }

--- a/doc/engineering/DESKTOP.md
+++ b/doc/engineering/DESKTOP.md
@@ -62,7 +62,7 @@ Low-frequency escape hatches:
 
 Smoke scenarios:
 
-- `pnpm --filter @rudderhq/desktop smoke` runs startup-recovery, renderer-recovery, and clean-instance Desktop smoke paths.
+- `pnpm --filter @rudderhq/desktop smoke` runs the development Desktop scenarios, authenticated update-session fetch smoke, and App Builder smoke.
 - `node desktop/scripts/smoke.mjs --mode=packaged` runs startup-recovery, renderer-recovery, clean packaged, and upgrade smoke paths. The upgrade path downgrades the temporary `prod_local` schema before relaunching.
 - Pass `--scenario=startup-recovery`, `--scenario=renderer-recovery`, `--scenario=clean`, `--scenario=upgrade`, or `--scenario=all` to target a specific smoke path manually.
 


### PR DESCRIPTION
## Summary
- route Desktop update blocker API calls through the authenticated Electron session
- defer update entry points until the account session and Local Workspace are ready
- add isolated Electron cookie coverage and document the smoke path

## Verification
- 58 focused Desktop updater tests pass on current origin/main
- Desktop typecheck, repository lint, product logic check, recursive typecheck, and build pass in the primary checkout
- Desktop distribution and packaged account-gate/App Builder smoke pass
- independent review and packaged black-box verification pass

## Notes
- full test suite reached 6057 passing tests before unrelated shared-memory PostgreSQL exhaustion
- aggregate desktop:verify has an unrelated Local Apps locator failure in existing dirty UI work