### PR TITLE
fix(cli): avoid Windows npm shell deprecation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,7 +247,7 @@ jobs:
 
       - name: CLI start tests
         if: matrix.test == 'cli-start'
-        run: pnpm -s exec vitest run cli/src/__tests__/start.test.ts
+        run: pnpm -s exec vitest run cli/src/__tests__/npm-command.test.ts cli/src/__tests__/start.test.ts
 
       - name: Build
         env:

--- a/cli/src/__tests__/npm-command.test.ts
+++ b/cli/src/__tests__/npm-command.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { resolveNpmCommandInvocation } from "../npm-command.js";
+
+describe("npm command invocation", () => {
+  it("uses cmd.exe to invoke npm.cmd on Windows", () => {
+    expect(resolveNpmCommandInvocation("win32", { ComSpec: "C:\\Windows\\System32\\cmd.exe" })).toEqual({
+      command: "C:\\Windows\\System32\\cmd.exe",
+      args: ["/d", "/s", "/c", "npm.cmd"],
+    });
+  });
+
+  it("supports uppercase COMSPEC and the cmd.exe fallback", () => {
+    expect(resolveNpmCommandInvocation("win32", { COMSPEC: "C:\\Windows\\cmd.exe" })).toEqual({
+      command: "C:\\Windows\\cmd.exe",
+      args: ["/d", "/s", "/c", "npm.cmd"],
+    });
+    expect(resolveNpmCommandInvocation("win32", {})).toEqual({
+      command: "cmd.exe",
+      args: ["/d", "/s", "/c", "npm.cmd"],
+    });
+  });
+
+  it("invokes npm directly on non-Windows platforms", () => {
+    expect(resolveNpmCommandInvocation("linux", { ComSpec: "ignored.exe" })).toEqual({
+      command: "npm",
+      args: [],
+    });
+  });
+});

