### PR TITLE
fix: reuse chat runtime profile selector

### DIFF
--- a/tests/e2e/goal-detail-lifecycle.spec.ts
+++ b/tests/e2e/goal-detail-lifecycle.spec.ts
@@ -923,10 +923,12 @@ test.describe("Goal Workspace v2", () => {
       .first();
     await ownerProperty.hover();
     await page.getByRole("button", { name: `Run profile for ${owner.name}`, exact: true }).click();
-    const runtimeProfile = page.locator('[data-slot="popover-content"]').filter({ hasText: "Run profile" }).last();
+    const runtimeProfile = page.getByTestId("issue-runtime-profile-panel");
     await expect(runtimeProfile).toBeVisible();
-    await runtimeProfile.getByTestId("issue-runtime-option-model-gpt-5.6-sol").click();
-    await runtimeProfile.getByTestId("issue-runtime-option-effort-max").click();
+    await runtimeProfile.getByTestId("issue-runtime-model-trigger").click();
+    await page.getByTestId("issue-runtime-option-model-gpt-5.6-sol").click();
+    await runtimeProfile.getByTestId("issue-runtime-effort-trigger").click();
+    await page.getByTestId("issue-runtime-option-effort-max").click();
     await runtimeProfile.getByTestId("issue-runtime-apply").click();
     await expect(runtimeProfile).toBeHidden();
 
@@ -944,9 +946,13 @@ test.describe("Goal Workspace v2", () => {
     await page.reload({ waitUntil: "domcontentloaded" });
     await ownerProperty.hover();
     await page.getByRole("button", { name: `Run profile for ${owner.name}`, exact: true }).click();
-    const reloadedProfile = page.locator('[data-slot="popover-content"]').filter({ hasText: "Run profile" }).last();
-    await expect(reloadedProfile.getByTestId("issue-runtime-option-model-gpt-5.6-sol")).toHaveAttribute("aria-selected", "true");
-    await expect(reloadedProfile.getByTestId("issue-runtime-option-effort-max")).toHaveAttribute("aria-selected", "true");
+    const reloadedProfile = page.getByTestId("issue-runtime-profile-panel");
+    await reloadedProfile.getByTestId("issue-runtime-model-trigger").click();
+    await expect(page.getByTestId("issue-runtime-option-model-gpt-5.6-sol")).toHaveAttribute("aria-selected", "true");
+    await page.keyboard.press("Escape");
+    await reloadedProfile.getByTestId("issue-runtime-effort-trigger").click();
+    await expect(page.getByTestId("issue-runtime-option-effort-max")).toHaveAttribute("aria-selected", "true");
+    await page.keyboard.press("Escape");
     await reloadedProfile.getByRole("button", { name: "Cancel", exact: true }).click();
 
     await page.getByRole("button", { name: "Change Goal owner", exact: true }).click();

--- a/tests/e2e/issue-runtime-model-selector.spec.ts
+++ b/tests/e2e/issue-runtime-model-selector.spec.ts
@@ -27,7 +27,7 @@ test.describe("Issue runtime model selector", () => {
       model: "gpt-5.4",
     });
     const replacementAgent = await createE2EChatAgent(page.request, organization.id, {
-      name: "Replacement runtime Agent",
+      name: "Replacement runtime Agent with a deliberately long name",
       model: "gpt-5.4-mini",
     });
     const issueRes = await page.request.post(`/api/orgs/${organization.id}/issues`, {
@@ -55,7 +55,10 @@ test.describe("Issue runtime model selector", () => {
     await expect(runtimeSelector).toHaveCSS("opacity", "1");
 
     await runtimeSelector.click();
+    await expect(page.getByTestId("issue-runtime-profile-panel")).toBeVisible();
+    await page.getByTestId("issue-runtime-model-trigger").click();
     await expect(page.getByTestId("issue-runtime-option-default-model")).toBeVisible();
+    await page.screenshot({ path: testInfo.outputPath("issue-runtime-selector-model-menu.png"), fullPage: false });
     const modelOption = page.locator('[data-testid^="issue-runtime-option-model-"]').first();
     await expect(modelOption).toBeVisible();
     const selectedModelLabel = await modelOption.textContent();
@@ -70,14 +73,19 @@ test.describe("Issue runtime model selector", () => {
         assigneeAgentRuntimeOverrides: { agentRuntimeConfig?: Record<string, unknown> } | null;
       };
       return persistedAfterPicker.assigneeAgentRuntimeOverrides?.agentRuntimeConfig?.model ?? null;
-    }).toBeTruthy();
+    }, { timeout: 20_000 }).toBeTruthy();
 
     await assigneeButton.focus();
     await page.keyboard.press("Tab");
     await expect(runtimeSelector).toBeFocused();
     await expect(runtimeSelector).toHaveCSS("opacity", "1");
     await page.keyboard.press("Enter");
+    await expect(page.getByTestId("issue-runtime-profile-panel")).toBeVisible();
+    await page.getByTestId("issue-runtime-model-trigger").focus();
+    await page.keyboard.press("ArrowRight");
     await expect(page.getByTestId("issue-runtime-option-default-model")).toBeVisible();
+    await page.keyboard.press("Escape");
+    await expect(page.getByTestId("issue-runtime-model-options")).toHaveCount(0);
     await page.keyboard.press("Escape");
 
     await page.getByRole("button", { name: "More issue actions" }).click();
@@ -88,6 +96,7 @@ test.describe("Issue runtime model selector", () => {
 
     await assigneeButton.hover();
     await runtimeSelector.click();
+    await page.getByTestId("issue-runtime-model-trigger").click();
     await page.getByTestId("issue-runtime-option-default-model").click();
     await page.getByTestId("issue-runtime-apply").click();
     await expect.poll(async () => {
@@ -97,7 +106,7 @@ test.describe("Issue runtime model selector", () => {
         assigneeAgentRuntimeOverrides: Record<string, unknown> | null;
       };
       return persistedAfterReset.assigneeAgentRuntimeOverrides;
-    }).toBeNull();
+    }, { timeout: 20_000 }).toBeNull();
 
     await assigneeButton.click();
     const replacementAssigneeButton = page.getByRole("button", {
@@ -118,13 +127,29 @@ test.describe("Issue runtime model selector", () => {
         assigneeAgentRuntimeOverrides: Record<string, unknown> | null;
       };
       return [persistedAfterReassign.assigneeAgentId, persistedAfterReassign.assigneeAgentRuntimeOverrides];
-    }).toEqual([replacementAgent.id, null]);
+    }, { timeout: 20_000 }).toEqual([replacementAgent.id, null]);
 
-    await page.setViewportSize({ width: 390, height: 844 });
+    await page.setViewportSize({ width: 375, height: 844 });
     await page.getByRole("button", { name: "Properties", exact: true }).click();
     const mobileRuntimeSelector = page.locator('[data-testid="issue-runtime-selector"]:visible');
     await expect(mobileRuntimeSelector).toHaveCount(1);
     await expect(mobileRuntimeSelector).toHaveCSS("opacity", "1");
+    await expect.poll(async () => {
+      const box = await mobileRuntimeSelector.boundingBox();
+      return box ? { left: box.x, right: box.x + box.width } : null;
+    }).toEqual(expect.objectContaining({
+      left: expect.any(Number),
+      right: expect.any(Number),
+    }));
+    const mobileSelectorBox = await mobileRuntimeSelector.boundingBox();
+    expect(mobileSelectorBox).not.toBeNull();
+    expect(mobileSelectorBox!.x).toBeGreaterThanOrEqual(0);
+    expect(mobileSelectorBox!.x + mobileSelectorBox!.width).toBeLessThanOrEqual(375);
+    await mobileRuntimeSelector.click();
+    await expect(page.getByTestId("issue-runtime-model-options")).toHaveCount(0);
+    await expect(page.getByTestId("issue-runtime-effort-options")).toHaveCount(0);
+    await page.getByTestId("issue-runtime-model-trigger").click();
+    await expect(page.getByTestId("issue-runtime-model-options")).toBeVisible();
     await page.screenshot({ path: testInfo.outputPath("issue-runtime-selector-mobile.png"), fullPage: false });
   });
 });

--- a/ui/src/components/InlineEntitySelector.tsx
+++ b/ui/src/components/InlineEntitySelector.tsx
@@ -289,7 +289,7 @@ export const InlineEntitySelector = forwardRef<HTMLButtonElement, InlineEntitySe
                         {optionContent}
                         <Check className={cn("ml-auto h-3.5 w-3.5 shrink-0 text-muted-foreground", isSelected ? "opacity-100" : "opacity-0")} />
                       </button>
-                      <div className="min-w-0 shrink-0">{accessory}</div>
+                      <div className="min-w-0 max-w-[45%] shrink-0 overflow-hidden">{accessory}</div>
                     </div>
                   );
                 }

