### PR TITLE
fix: harden COS release recovery [skip release]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -618,13 +618,14 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.source_ref }}
+          ref: ${{ github.sha }}
           fetch-depth: 0
       - name: Require immutable recovery inputs
         env:
           SOURCE_REF: ${{ inputs.source_ref }}
           CANDIDATE_RUN_ID: ${{ inputs.candidate_run_id }}
           RECOVERY_TAG: ${{ inputs.recovery_tag }}
+          WORKFLOW_SHA: ${{ github.sha }}
         run: |
           [[ "$SOURCE_REF" =~ ^[0-9a-f]{40}$ ]] || {
             echo "source_ref must be a full 40-character commit SHA for mirror recovery." >&2
@@ -638,8 +639,10 @@ jobs:
             echo "recovery_tag must be an existing stable tag such as v0.7.7." >&2
             exit 1
           }
-          test "$(git rev-parse HEAD)" = "$SOURCE_REF"
+          test "$GITHUB_REF" = "refs/heads/main"
+          test "$(git rev-parse HEAD)" = "$WORKFLOW_SHA"
           git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          git cat-file -e "$SOURCE_REF^{commit}"
           git merge-base --is-ancestor "$SOURCE_REF" refs/remotes/origin/main
       - name: Validate frozen candidate run and existing Release
         env:
@@ -708,15 +711,19 @@ jobs:
         run: |
           for attempt in 1 2 3; do
             echo "COS mirror attempt ${attempt}/3"
-            if node scripts/mirror-desktop-release-to-cos.mjs \
+            set +e
+            node scripts/mirror-desktop-release-to-cos.mjs \
               --tag "${{ inputs.recovery_tag }}" \
               --asset-dir dist/desktop-assets \
               --prefix releases \
-              --allow-existing-checksum-marker; then
+              --allow-existing-checksum-marker
+            status=$?
+            set -e
+            if [ "$status" -eq 0 ]; then
               exit 0
             fi
-            if [ "$attempt" -eq 3 ]; then
-              exit 1
+            if [ "$status" -ne 75 ] || [ "$attempt" -eq 3 ]; then
+              exit "$status"
             fi
             sleep $((attempt * 15))
           done
@@ -828,15 +835,19 @@ jobs:
         run: |
           for attempt in 1 2 3; do
             echo "COS mirror attempt ${attempt}/3"
-            if node scripts/mirror-desktop-release-to-cos.mjs \
+            set +e
+            node scripts/mirror-desktop-release-to-cos.mjs \
               --tag "${{ needs.preflight.outputs.tag }}" \
               --asset-dir dist/desktop-assets \
               --prefix releases \
-              --allow-existing-checksum-marker; then
+              --allow-existing-checksum-marker
+            status=$?
+            set -e
+            if [ "$status" -eq 0 ]; then
               exit 0
             fi
-            if [ "$attempt" -eq 3 ]; then
-              exit 1
+            if [ "$status" -ne 75 ] || [ "$attempt" -eq 3 ]; then
+              exit "$status"
             fi
             sleep $((attempt * 15))
           done
@@ -888,15 +899,19 @@ jobs:
         run: |
           for attempt in 1 2 3; do
             echo "COS mirror attempt ${attempt}/3"
-            if node scripts/mirror-desktop-release-to-cos.mjs \
+            set +e
+            node scripts/mirror-desktop-release-to-cos.mjs \
               --tag "${{ needs.preflight.outputs.tag }}" \
               --asset-dir dist/desktop-assets \
               --prefix releases \
-              --allow-existing-checksum-marker; then
+              --allow-existing-checksum-marker
+            status=$?
+            set -e
+            if [ "$status" -eq 0 ]; then
               exit 0
             fi
-            if [ "$attempt" -eq 3 ]; then
-              exit 1
+            if [ "$status" -ne 75 ] || [ "$attempt" -eq 3 ]; then
+              exit "$status"
             fi
             sleep $((attempt * 15))
           done

