### PR TITLE
Fix Desktop Local App startup recovery

### DIFF
--- a/desktop/scripts/smoke.mjs
+++ b/desktop/scripts/smoke.mjs
@@ -6775,6 +6775,13 @@ async function runLocalAppsScenario(mode) {
     registryPath,
   } = await seedApprovedLocalAppDefinition(scenarioRoot, project);
   const failingLocalApp = await seedFailingLocalAppDefinition(registry, scenarioRoot);
+  await registry.recordRuntimeDescriptor(definition.id, {
+    status: "orphaned_unverified",
+    pid: 991_101,
+    pgid: 991_101,
+    port: 31_911,
+    generation: "dead-orphan-smoke-generation",
+  });
   const preservedProjectSource = project.external
     ? null
     : {
@@ -6791,17 +6798,18 @@ async function runLocalAppsScenario(mode) {
   const packagedSmokeExecutable = mode === "packaged"
     ? await createPackagedIdentitySmokeExecutable(scenarioRoot)
     : null;
-  const run = await launchDesktop(
+  const launchEnv = {
+    ...project.launchEnv,
+    ...(mode === "packaged" && process.platform === "darwin" && process.env.HOME
+      ? { HOME: process.env.HOME }
+      : {}),
+    ...(packagedSmokeExecutable ? { RUDDER_DESKTOP_SMOKE_AUTH_BYPASS: "1" } : {}),
+  };
+  let run = await launchDesktop(
     scenarioRoot,
     mode,
     ports,
-    {
-      ...project.launchEnv,
-      ...(mode === "packaged" && process.platform === "darwin" && process.env.HOME
-        ? { HOME: process.env.HOME }
-        : {}),
-      ...(packagedSmokeExecutable ? { RUDDER_DESKTOP_SMOKE_AUTH_BYPASS: "1" } : {}),
-    },
+    launchEnv,
     packagedSmokeExecutable,
   );
   let runningDescriptor = null;
@@ -6809,6 +6817,16 @@ async function runLocalAppsScenario(mode) {
   let scenarioError = null;
   let cleanupError = null;
   try {
+    const recovered = await run.page.evaluate(
+      (definitionId) => window.desktopShell.localApps.status(definitionId),
+      definition.id,
+    );
+    assert.equal(recovered.status, "stopped", "Desktop restart should reconcile a provably dead Local App orphan");
+    assert.equal(
+      await readLocalAppRuntimeDescriptor(registryPath, definition.id),
+      null,
+      "provably dead Local App ownership should be removed from the registry",
+    );
     const company = await createCompany(run.baseUrl, "LAP");
     const companyRouteKey = company.urlKey ?? company.issuePrefix;
     await createCeo(run.baseUrl, company.id);
@@ -7225,6 +7243,18 @@ async function runLocalAppsScenario(mode) {
       return text && text !== "No runtime logs yet." && text !== "Loading logs…" ? text : null;
     });
     if (!project.external) assert.match(logText, /Rudder Local Apps smoke fixture listening/);
+    const logsBeforeRestart = await run.page.evaluate(
+      (definitionId) => window.desktopShell.localApps.logs(definitionId),
+      definition.id,
+    );
+    assert.ok(logsBeforeRestart.length > 0, "Local App logs should be available before Desktop restart");
+    await closeDesktop(run.electronApp);
+    run = await launchDesktop(scenarioRoot, mode, ports, launchEnv, packagedSmokeExecutable);
+    const logsAfterRestart = await run.page.evaluate(
+      (definitionId) => window.desktopShell.localApps.logs(definitionId),
+      definition.id,
+    );
+    assert.deepEqual(logsAfterRestart, logsBeforeRestart, "Local App logs should survive a full Desktop restart");
 
     const appsHomeUrl = new URL(`/${companyRouteKey}/apps`, run.baseUrl).href;
     await run.page.goto(appsHomeUrl);

--- a/desktop/src/local-app-runtime-log-store.test.ts
+++ b/desktop/src/local-app-runtime-log-store.test.ts
@@ -1,0 +1,26 @@
+import { mkdtemp, readdir, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { LocalAppRuntimeLogStore } from "./local-app-runtime-log-store.js";
+
+describe("Local App runtime log store", () => {
+  it("coalesces mode-private bounded UTF-8 snapshots and clears them", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "rudder-local-app-logs-"));
+    const store = new LocalAppRuntimeLogStore({ directory: root, maxBytes: 16, flushDelayMs: 1_000 });
+    store.schedule("binding-a", "obsolete");
+    store.schedule("binding-a", `prefix-${"界".repeat(8)}`);
+    await store.flush("binding-a");
+
+    const restored = await store.read("binding-a");
+    expect(restored.endsWith("界")).toBe(true);
+    expect(Buffer.byteLength(restored)).toBeLessThanOrEqual(16);
+    expect((await stat(root)).mode & 0o777).toBe(0o700);
+    const files = await readdir(root);
+    expect(files).toHaveLength(1);
+    expect((await stat(path.join(root, files[0]!))).mode & 0o777).toBe(0o600);
+
+    await store.clear("binding-a");
+    await expect(store.read("binding-a")).resolves.toBe("");
+  });
+});

--- a/desktop/src/local-app-runtime-log-store.ts
+++ b/desktop/src/local-app-runtime-log-store.ts
@@ -1,0 +1,116 @@
+import { createHash, randomUUID } from "node:crypto";
+import { chmod, mkdir, open, readFile, rename, rm } from "node:fs/promises";
+import path from "node:path";
+
+const DEFAULT_FLUSH_DELAY_MS = 50;
+
+function isMissingFile(error: unknown): boolean {
+  return (error as NodeJS.ErrnoException | null)?.code === "ENOENT";
+}
+
+export function boundedLocalAppLogTail(text: string, maxBytes: number): string {
+  const buffer = Buffer.from(text);
+  if (buffer.length <= maxBytes) return text;
+  let start = buffer.length - maxBytes;
+  while (start < buffer.length && (buffer[start]! & 0xc0) === 0x80) start += 1;
+  return buffer.subarray(start).toString("utf8");
+}
+
+export class LocalAppRuntimeLogStore {
+  private readonly directory: string;
+  private readonly maxBytes: number;
+  private readonly flushDelayMs: number;
+  private readonly pending = new Map<string, string>();
+  private readonly timers = new Map<string, NodeJS.Timeout>();
+  private readonly writes = new Map<string, Promise<void>>();
+
+  constructor(options: { directory: string; maxBytes: number; flushDelayMs?: number }) {
+    this.directory = options.directory;
+    this.maxBytes = options.maxBytes;
+    this.flushDelayMs = Math.max(1, options.flushDelayMs ?? DEFAULT_FLUSH_DELAY_MS);
+  }
+
+  private filePath(id: string): string {
+    const digest = createHash("sha256").update(id).digest("hex");
+    return path.join(this.directory, `${digest}.log`);
+  }
+
+  async read(id: string): Promise<string> {
+    try {
+      return boundedLocalAppLogTail(await readFile(this.filePath(id), "utf8"), this.maxBytes);
+    } catch (error) {
+      if (isMissingFile(error)) return "";
+      throw error;
+    }
+  }
+
+  schedule(id: string, text: string): void {
+    this.pending.set(id, boundedLocalAppLogTail(text, this.maxBytes));
+    if (this.timers.has(id)) return;
+    const timer = setTimeout(() => {
+      this.timers.delete(id);
+      void this.flushPending(id).catch(() => undefined);
+    }, this.flushDelayMs);
+    timer.unref();
+    this.timers.set(id, timer);
+  }
+
+  async clear(id: string): Promise<void> {
+    this.pending.delete(id);
+    const timer = this.timers.get(id);
+    if (timer) clearTimeout(timer);
+    this.timers.delete(id);
+    await this.enqueue(id, () => rm(this.filePath(id), { force: true }));
+  }
+
+  async flush(id: string): Promise<void> {
+    const timer = this.timers.get(id);
+    if (timer) clearTimeout(timer);
+    this.timers.delete(id);
+    await this.flushPending(id);
+    await (this.writes.get(id) ?? Promise.resolve());
+    if (this.pending.has(id)) await this.flush(id);
+  }
+
+  async flushAll(): Promise<void> {
+    const ids = new Set([...this.pending.keys(), ...this.timers.keys(), ...this.writes.keys()]);
+    await Promise.all([...ids].map((id) => this.flush(id)));
+  }
+
+  private async flushPending(id: string): Promise<void> {
+    const text = this.pending.get(id);
+    if (text === undefined) return;
+    this.pending.delete(id);
+    await this.enqueue(id, () => this.writeSnapshot(id, text));
+  }
+
+  private async enqueue(id: string, operation: () => Promise<void>): Promise<void> {
+    const previous = this.writes.get(id) ?? Promise.resolve();
+    const current = previous.catch(() => undefined).then(operation);
+    this.writes.set(id, current);
+    try {
+      await current;
+    } finally {
+      if (this.writes.get(id) === current) this.writes.delete(id);
+    }
+  }
+
+  private async writeSnapshot(id: string, text: string): Promise<void> {
+    await mkdir(this.directory, { recursive: true, mode: 0o700 });
+    await chmod(this.directory, 0o700);
+    const destination = this.filePath(id);
+    const temporary = `${destination}.${process.pid}.${randomUUID()}.tmp`;
+    const file = await open(temporary, "wx", 0o600);
+    try {
+      await file.writeFile(text, "utf8");
+      await file.sync();
+      await file.close();
+      await rename(temporary, destination);
+      await chmod(destination, 0o600);
+    } catch (error) {
+      await file.close().catch(() => undefined);
+      await rm(temporary, { force: true }).catch(() => undefined);
+      throw error;
+    }
+  }
+}

--- a/desktop/src/local-apps-controller.test.ts
+++ b/desktop/src/local-apps-controller.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, realpath } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, realpath, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
@@ -366,7 +366,7 @@ describe("Desktop Local Apps native controller", () => {
     const created = await registry.createDefinition(prepared);
     const runtime = {
       start: vi.fn(), stop: vi.fn(), status: vi.fn(async () => ({ status: "stopped" as const })),
-      logs: vi.fn(), attestedTarget: vi.fn(), shutdown: vi.fn(),
+      logs: vi.fn(), attestedTarget: vi.fn(), shutdown: vi.fn(), discardPersistedState: vi.fn(),
     };
     const controller = new LocalAppsController({
       registry, runtime, selectFolder: vi.fn(async () => null), confirmDefinition: vi.fn(async () => false),
@@ -375,13 +375,51 @@ describe("Desktop Local Apps native controller", () => {
     await expect(controller.start(created.id)).rejects.toThrow("canceled");
     await expect(controller.deleteDefinition(created.id)).resolves.toBeUndefined();
     await expect(registry.getDefinition(created.id)).rejects.toThrow("not found");
+    expect(runtime.discardPersistedState).toHaveBeenCalledWith(created.id);
+  });
+
+  it("folds legacy duplicate projects while retaining the safest opaque binding", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "rudder-local-app-controller-legacy-duplicate-"));
+    const registryPath = path.join(root, "registry.json");
+    const registry = new LocalAppRegistry({ registryPath, installationId: "install-a" });
+    const prepared = await registry.prepareDefinition(draft(root));
+    const first = await registry.createDefinition(prepared);
+    const state = JSON.parse(await readFile(registryPath, "utf8")) as {
+      definitions: Array<Record<string, unknown>>;
+    };
+    const duplicateId = "legacy-duplicate-binding";
+    state.definitions.push({
+      ...state.definitions[0],
+      id: duplicateId,
+      localBindingId: duplicateId,
+      appPublicId: "legacy-duplicate-public",
+      title: "Newest duplicate",
+      updatedAt: "2099-01-01T00:00:00.000Z",
+    });
+    await writeFile(registryPath, JSON.stringify(state), { mode: 0o600 });
+    const reloaded = new LocalAppRegistry({ registryPath, installationId: "install-a" });
+    let activeId: string | null = null;
+    const runtime = {
+      start: vi.fn(), stop: vi.fn(), logs: vi.fn(), attestedTarget: vi.fn(), shutdown: vi.fn(),
+      status: vi.fn(async (id: string) => ({ status: id === activeId ? "running" as const : "failed" as const })),
+    };
+    const controller = new LocalAppsController({
+      registry: reloaded, runtime, selectFolder: vi.fn(async () => null), confirmDefinition: vi.fn(async () => true),
+    });
+
+    await expect(controller.listDefinitions()).resolves.toMatchObject([{ id: duplicateId, title: "Newest duplicate" }]);
+    activeId = first.id;
+    await expect(controller.listDefinitions()).resolves.toMatchObject([{ id: first.id }]);
+    expect(await reloaded.listDefinitions()).toHaveLength(2);
   });
 
   it("does not serialize operations for different bindings", async () => {
     const root = await mkdtemp(path.join(tmpdir(), "rudder-local-app-controller-distinct-bindings-"));
+    const secondRoot = path.join(root, "second");
+    await mkdir(secondRoot);
     const registry = new LocalAppRegistry({ registryPath: path.join(root, "registry.json"), installationId: "install-a" });
     const firstPrepared = await registry.prepareDefinition({ ...draft(root), title: "First" });
-    const secondPrepared = await registry.prepareDefinition({ ...draft(root), title: "Second" });
+    const secondPrepared = await registry.prepareDefinition({ ...draft(secondRoot), title: "Second" });
     const first = await registry.createDefinition(firstPrepared);
     const second = await registry.createDefinition(secondPrepared);
     const approvalEntered = deferred<void>();
@@ -453,6 +491,48 @@ describe("Desktop Local Apps native controller", () => {
     await controller.start(created.id);
     expect(confirmDefinition).toHaveBeenCalledTimes(2);
     expect(runtime.start).toHaveBeenCalledWith(created.id);
+  });
+
+  it("reuses the existing binding when the same canonical project is registered again", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "rudder-local-app-controller-deduplicate-"));
+    const registry = new LocalAppRegistry({ registryPath: path.join(root, "registry.json"), installationId: "install-a" });
+    const runtime = {
+      start: vi.fn(), stop: vi.fn(), status: vi.fn(async () => ({ status: "stopped" as const })),
+      logs: vi.fn(), attestedTarget: vi.fn(), shutdown: vi.fn(),
+    };
+    const confirmDefinition = vi.fn(async () => true);
+    const controller = new LocalAppsController({
+      registry, runtime, selectFolder: vi.fn(async () => null), confirmDefinition,
+    });
+
+    const first = await controller.createDefinition(draft(root));
+    const second = await controller.createDefinition({ ...draft(root), title: "Updated title" });
+
+    expect(second.id).toBe(first.id);
+    expect(second.title).toBe("Updated title");
+    expect(await registry.listDefinitions()).toHaveLength(1);
+    expect(runtime.status).toHaveBeenCalledWith(first.id);
+    expect(confirmDefinition).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not replace a duplicate project binding whose ownership is still unverified", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "rudder-local-app-controller-deduplicate-active-"));
+    const registry = new LocalAppRegistry({ registryPath: path.join(root, "registry.json"), installationId: "install-a" });
+    const prepared = await registry.prepareDefinition(draft(root));
+    const existing = await registry.createDefinition(prepared);
+    const confirmDefinition = vi.fn(async () => true);
+    const runtime = {
+      start: vi.fn(), stop: vi.fn(), status: vi.fn(async () => ({ status: "orphaned_unverified" as const })),
+      logs: vi.fn(), attestedTarget: vi.fn(), shutdown: vi.fn(),
+    };
+    const controller = new LocalAppsController({
+      registry, runtime, selectFolder: vi.fn(async () => null), confirmDefinition,
+    });
+
+    await expect(controller.createDefinition({ ...draft(root), title: "Replacement" })).rejects.toThrow("unverified");
+    expect(confirmDefinition).not.toHaveBeenCalled();
+    expect((await registry.getDefinition(existing.id)).title).toBe(prepared.title);
+    expect(await registry.listDefinitions()).toHaveLength(1);
   });
 
   it("reviews and approves an unapproved definition before start", async () => {

--- a/desktop/src/local-apps-controller.ts
+++ b/desktop/src/local-apps-controller.ts
@@ -10,7 +10,7 @@ import type { LocalAppRuntimeManager, LocalAppRuntimeView } from "./local-apps-r
 type RuntimeController = Pick<
   LocalAppRuntimeManager,
   "start" | "stop" | "status" | "logs" | "attestedTarget" | "shutdown"
->;
+> & Partial<Pick<LocalAppRuntimeManager, "discardPersistedState">>;
 
 type ConfirmationAction = "create" | "update" | "start";
 
@@ -87,7 +87,29 @@ export class LocalAppsController {
   }
 
   async listDefinitions(): Promise<LocalAppDefinition[]> {
-    return this.registry.listDefinitions();
+    const definitions = await this.registry.listDefinitions();
+    const groups = new Map<string, LocalAppDefinition[]>();
+    for (const definition of definitions) {
+      const group = groups.get(definition.cwd) ?? [];
+      group.push(definition);
+      groups.set(definition.cwd, group);
+    }
+    const visible: LocalAppDefinition[] = [];
+    for (const group of groups.values()) {
+      if (group.length === 1) {
+        visible.push(group[0]!);
+        continue;
+      }
+      const candidates = await Promise.all(group.map(async (definition) => ({
+        definition,
+        status: await this.runtime.status(definition.id).then((view) => view.status).catch(() => null),
+      })));
+      const guarded = candidates.filter(({ status }) => status === null || !["stopped", "failed"].includes(status));
+      const selectable = guarded.length > 0 ? guarded : candidates;
+      selectable.sort((left, right) => right.definition.updatedAt.localeCompare(left.definition.updatedAt));
+      visible.push(selectable[0]!.definition);
+    }
+    return visible;
   }
 
   async pickAndDiscover(): Promise<{ canceled: true } | { canceled: false; draft: PreparedLocalAppDefinition }> {
@@ -171,6 +193,19 @@ export class LocalAppsController {
     return this.withAdmittedOperation(async () => {
       this.ensureFeatureEnabled();
       const prepared = await this.registry.prepareDefinition(rendererDraft(input));
+      const existing = await this.registry.findDefinitionByCwd(prepared.cwd);
+      if (existing) {
+        return this.withBindingOperation(existing.id, async () => {
+          ensureInactive((await this.runtime.status(existing.id)).status, "update");
+          this.ensureAcceptingOperations();
+          this.ensureFeatureEnabled();
+          await this.requireNativeConfirmation(prepared, "create");
+          this.ensureAcceptingOperations();
+          this.ensureFeatureEnabled();
+          const updated = await this.registry.updateDefinition(existing.id, prepared);
+          return this.registry.approveDefinition(updated.id, updated.trustFingerprint);
+        });
+      }
       this.ensureAcceptingOperations();
       this.ensureFeatureEnabled();
       await this.requireNativeConfirmation(prepared, "create");
@@ -212,6 +247,7 @@ export class LocalAppsController {
         ensureInactive((await this.runtime.status(id)).status, "delete");
         this.ensureAcceptingOperations();
         await this.registry.deleteDefinition(id);
+        await this.runtime.discardPersistedState?.(id);
       }));
   }
 

--- a/desktop/src/local-apps-main-runtime.ts
+++ b/desktop/src/local-apps-main-runtime.ts
@@ -39,6 +39,7 @@ export function createDesktopLocalAppsRuntime(options: {
   });
   const runtime = new LocalAppRuntimeManager({
     registry,
+    logDirectory: path.join(options.userDataPath, "local-apps", "logs"),
     nativeRuntimeRoot: path.join(options.userDataPath, "local-apps", "native-runtime"),
     ...(process.platform === "win32" ? { cleanupTimeoutMs: 30_000 } : {}),
   });

--- a/desktop/src/local-apps-registry.test.ts
+++ b/desktop/src/local-apps-registry.test.ts
@@ -138,6 +138,18 @@ describe("Desktop Local App registry", () => {
     await expect(registry.requireApprovedDefinition(created.id)).rejects.toThrow("Review changes");
   });
 
+  it("rejects a second definition for the same canonical project directory", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "rudder-local-app-registry-duplicate-"));
+    const registry = new LocalAppRegistry({ registryPath: path.join(root, "registry.json"), installationId: "install-a" });
+    const prepared = await registry.prepareDefinition(draft(root));
+    await registry.createDefinition(prepared);
+
+    await expect(registry.createDefinition({ ...prepared, title: "Duplicate" }))
+      .rejects.toThrow("already registered");
+    expect(await registry.listDefinitions()).toHaveLength(1);
+    await expect(registry.findDefinitionByCwd(prepared.cwd)).resolves.toMatchObject({ cwd: prepared.cwd });
+  });
+
   it("never exposes inherited environment values in renderer-facing definitions", async () => {
     const root = await mkdtemp(path.join(tmpdir(), "rudder-local-app-env-"));
     process.env.RUDDER_TEST_TOKEN = "do-not-expose";
@@ -279,10 +291,9 @@ describe("Desktop Local App registry", () => {
     const reloaded = new LocalAppRegistry({ registryPath, installationId: "install-a" });
     await expect(reloaded.listDefinitions()).resolves.toHaveLength(1);
     await expect(reloaded.getRuntimeDescriptor(created.id)).resolves.toMatchObject({
-      status: "orphaned_unverified",
-      pid: 77_701,
-      pgid: 77_701,
-      port: 31_701,
+      status: "quarantined",
+      pid: null,
+      pgid: null,
     });
     expect((await readdir(root)).some((name) => name.startsWith("registry.json.corrupt-"))).toBe(true);
 

--- a/desktop/src/local-apps-registry.ts
+++ b/desktop/src/local-apps-registry.ts
@@ -227,22 +227,6 @@ function quarantinedRuntimeDescriptor(value: unknown): LocalAppRuntimeDescriptor
     && !descriptor.generation.includes("\0")
     ? descriptor.generation
     : randomUUID();
-  const pid = descriptor?.pid;
-  const pgid = descriptor?.pgid;
-  const port = descriptor?.port;
-  if (isSafeLocalAppProcessId(pid)
-    && isSafeLocalAppProcessId(pgid)
-    && Number.isInteger(port)
-    && port! > 0
-    && port! <= 65_535) {
-    return {
-      status: "orphaned_unverified",
-      pid,
-      pgid,
-      port,
-      generation,
-    };
-  }
   return { status: "quarantined", pid: null, pgid: null, generation };
 }
 
@@ -451,9 +435,19 @@ export class LocalAppRegistry {
       updatedAt: now,
     };
     return this.mutate((state) => {
+      if (state.definitions.some((entry) => entry.cwd === definition.cwd)) {
+        throw new Error("Local App project is already registered");
+      }
       state.definitions.push(definition);
       return structuredClone(definition);
     });
+  }
+
+  async findDefinitionByCwd(cwd: string): Promise<LocalAppDefinition | null> {
+    const definition = (await this.load()).definitions
+      .filter((entry) => entry.cwd === cwd)
+      .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt))[0];
+    return definition ? structuredClone(definition) : null;
   }
 
   async updateDefinition(id: string, input: LocalAppDefinitionDraft): Promise<LocalAppDefinition> {

--- a/desktop/src/local-apps-runtime.test.ts
+++ b/desktop/src/local-apps-runtime.test.ts
@@ -833,6 +833,59 @@ describe("Desktop Local App runtime", { timeout: localAppRuntimeTestTimeoutMs },
     }
   });
 
