### PR TITLE
perf(release): cut migration gate latency

### DIFF
--- a/.agents/skills/maintainer/release-maintainer/SKILL.md
+++ b/.agents/skills/maintainer/release-maintainer/SKILL.md
@@ -53,8 +53,9 @@ exposing secrets, or expanding to another product/environment.
 
 ## Cross-Branch Invariants
 
-- Lock stable source to an immutable commit SHA or stable tag. Later `main`
-  movement does not silently retarget it.
+- Lock stable source to a full immutable commit SHA. Later `main` movement does
+  not silently retarget it, and manual stable dispatch must not use a branch or
+  tag as `source_ref`.
 - Freeze that source as soon as a stable release imperative arrives. New
   unrelated `main` work belongs to the next release instead of extending the
   active release window.
@@ -78,6 +79,11 @@ exposing secrets, or expanding to another product/environment.
   canary work when safe, and let stable cleanup remove its Release/tag.
 - Keep public install smoke, including slow Windows runtime installation. A slow
   real install is product evidence to optimize, not a release gate to delete.
+- Once a stable campaign is active, candidate-repair commits use `[skip release]`
+  unless a canary is explicitly needed. CI still validates the repair, while the
+  automatic canary path does not duplicate the manual stable candidate.
+- Do not dispatch a third run after the same stage fails twice on unchanged
+  inputs. Diagnose and repair that stage, then rerun the new immutable SHA once.
 - Preserve unrelated dirty work. Prefer a clean temporary worktree/clone for
   hands-on publication.
 
@@ -92,8 +98,8 @@ exposing secrets, or expanding to another product/environment.
    bounded release-notes subagent in parallel with read-only preflight. Give it
    the locked diff and require drafts for the GitHub notes plus both public
    changelogs; the primary agent reviews and integrates the drafts.
-5. State the selected version, locked source SHA, channel, and unresolved
-   blockers in a progress update.
+5. State the selected version, locked source SHA, channel, active workflow run,
+   last completed stage, and unresolved blockers in a progress update.
 6. Execute one stable publish path whose machine gates run before mutation; do
    not introduce a separate preview dispatch or second human hand-off.
 7. Verify every applicable public surface from the same locked source.

--- a/.agents/skills/maintainer/release-maintainer/references/shared.md
+++ b/.agents/skills/maintainer/release-maintainer/references/shared.md
@@ -55,6 +55,9 @@ early.
 - On an explicit stable release request, resolve and freeze the immutable SHA
   before drafting notes or waiting on unrelated `main` work. Later commits are
   next-release candidates unless the user explicitly retargets the release.
+- Manual stable dispatch accepts the full 40-character commit SHA only. This
+  gives automatic canary and manual stable runs the same concurrency identity;
+  a real stable dispatch replaces duplicate automatic work for that source.
 - Canary and stable share the non-cancelling `release-publish` concurrency
   group in the current workflow.
 - Do not let an in-flight canary for the same or an older base hold a ready
@@ -69,9 +72,25 @@ early.
   run is superseded, rerun the same locked SHA after the active publish ends.
 - A `GITHUB_TOKEN` tag push does not trigger another workflow automatically;
   dispatch Desktop explicitly where the workflow requires it.
-- Release-maintenance commits that should not publish canary use
-  `[skip release]`, and the resulting release workflow must be observed as
-  skipped.
+- After a stable campaign begins, release-only candidate repairs use
+  `[skip release]` unless canary publication is explicitly required. Confirm CI
+  for the repair SHA and confirm the automatic Release workflow was skipped.
+
+## Convergence Budget
+
+- Do not dispatch stable while exact-source CI is still running. One candidate
+  SHA gets one exact-source CI and one production stable execution.
+- Do not run manual stable and automatic canary gates concurrently for the same
+  SHA. Use the full SHA so workflow concurrency can replace the duplicate path.
+- The three-fixture historical migration runtime must finish within five
+  minutes per platform and emit its current phase every ten seconds. The full
+  prepublish platform job has a 25-minute hard ceiling, including packaged
+  Desktop verification.
+- A timeout is a failure with a named last phase, not permission to increase the
+  timeout. Fix the blocked lifecycle or process ownership before rerunning.
+- After two failures at the same stage with unchanged inputs, stop dispatching.
+  Record the run IDs, last phase, elapsed time, and candidate SHA; make one
+  scoped repair and start again from exact-source CI.
 
 ## Single Stable Execution
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,9 +7,8 @@ on:
   workflow_dispatch:
     inputs:
       source_ref:
-        description: "Commit SHA, branch, or tag to promote as stable"
+        description: "Full commit SHA to promote as stable"
         required: true
-        default: "main"
       dry_run:
         description: "Preview stable publish without publishing"
         required: true
@@ -17,6 +16,10 @@ on:
         default: true
 permissions:
   contents: read
+
+concurrency:
+  group: release-source-${{ github.event_name == 'workflow_dispatch' && inputs.source_ref || github.event.workflow_run.head_sha }}
+  cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' && !inputs.dry_run }}
 
 jobs:
   preflight:
@@ -40,6 +43,16 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.source_ref || github.event.workflow_run.head_sha }}
+
+      - name: Require immutable stable source SHA
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          SOURCE_REF: ${{ inputs.source_ref }}
+        run: |
+          if [[ ! "$SOURCE_REF" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Stable source_ref must be a full 40-character commit SHA, not a moving branch or tag." >&2
+            exit 1
+          fi
 
       - name: Resolve immutable release source
         id: source
@@ -97,12 +110,13 @@ jobs:
       github.event_name == 'workflow_run' ||
       (github.event_name == 'workflow_dispatch' && !inputs.dry_run)
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     permissions:
       contents: read
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v6
         with:
@@ -122,15 +136,6 @@ jobs:
       - name: Install dependencies
         shell: bash
         run: pnpm install --frozen-lockfile
-
-      - name: Install Playwright Chromium
-        shell: bash
-        run: |
-          if [ "$(uname -s)" = "Linux" ]; then
-            pnpm exec playwright install --with-deps chromium
-          else
-            pnpm exec playwright install chromium
-          fi
 
       - name: Cache PostgreSQL 18.4 runtime
         uses: actions/cache@v5
@@ -196,7 +201,19 @@ jobs:
 
       - name: Run historical schema upgrade matrix with shaped data
         shell: bash
+        timeout-minutes: 5
+        env:
+          RUDDER_RELEASE_COMPATIBILITY_HEARTBEAT_MS: "10000"
         run: pnpm --filter @rudderhq/db exec tsx ../../scripts/release-compatibility-runtime.ts
+
+      - name: Install Playwright Chromium
+        shell: bash
+        run: |
+          if [ "$(uname -s)" = "Linux" ]; then
+            pnpm exec playwright install --with-deps chromium
+          else
+            pnpm exec playwright install chromium
+          fi
 
       - name: Run packaged upgrade smoke
         shell: bash

--- a/doc/engineering/RELEASE-AUTOMATION-SETUP.md
+++ b/doc/engineering/RELEASE-AUTOMATION-SETUP.md
@@ -3,7 +3,7 @@
 This document covers the GitHub and npm setup required for the current Rudder release model:
 
 - automatic canaries from `main`
-- manual stable promotion from a chosen source ref
+- manual stable promotion from a full locked commit SHA
 - npm trusted publishing via GitHub OIDC
 - direct-main release execution with exact-source CI
 
@@ -258,7 +258,7 @@ After at least one good canary exists:
 
 1. freeze the tested immutable source SHA immediately; do not chase later
    unrelated `main` commits
-2. confirm the committed public package version on the source ref is the stable
+2. confirm the committed public package version on the source SHA is the stable
    version you want to ship
 3. when notes are missing, have a bounded release-notes subagent draft
    `releases/v0.1.0.md`, `docs/releases.mdx`, and `docs/zh/releases.mdx` in

--- a/doc/engineering/RELEASING.md
+++ b/doc/engineering/RELEASING.md
@@ -5,7 +5,7 @@ Maintainer runbook for shipping Rudder across npm, GitHub, and the website-facin
 The release model is now commit-driven:
 
 1. Every successful `CI` run for a `main` push publishes a canary automatically, except explicit release-infra maintenance commits marked `[skip release]`.
-2. Stable releases are manually promoted from a chosen tested commit or canary tag.
+2. Stable releases are manually promoted from a chosen tested commit SHA.
 3. Stable release notes live in `releases/vX.Y.Z.md`.
 4. Stable releases get user-facing GitHub Releases; canaries may get prerelease GitHub Releases for Desktop portable assets.
 
@@ -107,11 +107,23 @@ Use this model for an explicit stable release:
    read-only preflight. The primary agent reviews and integrates the drafts.
 3. Require successful exact-source CI, stable preflight, immutable npm/tag
    checks, and package validation before publication.
-4. Run one production stable execution. Do not make a separate dry-run workflow
+4. Use `[skip release]` on release-only candidate repair commits after the
+   stable campaign starts, unless a canary is explicitly required. This keeps
+   exact-source CI while suppressing a duplicate automatic canary release.
+5. Run one production stable execution with the full 40-character source SHA.
+   Do not make a separate dry-run workflow
    a human or agent hand-off and then repeat checkout, dependency installation,
    and validation in a second run.
-5. Preserve every public-surface verification gate, especially the real
+6. Preserve every public-surface verification gate, especially the real
    Windows/macOS/Linux install smoke.
+
+The historical migration runtime emits its current fixture and phase every ten
+seconds. It has a five-minute ceiling for all three historical fixtures on one
+platform; the complete per-platform prepublish gate has a 25-minute ceiling.
+Treat either timeout as a defect in the named stage, not as a reason to extend
+the budget. After two failures at the same stage on unchanged inputs, stop
+dispatching, record both run IDs and the last phase, fix the cause, and rerun one
+new immutable candidate from exact-source CI.
 
 The workflow still exposes `dry_run` for read-only preview requests and
 troubleshooting. For an already-authorized release whose equivalent machine
@@ -152,7 +164,7 @@ Canaries cover verification, npm, a traceability tag, and Desktop portable asset
 ## Core Invariants
 
 - canaries publish from `main`
-- stables publish from an explicitly chosen source ref
+- stables publish from an explicitly chosen full commit SHA
 - tags point at the original source commit, not a generated release commit
 - stable notes are always `releases/vX.Y.Z.md`
 - stable public changelog entries are always present in both `docs/releases.mdx`
@@ -215,14 +227,14 @@ Use [`.github/workflows/release.yml`](../.github/workflows/release.yml) from the
 Inputs:
 
 - `source_ref`
-  - commit SHA, branch, or tag
+  - full 40-character commit SHA; moving branches and tags are rejected
 - `dry_run`
   - optional read-only preview when true; an authorized stable release normally
     uses `false` after equivalent exact-source gates pass
 
 Before running stable:
 
-1. freeze the tested canary commit or immutable SHA immediately
+1. freeze the tested canary commit as a full immutable SHA immediately
 2. confirm the committed public package version is the stable version you want
    to ship
 3. if narratives are missing, start a bounded release-notes subagent in
@@ -234,7 +246,7 @@ Before running stable:
    rollback point as a progress update
 6. if a same-base canary is only waiting for Desktop assets, record its npm/tag
    state and stop the remaining wait; do not unpublish it
-7. run one production workflow with `dry_run: false`; the existing release
+7. run one production workflow with `dry_run: false` and the full SHA; the existing release
    request remains the npm, GitHub, Desktop, and production-docs authorization
 8. continue without another confirmation unless the user excluded
    `docs.rudderhq.dev` or a genuinely ambiguous/nonstandard decision appears
@@ -244,7 +256,7 @@ Before running stable:
 
 Example:
 
-- `source_ref`: `main`
+- `source_ref`: `0123456789abcdef0123456789abcdef01234567`
 - resulting stable version: `0.1.0`
 - follow-up version bump before the next canary line: `0.1.0 -> 0.1.1`
 

--- a/scripts/release-compatibility-runtime.ts
+++ b/scripts/release-compatibility-runtime.ts
@@ -1,6 +1,6 @@
 import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { copyFile, mkdir, mkdtemp, readFile, readdir, rm } from "node:fs/promises";
 import { createRequire } from "node:module";
 import net from "node:net";
 import os from "node:os";
@@ -22,6 +22,7 @@ const { drizzle: drizzlePg } = requireFromDb("drizzle-orm/postgres-js") as { dri
 const { migrate: migratePg } = requireFromDb("drizzle-orm/postgres-js/migrator") as { migrate: (...args: any[]) => Promise<void> };
 const MIGRATION_PATH = "packages/db/src/migrations";
 const FIXTURES = ["v0.7.1", "v0.7.0", "v0.6.5"] as const;
+const DEFAULT_HEARTBEAT_MS = 10_000;
 const IDS = {
   organization: "00000000-0000-4000-8000-000000000001",
   agent: "00000000-0000-4000-8000-000000000002",
@@ -35,8 +36,59 @@ const IDS = {
   grant: "00000000-0000-4000-8000-000000000008",
 };
 
-function gitShow(ref: string, file: string): string {
-  return execFileSync("git", ["show", `${ref}:${file}`], { cwd: REPO_ROOT, encoding: "utf8" });
+type SqlClient = ReturnType<typeof postgres>;
+
+function elapsedSeconds(startedAt: number): string {
+  return `${((Date.now() - startedAt) / 1000).toFixed(1)}s`;
+}
+
+function heartbeatIntervalMs(rawValue = process.env.RUDDER_RELEASE_COMPATIBILITY_HEARTBEAT_MS): number {
+  if (!rawValue) return DEFAULT_HEARTBEAT_MS;
+  const parsed = Number(rawValue);
+  return Number.isFinite(parsed) && parsed >= 1_000 ? parsed : DEFAULT_HEARTBEAT_MS;
+}
+
+function createFixtureProgress(ref: string): {
+  current: () => string;
+  phase: (name: string) => void;
+  stop: () => void;
+} {
+  const startedAt = Date.now();
+  let currentPhase = "initialize fixture";
+  const write = (event: "phase" | "waiting") => {
+    process.stdout.write(`[compatibility:${ref}] ${event}: ${currentPhase} (${elapsedSeconds(startedAt)})\n`);
+  };
+  write("phase");
+  const heartbeat = setInterval(() => write("waiting"), heartbeatIntervalMs());
+  heartbeat.unref();
+  return {
+    current: () => currentPhase,
+    phase: (name) => {
+      currentPhase = name;
+      write("phase");
+    },
+    stop: () => clearInterval(heartbeat),
+  };
+}
+
+function openSqlClient(connectionString: string): SqlClient {
+  return postgres(connectionString, {
+    max: 1,
+    connect_timeout: 5,
+    onnotice: () => {},
+  });
+}
+
+async function withSqlClient<T>(
+  connectionString: string,
+  operation: (sql: SqlClient) => Promise<T>,
+): Promise<T> {
+  const sql = openSqlClient(connectionString);
+  try {
+    return await operation(sql);
+  } finally {
+    await sql.end({ timeout: 1 }).catch(() => undefined);
+  }
 }
 
 function sqlLiteral(value: unknown): string {
@@ -76,23 +128,32 @@ async function availablePort(): Promise<number> {
 async function materializeMigrations(ref: string, root: string): Promise<string> {
   const folder = path.join(root, ref.replaceAll("/", "-"));
   const meta = path.join(folder, "meta");
+  const archiveRoot = path.join(root, `${ref.replaceAll("/", "-")}-archive`);
+  const archivePath = `${archiveRoot}.tar`;
   await mkdir(meta, { recursive: true });
-  const journalPath = `${MIGRATION_PATH}/meta/_journal.json`;
-  const journal = JSON.parse(gitShow(ref, journalPath)) as { entries?: Array<{ tag?: string }> };
-  const migrationFiles = execFileSync(
-    "git",
-    ["ls-tree", "-r", "--name-only", ref, "--", MIGRATION_PATH],
-    { cwd: REPO_ROOT, encoding: "utf8" },
-  )
-    .split("\n")
-    .filter((file) => file.startsWith(`${MIGRATION_PATH}/`) && file.endsWith(".sql"))
-    .map((file) => file.slice(MIGRATION_PATH.length + 1))
-    .filter((file) => !file.includes("/"));
-  if (migrationFiles.length === 0) throw new Error(`${ref} has no migration SQL files`);
-  for (const fileName of migrationFiles) {
-    await writeFile(path.join(folder, fileName), gitShow(ref, `${MIGRATION_PATH}/${fileName}`));
+  await mkdir(archiveRoot, { recursive: true });
+  try {
+    execFileSync(
+      "git",
+      ["archive", "--format=tar", "-o", archivePath, ref, "--", MIGRATION_PATH],
+      { cwd: REPO_ROOT },
+    );
+    execFileSync("tar", ["-xf", archivePath, "-C", archiveRoot]);
+    const archivedMigrations = path.join(archiveRoot, MIGRATION_PATH);
+    const migrationFiles = (await readdir(archivedMigrations))
+      .filter((fileName) => fileName.endsWith(".sql"))
+      .sort((left, right) => left.localeCompare(right));
+    if (migrationFiles.length === 0) throw new Error(`${ref} has no migration SQL files`);
+    await Promise.all(
+      migrationFiles.map((fileName) => (
+        copyFile(path.join(archivedMigrations, fileName), path.join(folder, fileName))
+      )),
+    );
+    await copyFile(path.join(archivedMigrations, "meta", "_journal.json"), path.join(meta, "_journal.json"));
+  } finally {
+    await rm(archiveRoot, { recursive: true, force: true });
+    await rm(archivePath, { force: true });
   }
-  await writeFile(path.join(meta, "_journal.json"), JSON.stringify(journal));
   return folder;
 }
 
@@ -146,10 +207,18 @@ async function startDatabase(root: string): Promise<{
   });
   const instance = selection.instance;
   await instance.initialise();
-  await instance.start();
-  const admin = postgres(`postgres://rudder:rudder@127.0.0.1:${port}/postgres`, { max: 1, onnotice: () => {} });
-  await admin`CREATE DATABASE rudder`;
-  await admin.end();
+  try {
+    await instance.start();
+    await withSqlClient(
+      `postgres://rudder:rudder@127.0.0.1:${port}/postgres`,
+      async (admin) => {
+        await admin`CREATE DATABASE rudder`;
+      },
+    );
+  } catch (error) {
+    await instance.stop().catch(() => undefined);
+    throw error;
+  }
   return {
     connectionString: `postgres://rudder:rudder@127.0.0.1:${port}/rudder`,
     stop: () => instance.stop(),
@@ -350,44 +419,69 @@ async function countShape(sql: ReturnType<typeof postgres>): Promise<Record<stri
 }
 
 async function runFixture(ref: string, root: string): Promise<void> {
-  const fixtureRoot = path.join(root, ref.replaceAll("/", "-"));
-  await mkdir(fixtureRoot, { recursive: true });
-  const oldFolder = await materializeMigrations(ref, fixtureRoot);
-  const oldJournal = JSON.parse(await readFile(path.join(oldFolder, "meta", "_journal.json"), "utf8")) as {
-    entries?: Array<{ tag?: string }>;
-  };
-  const db = await startDatabase(fixtureRoot);
-  const sql = postgres(db.connectionString, { max: 1, onnotice: () => {} });
+  const progress = createFixtureProgress(ref);
+  let db: Awaited<ReturnType<typeof startDatabase>> | null = null;
   try {
-    await migratePg(drizzlePg(sql), { migrationsFolder: oldFolder });
-    await applyHistoricalUnjournaledMigrations(sql, oldFolder, oldJournal);
-    const seeded = await seedProductionShape(sql);
-    const before = await countShape(sql);
-    await sql.end();
+    const fixtureRoot = path.join(root, ref.replaceAll("/", "-"));
+    await mkdir(fixtureRoot, { recursive: true });
+    progress.phase("materialize historical migrations");
+    const oldFolder = await materializeMigrations(ref, fixtureRoot);
+    const oldJournal = JSON.parse(await readFile(path.join(oldFolder, "meta", "_journal.json"), "utf8")) as {
+      entries?: Array<{ tag?: string }>;
+    };
+
+    progress.phase("start PostgreSQL");
+    db = await startDatabase(fixtureRoot);
+
+    progress.phase("load historical schema and shaped data");
+    const { seeded, before } = await withSqlClient(db.connectionString, async (sql) => {
+      await migratePg(drizzlePg(sql), { migrationsFolder: oldFolder });
+      await applyHistoricalUnjournaledMigrations(sql, oldFolder, oldJournal);
+      const seeded = await seedProductionShape(sql);
+      const before = await countShape(sql);
+      return { seeded, before };
+    });
+
+    progress.phase("apply candidate migrations");
     await applyPendingMigrations(db.connectionString);
-    const upgradedSql = postgres(db.connectionString, { max: 1, onnotice: () => {} });
-    const state = await inspectMigrations(db.connectionString);
-    if (state.status !== "upToDate") throw new Error(`${ref} remains pending after candidate migration`);
-    const report = await validatePostMigrationInvariants(db.connectionString);
-    if (!report.valid) throw new Error(`${ref} invariant failure: ${report.issues.map((issue) => issue.message).join("; ")}`);
-    const after = await countShape(upgradedSql);
-    await assertProductionShapeSentinels(upgradedSql, seeded);
-    await upgradedSql.end();
+
+    progress.phase("validate upgraded schema and shaped data");
+    const after = await withSqlClient(db.connectionString, async (upgradedSql) => {
+      const state = await inspectMigrations(db.connectionString);
+      if (state.status !== "upToDate") throw new Error(`${ref} remains pending after candidate migration`);
+      const report = await validatePostMigrationInvariants(db.connectionString);
+      if (!report.valid) throw new Error(`${ref} invariant failure: ${report.issues.map((issue) => issue.message).join("; ")}`);
+      const counts = await countShape(upgradedSql);
+      await assertProductionShapeSentinels(upgradedSql, seeded);
+      return counts;
+    });
     for (const [table, count] of Object.entries(before)) {
       const upgradedTable = table === "companies" ? "organizations" : table === "company_memberships" ? "organization_memberships" : table;
       if (after[upgradedTable] !== count) throw new Error(`${ref} changed ${table} row count (${count} -> ${after[upgradedTable] ?? 0})`);
     }
+
+    progress.phase("restart PostgreSQL");
     await db.restart();
-    const restartedSql = postgres(db.connectionString, { max: 1, onnotice: () => {} });
-    const restarted = await countShape(restartedSql);
-    await restartedSql.end();
+
+    progress.phase("verify restart persistence");
+    const restarted = await withSqlClient(db.connectionString, countShape);
     for (const [table, count] of Object.entries(after)) {
       if (restarted[table] !== count) throw new Error(`${ref} lost ${table} rows across restart`);
     }
+    progress.phase("complete");
     process.stdout.write(`verified ${ref}: ${Object.values(after).reduce((sum, count) => sum + count, 0)} shaped rows\n`);
+  } catch (error) {
+    throw new Error(
+      `${ref} failed during ${progress.current()}: ${error instanceof Error ? error.message : String(error)}`,
+    );
   } finally {
-    await sql.end().catch(() => undefined);
-    await db.stop().catch(() => undefined);
+    if (db) {
+      progress.phase("stop PostgreSQL");
+      await db.stop().catch((error) => {
+        process.stderr.write(`[compatibility:${ref}] PostgreSQL cleanup failed: ${String(error)}\n`);
+      });
+    }
+    progress.stop();
   }
 }
 

--- a/scripts/release-workflow-contract.test.mjs
+++ b/scripts/release-workflow-contract.test.mjs
@@ -34,6 +34,10 @@ describe("release workflow latency contracts", () => {
   it("resolves an immutable source and runs release preflight before installation", () => {
     expect(releaseWorkflow).toMatch(/^  preflight:/m);
     expect(releaseWorkflow).toContain("source_sha:");
+    expect(releaseWorkflow).toContain('description: "Full commit SHA to promote as stable"');
+    expect(releaseWorkflow).not.toContain('default: "main"');
+    expect(releaseWorkflow).toContain("Require immutable stable source SHA");
+    expect(releaseWorkflow).toContain('^[0-9a-f]{40}$');
     expect(releaseWorkflow).toContain("Require release source from main history");
     expect(releaseWorkflow).toContain('git merge-base --is-ancestor "$SOURCE_SHA" refs/remotes/origin/main');
     expect(releaseWorkflow).toContain("Require successful CI for exact source");
@@ -58,6 +62,15 @@ describe("release workflow latency contracts", () => {
     const installIndex = releaseWorkflow.indexOf("Install dependencies");
     expect(preflightIndex).toBeGreaterThan(-1);
     expect(installIndex).toBeGreaterThan(preflightIndex);
+  });
+
+  it("deduplicates automatic canary and stable work for the same locked source", () => {
+    expect(releaseWorkflow).toContain(
+      "group: release-source-${{ github.event_name == 'workflow_dispatch' && inputs.source_ref || github.event.workflow_run.head_sha }}",
+    );
+    expect(releaseWorkflow).toContain(
+      "cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' && !inputs.dry_run }}",
+    );
   });
 
   it("blocks stable and canary publication on the migration compatibility matrix", () => {
@@ -101,6 +114,8 @@ describe("release workflow latency contracts", () => {
     );
     expect(gateJob).toContain("Prepublish database and packaged upgrade gate");
     expect(gateJob).toContain("os: [ubuntu-latest, macos-latest, windows-latest]");
+    expect(gateJob).toContain("fail-fast: true");
+    expect(gateJob).toContain("timeout-minutes: 25");
     expect(gateJob).toContain("Cache PostgreSQL 18.4 runtime");
     expect(gateJob).toContain("actions/cache@v5");
     expect(gateJob).toContain("Prepare PostgreSQL 18.4 runtime");
@@ -113,12 +128,22 @@ describe("release workflow latency contracts", () => {
     expect(gateJob).toContain("if: runner.os != 'Windows'");
     expect(gateJob).toContain("src/client.test.ts src/migration-manifest.test.ts");
     expect(gateJob).toContain("pnpm --filter @rudderhq/db exec tsx ../../scripts/release-compatibility-runtime.ts");
+    expect(gateJob).toMatch(/Run historical schema upgrade matrix with shaped data[\s\S]*timeout-minutes: 5/);
+    expect(gateJob).toContain('RUDDER_RELEASE_COMPATIBILITY_HEARTBEAT_MS: "10000"');
+    expect(gateJob.indexOf("Install Playwright Chromium")).toBeGreaterThan(
+      gateJob.indexOf("Run historical schema upgrade matrix with shaped data"),
+    );
     expect(releaseCompatibilityRuntimeScript).toContain("fileURLToPath(import.meta.url)");
     expect(releaseCompatibilityRuntimeScript).toContain("cwd: REPO_ROOT");
     expect(releaseCompatibilityRuntimeScript).not.toContain('["-C", REPO_ROOT');
     expect(releaseCompatibilityRuntimeScript).toContain("chat_conversations");
     expect(releaseCompatibilityRuntimeScript).toContain("principal_permission_grants");
     expect(releaseCompatibilityRuntimeScript).toContain("await db.restart()");
+    expect(releaseCompatibilityRuntimeScript).toContain("[compatibility:${ref}] ${event}:");
+    expect(releaseCompatibilityRuntimeScript).toContain("connect_timeout: 5");
+    expect(releaseCompatibilityRuntimeScript).toContain("await sql.end({ timeout: 1 })");
+    expect(releaseCompatibilityRuntimeScript).toContain('["archive", "--format=tar"');
+    expect(releaseCompatibilityRuntimeScript).not.toContain("gitShow(");
 
     const gateIndex = releaseWorkflow.indexOf("\n  prepublish-upgrade-gate:\n");
     const npmPublishIndex = releaseWorkflow.indexOf("./scripts/release.sh canary --skip-verify");


### PR DESCRIPTION
## Context

The v0.7.2 release campaign repeatedly reran exact-source CI and prepublish gates. Windows historical migration exceeded 54 minutes because PostgreSQL startup held the parent process pipes; main commit 0e6fdc5bc fixed that lifecycle bug.

This PR is the follow-up convergence work. It does not retarget or restart the active 0.7.2 release.

## Changes

- replace per-file git show reconstruction with one git archive extraction
- add fixture and phase progress plus 10-second heartbeats
- close every PostgreSQL client in finally and clean up failed startup
- cap the full three-fixture migration runtime at 5 minutes and each platform gate at 25 minutes
- fail fast across platforms and defer Playwright installation until database checks pass
- require full stable source SHAs and deduplicate same-SHA automatic canary versus manual stable work
- update release-maintainer guidance and engineering runbooks with freeze, skip-release, retry, and status-sync rules

## Measured result

Local full runtime for v0.7.1, v0.7.0, and v0.6.5 shaped fixtures:

- before: 79.25 seconds
- after: 12.10 seconds
- reduction: about 85 percent

The migration, shaped-data sentinels, invariant checks, PostgreSQL restart, and persistence checks remain enabled.

## Verification

- release workflow and compatibility tests: 19 passed
- local PostgreSQL provider tests: 9 passed
- full historical compatibility runtime: passed all 3 fixtures
- DB typecheck: passed
- import lint: passed
- product logic registry: 93 contracts valid
- release workflow YAML parse and git diff check: passed
