### PR TITLE
[codex] eliminate streaming composer repaint flicker

### DIFF
--- a/tests/e2e/chat-streaming.spec.ts
+++ b/tests/e2e/chat-streaming.spec.ts
@@ -836,32 +836,46 @@ test.describe("Chat streaming", () => {
 
     const streamingBoundary = await composerSurface.evaluate((element) => {
       const before = getComputedStyle(element, "::before");
+      const after = getComputedStyle(element, "::after");
       return {
-        animationName: before.animationName,
-        animationDuration: before.animationDuration,
-        backgroundImage: before.backgroundImage,
+        beforeContent: before.content,
+        beforeFilter: before.filter,
+        afterContent: after.content,
+        afterFilter: after.filter,
       };
     });
-    expect(streamingBoundary.animationName).toBe("none");
-    expect(streamingBoundary.animationDuration).toBe("0s");
-    expect(streamingBoundary.backgroundImage).not.toContain("conic-gradient");
+    expect(streamingBoundary).toEqual({
+      beforeContent: "none",
+      beforeFilter: "none",
+      afterContent: "none",
+      afterFilter: "none",
+    });
 
     const frameSamples = await composerSurface.evaluate(async (element) => {
-      const samples: Array<{ animationName: string; backgroundImage: string }> = [];
+      const samples: Array<{ borderColor: string; boxShadow: string }> = [];
       for (let index = 0; index < 90; index += 1) {
-        const before = getComputedStyle(element, "::before");
+        const style = getComputedStyle(element);
         samples.push({
-          animationName: before.animationName,
-          backgroundImage: before.backgroundImage,
+          borderColor: style.borderColor,
+          boxShadow: style.boxShadow,
         });
         await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
       }
       return samples;
     });
-    expect(new Set(frameSamples.map((sample) => sample.animationName))).toEqual(new Set(["none"]));
-    expect(new Set(frameSamples.map((sample) => sample.backgroundImage)).size).toBe(1);
+    expect(new Set(frameSamples.map((sample) => sample.borderColor)).size).toBe(1);
+    expect(new Set(frameSamples.map((sample) => sample.boxShadow)).size).toBe(1);
 
-    await composerSurface.screenshot({ path: testInfo.outputPath("chat-composer-streaming-light.png") });
+    await editor.blur();
+    const lightFrameA = await composerSurface.screenshot({
+      path: testInfo.outputPath("chat-composer-streaming-light.png"),
+    });
+    await page.waitForTimeout(800);
+    await expect(composerSurface).toHaveClass(/chat-composer--streaming/);
+    const lightFrameB = await composerSurface.screenshot({
+      path: testInfo.outputPath("chat-composer-streaming-light-after-refresh.png"),
+    });
+    expect(lightFrameB.equals(lightFrameA)).toBe(true);
 
     await page.evaluate(() => {
       window.localStorage.setItem("rudder.theme", "dark");
@@ -869,10 +883,11 @@ test.describe("Chat streaming", () => {
     });
     await expect(page.locator("html")).toHaveClass(/dark/);
     await composerSurface.screenshot({ path: testInfo.outputPath("chat-composer-streaming-dark.png") });
-    const darkStreamingAnimation = await composerSurface.evaluate((element) =>
-      getComputedStyle(element, "::before").animationName,
-    );
-    expect(darkStreamingAnimation).toBe("none");
+    const darkStreamingLayers = await composerSurface.evaluate((element) => ({
+      before: getComputedStyle(element, "::before").content,
+      after: getComputedStyle(element, "::after").content,
+    }));
+    expect(darkStreamingLayers).toEqual({ before: "none", after: "none" });
 
     await page.getByRole("button", { name: "Stop streaming" }).click();
     await expect(page.getByText("Response stopped")).toBeVisible({ timeout: 15_000 });

--- a/ui/src/components/chat/ChatComposer.tsx
+++ b/ui/src/components/chat/ChatComposer.tsx
@@ -50,7 +50,7 @@ export const ChatComposerSurface = forwardRef<
       data-testid={testId}
       {...fileDropTargetProps}
       className={cn(
-        "chat-composer relative rounded-[var(--radius-lg)] p-3 transition-all duration-300",
+        "chat-composer relative rounded-[var(--radius-lg)] p-3 transition-[border-color,box-shadow] duration-300",
         streaming && "chat-composer--streaming",
         fileDragActive
           && "ring-2 ring-[color:var(--accent-base)] ring-offset-2 ring-offset-background",

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -1579,8 +1579,7 @@
      Surfaces with decorative pseudo-elements or full-width section bars should define a
      domain-specific pending state instead of borrowing the generic conic boundary. */
   .active-surface-ring,
-  .command-palette-content--searching,
-  .chat-composer--streaming {
+  .command-palette-content--searching {
     position: relative;
     isolation: isolate;
     --active-surface-accent: var(--accent-base);
@@ -1630,25 +1629,14 @@
   }
 
   .chat-composer.chat-composer--streaming {
-    --active-surface-ring-width: 2px;
-    --active-surface-ring-inner-radius: calc(var(--radius-lg) - var(--active-surface-ring-width));
-    --active-surface-ring-cover:
-      linear-gradient(
-        180deg,
-        color-mix(in oklab, var(--surface-elevated) 99%, transparent) 0%,
-        color-mix(in oklab, var(--surface-elevated) 94%, var(--surface-page)) 100%
-      );
     border-color: color-mix(in oklab, var(--ring) 48%, var(--border-base));
     box-shadow:
       var(--shadow-md),
-      0 0 0 1px color-mix(in oklab, var(--ring) 18%, transparent),
-      0 18px 54px -38px color-mix(in oklab, var(--accent-base) 46%, transparent),
-      inset 0 1px 0 color-mix(in oklab, white 46%, transparent);
+      0 0 0 1px color-mix(in oklab, var(--ring) 18%, transparent);
   }
 
   .active-surface-ring::before,
-  .command-palette-content--searching::before,
-  .chat-composer--streaming::before {
+  .command-palette-content--searching::before {
     content: "";
     position: absolute;
     inset: 0;
@@ -1700,18 +1688,8 @@
     animation: none;
   }
 
-  .chat-composer--streaming::before {
-    inset: -2px;
-    border-radius: calc(var(--radius-lg) + 2px);
-    background: color-mix(in oklab, var(--accent-base) 26%, transparent);
-    opacity: 0.55;
-    animation: none;
-    filter: drop-shadow(0 0 4px color-mix(in oklab, var(--accent-base) 16%, transparent));
-  }
-
   .active-surface-ring::after,
-  .command-palette-content--searching::after,
-  .chat-composer--streaming::after {
+  .command-palette-content--searching::after {
     content: "";
     position: absolute;
     inset: var(--active-surface-ring-width);
@@ -1751,8 +1729,7 @@
   }
 
   .active-surface-ring > *,
-  .command-palette-content--searching > *,
-  .chat-composer--streaming > * {
+  .command-palette-content--searching > * {
     position: relative;
     z-index: 2;
   }
@@ -1933,8 +1910,7 @@
     .automation-trigger-menu-content[data-state="closed"],
     .chat-review-block--action-pending,
     .active-surface-ring::before,
-    .command-palette-content--searching::before,
-    .chat-composer--streaming::before {
+    .command-palette-content--searching::before {
       animation: none;
       transition: none;
     }

--- a/ui/src/lib/index-css.test.ts
+++ b/ui/src/lib/index-css.test.ts
@@ -246,23 +246,15 @@ describe("index.css motion rules", () => {
     expect(reducedMotion).toContain("animation: none");
   });
 
-  it("keeps the chat composer streaming boundary static and integrated with the input surface", () => {
-    const composerStreaming =
-      indexCss.match(/\n\s*\.chat-composer\.chat-composer--streaming \{\s*\n\s*--active-surface-ring-width: 2px;[\s\S]*?\n\s*\}/)?.[0] ?? "";
-    const composerRing =
-      indexCss.match(/\n\s*\.chat-composer--streaming::before \{\s*\n\s*inset: -2px;[\s\S]*?\n\s*\}/)?.[0] ?? "";
+  it("keeps the streaming chat composer free of repainting pseudo-element layers", () => {
+    const composerStreaming = cssBlock(".chat-composer.chat-composer--streaming");
 
-    expect(composerStreaming).toContain("--active-surface-ring-width: 2px");
     expect(composerStreaming).toContain("border-color: color-mix(in oklab, var(--ring) 48%, var(--border-base))");
-    expect(composerStreaming).toContain("var(--surface-elevated) 99%");
-    expect(composerStreaming).toContain("inset 0 1px 0");
-    expect(composerRing).toContain("inset: -2px");
-    expect(composerRing).toContain("border-radius: calc(var(--radius-lg) + 2px)");
-    expect(composerRing).toContain("background: color-mix(in oklab, var(--accent-base) 26%, transparent)");
-    expect(composerRing).toContain("opacity: 0.55");
-    expect(composerRing).toContain("animation: none");
-    expect(composerRing).not.toContain("var(--command-palette-search-angle)");
-    expect(composerRing).toContain("filter: drop-shadow");
+    expect(composerStreaming).toContain("var(--shadow-md)");
+    expect(composerStreaming).not.toContain("filter:");
+    expect(composerStreaming).not.toContain("linear-gradient");
+    expect(indexCss).not.toContain(".chat-composer--streaming::before");
+    expect(indexCss).not.toContain(".chat-composer--streaming::after");
   });
 
   it("keeps the Feishu read-only composer from drawing a nested border", () => {


### PR DESCRIPTION
## What changed

- remove the streaming chat composer from the shared pseudo-element active-surface stack
- keep working feedback as a static border and shadow without filtered or gradient compositor layers
- narrow the composer transition to border color and box shadow
- strengthen the streaming E2E with pseudo-element checks, 90-frame style sampling, and an exact pixel comparison across an 800 ms refresh interval

## Root cause

The previous fix stopped the visible ring animation, but the streaming composer still owned filtered `::before` and full-surface `::after` layers. The chat process timer refreshes every 500 ms, so Electron/Chromium repeatedly recomposited those layers and could flash the entire composer even though the CSS animation name was `none`.

## Validation

- `pnpm exec vitest run ui/src/lib/index-css.test.ts ui/src/components/TextDots.test.ts` (41 passed)
- `pnpm --filter @rudderhq/ui typecheck`
- `pnpm --filter @rudderhq/ui build`
- `pnpm product-logic:check` (96 contracts valid)
- isolated Playwright streaming case (1 passed), including exact pixel equality across the working-state refresh interval

## Risk

Low. The working state keeps a static visual boundary and Stop control; the change only removes decorative compositor layers and broad transition scope.