+  it("reconciles a persisted orphan only when every ownership signal is provably dead", async () => {
+    const { registry, definition } = await approvedFixture();
+    await registry.recordRuntimeDescriptor(definition.id, {
+      status: "orphaned_unverified", pid: 991_003, pgid: 991_003, generation: "dead-orphan", port: 31_993,
+    });
+    const probePersistedRuntimeLiveness = vi.fn(async () => ({
+      pid: "dead" as const, processGroup: "dead" as const, listener: "dead" as const,
+    }));
+    const manager = new LocalAppRuntimeManager({
+      registry,
+      platform: process.platform,
+      probePersistedRuntimeLiveness,
+    });
+
+    await expect(manager.status(definition.id)).resolves.toMatchObject({ status: "stopped" });
+    await expect(registry.getRuntimeDescriptor(definition.id)).resolves.toBeNull();
+    expect(probePersistedRuntimeLiveness).toHaveBeenCalledWith({
+      pid: 991_003, pgid: 991_003, port: 31_993,
+    });
+  });
+
+  it("restores bounded Local App logs after the Desktop runtime is recreated", async () => {
+    const { root, registry, definition } = await approvedFixture();
+    const logDirectory = path.join(root, "persisted-logs");
+    const manager = new LocalAppRuntimeManager({
+      registry,
+      platform: process.platform,
+      ...(windowsFixtureProcessPlatform ? { processPlatform: windowsFixtureProcessPlatform } : {}),
+      watchdogStartTimeoutMs: localAppWatchdogStartTimeoutMs,
+      ...(windowsFixtureWatchdogSpawner ? { spawnWatchdog: windowsFixtureWatchdogSpawner } : {}),
+      verifyListenerOwnership: fixtureListenerOwnershipOverride,
+      logDirectory,
+      maxLogBytes: 256,
+    });
+    try {
+      await manager.start(definition.id);
+      await vi.waitFor(async () => {
+        expect(await manager.logs(definition.id)).not.toEqual([]);
+      });
+      await manager.stop(definition.id);
+      const expectedLogs = await manager.logs(definition.id);
+      await manager.shutdown();
+
+      const restored = new LocalAppRuntimeManager({ registry, logDirectory, maxLogBytes: 256 });
+      expect(await restored.logs(definition.id)).toEqual(expectedLogs);
+      expect(Buffer.byteLength((await restored.logs(definition.id)).join("\n"))).toBeLessThanOrEqual(256);
+      await restored.shutdown();
+    } finally {
+      await manager.stop(definition.id).catch(() => undefined);
+      await manager.shutdown().catch(() => undefined);
+    }
+  });
+
   it.runIf(process.platform !== "win32").each([
     {
       label: "a live process group",

--- a/desktop/src/local-apps-runtime.ts
+++ b/desktop/src/local-apps-runtime.ts
@@ -20,6 +20,7 @@ import {
   type LocalAppPersistedRuntimeLiveness,
   type LocalAppProcessPlatform,
 } from "./local-app-process-platform.js";
+import { boundedLocalAppLogTail, LocalAppRuntimeLogStore } from "./local-app-runtime-log-store.js";
 import type {
   LocalAppDefinition,
   LocalAppRegistry,
@@ -110,6 +111,7 @@ type RuntimeManagerOptions = {
   hostExecutablePath?: string;
   platform?: NodeJS.Platform;
   maxLogBytes?: number;
+  logDirectory?: string;
   verifyListenerOwnership?: (input: {
     port: number;
     pid: number;
@@ -336,6 +338,7 @@ export class LocalAppRuntimeManager {
   private readonly hostExecutablePath: string;
   private readonly processPlatform: LocalAppProcessPlatform;
   private readonly maxLogBytes: number;
+  private readonly logStore: LocalAppRuntimeLogStore | null;
   private readonly verifyListenerOwnership: (input: {
     port: number;
     pid: number;
@@ -380,6 +383,9 @@ export class LocalAppRuntimeManager {
       probeLoopbackListener: probeLoopbackListenerLiveness,
     });
     this.maxLogBytes = Math.max(256, options.maxLogBytes ?? 64 * 1024);
+    this.logStore = options.logDirectory
+      ? new LocalAppRuntimeLogStore({ directory: options.logDirectory, maxBytes: this.maxLogBytes })
+      : null;
     this.verifyListenerOwnership = options.verifyListenerOwnership
       ?? this.processPlatform.verifyListenerOwnership;
     this.spawnWatchdog = options.spawnWatchdog ?? spawn;
@@ -419,10 +425,8 @@ export class LocalAppRuntimeManager {
 
   private appendLog(record: RuntimeRecord, chunk: Buffer | string): void {
     record.logText += chunk.toString();
-    const bytes = Buffer.byteLength(record.logText);
-    if (bytes <= this.maxLogBytes) return;
-    const buffer = Buffer.from(record.logText);
-    record.logText = buffer.subarray(buffer.length - this.maxLogBytes).toString("utf8");
+    record.logText = boundedLocalAppLogTail(record.logText, this.maxLogBytes);
+    this.logStore?.schedule(record.definition.id, record.logText);
   }
 
   private recordFromPersistedDescriptor(
@@ -454,7 +458,7 @@ export class LocalAppRuntimeManager {
 
   private async persistedStatus(id: string, definition: LocalAppDefinition): Promise<RuntimeRecord> {
     let descriptor = await this.registry.getRuntimeDescriptor(id);
-    if (descriptor && ["starting", "running", "stopping"].includes(descriptor.status)) {
+    if (descriptor && ["starting", "running", "stopping", "orphaned_unverified"].includes(descriptor.status)) {
       const liveness = await this.probePersistedRuntimeLiveness({
         pid: descriptor.pid,
         pgid: descriptor.pgid,
@@ -473,6 +477,9 @@ export class LocalAppRuntimeManager {
       }
     }
     const record = this.recordFromPersistedDescriptor(definition, descriptor);
+    if (this.logStore) {
+      record.logText = await this.logStore.read(id).catch(() => "");
+    }
     this.records.set(id, record);
     return record;
   }
@@ -1188,6 +1195,7 @@ export class LocalAppRuntimeManager {
       verified: false,
       logText: "",
     };
+    await this.logStore?.clear(id).catch(() => undefined);
     this.records.set(id, record);
     let generationClaimed = false;
     try {
@@ -1311,7 +1319,13 @@ export class LocalAppRuntimeManager {
 
   async logs(id: string): Promise<string[]> {
     const record = await this.getRecord(id);
+    await this.logStore?.flush(id).catch(() => undefined);
     return record.logText ? record.logText.split(/\r?\n/).filter(Boolean) : [];
+  }
+
+  async discardPersistedState(id: string): Promise<void> {
+    this.records.delete(id);
+    await this.logStore?.clear(id).catch(() => undefined);
   }
 
   async attestedTarget(id: string): Promise<{ origin: string; openPath: string; partition: string } | null> {
@@ -1400,7 +1414,7 @@ export class LocalAppRuntimeManager {
   shutdown(): Promise<void> {
     if (this.shutdownPromise) return this.shutdownPromise;
     this.acceptingLifecycleOperations = false;
-    this.shutdownPromise = this.shutdownInternal();
+    this.shutdownPromise = this.shutdownInternal().finally(() => this.logStore?.flushAll().catch(() => undefined));
     return this.shutdownPromise;
   }
 }


### PR DESCRIPTION
## Summary

- reconcile provably dead orphaned Local App runtimes during Desktop restoration
- prevent duplicate canonical project registrations while preserving legacy binding identity
- persist bounded, private Local App logs across Desktop restarts and remove them with deleted definitions
- extend unit and Electron smoke coverage for recovery and log persistence

## Verification

- Focused Desktop tests: 93 passed, 5 skipped
- Full Desktop Vitest suite: 963 passed, 17 skipped
- Desktop typecheck passed
- Changed-file lint passed
- Product logic check passed: 96 contracts valid
- Desktop production build passed
- Local Apps Electron smoke passed before final review, including dead-orphan recovery and logs surviving a full Desktop restart

## Residual verification note

A final desktop:verify rerun reached an unrelated App Builder preview hang while the machine was under heavy concurrent build load. A subsequent isolated Local Apps rerun failed before touching Local App startup because its embedded PostgreSQL process exited and API calls returned ECONNREFUSED. The affected focused tests and prior real Electron Local Apps smoke remain green. No release or product-contract edit is included.