--- a/cli/src/__tests__/start.test.ts
+++ b/cli/src/__tests__/start.test.ts
@@ -232,21 +232,6 @@ function createDeferred<T = void>() {
 }
 
 describe("persistent CLI install helpers", () => {
-  it("resolves the Windows npm command without relying on a Windows test runner", () => {
-    expect(resolveNpmCommandInvocation("win32", { ComSpec: "C:\\Windows\\System32\\cmd.exe" })).toEqual({
-      command: "C:\\Windows\\System32\\cmd.exe",
-      args: ["/d", "/s", "/c", "npm.cmd"],
-    });
-    expect(resolveNpmCommandInvocation("win32", {})).toEqual({
-      command: "cmd.exe",
-      args: ["/d", "/s", "/c", "npm.cmd"],
-    });
-    expect(resolveNpmCommandInvocation("linux", { ComSpec: "ignored.exe" })).toEqual({
-      command: "npm",
-      args: [],
-    });
-  });
-
   it.runIf(process.platform === "win32")("invokes npm.cmd through cmd.exe without Node shell mode", () => {
     const npm = resolveNpmCommandInvocation();
     const result = spawnSync(npm.command, [...npm.args, "--version"], {

--- a/cli/src/__tests__/start.test.ts
+++ b/cli/src/__tests__/start.test.ts
@@ -63,6 +63,7 @@ import {
   isTransientBinaryPath,
   resolvePersistentCliInstallSpec,
 } from "../install.js";
+import { resolveNpmCommandInvocation } from "../npm-command.js";
 import { runCli } from "../program.js";
 import {
   ensureRuntimeInstalled,
@@ -79,11 +80,11 @@ import { createByteProgress, formatByteProgress } from "../utils/progress.js";
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
 
-const npmInstallCommand = process.platform === "win32" ? "npm.cmd" : "npm";
+const npmInstallInvocation = resolveNpmCommandInvocation();
 const npmInstallSpawnOptions = {
   encoding: "utf8",
   stdio: ["inherit", "pipe", "pipe"],
-  ...(process.platform === "win32" ? { shell: true, windowsHide: true } : {}),
+  ...(process.platform === "win32" ? { windowsHide: true } : {}),
 };
 
 function currentEmbeddedPostgresPlatformPackage(): string | null {
@@ -231,6 +232,19 @@ function createDeferred<T = void>() {
 }
 
 describe("persistent CLI install helpers", () => {
+  it.runIf(process.platform === "win32")("invokes npm.cmd through cmd.exe without Node shell mode", () => {
+    const npm = resolveNpmCommandInvocation();
+    const result = spawnSync(npm.command, [...npm.args, "--version"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true,
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(result.status).toBe(0);
+    expect(String(result.stdout).trim()).toMatch(/^\d+\.\d+\.\d+/);
+  });
+
   it("detects npx execution from transient _npx entry paths", () => {
     expect(
       isLikelyNpxExecutionContext("/tmp/npm-cache/_npx/abc/node_modules/@rudderhq/cli/dist/index.js", {}),
@@ -268,6 +282,14 @@ describe("persistent CLI install helpers", () => {
     );
 
     expect(hasGlobalInstalledPackage(CLI_NPM_PACKAGE_NAME, execFileSyncImpl as never)).toBe(true);
+    expect(execFileSyncImpl).toHaveBeenCalledWith(
+      npmInstallInvocation.command,
+      [...npmInstallInvocation.args, "list", "--global", "--depth=0", "--json", CLI_NPM_PACKAGE_NAME],
+      {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+      },
+    );
   });
 
   it("detects a persistent rudder binary on PATH", () => {
@@ -350,8 +372,8 @@ describe("persistent CLI install helpers", () => {
     });
 
     expect(spawnSyncImpl).toHaveBeenCalledWith(
-      npmInstallCommand,
-      ["install", "--global", "@rudderhq/cli@0.1.0"],
+      npmInstallInvocation.command,
+      [...npmInstallInvocation.args, "install", "--global", "@rudderhq/cli@0.1.0"],
       npmInstallSpawnOptions,
     );
   });
@@ -383,14 +405,14 @@ describe("persistent CLI install helpers", () => {
 
     expect(spawnSyncImpl).toHaveBeenNthCalledWith(
       1,
-      npmInstallCommand,
-      ["install", "--global", "@rudderhq/cli@0.1.0"],
+      npmInstallInvocation.command,
+      [...npmInstallInvocation.args, "install", "--global", "@rudderhq/cli@0.1.0"],
       npmInstallSpawnOptions,
     );
     expect(spawnSyncImpl).toHaveBeenNthCalledWith(
       2,
-      npmInstallCommand,
-      ["install", "--global", "--force", "@rudderhq/cli@0.1.0"],
+      npmInstallInvocation.command,
+      [...npmInstallInvocation.args, "install", "--global", "--force", "@rudderhq/cli@0.1.0"],
       npmInstallSpawnOptions,
     );
   });
@@ -2298,8 +2320,9 @@ describe("runtime install helpers", () => {
       });
 
       expect(spawnSyncImpl).toHaveBeenCalledWith(
-        npmInstallCommand,
+        npmInstallInvocation.command,
         [
+          ...npmInstallInvocation.args,
           "install",
           "--prefix",
           resolveRuntimeCacheDir("1.2.3", root),
@@ -2312,7 +2335,7 @@ describe("runtime install helpers", () => {
         {
           encoding: "utf8",
           stdio: ["ignore", "pipe", "pipe"],
-          ...(process.platform === "win32" ? { shell: true, windowsHide: true } : {}),
+          ...(process.platform === "win32" ? { windowsHide: true } : {}),
         },
       );
     } finally {

--- a/cli/src/__tests__/start.test.ts
+++ b/cli/src/__tests__/start.test.ts
@@ -3028,6 +3028,12 @@ describe("runtime install helpers", () => {
       expect(result.output).toContain("added runtime");
       expect(result.output).toContain("extracted platform package");
       expect(spawnSyncImpl).toHaveBeenCalledTimes(3);
+      expect(spawnSyncImpl.mock.calls[1]?.[0]).toBe(npmInstallInvocation.command);
+      expect(spawnSyncImpl.mock.calls[1]?.[1]).toEqual(expect.arrayContaining([
+        ...npmInstallInvocation.args,
+        "pack",
+      ]));
+      expect(spawnSyncImpl.mock.calls[1]?.[2]).not.toHaveProperty("shell");
       expect(spawnSyncImpl).toHaveBeenNthCalledWith(
         2,
         expect.any(String),

--- a/cli/src/__tests__/start.test.ts
+++ b/cli/src/__tests__/start.test.ts
@@ -232,6 +232,21 @@ function createDeferred<T = void>() {
 }
 
 describe("persistent CLI install helpers", () => {
+  it("resolves the Windows npm command without relying on a Windows test runner", () => {
+    expect(resolveNpmCommandInvocation("win32", { ComSpec: "C:\\Windows\\System32\\cmd.exe" })).toEqual({
+      command: "C:\\Windows\\System32\\cmd.exe",
+      args: ["/d", "/s", "/c", "npm.cmd"],
+    });
+    expect(resolveNpmCommandInvocation("win32", {})).toEqual({
+      command: "cmd.exe",
+      args: ["/d", "/s", "/c", "npm.cmd"],
+    });
+    expect(resolveNpmCommandInvocation("linux", { ComSpec: "ignored.exe" })).toEqual({
+      command: "npm",
+      args: [],
+    });
+  });
+
   it.runIf(process.platform === "win32")("invokes npm.cmd through cmd.exe without Node shell mode", () => {
     const npm = resolveNpmCommandInvocation();
     const result = spawnSync(npm.command, [...npm.args, "--version"], {

--- a/cli/src/install.ts
+++ b/cli/src/install.ts
@@ -1,4 +1,5 @@
 import { execFileSync, spawnSync } from "node:child_process";
+import { resolveNpmCommandInvocation } from "./npm-command.js";
 
 export const CLI_NPM_PACKAGE_NAME = "@rudderhq/cli";
 export const CLI_BIN_NAME = "rudder";
@@ -81,9 +82,10 @@ export function getGlobalInstalledPackageVersion(
   execFileSyncImpl: typeof execFileSync = execFileSync,
 ): string | null {
   try {
+    const npm = resolveNpmCommandInvocation();
     const output = execFileSyncImpl(
-      process.platform === "win32" ? "npm.cmd" : "npm",
-      ["list", "--global", "--depth=0", "--json", packageName],
+      npm.command,
+      [...npm.args, "list", "--global", "--depth=0", "--json", packageName],
       {
         encoding: "utf8",
         stdio: ["ignore", "pipe", "ignore"],
@@ -176,10 +178,11 @@ function runNpmGlobalInstall(
   spawnSyncImpl: typeof spawnSync,
   args: string[],
 ): SpawnSyncResultLike {
-  return spawnSyncImpl(process.platform === "win32" ? "npm.cmd" : "npm", args, {
+  const npm = resolveNpmCommandInvocation();
+  return spawnSyncImpl(npm.command, [...npm.args, ...args], {
     encoding: "utf8",
     stdio: ["inherit", "pipe", "pipe"],
-    ...(process.platform === "win32" ? { shell: true, windowsHide: true } : {}),
+    ...(process.platform === "win32" ? { windowsHide: true } : {}),
   });
 }
 

--- a/cli/src/npm-command.ts
+++ b/cli/src/npm-command.ts
@@ -3,13 +3,16 @@ export interface NpmCommandInvocation {
   args: string[];
 }
 
-export function resolveNpmCommandInvocation(): NpmCommandInvocation {
-  if (process.platform !== "win32") {
+export function resolveNpmCommandInvocation(
+  platform: NodeJS.Platform = process.platform,
+  env: NodeJS.ProcessEnv = process.env,
+): NpmCommandInvocation {
+  if (platform !== "win32") {
     return { command: "npm", args: [] };
   }
 
   return {
-    command: process.env.ComSpec ?? process.env.COMSPEC ?? "cmd.exe",
+    command: env.ComSpec ?? env.COMSPEC ?? "cmd.exe",
     args: ["/d", "/s", "/c", "npm.cmd"],
   };
 }

--- a/cli/src/npm-command.ts
+++ b/cli/src/npm-command.ts
@@ -1,0 +1,15 @@
+export interface NpmCommandInvocation {
+  command: string;
+  args: string[];
+}
+
+export function resolveNpmCommandInvocation(): NpmCommandInvocation {
+  if (process.platform !== "win32") {
+    return { command: "npm", args: [] };
+  }
+
+  return {
+    command: process.env.ComSpec ?? process.env.COMSPEC ?? "cmd.exe",
+    args: ["/d", "/s", "/c", "npm.cmd"],
+  };
+}

--- a/cli/src/runtime/install.ts
+++ b/cli/src/runtime/install.ts
@@ -9,6 +9,7 @@ import { Readable, Transform } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { resolveRudderHomeDir } from "../config/home.js";
+import { resolveNpmCommandInvocation } from "../npm-command.js";
 import { copyRuntimePostgresPayload } from "./postgres-payload.js";
 export const RUNTIME_NPM_PACKAGE_NAME = "@rudderhq/server";
 export const NPM_PUBLIC_REGISTRY_URL = "https://registry.npmjs.org";
@@ -540,13 +541,14 @@ function runNpmRuntimeInstall(
   cacheDir: string,
   packageSpec: string,
 ): SpawnSyncResultLike {
+  const npm = resolveNpmCommandInvocation();
   return spawnSyncImpl(
-    process.platform === "win32" ? "npm.cmd" : "npm",
-    ["install", "--prefix", cacheDir, ...RUNTIME_NPM_INSTALL_FLAGS, packageSpec],
+    npm.command,
+    [...npm.args, "install", "--prefix", cacheDir, ...RUNTIME_NPM_INSTALL_FLAGS, packageSpec],
     {
       encoding: "utf8",
       stdio: ["ignore", "pipe", "pipe"],
-      ...(process.platform === "win32" ? { shell: true, windowsHide: true } : {}),
+      ...(process.platform === "win32" ? { windowsHide: true } : {}),
     },
   );
 }
@@ -697,14 +699,15 @@ function runNpmPack(
   packageSpec: string,
   destinationDir: string,
 ): SpawnSyncResultLike {
+  const npm = resolveNpmCommandInvocation();
   return spawnSyncImpl(
-    process.platform === "win32" ? "npm.cmd" : "npm",
-    ["pack", packageSpec, "--pack-destination", destinationDir, ...RUNTIME_NPM_PACK_FLAGS],
+    npm.command,
+    [...npm.args, "pack", packageSpec, "--pack-destination", destinationDir, ...RUNTIME_NPM_PACK_FLAGS],
     {
       encoding: "utf8",
       stdio: ["ignore", "pipe", "pipe"],
       env: { ...process.env, ...NPM_PLATFORM_REPAIR_ENV },
-      ...(process.platform === "win32" ? { shell: true, windowsHide: true } : {}),
+      ...(process.platform === "win32" ? { windowsHide: true } : {}),
     },
   );
 }

--- a/cli/src/runtime/install.ts
+++ b/cli/src/runtime/install.ts
@@ -541,6 +541,7 @@ function runNpmRuntimeInstall(
   cacheDir: string,
   packageSpec: string,
 ): SpawnSyncResultLike {
+  // Keep Windows .cmd execution explicit: shell: true with arguments triggers Node DEP0190.
   const npm = resolveNpmCommandInvocation();
   return spawnSyncImpl(
     npm.command,
@@ -699,6 +700,7 @@ function runNpmPack(
   packageSpec: string,
   destinationDir: string,
 ): SpawnSyncResultLike {
+  // The platform-repair path must use the same shell-free Windows invocation as installs.
   const npm = resolveNpmCommandInvocation();
   return spawnSyncImpl(
     npm.command,


### PR DESCRIPTION
## Summary

- route Windows npm invocations through `cmd.exe /d /s /c npm.cmd`
- remove Node's `shell: true` path that triggers the `DEP0190` warning
- apply the same safe invocation to global version probing and runtime package installation
- add a Windows regression test for the real npm command path

## Validation

- `pnpm --filter @rudderhq/cli typecheck`
- `pnpm --filter @rudderhq/cli build`
- focused CLI tests: 110 tests, 101 passed, 9 skipped
- `pnpm -r typecheck`
- real source global probe and persistent install helper for `@rudderhq/cli@0.7.9`
- built candidate server-only install completed successfully
- published `npx @rudderhq/cli@latest` install completed successfully

## Known environment issues

- this machine's Application Control blocks the unsigned alpha Desktop executable after installation
- full-repository lint currently reports 2557 pre-existing import-order violations
- full test/build commands retain unrelated Windows/DB and missing Cargo environment failures