--- a/scripts/mirror-desktop-release-to-cos.mjs
+++ b/scripts/mirror-desktop-release-to-cos.mjs
@@ -931,6 +931,12 @@ export function isRetryableNetworkError(error) {
   return error instanceof TypeError && error.message === "fetch failed" && errorChainHasRetryableCode(error);
 }
 
+export function exitCodeForMirrorError(error) {
+  return error instanceof RetryableNetworkError || isRetryableNetworkError(error)
+    ? RETRYABLE_NETWORK_EXIT_CODE
+    : 1;
+}
+
 async function fetchWithRetry(
   fetchImpl,
   input,
@@ -1019,7 +1025,7 @@ async function main() {
     console.error(formatError(error));
     if (error instanceof Error && error.stack) console.error(error.stack);
     usage();
-    process.exitCode = error instanceof RetryableNetworkError ? RETRYABLE_NETWORK_EXIT_CODE : 1;
+    process.exitCode = exitCodeForMirrorError(error);
   }
 }
 

--- a/scripts/mirror-desktop-release-to-cos.mjs
+++ b/scripts/mirror-desktop-release-to-cos.mjs
@@ -16,6 +16,19 @@ const DEFAULT_MULTIPART_PART_SIZE = 32 * 1024 * 1024;
 const DEFAULT_MULTIPART_RETRIES = 3;
 const DEFAULT_NETWORK_RETRIES = 3;
 const DEFAULT_NETWORK_RETRY_DELAY_MS = 2000;