--- a/ui/src/components/IssueProperties.test.tsx
+++ b/ui/src/components/IssueProperties.test.tsx
@@ -334,7 +334,7 @@ describe("IssueProperties", () => {
       expect(avatar?.classList.contains("h-6")).toBe(true);
       expect(avatar?.classList.contains("w-6")).toBe(true);
       expect(trigger?.classList.contains("min-w-0")).toBe(true);
-      expect(trigger?.classList.contains("w-full")).toBe(true);
+      expect(trigger?.classList.contains("flex-1")).toBe(true);
       expect(trigger?.classList.contains("max-w-full")).toBe(true);
       expect(trigger?.classList.contains("justify-start")).toBe(true);
       expect(trigger?.classList.contains("overflow-hidden")).toBe(true);
@@ -780,6 +780,10 @@ describe("IssueProperties", () => {
     });
     act(() => {
       container.querySelector<HTMLButtonElement>('[data-testid="issue-runtime-selector"]')
+        ?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    act(() => {
+      document.body.querySelector<HTMLButtonElement>('[data-testid="issue-runtime-model-trigger"]')
         ?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     });
     const modelOption = document.body.querySelector<HTMLButtonElement>('[data-testid^="issue-runtime-option-model-"]');

--- a/ui/src/components/IssueProperties.tsx
+++ b/ui/src/components/IssueProperties.tsx
@@ -968,7 +968,7 @@ export function IssueProperties({
           open={assigneeOpen}
           onOpenChange={(open) => { setAssigneeOpen(open); if (!open) setAssigneeSearch(""); }}
           triggerContent={assigneeTrigger}
-          triggerClassName="min-w-0 w-full max-w-full justify-start overflow-hidden"
+          triggerClassName="min-w-0 max-w-full flex-1 justify-start overflow-hidden"
           popoverClassName="w-[19rem]"
           popoverAlign="start"
           rowAlign="start"
@@ -991,7 +991,7 @@ export function IssueProperties({
           open={reviewerOpen}
           onOpenChange={(open) => { setReviewerOpen(open); if (!open) setReviewerSearch(""); }}
           triggerContent={reviewerTrigger}
-          triggerClassName="min-w-0 w-full max-w-full justify-start overflow-hidden"
+          triggerClassName="min-w-0 max-w-full flex-1 justify-start overflow-hidden"
           popoverClassName="w-[19rem]"
           popoverAlign="start"
           rowAlign="start"

--- a/ui/src/components/IssueRuntimeSelector.tsx
+++ b/ui/src/components/IssueRuntimeSelector.tsx
@@ -1,7 +1,7 @@
 import type { AgentRuntimeModel } from "@/api/agents";
 import { agentsApi } from "@/api/agents";
+import { RuntimeProfileControls } from "@/components/RuntimeProfileControls";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import { useScrollbarActivityRef } from "@/hooks/useScrollbarActivityRef";
 import { queryKeys } from "@/lib/queryKeys";
 import { resolveRuntimeModels } from "@/lib/runtime-models";
 import {
@@ -14,7 +14,7 @@ import {
 import { cn } from "@/lib/utils";
 import type { Agent, IssueAssigneeAgentRuntimeOverrides } from "@rudderhq/shared";
 import { useQuery } from "@tanstack/react-query";
-import { Check, ChevronDown, ChevronLeft, ChevronRight, Loader2, SlidersHorizontal } from "lucide-react";
+import { ChevronDown, ChevronLeft, ChevronRight, SlidersHorizontal } from "lucide-react";
 import { useEffect, useRef, useState, type CSSProperties } from "react";
 import { createPortal } from "react-dom";
 
@@ -169,20 +169,12 @@ export function IssueRuntimeSelector({
   const supported = supportsIssueRuntimeOverrides(agent);
   const [open, setOpen] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
-  const [activeSubmenu, setActiveSubmenu] = useState<"model" | "effort" | null>(null);
   const [menuPosition, setMenuPosition] = useState<CSSProperties | null>(null);
-  const [submenuPosition, setSubmenuPosition] = useState<CSSProperties | null>(null);
   const [draftModel, setDraftModel] = useState<string | null>(null);
   const [draftEffort, setDraftEffort] = useState<string | null>(null);
   const [draftInitialized, setDraftInitialized] = useState(false);
   const menuRootRef = useRef<HTMLDivElement | null>(null);
-  const submenuRootRef = useRef<HTMLDivElement | null>(null);
-  const submenuScrollRef = useScrollbarActivityRef();
   const menuTriggerRef = useRef<HTMLButtonElement | null>(null);
-  const modelTriggerRef = useRef<HTMLButtonElement | null>(null);
-  const effortTriggerRef = useRef<HTMLButtonElement | null>(null);
-  const firstModelOptionRef = useRef<HTMLButtonElement | null>(null);
-  const firstEffortOptionRef = useRef<HTMLButtonElement | null>(null);
   const effortKey = runtimeEffortKey(agent.agentRuntimeType)!;
   const adapterModelsQuery = useQuery({
     queryKey: queryKeys.agents.adapterModels(orgId, agent.agentRuntimeType),
@@ -204,12 +196,18 @@ export function IssueRuntimeSelector({
 
   const closeMenu = () => {
     setMenuOpen(false);
-    setActiveSubmenu(null);
     setDraftInitialized(false);
   };
 
   const positionFor = (rect: DOMRect, width: number, height: number): CSSProperties => {
     const viewportPadding = 12;
+    const mobileNavigation = document.querySelector<HTMLElement>("[data-mobile-bottom-navigation]");
+    const viewportBottom = mobileNavigation && mobileNavigation.getClientRects().length > 0
+      ? Math.min(
+        window.innerHeight - viewportPadding,
+        mobileNavigation.getBoundingClientRect().top - viewportPadding,
+      )
+      : window.innerHeight - viewportPadding;
     const right = window.innerWidth - rect.right;
     const left = right >= width + viewportPadding
       ? rect.right + 8
@@ -218,35 +216,8 @@ export function IssueRuntimeSelector({
       left,
       top: Math.max(
         viewportPadding,
-        Math.min(rect.top, window.innerHeight - viewportPadding - height),
+        Math.min(rect.top, viewportBottom - height),
       ),
-    };
-  };
-
-  const positionSubmenuFor = (rect: DOMRect, width: number, height: number): CSSProperties => {
-    const viewportPadding = 12;
-    const gap = 8;
-    const right = window.innerWidth - rect.right;
-    const left = right >= width + gap + viewportPadding
-      ? rect.right + gap
-      : Math.max(viewportPadding, rect.left - width - gap);
-    const availableBelow = Math.max(0, window.innerHeight - viewportPadding - rect.top);
-    const availableAbove = Math.max(0, rect.bottom - viewportPadding);
-    const keepTriggerAligned = availableBelow >= 120;
-    const maxHeight = Math.min(
-      height,
-      keepTriggerAligned ? availableBelow : Math.max(availableAbove, availableBelow),
-    );
-    const top = keepTriggerAligned
-      ? Math.max(viewportPadding, rect.top)
-      : Math.max(
-        viewportPadding,
-        Math.min(rect.top, window.innerHeight - viewportPadding - maxHeight),
-      );
-    return {
-      left,
-      top,
-      maxHeight: `${maxHeight}px`,
     };
   };
 
@@ -256,26 +227,7 @@ export function IssueRuntimeSelector({
     setDraftEffort(currentEffort);
     setDraftInitialized(true);
     setMenuPosition(positionFor(menuTriggerRef.current.getBoundingClientRect(), 304, 176));
-    setActiveSubmenu(null);
     setMenuOpen(true);
-  };
-
-  const openSubmenu = (kind: "model" | "effort", trigger: HTMLButtonElement | null) => {
-    if (!trigger) return;
-    setSubmenuPosition(positionSubmenuFor(trigger.getBoundingClientRect(), 256, 320));
-    setActiveSubmenu(kind);
-  };
-
-  const closeSubmenu = (kind: "model" | "effort") => {
-    setActiveSubmenu(null);
-    requestAnimationFrame(() => {
-      (kind === "model" ? modelTriggerRef : effortTriggerRef).current?.focus();
-    });
-  };
-
-  const finishMenuSelection = () => {
-    closeMenu();
-    requestAnimationFrame(() => menuTriggerRef.current?.focus());
   };
 
   useEffect(() => {
@@ -284,7 +236,7 @@ export function IssueRuntimeSelector({
       if (!(event.target instanceof Node)) return;
       if (
         menuRootRef.current?.contains(event.target)
-        || submenuRootRef.current?.contains(event.target)
+        || (event.target instanceof Element && event.target.closest("[data-runtime-profile-submenu]"))
         || menuTriggerRef.current?.contains(event.target)
       ) return;
       closeMenu();
@@ -295,17 +247,23 @@ export function IssueRuntimeSelector({
 
   useEffect(() => {
     if (!menuOpen) return;
+    const handleKeyDown = (event: globalThis.KeyboardEvent) => {
+      if (event.key !== "Escape" && event.key !== "ArrowLeft") return;
+      if (document.querySelector("[data-runtime-profile-submenu]")) return;
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      closeMenu();
+      requestAnimationFrame(() => menuTriggerRef.current?.focus());
+    };
+    window.addEventListener("keydown", handleKeyDown, true);
+    return () => window.removeEventListener("keydown", handleKeyDown, true);
+  }, [menuOpen]);
+
+  useEffect(() => {
+    if (!menuOpen) return;
     const updatePosition = () => {
       if (menuTriggerRef.current) {
         setMenuPosition(positionFor(menuTriggerRef.current.getBoundingClientRect(), 304, 176));
-      }
-      if (activeSubmenu) {
-        const trigger = activeSubmenu === "model"
-          ? modelTriggerRef.current
-          : effortTriggerRef.current;
-        if (trigger) {
-          setSubmenuPosition(positionSubmenuFor(trigger.getBoundingClientRect(), 256, 320));
-        }
       }
     };
     window.addEventListener("resize", updatePosition);
@@ -314,19 +272,7 @@ export function IssueRuntimeSelector({
       window.removeEventListener("resize", updatePosition);
       window.removeEventListener("scroll", updatePosition, true);
     };
-  }, [activeSubmenu, menuOpen]);
-
-  useEffect(() => {
-    if (!menuOpen) return;
-    requestAnimationFrame(() => modelTriggerRef.current?.focus());
   }, [menuOpen]);
-
-  useEffect(() => {
-    if (!menuOpen || !activeSubmenu) return;
-    requestAnimationFrame(() => {
-      (activeSubmenu === "model" ? firstModelOptionRef : firstEffortOptionRef).current?.focus();
-    });
-  }, [activeSubmenu, menuOpen]);
 
   if (!supported) return null;
 
@@ -363,6 +309,11 @@ export function IssueRuntimeSelector({
     }
   };
 
+  const finishMenuSelection = () => {
+    closeMenu();
+    requestAnimationFrame(() => menuTriggerRef.current?.focus());
+  };
+
   const selectMenuModel = (nextModel: string | null) => {
     const nextEffectiveModel = nextModel ?? configuredModel(agent);
     const nextEfforts = effortOptions(
@@ -385,16 +336,55 @@ export function IssueRuntimeSelector({
     finishMenuSelection();
   };
 
+  const runtimeControls = (mode: "menu" | "staged") => (
+    <RuntimeProfileControls
+      ariaContext={`${agent.name} runtime`}
+      disabled={disabled}
+      errorMessage={adapterModelsQuery.error ? "Models are temporarily unavailable." : null}
+      testIds={{
+        modelTrigger: "issue-runtime-model-trigger",
+        modelOptions: "issue-runtime-model-options",
+        modelOption: (id) => id == null
+          ? "issue-runtime-option-default-model"
+          : `issue-runtime-option-model-${id}`,
+        effortTrigger: "issue-runtime-effort-trigger",
+        effortOptions: "issue-runtime-effort-options",
+        effortOption: (id) => `issue-runtime-option-effort-${id ?? "default"}`,
+      }}
+      model={{
+        valueLabel: effectiveModel,
+        selectedId: selectedModel,
+        defaultOption: { id: null, label: `Agent default · ${configuredModel(agent)}` },
+        options,
+        loading: adapterModelsQuery.isPending,
+        emptyLabel: adapterModelsQuery.error ? "Models unavailable" : "No models found.",
+        onSelect: mode === "menu" ? selectMenuModel : selectModel,
+      }}
+      effort={hasThinkingOptions ? {
+        valueLabel: effortLabel(effectiveEffort),
+        selectedId: effectiveEffort,
+        defaultOption: {
+          id: null,
+          label: `Agent default · ${effortLabel(configuredEffort(agent))}`,
+        },
+        options: thinkingOptions.filter((option) => option.id != null),
+        onSelect: mode === "menu" ? selectMenuEffort : setDraftEffort,
+      } : undefined}
+    />
+  );
+
   if (variant === "menu") {
     const menuPanel = menuOpen && menuPosition && typeof document !== "undefined" ? createPortal(
       <div
         ref={menuRootRef}
+        data-issue-runtime-portal
+        data-runtime-profile-panel
         data-testid="issue-runtime-profile-panel"
         role="dialog"
         aria-label={`Model and thinking for ${agent.name}`}
-        className="pointer-events-auto surface-overlay fixed z-[65] w-[19rem] max-w-[calc(100vw-1.5rem)] rounded-[var(--radius-lg)] border p-1.5 shadow-lg"
+        className="pointer-events-auto surface-overlay fixed z-[75] w-[19rem] max-w-[calc(100vw-1.5rem)] rounded-[var(--radius-lg)] border p-1.5 shadow-lg"
         style={menuPosition}
-        onKeyDown={(event) => {
+        onKeyDownCapture={(event) => {
           if (event.key === "Escape") {
             event.preventDefault();
             event.stopPropagation();
@@ -403,12 +393,8 @@ export function IssueRuntimeSelector({
           } else if (event.key === "ArrowLeft") {
             event.preventDefault();
             event.stopPropagation();
-            if (activeSubmenu) {
-              closeSubmenu(activeSubmenu);
-            } else {
-              closeMenu();
-              requestAnimationFrame(() => menuTriggerRef.current?.focus());
-            }
+            closeMenu();
+            requestAnimationFrame(() => menuTriggerRef.current?.focus());
           }
         }}
       >
@@ -424,125 +410,8 @@ export function IssueRuntimeSelector({
           <span className="min-w-0 flex-1 truncate font-medium">{agent.name}</span>
         </button>
         <div className="border-t border-[color:var(--border-soft)] pt-1">
-          <button
-            ref={modelTriggerRef}
-            type="button"
-            data-testid="issue-runtime-model-trigger"
-            aria-haspopup="listbox"
-            aria-expanded={activeSubmenu === "model"}
-            className="chat-composer-menu-row grid min-h-10 grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto] gap-2"
-            onClick={() => openSubmenu("model", modelTriggerRef.current)}
-            onKeyDown={(event) => {
-              if (event.key === "ArrowRight" || event.key === "ArrowDown") {
-                event.preventDefault();
-                openSubmenu("model", modelTriggerRef.current);
-              }
-            }}
-          >
-            <span className="font-medium text-foreground">Model</span>
-            <span className="min-w-0 truncate text-right text-muted-foreground">{effectiveModel}</span>
-            <ChevronRight className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
-          </button>
-          {hasThinkingOptions ? (
-            <button
-              ref={effortTriggerRef}
-              type="button"
-              data-testid="issue-runtime-effort-trigger"
-              aria-haspopup="listbox"
-              aria-expanded={activeSubmenu === "effort"}
-              className="chat-composer-menu-row grid min-h-10 grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto] gap-2"
-              onClick={() => openSubmenu("effort", effortTriggerRef.current)}
-              onKeyDown={(event) => {
-                if (event.key === "ArrowRight" || event.key === "ArrowDown") {
-                  event.preventDefault();
-                  openSubmenu("effort", effortTriggerRef.current);
-                }
-              }}
-            >
-              <span className="font-medium text-foreground">Thinking</span>
-              <span className="min-w-0 truncate text-right text-muted-foreground">{effortLabel(effectiveEffort)}</span>
-              <ChevronRight className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
-            </button>
-          ) : null}
+          {runtimeControls("menu")}
         </div>
-      </div>,
-      document.body,
-    ) : null;
-
-    const submenuOptions = activeSubmenu === "model" ? (
-      <>
-        <button
-          ref={firstModelOptionRef}
-          type="button"
-          role="option"
-          aria-selected={selectedModel == null}
-          data-testid="issue-runtime-option-default-model"
-          className="chat-composer-menu-row"
-          onClick={() => selectMenuModel(null)}
-        >
-          <span className="min-w-0 flex-1 truncate">{`Agent default · ${configuredModel(agent)}`}</span>
-          {selectedModel == null ? <Check className="h-4 w-4 shrink-0" aria-hidden="true" /> : null}
-        </button>
-        {adapterModelsQuery.isPending ? (
-          <div className="flex items-center gap-2 px-2.5 py-2 text-xs text-muted-foreground">
-            <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
-            Loading models...
-          </div>
-        ) : options.length > 0 ? options.map((model) => (
-          <button
-            key={model.id}
-            type="button"
-            role="option"
-            aria-selected={selectedModel === model.id}
-            data-testid={`issue-runtime-option-model-${model.id}`}
-            className="chat-composer-menu-row"
-            onClick={() => selectMenuModel(model.id)}
-          >
-            <span className="min-w-0 flex-1 truncate">{model.label}</span>
-            {selectedModel === model.id ? <Check className="h-4 w-4 shrink-0" aria-hidden="true" /> : null}
-          </button>
-        )) : (
-          <div className="px-2.5 py-2 text-xs text-muted-foreground">
-            {adapterModelsQuery.error ? "Models unavailable" : "No models found."}
-          </div>
-        )}
-      </>
-    ) : hasThinkingOptions ? thinkingOptions.map((option) => (
-      <button
-        key={option.id ?? "default"}
-        ref={option.id == null ? firstEffortOptionRef : undefined}
-        type="button"
-        role="option"
-        aria-selected={effectiveEffort === option.id}
-        data-testid={`issue-runtime-option-effort-${option.id ?? "default"}`}
-        className="chat-composer-menu-row"
-        onClick={() => selectMenuEffort(option.id)}
-      >
-        <span className="min-w-0 flex-1 truncate">{option.label}{option.id == null ? ` · ${effortLabel(configuredEffort(agent))}` : ""}</span>
-        {effectiveEffort === option.id ? <Check className="h-4 w-4 shrink-0" aria-hidden="true" /> : null}
-      </button>
-    )) : null;
-
-    const submenu = menuOpen && activeSubmenu && submenuPosition && typeof document !== "undefined" ? createPortal(
-      <div
-        ref={(node) => {
-          submenuRootRef.current = node;
-          submenuScrollRef(node);
-        }}
-        data-testid={`issue-runtime-${activeSubmenu}-options`}
-        role="listbox"
-        aria-label={activeSubmenu === "model" ? "Model options" : "Thinking options"}
-        className="pointer-events-auto surface-overlay scrollbar-auto-hide scrollbar-menu-inset fixed z-[70] max-h-80 w-64 overflow-y-auto rounded-[var(--radius-lg)] border p-1.5 shadow-lg"
-        style={submenuPosition}
-        onKeyDown={(event) => {
-          if (event.key === "Escape" || event.key === "ArrowLeft") {
-            event.preventDefault();
-            event.stopPropagation();
-            closeSubmenu(activeSubmenu);
-          }
-        }}
-      >
-        {submenuOptions}
       </div>,
       document.body,
     ) : null;
@@ -557,7 +426,7 @@ export function IssueRuntimeSelector({
           aria-haspopup="dialog"
           aria-expanded={menuOpen}
           className={cn(
-            "chat-composer-menu-row min-w-0",
+            "chat-composer-menu-row !w-auto min-w-0 max-w-full",
             disabled && "cursor-not-allowed opacity-60",
           )}
           disabled={disabled}
@@ -576,7 +445,6 @@ export function IssueRuntimeSelector({
           <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />
         </button>
         {menuPanel}
-        {submenu}
       </>
     );
   }
@@ -607,71 +475,31 @@ export function IssueRuntimeSelector({
         </button>
       </PopoverTrigger>
       <PopoverContent
+        data-testid="issue-runtime-profile-panel"
+        data-runtime-profile-panel
         align="end"
         side="bottom"
         sideOffset={6}
         collisionPadding={12}
-        className="max-h-[min(32rem,var(--radix-popover-content-available-height))] w-72 overflow-y-auto p-2"
+        className="surface-overlay w-[19rem] max-w-[calc(100vw-1.5rem)] p-1.5"
+        onInteractOutside={(event) => {
+          const target = event.target;
+          if (target instanceof Element && target.closest("[data-runtime-profile-submenu]")) {
+            event.preventDefault();
+          }
+        }}
       >
-        <div className="mb-2 border-b border-border pb-2">
-          <p className="text-xs font-medium text-foreground">Run profile</p>
-          <p className="mt-0.5 text-[11px] text-muted-foreground">
-            Applies to runs that have not started.
-          </p>
+        <button
+          type="button"
+          className="chat-composer-menu-row mb-1"
+          onClick={() => setOpen(false)}
+        >
+          <ChevronLeft className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+          <span className="min-w-0 flex-1 truncate font-medium">{agent.name}</span>
+        </button>
+        <div className="border-t border-[color:var(--border-soft)] pt-1">
+          {runtimeControls("staged")}
         </div>
-        <div className="space-y-1" role="listbox" aria-label="Model">
-          <p className="px-2 pt-1 text-[10px] font-medium uppercase tracking-[0.14em] text-muted-foreground">Model</p>
-          <button
-            type="button"
-            role="option"
-            aria-selected={selectedModel == null}
-            data-testid="issue-runtime-option-default-model"
-            className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-xs hover:bg-accent/60"
-            onClick={() => selectModel(null)}
-          >
-            <span className="min-w-0 flex-1 truncate">Agent default · {configuredModel(agent)}</span>
-            {draftModel == null ? <Check className="h-3.5 w-3.5 shrink-0" aria-hidden="true" /> : null}
-          </button>
-          {adapterModelsQuery.isPending ? (
-            <div className="flex items-center gap-2 px-2 py-2 text-xs text-muted-foreground">
-              <Loader2 className="h-3.5 w-3.5 animate-spin" /> Loading models...
-            </div>
-          ) : options.length > 0 ? options.map((model) => (
-            <button
-              key={model.id}
-              type="button"
-              role="option"
-              aria-selected={selectedModel === model.id}
-              data-testid={`issue-runtime-option-model-${model.id}`}
-              className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-xs hover:bg-accent/60"
-              onClick={() => selectModel(model.id)}
-            >
-              <span className="min-w-0 flex-1 truncate">{model.label}</span>
-              {selectedModel === model.id ? <Check className="h-3.5 w-3.5 shrink-0" aria-hidden="true" /> : null}
-            </button>
-          )) : (
-            <p className="px-2 py-2 text-xs text-muted-foreground">No models found.</p>
-          )}
-        </div>
-        {hasThinkingOptions ? (
-          <div className="mt-2 border-t border-border pt-2" role="listbox" aria-label="Thinking">
-            <p className="px-2 pt-1 text-[10px] font-medium uppercase tracking-[0.14em] text-muted-foreground">Thinking</p>
-            {thinkingOptions.map((option) => (
-              <button
-                key={option.id ?? "default"}
-                type="button"
-                role="option"
-                aria-selected={effectiveEffort === option.id}
-                data-testid={`issue-runtime-option-effort-${option.id ?? "default"}`}
-                className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-xs hover:bg-accent/60"
-                onClick={() => setDraftEffort(option.id)}
-              >
-                <span className="min-w-0 flex-1 truncate">{option.label}{option.id == null ? ` · ${effortLabel(configuredEffort(agent))}` : ""}</span>
-                {effectiveEffort === option.id ? <Check className="h-3.5 w-3.5 shrink-0" aria-hidden="true" /> : null}
-              </button>
-            ))}
-          </div>
-        ) : null}
         <div className="mt-2 flex justify-end gap-2 border-t border-border pt-2">
           <button type="button" className="rounded px-2 py-1.5 text-xs text-muted-foreground hover:bg-accent/60" onClick={() => setOpen(false)}>
             Cancel

--- a/ui/src/components/MobileBottomNav.tsx
+++ b/ui/src/components/MobileBottomNav.tsx
@@ -61,6 +61,7 @@ export function MobileBottomNav({ visible }: MobileBottomNavProps) {
 
   return (
     <nav
+      data-mobile-bottom-navigation
       className={cn(
         "fixed bottom-0 left-0 right-0 z-30 border-t border-border bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/85 transition-transform duration-200 ease-out md:hidden pb-[env(safe-area-inset-bottom)]",
         visible ? "translate-y-0" : "translate-y-full",

--- a/ui/src/components/RuntimeProfileControls.tsx
+++ b/ui/src/components/RuntimeProfileControls.tsx
@@ -1,0 +1,346 @@
+import { useScrollbarActivityRef } from "@/hooks/useScrollbarActivityRef";
+import { cn } from "@/lib/utils";
+import { Check, ChevronRight, Loader2 } from "lucide-react";
+import {
+  useEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+  type KeyboardEvent,
+  type Ref,
+} from "react";
+import { createPortal } from "react-dom";
+
+export type RuntimeProfileOption = {
+  id: string | null;
+  label: string;
+};
+
+type RuntimeProfileControl = {
+  valueLabel: string;
+  dataValue?: string;
+  selectedId: string | null;
+  defaultOption: RuntimeProfileOption;
+  options: readonly RuntimeProfileOption[];
+  onSelect: (id: string | null) => void;
+  loading?: boolean;
+  emptyLabel?: string;
+};
+
+export type RuntimeProfileControlTestIds = {
+  modelTrigger: string;
+  modelOptions: string;
+  modelOption: (id: string | null) => string;
+  effortTrigger: string;
+  effortOptions: string;
+  effortOption: (id: string | null) => string;
+};
+
+export function RuntimeProfileControls(props: {
+  ariaContext: string;
+  model: RuntimeProfileControl;
+  effort?: RuntimeProfileControl;
+  disabled?: boolean;
+  pending?: boolean;
+  errorMessage?: string | null;
+  modelSelectRef?: Ref<HTMLButtonElement>;
+  testIds: RuntimeProfileControlTestIds;
+}) {
+  const [activeSubmenu, setActiveSubmenu] = useState<"model" | "effort" | null>(null);
+  const [submenuPosition, setSubmenuPosition] = useState<CSSProperties | null>(null);
+  const modelTriggerRef = useRef<HTMLButtonElement | null>(null);
+  const effortTriggerRef = useRef<HTMLButtonElement | null>(null);
+  const firstModelOptionRef = useRef<HTMLButtonElement | null>(null);
+  const firstEffortOptionRef = useRef<HTMLButtonElement | null>(null);
+  const modelSubmenuScrollRef = useScrollbarActivityRef();
+  const effortSubmenuScrollRef = useScrollbarActivityRef();
+  const disabled = props.disabled || props.pending;
+
+  const viewportBottomBoundary = (padding: number) => {
+    const viewportBottom = window.innerHeight - padding;
+    const mobileNavigation = document.querySelector<HTMLElement>("[data-mobile-bottom-navigation]");
+    if (!mobileNavigation || mobileNavigation.getClientRects().length === 0) {
+      return viewportBottom;
+    }
+    return Math.min(viewportBottom, mobileNavigation.getBoundingClientRect().top - padding);
+  };
+
+  useEffect(() => {
+    if (!activeSubmenu) return;
+    const handleKeyDown = (event: globalThis.KeyboardEvent) => {
+      if (event.key !== "Escape" && event.key !== "ArrowLeft") return;
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      closeSubmenu(activeSubmenu);
+    };
+    window.addEventListener("keydown", handleKeyDown, true);
+    return () => window.removeEventListener("keydown", handleKeyDown, true);
+  }, [activeSubmenu]);
+
+  const setModelTriggerRefs = (node: HTMLButtonElement | null) => {
+    modelTriggerRef.current = node;
+    if (typeof props.modelSelectRef === "function") props.modelSelectRef(node);
+    else if (props.modelSelectRef) props.modelSelectRef.current = node;
+  };
+
+  const openSubmenu = (
+    kind: "model" | "effort",
+    trigger: HTMLButtonElement | null,
+    focusFirstOption = false,
+  ) => {
+    if (disabled || !trigger) return;
+    const rect = trigger.getBoundingClientRect();
+    const width = 256;
+    const viewportPadding = 12;
+    const viewportBottom = viewportBottomBoundary(viewportPadding);
+    const availableRight = window.innerWidth - rect.right;
+    const left = availableRight >= width + viewportPadding
+      ? rect.right + 8
+      : Math.max(viewportPadding, rect.left - width - 8);
+    const profilePanel = trigger.closest<HTMLElement>("[data-runtime-profile-panel]");
+    const profileRect = profilePanel?.getBoundingClientRect();
+    const overlapsProfileHorizontally = profileRect
+      ? left < profileRect.right && left + width > profileRect.left
+      : false;
+
+    if (profileRect && overlapsProfileHorizontally) {
+      const gap = 8;
+      const availableBelowPanel = Math.max(0, viewportBottom - profileRect.bottom - gap);
+      const availableAbovePanel = Math.max(0, profileRect.top - viewportPadding - gap);
+      const placeBelow = availableBelowPanel >= availableAbovePanel;
+      const maxHeight = Math.min(
+        320,
+        placeBelow ? availableBelowPanel : availableAbovePanel,
+      );
+      setSubmenuPosition({
+        left: Math.min(
+          Math.max(viewportPadding, rect.left),
+          window.innerWidth - viewportPadding - width,
+        ),
+        top: placeBelow ? profileRect.bottom + gap : profileRect.top - gap - maxHeight,
+        maxHeight: `${maxHeight}px`,
+      });
+      setActiveSubmenu(kind);
+      if (focusFirstOption) {
+        requestAnimationFrame(() => {
+          (kind === "model" ? firstModelOptionRef : firstEffortOptionRef).current?.focus();
+        });
+      }
+      return;
+    }
+
+    const availableBelow = Math.max(0, viewportBottom - rect.top);
+    const availableAbove = Math.max(0, rect.bottom - viewportPadding);
+    const alignBelow = availableBelow >= 120;
+    const maxHeight = Math.min(
+      320,
+      alignBelow ? availableBelow : Math.max(availableAbove, availableBelow),
+    );
+    setSubmenuPosition({
+      left,
+      top: alignBelow
+        ? Math.max(viewportPadding, rect.top)
+        : Math.max(viewportPadding, Math.min(rect.bottom - maxHeight, viewportBottom - maxHeight)),
+      maxHeight: `${maxHeight}px`,
+    });
+    setActiveSubmenu(kind);
+    if (focusFirstOption) {
+      requestAnimationFrame(() => {
+        (kind === "model" ? firstModelOptionRef : firstEffortOptionRef).current?.focus();
+      });
+    }
+  };
+
+  const closeSubmenu = (kind: "model" | "effort") => {
+    setActiveSubmenu(null);
+    requestAnimationFrame(() => {
+      (kind === "model" ? modelTriggerRef : effortTriggerRef).current?.focus();
+    });
+  };
+
+  const handleSubmenuKeyDown = (
+    event: KeyboardEvent<HTMLDivElement>,
+    kind: "model" | "effort",
+  ) => {
+    if (event.key !== "ArrowLeft" && event.key !== "Escape") return;
+    event.preventDefault();
+    event.stopPropagation();
+    closeSubmenu(kind);
+  };
+
+  const renderOptions = (
+    kind: "model" | "effort",
+    control: RuntimeProfileControl,
+  ) => {
+    const optionTestId = kind === "model" ? props.testIds.modelOption : props.testIds.effortOption;
+    const firstOptionRef = kind === "model" ? firstModelOptionRef : firstEffortOptionRef;
+    const allOptions = [control.defaultOption, ...control.options];
+
+    return (
+      <>
+        {allOptions.map((option, index) => {
+          const selected = control.selectedId === option.id;
+          return (
+            <button
+              key={option.id ?? "default"}
+              ref={index === 0 ? firstOptionRef : undefined}
+              type="button"
+              role="option"
+              aria-selected={selected}
+              data-testid={optionTestId(option.id)}
+              className="chat-composer-menu-row"
+              onClick={() => {
+                control.onSelect(option.id);
+                setActiveSubmenu(null);
+              }}
+            >
+              <span className="min-w-0 flex-1 truncate">{option.label}</span>
+              {selected ? <Check className="h-4 w-4 shrink-0" aria-hidden="true" /> : null}
+            </button>
+          );
+        })}
+        {control.loading ? (
+          <div className="flex items-center gap-2 px-2.5 py-2 text-xs text-muted-foreground">
+            <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
+            Loading models...
+          </div>
+        ) : control.options.length === 0 ? (
+          <div className="px-2.5 py-2 text-xs text-muted-foreground">
+            {control.emptyLabel ?? "No options found."}
+          </div>
+        ) : null}
+      </>
+    );
+  };
+
+  const submenuClassName = cn(
+    "pointer-events-auto surface-overlay scrollbar-auto-hide scrollbar-menu-inset fixed z-[80] w-64 overflow-y-auto rounded-[var(--radius-lg)] border p-1.5 shadow-lg",
+  );
+  const triggerClassName = cn(
+    "chat-composer-menu-row grid min-h-10 grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto] gap-2",
+    disabled && "cursor-not-allowed opacity-60",
+  );
+
+  const modelSubmenu = activeSubmenu === "model" && submenuPosition && typeof document !== "undefined"
+    ? createPortal(
+        <div
+          ref={modelSubmenuScrollRef}
+          data-runtime-profile-submenu
+          data-chat-runtime-submenu
+          data-issue-runtime-portal
+          data-testid={props.testIds.modelOptions}
+          role="listbox"
+          aria-label={`${props.ariaContext} model`}
+          className={submenuClassName}
+          style={submenuPosition}
+          onKeyDown={(event) => handleSubmenuKeyDown(event, "model")}
+        >
+          {renderOptions("model", props.model)}
+        </div>,
+        document.body,
+      )
+    : null;
+
+  const effortSubmenu = props.effort
+    && activeSubmenu === "effort"
+    && submenuPosition
+    && typeof document !== "undefined"
+    ? createPortal(
+        <div
+          ref={effortSubmenuScrollRef}
+          data-runtime-profile-submenu
+          data-chat-runtime-submenu
+          data-issue-runtime-portal
+          data-testid={props.testIds.effortOptions}
+          role="listbox"
+          aria-label={`${props.ariaContext} thinking`}
+          className={submenuClassName}
+          style={submenuPosition}
+          onKeyDown={(event) => handleSubmenuKeyDown(event, "effort")}
+        >
+          {renderOptions("effort", props.effort)}
+        </div>,
+        document.body,
+      )
+    : null;
+
+  return (
+    <div className="relative min-w-0">
+      <button
+        ref={setModelTriggerRefs}
+        type="button"
+        data-testid={props.testIds.modelTrigger}
+        aria-label={`Model for ${props.ariaContext}`}
+        aria-haspopup="listbox"
+        aria-expanded={activeSubmenu === "model"}
+        className={triggerClassName}
+        disabled={disabled}
+        title={props.errorMessage ?? undefined}
+        data-value={props.model.dataValue}
+        onPointerMove={(event) => {
+          if (event.pointerType === "mouse") openSubmenu("model", modelTriggerRef.current);
+        }}
+        onClick={() => openSubmenu("model", modelTriggerRef.current, true)}
+        onKeyDown={(event) => {
+          if (event.key === "ArrowRight" || event.key === "ArrowDown") {
+            event.preventDefault();
+            openSubmenu("model", modelTriggerRef.current, true);
+          }
+        }}
+      >
+        <span className="font-medium text-foreground">Model</span>
+        <span className="min-w-0 truncate text-right text-muted-foreground">
+          {props.model.valueLabel}
+        </span>
+        {props.model.loading || props.pending ? (
+          <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" aria-hidden="true" />
+        ) : (
+          <ChevronRight className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+        )}
+      </button>
+      {props.effort ? (
+        <button
+          ref={effortTriggerRef}
+          type="button"
+          data-testid={props.testIds.effortTrigger}
+          aria-label={`Thinking for ${props.ariaContext}`}
+          aria-haspopup="listbox"
+          aria-expanded={activeSubmenu === "effort"}
+          className={triggerClassName}
+          disabled={disabled}
+          data-value={props.effort.dataValue}
+          onPointerMove={(event) => {
+            if (event.pointerType === "mouse") openSubmenu("effort", effortTriggerRef.current);
+          }}
+          onClick={() => openSubmenu("effort", effortTriggerRef.current, true)}
+          onKeyDown={(event) => {
+            if (event.key === "ArrowRight" || event.key === "ArrowDown") {
+              event.preventDefault();
+              openSubmenu("effort", effortTriggerRef.current, true);
+            }
+          }}
+        >
+          <span className="font-medium text-foreground">Thinking</span>
+          <span className="min-w-0 truncate text-right text-muted-foreground">
+            {props.effort.valueLabel}
+          </span>
+          {props.pending ? (
+            <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" aria-hidden="true" />
+          ) : (
+            <ChevronRight className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+          )}
+        </button>
+      ) : null}
+      {props.errorMessage ? (
+        <>
+          <div className="mt-1 flex min-h-7 items-center gap-1.5 border-t border-[color:var(--border-soft)] px-2.5 pt-1.5 text-[11px] text-muted-foreground">
+            <span>{props.errorMessage}</span>
+          </div>
+          <span className="sr-only" role="status">{props.errorMessage}</span>
+        </>
+      ) : null}
+      {modelSubmenu}
+      {effortSubmenu}
+    </div>
+  );
+}

--- a/ui/src/pages/Chat.model-selector.tsx
+++ b/ui/src/pages/Chat.model-selector.tsx
@@ -3,18 +3,17 @@ import { agentsApi } from "@/api/agents";
 import {
   shouldShowThinkingEffort,
   thinkingEffortKeyForRuntime,
-  thinkingEffortLabelForRuntime,
   thinkingEffortOptionsForRuntime,
 } from "@/components/AgentConfigForm.helpers";
 import { AgentIcon } from "@/components/AgentIconPicker";
-import { useScrollbarActivityRef } from "@/hooks/useScrollbarActivityRef";
+import { RuntimeProfileControls } from "@/components/RuntimeProfileControls";
 import { formatChatAgentLabel } from "@/lib/agent-labels";
 import { queryKeys } from "@/lib/queryKeys";
 import { resolveRuntimeModels } from "@/lib/runtime-models";
 import { cn } from "@/lib/utils";
 import type { Agent, ChatConversation, ChatRuntimeDescriptor } from "@rudderhq/shared";
 import { useQuery } from "@tanstack/react-query";
-import { Bot, Check, ChevronLeft, ChevronRight, Loader2, Lock } from "lucide-react";
+import { Bot, ChevronLeft, ChevronRight, Loader2, Lock } from "lucide-react";
 import {
   useEffect,
   useRef,
@@ -206,14 +205,6 @@ export function ChatConversationRuntimeControls(props: {
   modelSelectRef?: Ref<HTMLButtonElement>;
   onChange: (overrides: ChatRuntimeOverrides) => void;
 }) {
-  const [activeSubmenu, setActiveSubmenu] = useState<"model" | "effort" | null>(null);
-  const [submenuPosition, setSubmenuPosition] = useState<CSSProperties | null>(null);
-  const modelTriggerRef = useRef<HTMLButtonElement | null>(null);
-  const effortTriggerRef = useRef<HTMLButtonElement | null>(null);
-  const firstModelOptionRef = useRef<HTMLButtonElement | null>(null);
-  const firstEffortOptionRef = useRef<HTMLButtonElement | null>(null);
-  const modelSubmenuScrollRef = useScrollbarActivityRef();
-  const effortSubmenuScrollRef = useScrollbarActivityRef();
   const options = chatConversationModelOptions(
     props.agent,
     props.adapterModels,
@@ -221,7 +212,6 @@ export function ChatConversationRuntimeControls(props: {
   );
   const configuredModel = configuredAgentModel(props.agent);
   const configuredEffort = configuredAgentEffort(props.agent);
-  const effortControlLabel = thinkingEffortLabelForRuntime(props.agent.agentRuntimeType);
   const effectiveModel = props.overrides.modelOverride ?? configuredModel;
   const effectiveModelMetadata = options.find((candidate) => candidate.id === effectiveModel);
   const showThinkingEffort = shouldShowThinkingEffort(
@@ -243,260 +233,47 @@ export function ChatConversationRuntimeControls(props: {
     : props.error
       ? "Models are temporarily unavailable."
       : null;
-  const disabled = props.disabled || props.pending;
   const effectiveEffort = currentEffortOverride ?? configuredEffort;
-  const setModelTriggerRefs = (node: HTMLButtonElement | null) => {
-    modelTriggerRef.current = node;
-    if (typeof props.modelSelectRef === "function") props.modelSelectRef(node);
-    else if (props.modelSelectRef) props.modelSelectRef.current = node;
-  };
-  const openSubmenu = (
-    kind: "model" | "effort",
-    trigger: HTMLButtonElement | null,
-    focusFirstOption = false,
-  ) => {
-    if (disabled || !trigger) return;
-    const rect = trigger.getBoundingClientRect();
-    const width = 256;
-    const viewportPadding = 12;
-    const availableRight = window.innerWidth - rect.right;
-    const left = availableRight >= width + viewportPadding
-      ? rect.right + 8
-      : Math.max(viewportPadding, rect.left - width - 8);
-    setSubmenuPosition({
-      left,
-      top: Math.max(
-        viewportPadding,
-        Math.min(rect.top, window.innerHeight - viewportPadding - 320),
-      ),
-    });
-    setActiveSubmenu(kind);
-    if (focusFirstOption) {
-      requestAnimationFrame(() => {
-        (kind === "model" ? firstModelOptionRef : firstEffortOptionRef).current?.focus();
-      });
-    }
-  };
-  const closeSubmenu = (kind: "model" | "effort") => {
-    setActiveSubmenu(null);
-    requestAnimationFrame(() => {
-      (kind === "model" ? modelTriggerRef : effortTriggerRef).current?.focus();
-    });
-  };
-  const handleSubmenuKeyDown = (
-    event: KeyboardEvent<HTMLDivElement>,
-    kind: "model" | "effort",
-  ) => {
-    if (event.key !== "ArrowLeft" && event.key !== "Escape") return;
-    event.preventDefault();
-    event.stopPropagation();
-    closeSubmenu(kind);
-  };
-  const submenuClassName = cn(
-    "surface-overlay scrollbar-auto-hide scrollbar-menu-inset fixed z-[70] max-h-80 w-64 overflow-y-auto rounded-[var(--radius-lg)] border p-1.5 shadow-lg",
-  );
-  const triggerClassName = cn(
-    "chat-composer-menu-row grid min-h-10 grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto] gap-2",
-    disabled && "cursor-not-allowed opacity-60",
-  );
 
   return (
-    <div className="relative min-w-0">
-      <div className="relative">
-        <button
-          ref={setModelTriggerRefs}
-          type="button"
-          data-testid="chat-model-selector"
-          aria-label={`Model for this conversation (${props.agent.name} runtime)`}
-          aria-haspopup="listbox"
-          aria-expanded={activeSubmenu === "model"}
-          className={triggerClassName}
-          disabled={disabled}
-          title={errorMessage ?? "Only this conversation will use the selected model."}
-          data-value={props.overrides.modelOverride ?? ""}
-          onPointerEnter={() => openSubmenu("model", modelTriggerRef.current)}
-          onClick={() => openSubmenu("model", modelTriggerRef.current, true)}
-          onKeyDown={(event) => {
-            if (event.key === "ArrowRight" || event.key === "ArrowDown") {
-              event.preventDefault();
-              openSubmenu("model", modelTriggerRef.current, true);
-            }
-          }}
-        >
-          <span className="font-medium text-foreground">Model</span>
-          <span className="min-w-0 truncate text-right text-muted-foreground">
-            {effectiveModel}
-          </span>
-          {props.isLoading || props.pending ? (
-            <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" aria-hidden="true" />
-          ) : (
-            <ChevronRight className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
-          )}
-        </button>
-        {activeSubmenu === "model" && submenuPosition && typeof document !== "undefined" ? createPortal(
-          <div
-            ref={modelSubmenuScrollRef}
-            data-chat-runtime-submenu
-            data-testid="chat-model-options"
-            role="listbox"
-            aria-label="Conversation model"
-            className={submenuClassName}
-            style={submenuPosition}
-            onKeyDown={(event) => handleSubmenuKeyDown(event, "model")}
-          >
-            <button
-              ref={firstModelOptionRef}
-              type="button"
-              role="option"
-              aria-selected={props.overrides.modelOverride == null}
-              data-testid="chat-model-option-default"
-              className="chat-composer-menu-row"
-              onClick={() => {
-                props.onChange(normalizedChatRuntimeOverridesForModel(
-                  props.agent,
-                  props.overrides,
-                  null,
-                  options.find((candidate) => candidate.id === configuredModel),
-                ));
-                setActiveSubmenu(null);
-              }}
-            >
-              <span className="min-w-0 flex-1 truncate">{`Agent default · ${configuredModel}`}</span>
-              {props.overrides.modelOverride == null ? (
-                <Check className="h-4 w-4 shrink-0" aria-hidden="true" />
-              ) : null}
-            </button>
-            {options.map((model) => {
-              const selected = props.overrides.modelOverride === model.id;
-              return (
-                <button
-                  key={model.id}
-                  type="button"
-                  role="option"
-                  aria-selected={selected}
-                  data-testid={`chat-model-option-${model.id}`}
-                  className="chat-composer-menu-row"
-                  onClick={() => {
-                    props.onChange(normalizedChatRuntimeOverridesForModel(
-                      props.agent,
-                      props.overrides,
-                      model.id,
-                      model,
-                    ));
-                    setActiveSubmenu(null);
-                  }}
-                >
-                  <span className="min-w-0 flex-1 truncate">{model.label}</span>
-                  {selected ? <Check className="h-4 w-4 shrink-0" aria-hidden="true" /> : null}
-                </button>
-              );
-            })}
-            {errorMessage && options.length === 0 ? (
-              <div className="px-2.5 py-2 text-xs text-muted-foreground">
-                Models unavailable
-              </div>
-            ) : null}
-          </div>,
-          document.body,
-        ) : null}
-      </div>
-      {showThinkingEffort ? (
-        <div className="relative">
-          <button
-            ref={effortTriggerRef}
-            type="button"
-            data-testid="chat-effort-selector"
-            aria-label={`${effortControlLabel} for this conversation (${props.agent.name} runtime)`}
-            aria-haspopup="listbox"
-            aria-expanded={activeSubmenu === "effort"}
-            className={triggerClassName}
-            disabled={disabled}
-            data-value={currentEffortOverride ?? ""}
-            onPointerEnter={() => openSubmenu("effort", effortTriggerRef.current)}
-            onClick={() => openSubmenu("effort", effortTriggerRef.current, true)}
-            onKeyDown={(event) => {
-              if (event.key === "ArrowRight" || event.key === "ArrowDown") {
-                event.preventDefault();
-                openSubmenu("effort", effortTriggerRef.current, true);
-              }
-            }}
-          >
-            <span className="font-medium text-foreground">
-              Thinking
-            </span>
-            <span className="min-w-0 truncate text-right text-muted-foreground">
-              {effortLabel(effectiveEffort)}
-            </span>
-            {props.pending ? (
-              <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" aria-hidden="true" />
-            ) : (
-              <ChevronRight className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
-            )}
-          </button>
-          {activeSubmenu === "effort" && submenuPosition && typeof document !== "undefined" ? createPortal(
-            <div
-              ref={effortSubmenuScrollRef}
-              data-chat-runtime-submenu
-              data-testid="chat-effort-options"
-              role="listbox"
-              aria-label={`Conversation ${effortControlLabel.toLowerCase()}`}
-              className={submenuClassName}
-              style={submenuPosition}
-              onKeyDown={(event) => handleSubmenuKeyDown(event, "effort")}
-            >
-              <button
-                ref={firstEffortOptionRef}
-                type="button"
-                role="option"
-                aria-selected={currentEffortOverride == null}
-                data-testid="chat-effort-option-default"
-                className="chat-composer-menu-row"
-                onClick={() => {
-                  props.onChange({ ...props.overrides, effortOverride: null });
-                  setActiveSubmenu(null);
-                }}
-              >
-                <span className="min-w-0 flex-1 truncate">
-                  {`Agent default · ${effortLabel(configuredEffort)}`}
-                </span>
-                {currentEffortOverride == null ? (
-                  <Check className="h-4 w-4 shrink-0" aria-hidden="true" />
-                ) : null}
-              </button>
-              {effortOptions.map((option) => {
-                const selected = currentEffortOverride === option.id;
-                return (
-                  <button
-                    key={option.id}
-                    type="button"
-                    role="option"
-                    aria-selected={selected}
-                    data-testid={`chat-effort-option-${option.id}`}
-                    className="chat-composer-menu-row"
-                    onClick={() => {
-                      props.onChange({ ...props.overrides, effortOverride: option.id });
-                      setActiveSubmenu(null);
-                    }}
-                  >
-                    <span className="min-w-0 flex-1 truncate">{option.label}</span>
-                    {selected ? <Check className="h-4 w-4 shrink-0" aria-hidden="true" /> : null}
-                  </button>
-                );
-              })}
-            </div>,
-            document.body,
-          ) : null}
-        </div>
-      ) : null}
-      {errorMessage ? (
-        <div className="mt-1 flex min-h-7 items-center gap-1.5 border-t border-[color:var(--border-soft)] px-2.5 pt-1.5 text-[11px] text-muted-foreground">
-          <span>{errorMessage}</span>
-        </div>
-      ) : null}
-      {errorMessage ? (
-        <span className="sr-only" role="status">{errorMessage}</span>
-      ) : null}
-    </div>
+    <RuntimeProfileControls
+      ariaContext={`this conversation (${props.agent.name} runtime)`}
+      disabled={props.disabled}
+      pending={props.pending}
+      errorMessage={errorMessage}
+      modelSelectRef={props.modelSelectRef}
+      testIds={{
+        modelTrigger: "chat-model-selector",
+        modelOptions: "chat-model-options",
+        modelOption: (id) => id == null ? "chat-model-option-default" : `chat-model-option-${id}`,
+        effortTrigger: "chat-effort-selector",
+        effortOptions: "chat-effort-options",
+        effortOption: (id) => id == null ? "chat-effort-option-default" : `chat-effort-option-${id}`,
+      }}
+      model={{
+        valueLabel: effectiveModel,
+        dataValue: props.overrides.modelOverride ?? "",
+        selectedId: props.overrides.modelOverride,
+        defaultOption: { id: null, label: `Agent default · ${configuredModel}` },
+        options,
+        loading: props.isLoading,
+        emptyLabel: errorMessage ? "Models unavailable" : "No models found.",
+        onSelect: (modelOverride) => props.onChange(normalizedChatRuntimeOverridesForModel(
+          props.agent,
+          props.overrides,
+          modelOverride,
+          options.find((candidate) => candidate.id === (modelOverride ?? configuredModel)),
+        )),
+      }}
+      effort={showThinkingEffort ? {
+        valueLabel: effortLabel(effectiveEffort),
+        dataValue: currentEffortOverride ?? "",
+        selectedId: currentEffortOverride,
+        defaultOption: { id: null, label: `Agent default · ${effortLabel(configuredEffort)}` },
+        options: effortOptions,
+        onSelect: (effortOverride) => props.onChange({ ...props.overrides, effortOverride }),
+      } : undefined}
+    />
   );
 }
 
@@ -594,12 +371,13 @@ export function ChatAgentRuntimeSelector(props: {
       {open && position && props.agent && typeof document !== "undefined" ? createPortal(
         <div
           data-chat-runtime-submenu
+          data-runtime-profile-panel
           data-testid="chat-agent-runtime-panel"
           role="dialog"
           aria-label={`Model and thinking for ${props.agent.name}`}
           className="surface-overlay fixed z-[65] w-[19rem] max-w-[calc(100vw-1.5rem)] rounded-[var(--radius-lg)] border p-1.5 shadow-lg"
           style={position}
-          onKeyDown={(event) => {
+          onKeyDownCapture={(event) => {
             if (event.key !== "Escape" && event.key !== "ArrowLeft") return;
             event.preventDefault();
             event.stopPropagation();

--- a/ui/src/pages/GoalDetail.test.tsx
+++ b/ui/src/pages/GoalDetail.test.tsx
@@ -534,6 +534,7 @@ describe("GoalDetail", () => {
     const container = renderPage();
     await waitUntil(() => expect(container.querySelector('[data-testid="issue-runtime-selector"]')).not.toBeNull());
     act(() => container.querySelector<HTMLButtonElement>('[data-testid="issue-runtime-selector"]')?.click());
+    act(() => document.body.querySelector<HTMLButtonElement>('[data-testid="issue-runtime-model-trigger"]')?.click());
     await waitUntil(() => expect(document.body.querySelector('[data-testid="issue-runtime-option-model-gpt-5.6-terra"]')).not.toBeNull());
     act(() => document.body.querySelector<HTMLButtonElement>('[data-testid="issue-runtime-option-model-gpt-5.6-terra"]')?.click());
     act(() => document.body.querySelector<HTMLButtonElement>('[data-testid="issue-runtime-apply"]')?.click());

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -2525,7 +2525,7 @@ export function IssueDetail({ embeddedIssueId = null, embedded = false }: IssueD
             <SheetTitle className="text-sm">Properties</SheetTitle>
           </SheetHeader>
           <ScrollArea className="flex-1 overflow-y-auto">
-            <div className="space-y-3 px-4 pb-4">
+            <div className="w-[100vw] max-w-[100vw] space-y-3 overflow-x-hidden px-4 pb-4">
               <IssueProperties
                 issue={issue}
                 onUpdate={(data) => updateIssue.mutate(data)}


### PR DESCRIPTION
## Summary
- extract the Chat runtime profile controls into a shared selector UI
- reuse the shared Model/Thinking panel in Automation, Issue, and Goal while preserving immediate versus staged persistence
- keep long assignee names and nested selector portals bounded on 375px mobile layouts

## Verification
- `pnpm build`
- `pnpm -r typecheck`
- `pnpm product-logic:check` (96 contracts)
- `pnpm lint:changed`
- focused UI Vitest: 62 passing
- Automation runtime selector E2E: 3 passing
- Issue runtime selector E2E, including 375px long-name regression: 1 passing
- Goal owner runtime profile E2E: 1 passing
- Chat selector dismiss E2E: 1 passing
- independent black-box verifier: PASS for `selector-reuse-final-v2`
- independent final reviewer: accept

The repository-wide `pnpm test:run` is not claimed as complete: an earlier run was stopped after the source candidate changed, invalidating that run as exact-candidate evidence. All completed projects/files before interruption passed; the task-focused suites and exact-candidate full build passed.

## Product Logic
- no `doc/product/**` changes
- no API or database contract changes