+const RETRYABLE_NETWORK_EXIT_CODE = 75;
+const RETRYABLE_NETWORK_CODES = new Set([
+  "EAI_AGAIN",
+  "ECONNRESET",
+  "EHOSTUNREACH",
+  "ENETDOWN",
+  "ENETUNREACH",
+  "ETIMEDOUT",
+  "UND_ERR_BODY_TIMEOUT",
+  "UND_ERR_CONNECT_TIMEOUT",
+  "UND_ERR_HEADERS_TIMEOUT",
+  "UND_ERR_SOCKET",
+]);
 const SIGNABLE_HEADERS = new Set([
   "cache-control",
   "content-disposition",
@@ -897,6 +910,27 @@ async function httpError(action, response) {
   return new Error(`${action} failed with HTTP ${response.status}${detail ? `: ${detail}` : ""}`);
 }
 
+export class RetryableNetworkError extends Error {
+  constructor(message, options) {
+    super(message, options);
+    this.name = "RetryableNetworkError";
+  }
+}
+
+function errorChainHasRetryableCode(error, seen = new Set()) {
+  if (!error || (typeof error !== "object" && typeof error !== "function") || seen.has(error)) return false;
+  seen.add(error);
+  if (typeof error.code === "string" && RETRYABLE_NETWORK_CODES.has(error.code)) return true;
+  if (Array.isArray(error.errors) && error.errors.some((nested) => errorChainHasRetryableCode(nested, seen))) {
+    return true;
+  }
+  return errorChainHasRetryableCode(error.cause, seen);
+}
+
+export function isRetryableNetworkError(error) {
+  return error instanceof TypeError && error.message === "fetch failed" && errorChainHasRetryableCode(error);
+}
+
 async function fetchWithRetry(
   fetchImpl,
   input,
@@ -909,9 +943,12 @@ async function fetchWithRetry(
     try {
       return await fetchImpl(input, init);
     } catch (error) {
+      if (!isRetryableNetworkError(error)) throw error;
       lastError = error;
       if (attempt === networkRetries) {
-        throw new Error(`${operation} failed after ${networkRetries} network attempts.`, { cause: error });
+        throw new RetryableNetworkError(`${operation} failed after ${networkRetries} network attempts.`, {
+          cause: error,
+        });
       }
       await retrySleep(retryDelayMs * attempt);
     }
@@ -982,7 +1019,7 @@ async function main() {
     console.error(formatError(error));
     if (error instanceof Error && error.stack) console.error(error.stack);
     usage();
-    process.exitCode = 1;
+    process.exitCode = error instanceof RetryableNetworkError ? RETRYABLE_NETWORK_EXIT_CODE : 1;
   }
 }
 

--- a/scripts/release-cos-mirror.test.mjs
+++ b/scripts/release-cos-mirror.test.mjs
@@ -7,6 +7,7 @@ import {
   assumeTencentRoleWithWebIdentity,
   CosReleaseMirror,
   createCosAuthorization,
+  exitCodeForMirrorError,
   getTencentStsCredentials,
   mirrorDesktopReleaseToCos,
   objectKeyForReleaseAsset,
@@ -209,6 +210,31 @@ describe("Tencent COS Desktop release mirror", () => {
       }),
     ).rejects.toBeInstanceOf(RetryableNetworkError);
     expect(attempts).toBe(3);
+  });
+
+  it("maps a raw retryable COS fetch failure to the workflow retry exit code", async () => {
+    const failure = new TypeError("fetch failed", {
+      cause: Object.assign(new Error("socket reset"), { code: "ECONNRESET" }),
+    });
+    const mirror = new CosReleaseMirror({
+      bucket,
+      credentials,
+      fetchImpl: async () => {
+        throw failure;
+      },
+      region,
+    });
+
+    let observed;
+    try {
+      await mirror.readObject("releases/v0.7.9/Rudder-test.zip", false);
+    } catch (error) {
+      observed = error;
+    }
+
+    expect(observed).toBe(failure);
+    expect(exitCodeForMirrorError(observed)).toBe(75);
+    expect(exitCodeForMirrorError(new Error("checksum conflict"))).toBe(1);
   });
 
   it("does not retry HTTP authorization failures", async () => {

--- a/scripts/release-cos-mirror.test.mjs
+++ b/scripts/release-cos-mirror.test.mjs
@@ -10,6 +10,8 @@ import {
   getTencentStsCredentials,
   mirrorDesktopReleaseToCos,
   objectKeyForReleaseAsset,
+  requestGitHubOidcToken,
+  RetryableNetworkError,
 } from "./mirror-desktop-release-to-cos.mjs";
 
 const tempDirs = [];
@@ -126,7 +128,11 @@ describe("Tencent COS Desktop release mirror", () => {
       const key = url.hostname;
       const attempt = (attempts.get(key) ?? 0) + 1;
       attempts.set(key, attempt);
-      if (attempt === 1) throw new TypeError("fetch failed", { cause: new Error("ECONNRESET") });
+      if (attempt === 1) {
+        throw new TypeError("fetch failed", {
+          cause: Object.assign(new Error("socket reset"), { code: "ECONNRESET" }),
+        });
+      }
       if (key === "oidc.actions.test") return jsonResponse({ value: "github-oidc-jwt" });
       expect(init.method).toBe("POST");
       return jsonResponse({
@@ -156,6 +162,71 @@ describe("Tencent COS Desktop release mirror", () => {
       ["oidc.actions.test", 2],
       ["sts.tencentcloudapi.com", 2],
     ]));
+  });
+
+  it.each([
+    ["AbortError", Object.assign(new Error("cancelled"), { name: "AbortError" })],
+    ["arbitrary error", new Error("programming failure")],
+    [
+      "non-retryable fetch cause",
+      new TypeError("fetch failed", {
+        cause: Object.assign(new Error("EINVAL"), { code: "EINVAL" }),
+      }),
+    ],
+  ])("does not retry %s", async (_label, failure) => {
+    let attempts = 0;
+    await expect(
+      requestGitHubOidcToken({
+        fetchImpl: async () => {
+          attempts += 1;
+          throw failure;
+        },
+        networkRetries: 3,
+        requestToken: "oidc-request-token",
+        requestUrl: "https://oidc.actions.test/token",
+        retryDelayMs: 0,
+        sleep: async () => {},
+      }),
+    ).rejects.toBe(failure);
+    expect(attempts).toBe(1);
+  });
+
+  it("marks exhausted transient fetch failures for workflow-level retry", async () => {
+    let attempts = 0;
+    await expect(
+      requestGitHubOidcToken({
+        fetchImpl: async () => {
+          attempts += 1;
+          throw new TypeError("fetch failed", {
+            cause: Object.assign(new Error("socket reset"), { code: "ECONNRESET" }),
+          });
+        },
+        networkRetries: 3,
+        requestToken: "oidc-request-token",
+        requestUrl: "https://oidc.actions.test/token",
+        retryDelayMs: 0,
+        sleep: async () => {},
+      }),
+    ).rejects.toBeInstanceOf(RetryableNetworkError);
+    expect(attempts).toBe(3);
+  });
+
+  it("does not retry HTTP authorization failures", async () => {
+    let attempts = 0;
+    await expect(
+      requestGitHubOidcToken({
+        fetchImpl: async () => {
+          attempts += 1;
+          return new Response("forbidden", { status: 403 });
+        },
+        networkRetries: 3,
+        requestToken: "oidc-request-token",
+        requestUrl: "https://oidc.actions.test/token",
+        retryDelayMs: 0,
+        sleep: async () => {},
+      }),
+    ).rejects.toThrow("HTTP 403");
+    expect(attempts).toBe(1);
   });
 
   it("rejects Tencent STS responses missing the temporary credential triplet", async () => {

--- a/scripts/release-workflow-contract.test.mjs
+++ b/scripts/release-workflow-contract.test.mjs
@@ -197,10 +197,21 @@ describe("unified delivery workflows", () => {
   });
 
   it("retries transient COS mirror failures before failing the release gate", () => {
-    for (const jobName of ["mirror-canary", "mirror-stable"]) {
-      expect(workflowJob(releaseWorkflow, jobName)).toContain("for attempt in 1 2 3");
-      expect(workflowJob(releaseWorkflow, jobName)).toContain("COS mirror attempt ${attempt}/3");
+    for (const jobName of ["mirror-recovery", "mirror-canary", "mirror-stable"]) {
+      const job = workflowJob(releaseWorkflow, jobName);
+      expect(job).toContain("for attempt in 1 2 3");
+      expect(job).toContain("COS mirror attempt ${attempt}/3");
+      expect(job).toContain('if [ "$status" -ne 75 ] || [ "$attempt" -eq 3 ]');
+      expect(job).toContain('exit "$status"');
     }
+  });
+
+  it("runs mirror recovery from trusted main workflow code while preserving the released source", () => {
+    const recovery = workflowJob(releaseWorkflow, "mirror-recovery");
+    expect(recovery).toContain("ref: ${{ github.sha }}");
+    expect(recovery).toContain('test "$GITHUB_REF" = "refs/heads/main"');
+    expect(recovery).toContain('git cat-file -e "$SOURCE_REF^{commit}"');
+    expect(recovery).toContain('test "$SOURCE_REF" = "$remote_tag_sha"');
   });
 
   it("waits for the exact manifest versions before creating public release surfaces", () => {


### PR DESCRIPTION
## Thinking Path

> - Rudder stable releases publish immutable npm, GitHub, Desktop, docs, and COS surfaces
> - v0.7.9 published through Desktop assets before COS mirroring hit a transient fetch failure
> - Recovery must preserve the published source while using trusted current workflow code
> - Retry behavior must distinguish retryable network failures from deterministic integrity failures
> - This change adds a fail-closed COS-only recovery path and contract coverage

## What Changed

- add trusted mirror-only recovery validation for the frozen v0.7.9 candidate
- retry only explicit transient Node/undici network failures via exit 75
- preserve deterministic failure propagation and checksum-marker-last ordering
- add workflow and mirror contract tests

## Verification

- focused release contract suite: 41/41 passed
- exact-source CI run 32034233697: success on af35b448a86bf6cd1bf033219df7963509a63003
- independent stage review: accept, no P0/P1/P2

## Product Logic Alignment

- Product docs read: release engineering contracts
- Affected contract IDs: none
- Product doc impact: none; release automation only
- Tests or E2E proving affected contracts: release workflow and COS mirror contract tests

## Risks

- Low product risk; release-only recovery logic remains fail-closed and cannot republish npm.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have considered and documented risks above