### PR TITLE
feat(desktop): add readable Windows glass shell

### DIFF
--- a/design-qa.md
+++ b/design-qa.md
@@ -1,0 +1,25 @@
+# Windows Transparent Desktop Shell Design QA
+
+- Source visual truth: `C:\Users\zeela\AppData\Local\Temp\codex-clipboard-ef6f5502-1407-48b7-b8d0-02296852d55a.png`
+- Implementation screenshot: `C:\Users\zeela\AppData\Local\Temp\rudder-windows-glass-fixed.png`
+- State: Windows Desktop, restored application window, light theme, Dashboard loaded
+- Source pixels: `1197 × 755`
+- Implementation pixels: `1498 × 945` at Windows 125% display scale (`1197 × 755` logical window target)
+
+## Findings
+
+No actionable P0, P1, or P2 visual differences remain for the reported navigation-shell regression.
+
+- Windows now uses the same transparent desktop-shell structure as macOS while retaining native Windows window actions through custom caption controls.
+- The primary rail receives its intended `primary-rail-shell` surface class; without that connection, the CSS glass layer did not affect the rendered component.
+- Windows uses a stronger translucent paper tint than macOS so content in a window behind Rudder cannot remain readable through the navigation and workspace gutters.
+- The layered hierarchy is preserved: navigation remains visibly translucent and work cards remain opaque.
+- Restored windows keep rounded transparent outer corners, while maximized windows remove rounded clipping.
+
+## Verification Evidence
+
+- The reference and implementation captures were compared in the same Dashboard state and logical window target.
+- Focused component and CSS tests cover the rendered rail class, platform styling, caption controls, and Windows light/dark tint values.
+- Desktop smoke covers Windows platform detection, computed glass styles, caption controls, and a transparent rounded corner pixel.
+
+final result: passed

--- a/desktop/scripts/smoke.mjs
+++ b/desktop/scripts/smoke.mjs
@@ -2655,6 +2655,53 @@ function resolveMacPackagedSmokeHomeEnv() {
     : {};
 }
 
+async function assertDesktopGlassShell(electronApp, page, context) {
+  const rendererState = await page.evaluate(() => {
+    const shellProbe = document.createElement("div");
+    const primaryRailProbe = document.createElement("div");
+    shellProbe.className = "app-shell-backdrop";
+    primaryRailProbe.className = "primary-rail-shell";
+    document.body.append(shellProbe, primaryRailProbe);
+    const result = {
+      platform: window.desktopShell?.platform ?? null,
+      glass: document.documentElement.classList.contains("desktop-shell-glass"),
+      macos: document.documentElement.classList.contains("desktop-shell-macos"),
+      windows: document.documentElement.classList.contains("desktop-shell-windows"),
+      captionControls: document.querySelectorAll(".desktop-caption-control").length,
+      shellBackground: getComputedStyle(shellProbe).backgroundImage,
+      primaryRailBackground: getComputedStyle(primaryRailProbe).backgroundImage,
+    };
+    shellProbe.remove();
+    primaryRailProbe.remove();
+    return result;
+  });
+
+  assert.equal(rendererState.glass, true, `${context} should enable the cross-platform glass shell class`);
+  if (process.platform === "win32") {
+    assert.equal(rendererState.platform, "win32", `${context} should expose the Windows desktop platform`);
+    assert.equal(rendererState.windows, true, `${context} should enable Windows shell styling`);
+    assert.equal(rendererState.macos, false, `${context} should not enable macOS-only styling on Windows`);
+    assert.equal(rendererState.captionControls, 3, `${context} should render minimize, maximize, and close controls`);
+    assert.match(
+      rendererState.shellBackground,
+      /rgba\(250,\s*248,\s*245,\s*0\.9\)/,
+      `${context} should tint the Windows shell enough to prevent readable background bleed`,
+    );
+    assert.match(
+      rendererState.primaryRailBackground,
+      /rgba\(244,\s*242,\s*239,\s*0\.74\)/,
+      `${context} should keep the Windows navigation rail translucent but readable`,
+    );
+    const cornerAlpha = await electronApp.evaluate(async ({ BrowserWindow }) => {
+      const window = BrowserWindow.getFocusedWindow() ?? BrowserWindow.getAllWindows()[0];
+      if (!window) return null;
+      const image = await window.capturePage({ x: 0, y: 0, width: 1, height: 1 });
+      return image.toBitmap()[3] ?? null;
+    });
+    assert.equal(cornerAlpha, 0, `${context} should keep the rounded Windows corner fully transparent`);
+  }
+}
+
 async function launchDesktopWindow(userDataDir, mode, ports, extraEnv = {}, executableOverride = null) {
   console.log(`[desktop-smoke] launching ${mode} desktop app`);
   const paths = resolveInstancePaths(userDataDir);
@@ -3773,6 +3820,7 @@ async function launchDesktop(userDataDir, mode, ports, extraEnv = {}, executable
   // hands off to the application window. The shared tolerance stays strict
   // enough to reject the former 1440px default.
   await assertFreshDesktopWindowSize(electronApp, "the ready application window");
+  await assertDesktopGlassShell(electronApp, page, "the ready application window");
   const baseUrl = new URL(page.url()).origin;
   console.log(`[desktop-smoke] board loaded at ${baseUrl}`);
   return { electronApp, page, baseUrl };

--- a/desktop/src/desktop-window-effects.test.ts
+++ b/desktop/src/desktop-window-effects.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import {
+  normalizeDesktopWindowEffectMode,
+  resolveDesktopWindowBackgroundColorForEffect,
+  resolveDesktopWindowChromeOptions,
+  resolveDesktopWindowEffectMode,
+  resolveDesktopWindowEffects,
+  resolveRoundedWindowShapeRects,
+} from "./desktop-window-effects.js";
+import type { DesktopAppearance } from "./theme-preference.js";
+
+const desktopWindowBackground: Record<DesktopAppearance, string> = {
+  light: "#f1f0ef",
+  dark: "#1f1f1d",
+};
+const transparentWindowBackground: Record<DesktopAppearance, string> = {
+  light: "rgba(246, 244, 241, 0.18)",
+  dark: "rgba(18, 20, 24, 0.28)",
+};
+
+describe("desktop window effect mode", () => {
+  it("normalizes supported values and rejects unknown values", () => {
+    expect(normalizeDesktopWindowEffectMode("transparent-vibrant")).toBe("transparent_vibrant");
+    expect(normalizeDesktopWindowEffectMode(" TRANSPARENT ")).toBe("transparent");
+    expect(normalizeDesktopWindowEffectMode("opaque")).toBe("opaque");
+    expect(normalizeDesktopWindowEffectMode("glass")).toBeNull();
+  });
+
+  it("prefers the cross-platform env var while preserving the legacy macOS env fallback", () => {
+    expect(resolveDesktopWindowEffectMode({}, "darwin")).toBe("opaque");
+    expect(resolveDesktopWindowEffectMode({}, "win32")).toBe("transparent_vibrant");
+    expect(resolveDesktopWindowEffectMode({}, "linux")).toBe("opaque");
+    expect(resolveDesktopWindowEffectMode({ RUDDER_DESKTOP_MAC_WINDOW_MODE: "transparent" }, "darwin"))
+      .toBe("transparent");
+    expect(resolveDesktopWindowEffectMode({ RUDDER_DESKTOP_MAC_WINDOW_MODE: "opaque" }, "win32"))
+      .toBe("transparent_vibrant");
+    expect(resolveDesktopWindowEffectMode({
+      RUDDER_DESKTOP_WINDOW_EFFECT_MODE: "transparent",
+      RUDDER_DESKTOP_MAC_WINDOW_MODE: "opaque",
+    }, "win32")).toBe("transparent");
+  });
+});
+
+describe("desktop window effects", () => {
+  it("uses a frameless host window only on Windows", () => {
+    expect(resolveDesktopWindowChromeOptions("win32")).toEqual({ frame: false, roundedCorners: true });
+    expect(resolveDesktopWindowChromeOptions("darwin")).toEqual({});
+    expect(resolveDesktopWindowChromeOptions("linux")).toEqual({});
+  });
+
+  it("builds a rounded restored-window shape for Windows", () => {
+    const rects = resolveRoundedWindowShapeRects(100, 80, 10);
+
+    expect(rects).toHaveLength(13);
+    expect(rects[0]).toEqual({ x: 7, y: 0, width: 86, height: 1 });
+    expect(rects[5]).toEqual({ x: 1, y: 6, width: 98, height: 4 });
+    expect(rects[6]).toEqual({ x: 0, y: 10, width: 100, height: 60 });
+    expect(rects[12]).toEqual({ x: 7, y: 79, width: 86, height: 1 });
+  });
+
+  it("uses native macOS vibrancy while keeping the hidden inset titlebar", () => {
+    expect(resolveDesktopWindowEffects({
+      platform: "darwin",
+      mode: "transparent_vibrant",
+      appearance: "light",
+      desktopWindowBackground,
+      transparentWindowBackground,
+    })).toEqual({
+      titleBarStyle: "hiddenInset",
+      transparent: true,
+      backgroundColor: transparentWindowBackground.light,
+      vibrancy: "under-window",
+      visualEffectState: "active",
+    });
+  });
+
+  it("keeps the Windows host window fully transparent", () => {
+    expect(resolveDesktopWindowEffects({
+      platform: "win32",
+      mode: "transparent_vibrant",
+      appearance: "dark",
+      desktopWindowBackground,
+      transparentWindowBackground,
+    })).toEqual({
+      transparent: true,
+      backgroundColor: "#00000000",
+    });
+  });
+
+  it("keeps the opaque escape hatch free of transparent flags", () => {
+    expect(resolveDesktopWindowEffects({
+      platform: "win32",
+      mode: "opaque",
+      appearance: "dark",
+      desktopWindowBackground,
+      transparentWindowBackground,
+    })).toEqual({ backgroundColor: desktopWindowBackground.dark });
+  });
+
+  it("chooses the matching background color when the theme changes", () => {
+    expect(resolveDesktopWindowBackgroundColorForEffect({
+      mode: "opaque",
+      appearance: "light",
+      desktopWindowBackground,
+      transparentWindowBackground,
+    })).toBe(desktopWindowBackground.light);
+    expect(resolveDesktopWindowBackgroundColorForEffect({
+      mode: "transparent",
+      appearance: "dark",
+      desktopWindowBackground,
+      transparentWindowBackground,
+    })).toBe(transparentWindowBackground.dark);
+  });
+});

--- a/desktop/src/desktop-window-effects.ts
+++ b/desktop/src/desktop-window-effects.ts
@@ -1,0 +1,157 @@
+import type { DesktopAppearance } from "./theme-preference.js";
+
+export type DesktopWindowEffectMode = "opaque" | "transparent" | "transparent_vibrant";
+
+export type DesktopWindowEffectOptions = {
+  backgroundColor: string;
+  titleBarStyle?: "hiddenInset";
+  transparent?: boolean;
+  vibrancy?: "under-window";
+  visualEffectState?: "active";
+};
+
+export type DesktopWindowChromeOptions = {
+  frame?: boolean;
+  roundedCorners?: boolean;
+};
+
+const WINDOWS_TRANSPARENT_WINDOW_BACKGROUND = "#00000000";
+export const WINDOWS_DESKTOP_WINDOW_CORNER_RADIUS = 10;
+
+export type DesktopWindowShapeRect = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
+type DesktopWindowEffectInput = {
+  platform: NodeJS.Platform;
+  mode: DesktopWindowEffectMode;
+  appearance: DesktopAppearance;
+  desktopWindowBackground: Record<DesktopAppearance, string>;
+  transparentWindowBackground: Record<DesktopAppearance, string>;
+};
+
+export function normalizeDesktopWindowEffectMode(value: string | null | undefined): DesktopWindowEffectMode | null {
+  const normalized = value?.trim().toLowerCase();
+  if (normalized === "opaque") return "opaque";
+  if (normalized === "transparent") return "transparent";
+  if (normalized === "transparent_vibrant" || normalized === "transparent-vibrant") return "transparent_vibrant";
+  return null;
+}
+
+export function resolveDesktopWindowEffectMode(
+  env: NodeJS.ProcessEnv,
+  platform: NodeJS.Platform = process.platform,
+): DesktopWindowEffectMode {
+  const value = env.RUDDER_DESKTOP_WINDOW_EFFECT_MODE
+    ?? (platform === "darwin" ? env.RUDDER_DESKTOP_MAC_WINDOW_MODE : undefined);
+  const override = normalizeDesktopWindowEffectMode(value);
+  if (override) return override;
+  return platform === "win32" ? "transparent_vibrant" : "opaque";
+}
+
+export function resolveDesktopWindowChromeOptions(platform: NodeJS.Platform): DesktopWindowChromeOptions {
+  return platform === "win32" ? { frame: false, roundedCorners: true } : {};
+}
+
+export function resolveRoundedWindowShapeRects(
+  width: number,
+  height: number,
+  radius = WINDOWS_DESKTOP_WINDOW_CORNER_RADIUS,
+): DesktopWindowShapeRect[] {
+  const normalizedWidth = Math.max(0, Math.floor(width));
+  const normalizedHeight = Math.max(0, Math.floor(height));
+  const normalizedRadius = Math.max(0, Math.floor(radius));
+  if (normalizedWidth <= 0 || normalizedHeight <= 0) return [];
+  if (normalizedRadius <= 0) {
+    return [{ x: 0, y: 0, width: normalizedWidth, height: normalizedHeight }];
+  }
+
+  const radiusForBounds = Math.min(
+    normalizedRadius,
+    Math.floor(normalizedWidth / 2),
+    Math.floor(normalizedHeight / 2),
+  );
+  const rects: DesktopWindowShapeRect[] = [];
+  let activeRect: DesktopWindowShapeRect | null = null;
+
+  for (let y = 0; y < normalizedHeight; y += 1) {
+    const distanceFromTop = y + 0.5;
+    const distanceFromBottom = normalizedHeight - y - 0.5;
+    const cornerDistanceY = Math.min(distanceFromTop, distanceFromBottom);
+    let inset = 0;
+
+    if (cornerDistanceY < radiusForBounds) {
+      const dy = radiusForBounds - cornerDistanceY;
+      inset = Math.ceil(radiusForBounds - Math.sqrt((radiusForBounds * radiusForBounds) - (dy * dy)));
+    }
+
+    const rowRect = {
+      x: inset,
+      y,
+      width: Math.max(0, normalizedWidth - (inset * 2)),
+      height: 1,
+    };
+    if (rowRect.width <= 0) continue;
+
+    if (activeRect && activeRect.x === rowRect.x && activeRect.width === rowRect.width) {
+      activeRect.height += 1;
+    } else {
+      activeRect = rowRect;
+      rects.push(activeRect);
+    }
+  }
+
+  return rects;
+}
+
+export function resolveDesktopWindowBackgroundColorForEffect({
+  mode,
+  appearance,
+  desktopWindowBackground,
+  transparentWindowBackground,
+}: Pick<DesktopWindowEffectInput, "mode" | "appearance" | "desktopWindowBackground" | "transparentWindowBackground">): string {
+  return mode === "opaque"
+    ? desktopWindowBackground[appearance]
+    : transparentWindowBackground[appearance];
+}
+
+export function resolveDesktopWindowEffects({
+  platform,
+  mode,
+  appearance,
+  desktopWindowBackground,
+  transparentWindowBackground,
+}: DesktopWindowEffectInput): DesktopWindowEffectOptions {
+  const titleBarStyle = platform === "darwin" ? "hiddenInset" : undefined;
+  const transparentBackground = transparentWindowBackground[appearance];
+  if (mode === "transparent") {
+    return {
+      ...(titleBarStyle ? { titleBarStyle } : {}),
+      transparent: true,
+      backgroundColor: platform === "win32" ? WINDOWS_TRANSPARENT_WINDOW_BACKGROUND : transparentBackground,
+    };
+  }
+  if (mode === "transparent_vibrant") {
+    if (platform === "darwin") {
+      return {
+        titleBarStyle: "hiddenInset",
+        transparent: true,
+        backgroundColor: transparentBackground,
+        vibrancy: "under-window",
+        visualEffectState: "active",
+      };
+    }
+    return {
+      transparent: true,
+      backgroundColor: platform === "win32" ? WINDOWS_TRANSPARENT_WINDOW_BACKGROUND : transparentBackground,
+    };
+  }
+  return {
+    ...(titleBarStyle ? { titleBarStyle } : {}),
+    backgroundColor: desktopWindowBackground[appearance],
+    ...(platform === "darwin" ? { vibrancy: "under-window", visualEffectState: "active" } : {}),
+  };
+}

--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -103,7 +103,12 @@ import {
 } from "./desktop-update-helper.js";
 import { createDesktopUpdatePolicyLoader } from "./desktop-update-policy-loader.js";
 import { resolveDesktopUpdateTrustKeys } from "./desktop-update-trust.js";
-import { resolveMacWindowMode as resolveMacWindowModeSetting, type MacWindowMode } from "./desktop-window-mode.js";
+import {
+  resolveDesktopWindowChromeOptions,
+  resolveDesktopWindowEffectMode,
+  resolveDesktopWindowEffects,
+  resolveRoundedWindowShapeRects,
+} from "./desktop-window-effects.js";
 import {
   toWorkspaceLaunchTargetPayload,
   type DesktopWorkspaceLaunchTargetPayload,
@@ -851,45 +856,6 @@ const {
 applyPreparedAutomaticCandidateForQuit = prepareAutomaticCandidateForQuit;
 handoffPreparedAutomaticCandidateForQuit = handoffPreparedAutomaticCandidate;
 
-function resolveDesktopWindowBackgroundColor(appearance: DesktopAppearance = currentAppearance): string {
-  return DESKTOP_WINDOW_BACKGROUND[appearance];
-}
-
-function resolveTransparentWindowBackgroundColor(appearance: DesktopAppearance = currentAppearance): string {
-  return TRANSPARENT_DESKTOP_WINDOW_BACKGROUND[appearance];
-}
-
-function resolveMacWindowMode(): MacWindowMode {
-  return resolveMacWindowModeSetting(process.env.RUDDER_DESKTOP_MAC_WINDOW_MODE);
-}
-
-function resolveMacWindowEffects(): Pick<BrowserWindowConstructorOptions,
-  "backgroundColor" | "titleBarStyle" | "transparent" | "vibrancy" | "visualEffectState"> {
-  const mode = resolveMacWindowMode();
-  if (mode === "transparent") {
-    return {
-      titleBarStyle: "hiddenInset",
-      transparent: true,
-      backgroundColor: resolveTransparentWindowBackgroundColor(currentAppearance),
-    };
-  }
-  if (mode === "transparent_vibrant") {
-    return {
-      titleBarStyle: "hiddenInset",
-      transparent: true,
-      backgroundColor: resolveTransparentWindowBackgroundColor(currentAppearance),
-      vibrancy: "under-window",
-      visualEffectState: "active",
-    };
-  }
-  return {
-    titleBarStyle: "hiddenInset",
-    backgroundColor: resolveDesktopWindowBackgroundColor(),
-    vibrancy: "under-window",
-    visualEffectState: "active",
-  };
-}
-
 function createDesktopWebPreferences(preloadPath: string): Electron.WebPreferences {
   return {
     preload: preloadPath,
@@ -913,9 +879,13 @@ function createBootWebPreferences(preloadPath: string): Electron.WebPreferences 
 function applyDesktopAppearance(appearance: DesktopAppearance): void {
   currentAppearance = appearance;
   if (mainWindow && !mainWindow.isDestroyed()) {
-    const backgroundColor = process.platform === "darwin" && resolveMacWindowMode() !== "opaque"
-      ? resolveTransparentWindowBackgroundColor(appearance)
-      : resolveDesktopWindowBackgroundColor(appearance);
+    const backgroundColor = resolveDesktopWindowEffects({
+      platform: process.platform,
+      mode: resolveDesktopWindowEffectMode(process.env, process.platform),
+      appearance,
+      desktopWindowBackground: DESKTOP_WINDOW_BACKGROUND,
+      transparentWindowBackground: TRANSPARENT_DESKTOP_WINDOW_BACKGROUND,
+    }).backgroundColor;
     mainWindow.setBackgroundColor(backgroundColor);
   }
 }
@@ -1728,13 +1698,39 @@ function installMainWindowSidePanelCloseShortcutHandler(window: BrowserWindow): 
   });
 }
 
+function syncWindowsRoundedWindowShape(window: BrowserWindow): void {
+  if (process.platform !== "win32" || window.isDestroyed()) return;
+  if (window.isMaximized() || window.isFullScreen()) {
+    window.setShape([]);
+    return;
+  }
+
+  const { width, height } = window.getContentBounds();
+  window.setShape(resolveRoundedWindowShapeRects(width, height));
+}
+
+function installWindowsRoundedWindowShape(window: BrowserWindow): void {
+  if (process.platform !== "win32") return;
+
+  const sync = () => syncWindowsRoundedWindowShape(window);
+  window.once("ready-to-show", sync);
+  window.on("resize", sync);
+  window.on("maximize", sync);
+  window.on("unmaximize", sync);
+  window.on("enter-full-screen", sync);
+  window.on("leave-full-screen", sync);
+}
+
 async function createDesktopWindow(initialUrl: string, kind: "app" | "boot"): Promise<BrowserWindow> {
   const preloadPath = path.resolve(MODULE_DIR, kind === "boot" ? "boot-preload.js" : "preload.js");
-  const macWindowEffects = process.platform === "darwin"
-    ? resolveMacWindowEffects()
-    : {
-        backgroundColor: resolveDesktopWindowBackgroundColor(),
-      };
+  const desktopWindowEffects: Pick<BrowserWindowConstructorOptions,
+    "backgroundColor" | "titleBarStyle" | "transparent" | "vibrancy" | "visualEffectState"> = resolveDesktopWindowEffects({
+      platform: process.platform,
+      mode: resolveDesktopWindowEffectMode(process.env, process.platform),
+      appearance: currentAppearance,
+      desktopWindowBackground: DESKTOP_WINDOW_BACKGROUND,
+      transparentWindowBackground: TRANSPARENT_DESKTOP_WINDOW_BACKGROUND,
+    });
   const initialWindowSize = resolveInitialDesktopWindowSize(
     screen.getPrimaryDisplay().workAreaSize,
   );
@@ -1743,7 +1739,8 @@ async function createDesktopWindow(initialUrl: string, kind: "app" | "boot"): Pr
     title: APP_NAME,
     show: false,
     autoHideMenuBar: process.platform !== "darwin",
-    ...macWindowEffects,
+    ...(kind === "app" ? resolveDesktopWindowChromeOptions(process.platform) : {}),
+    ...desktopWindowEffects,
     ...(desktopWindowIcon ? { icon: desktopWindowIcon } : {}),
     webPreferences: kind === "boot"
       ? createBootWebPreferences(preloadPath)
@@ -1752,6 +1749,9 @@ async function createDesktopWindow(initialUrl: string, kind: "app" | "boot"): Pr
 
   if (process.platform !== "darwin") {
     window.setMenuBarVisibility(false);
+  }
+  if (kind === "app") {
+    installWindowsRoundedWindowShape(window);
   }
 
   if (kind === "app") {
@@ -2777,6 +2777,29 @@ function registerIpc(): void {
     assertCurrentMainFrame(event, "Desktop restart");
     await restartFromResidentControls();
   });
+  ipcMain.handle("desktop:minimize-window", async (event) => {
+    assertCurrentMainFrame(event, "Desktop window minimize");
+    BrowserWindow.fromWebContents(event.sender)?.minimize();
+  });
+  ipcMain.handle("desktop:toggle-maximize-window", async (event): Promise<boolean> => {
+    assertCurrentMainFrame(event, "Desktop window maximize");
+    const window = BrowserWindow.fromWebContents(event.sender);
+    if (!window) return false;
+    if (window.isMaximized()) {
+      window.unmaximize();
+    } else {
+      window.maximize();
+    }
+    return window.isMaximized();
+  });
+  ipcMain.handle("desktop:close-window", async (event) => {
+    assertCurrentMainFrame(event, "Desktop window close");
+    BrowserWindow.fromWebContents(event.sender)?.close();
+  });
+  ipcMain.handle("desktop:is-window-maximized", async (event): Promise<boolean> => {
+    assertCurrentMainFrame(event, "Desktop window maximize state");
+    return BrowserWindow.fromWebContents(event.sender)?.isMaximized() ?? false;
+  });
   ipcMain.handle("desktop:check-for-updates", async () => checkForUpdates());
   ipcMain.handle("desktop:install-update", async (_event, version: string) => installUpdate(version));
   ipcMain.handle("desktop:apply-update", async (_event, updateId: string, options?: { force?: boolean }) =>
@@ -2989,7 +3012,7 @@ async function bootstrap(): Promise<void> {
   if (desktopDebugEnabled()) {
     console.info("[rudder-desktop] bootstrap:start", {
       profile: profile.name,
-      macWindowMode: process.platform === "darwin" ? resolveMacWindowMode() : "opaque",
+      windowEffectMode: resolveDesktopWindowEffectMode(process.env, process.platform),
       bootOnly: desktopBootOnlyMode(),
     });
   }

--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -107,7 +107,6 @@ import {
   resolveDesktopWindowChromeOptions,
   resolveDesktopWindowEffectMode,
   resolveDesktopWindowEffects,
-  resolveRoundedWindowShapeRects,
 } from "./desktop-window-effects.js";
 import {
   toWorkspaceLaunchTargetPayload,
@@ -186,6 +185,10 @@ import {
   type DesktopUpdateChannel
 } from "./update-check.js";
 import { resolveInitialDesktopWindowSize } from "./window-size.js";
+import {
+  installWindowsRoundedWindowShape,
+  registerWindowsWindowIpcHandlers,
+} from "./windows-window-shell.js";
 const MODULE_DIR = path.dirname(fileURLToPath(import.meta.url));
 const APP_BUILDER_RUNNER_PATH = path.join(MODULE_DIR, "app-builder-runner.mjs");
 type BootState = {
@@ -1698,29 +1701,6 @@ function installMainWindowSidePanelCloseShortcutHandler(window: BrowserWindow): 
   });
 }
 
-function syncWindowsRoundedWindowShape(window: BrowserWindow): void {
-  if (process.platform !== "win32" || window.isDestroyed()) return;
-  if (window.isMaximized() || window.isFullScreen()) {
-    window.setShape([]);
-    return;
-  }
-
-  const { width, height } = window.getContentBounds();
-  window.setShape(resolveRoundedWindowShapeRects(width, height));
-}
-
-function installWindowsRoundedWindowShape(window: BrowserWindow): void {
-  if (process.platform !== "win32") return;
-
-  const sync = () => syncWindowsRoundedWindowShape(window);
-  window.once("ready-to-show", sync);
-  window.on("resize", sync);
-  window.on("maximize", sync);
-  window.on("unmaximize", sync);
-  window.on("enter-full-screen", sync);
-  window.on("leave-full-screen", sync);
-}
-
 async function createDesktopWindow(initialUrl: string, kind: "app" | "boot"): Promise<BrowserWindow> {
   const preloadPath = path.resolve(MODULE_DIR, kind === "boot" ? "boot-preload.js" : "preload.js");
   const desktopWindowEffects: Pick<BrowserWindowConstructorOptions,
@@ -2777,29 +2757,7 @@ function registerIpc(): void {
     assertCurrentMainFrame(event, "Desktop restart");
     await restartFromResidentControls();
   });
-  ipcMain.handle("desktop:minimize-window", async (event) => {
-    assertCurrentMainFrame(event, "Desktop window minimize");
-    BrowserWindow.fromWebContents(event.sender)?.minimize();
-  });
-  ipcMain.handle("desktop:toggle-maximize-window", async (event): Promise<boolean> => {
-    assertCurrentMainFrame(event, "Desktop window maximize");
-    const window = BrowserWindow.fromWebContents(event.sender);
-    if (!window) return false;
-    if (window.isMaximized()) {
-      window.unmaximize();
-    } else {
-      window.maximize();
-    }
-    return window.isMaximized();
-  });
-  ipcMain.handle("desktop:close-window", async (event) => {
-    assertCurrentMainFrame(event, "Desktop window close");
-    BrowserWindow.fromWebContents(event.sender)?.close();
-  });
-  ipcMain.handle("desktop:is-window-maximized", async (event): Promise<boolean> => {
-    assertCurrentMainFrame(event, "Desktop window maximize state");
-    return BrowserWindow.fromWebContents(event.sender)?.isMaximized() ?? false;
-  });
+  registerWindowsWindowIpcHandlers(assertCurrentMainFrame);
   ipcMain.handle("desktop:check-for-updates", async () => checkForUpdates());
   ipcMain.handle("desktop:install-update", async (_event, version: string) => installUpdate(version));
   ipcMain.handle("desktop:apply-update", async (_event, updateId: string, options?: { force?: boolean }) =>

--- a/desktop/src/preload.ts
+++ b/desktop/src/preload.ts
@@ -294,6 +294,7 @@ contextBridge.exposeInMainWorld("desktopIdentity", {
 });
 
 contextBridge.exposeInMainWorld("desktopShell", {
+  platform: process.platform,
   getBootState: () => ipcRenderer.invoke("desktop:get-boot-state") as Promise<BootState>,
   onBootState: (listener: (state: BootState) => void) => {
     const wrapped = (_event: IpcRendererEvent, payload: BootState) => {
@@ -325,6 +326,10 @@ contextBridge.exposeInMainWorld("desktopShell", {
   copyImage: (payload: DesktopImageDataPayload) => ipcRenderer.invoke("desktop:copy-image", payload),
   showImageInFolder: (payload: DesktopImageDataPayload) => ipcRenderer.invoke("desktop:show-image-in-folder", payload),
   setAppearance: (theme: "light" | "dark" | "system") => ipcRenderer.invoke("desktop:set-appearance", theme),
+  minimizeWindow: () => ipcRenderer.invoke("desktop:minimize-window") as Promise<void>,
+  toggleMaximizeWindow: () => ipcRenderer.invoke("desktop:toggle-maximize-window") as Promise<boolean>,
+  closeWindow: () => ipcRenderer.invoke("desktop:close-window") as Promise<void>,
+  isWindowMaximized: () => ipcRenderer.invoke("desktop:is-window-maximized") as Promise<boolean>,
   getUpdateChannel: () => ipcRenderer.invoke("desktop:get-update-channel") as Promise<DesktopUpdateChannel>,
   setUpdateChannel: (channel: DesktopUpdateChannel) =>
     ipcRenderer.invoke("desktop:set-update-channel", channel) as Promise<DesktopUpdateChannel>,
@@ -617,6 +622,7 @@ declare global {
       onStateChanged(listener: (state: DesktopIdentityState) => void): () => void;
     };
     desktopShell: {
+      platform: NodeJS.Platform;
       getBootState(): Promise<BootState>;
       onBootState(listener: (state: BootState) => void): () => void;
       openPath(targetPath: string): Promise<void>;
@@ -634,6 +640,10 @@ declare global {
       copyImage(payload: DesktopImageDataPayload): Promise<void>;
       showImageInFolder(payload: DesktopImageDataPayload): Promise<void>;
       setAppearance(theme: "light" | "dark" | "system"): Promise<void>;
+      minimizeWindow(): Promise<void>;
+      toggleMaximizeWindow(): Promise<boolean>;
+      closeWindow(): Promise<void>;
+      isWindowMaximized(): Promise<boolean>;
       getUpdateChannel(): Promise<DesktopUpdateChannel>;
       setUpdateChannel(channel: DesktopUpdateChannel): Promise<DesktopUpdateChannel>;
       reloadApp(): Promise<void>;

--- a/desktop/src/windows-window-shell.ts
+++ b/desktop/src/windows-window-shell.ts
@@ -1,0 +1,49 @@
+import { BrowserWindow, ipcMain, type IpcMainInvokeEvent } from "electron";
+import { resolveRoundedWindowShapeRects } from "./desktop-window-effects.js";
+
+type MainFrameAssertion = (event: IpcMainInvokeEvent, action: string) => void;
+
+function syncWindowsRoundedWindowShape(window: BrowserWindow): void {
+  if (process.platform !== "win32" || window.isDestroyed()) return;
+  if (window.isMaximized() || window.isFullScreen()) {
+    window.setShape([]);
+    return;
+  }
+
+  const { width, height } = window.getContentBounds();
+  window.setShape(resolveRoundedWindowShapeRects(width, height));
+}
+
+export function installWindowsRoundedWindowShape(window: BrowserWindow): void {
+  if (process.platform !== "win32") return;
+
+  const sync = () => syncWindowsRoundedWindowShape(window);
+  window.once("ready-to-show", sync);
+  window.on("resize", sync);
+  window.on("maximize", sync);
+  window.on("unmaximize", sync);
+  window.on("enter-full-screen", sync);
+  window.on("leave-full-screen", sync);
+}
+
+export function registerWindowsWindowIpcHandlers(assertCurrentMainFrame: MainFrameAssertion): void {
+  ipcMain.handle("desktop:minimize-window", async (event) => {
+    assertCurrentMainFrame(event, "Desktop window minimize");
+    BrowserWindow.fromWebContents(event.sender)?.minimize();
+  });
+  ipcMain.handle("desktop:toggle-maximize-window", async (event): Promise<boolean> => {
+    assertCurrentMainFrame(event, "Desktop window maximize");
+    const window = BrowserWindow.fromWebContents(event.sender);
+    if (!window) return false;
+    window.isMaximized() ? window.unmaximize() : window.maximize();
+    return window.isMaximized();
+  });
+  ipcMain.handle("desktop:close-window", async (event) => {
+    assertCurrentMainFrame(event, "Desktop window close");
+    BrowserWindow.fromWebContents(event.sender)?.close();
+  });
+  ipcMain.handle("desktop:is-window-maximized", async (event): Promise<boolean> => {
+    assertCurrentMainFrame(event, "Desktop window maximize state");
+    return BrowserWindow.fromWebContents(event.sender)?.isMaximized() ?? false;
+  });
+}

--- a/doc/engineering/DESKTOP.md
+++ b/doc/engineering/DESKTOP.md
@@ -172,10 +172,26 @@ Platform behavior:
 - Windows: resident control lives in the notification area
 - Linux: resident control uses tray/AppIndicator support when the current desktop environment is likely to support it; otherwise Desktop safely falls back to windowed quit-on-close behavior
 
+## Desktop glass
+
+Rudder Desktop uses a transparent, tinted shell by default on Windows to keep
+the same paper-glass workspace character without relying on platform vibrancy.
+Windows uses a transparent frameless application window with Rudder-owned
+caption controls and rounded restored-window clipping. macOS and Linux keep the
+opaque default for compositor stability, but can opt into a transparent mode;
+macOS transparent-vibrant mode additionally uses native vibrancy.
+
+Use `RUDDER_DESKTOP_WINDOW_EFFECT_MODE=opaque` as the escape hatch when a
+platform, GPU driver, virtual machine, remote-desktop session, or compositor
+renders transparent windows poorly. Supported values are `opaque`,
+`transparent`, and `transparent_vibrant`. The legacy
+`RUDDER_DESKTOP_MAC_WINDOW_MODE` variable remains accepted for compatibility.
+
 ## Window chrome contract
 
 On macOS, Rudder Desktop keeps the native traffic-light window controls while hiding the default window title text.
 The app uses Electron's `titleBarStyle: "hiddenInset"` so the top chrome remains a real macOS window region instead of a fake in-app replacement.
+The ready application window is frameless on Windows so the transparent shell reaches the outer edge; Rudder renders accessible minimize, maximize/restore, and close controls at the top-right while retaining a framed startup/recovery window for safe fallback handling.
 
 This means the top row of the app is treated as shared chrome:
 

--- a/ui/index.html
+++ b/ui/index.html
@@ -78,15 +78,19 @@
           document.documentElement.style.colorScheme = "dark";
         }
 
-        const isMacDesktopShell =
+        const isDesktopShell =
           typeof window !== "undefined"
-          && Boolean(window.desktopShell)
-          && /Mac/i.test(window.navigator.userAgent);
+          && Boolean(window.desktopShell);
+        const desktopPlatform = window.desktopShell?.platform;
+        const isMacDesktopShell = isDesktopShell && desktopPlatform === "darwin";
+        const isWindowsDesktopShell = isDesktopShell && desktopPlatform === "win32";
+        document.documentElement.classList.toggle("desktop-shell-glass", isDesktopShell);
         document.documentElement.classList.toggle("desktop-shell-macos", isMacDesktopShell);
-        document.documentElement.style.backgroundColor = isMacDesktopShell
+        document.documentElement.classList.toggle("desktop-shell-windows", isWindowsDesktopShell);
+        document.documentElement.style.backgroundColor = isDesktopShell
           ? "transparent"
           : (isDark ? darkBaseThemeColors[baseColor] : lightBaseThemeColors[baseColor]);
-        if (isMacDesktopShell && typeof window.desktopShell?.setAppearance === "function") {
+        if (isDesktopShell && typeof window.desktopShell?.setAppearance === "function") {
           void window.desktopShell.setAppearance(theme);
         }
       })();

--- a/ui/src/components/DesktopWindowControls.test.tsx
+++ b/ui/src/components/DesktopWindowControls.test.tsx
@@ -1,0 +1,85 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DesktopWindowControls } from "./DesktopWindowControls";
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const mockState = vi.hoisted(() => ({
+  desktopShell: {
+    platform: "win32" as NodeJS.Platform,
+    minimizeWindow: vi.fn(),
+    toggleMaximizeWindow: vi.fn(),
+    closeWindow: vi.fn(),
+    isWindowMaximized: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/desktop-shell", () => ({
+  readDesktopShell: () => mockState.desktopShell,
+}));
+
+describe("DesktopWindowControls", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    mockState.desktopShell.platform = "win32";
+    mockState.desktopShell.minimizeWindow.mockResolvedValue(undefined);
+    mockState.desktopShell.toggleMaximizeWindow.mockResolvedValue(true);
+    mockState.desktopShell.closeWindow.mockResolvedValue(undefined);
+    mockState.desktopShell.isWindowMaximized.mockResolvedValue(false);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    document.documentElement.classList.remove("desktop-shell-window-maximized");
+    document.body.classList.remove("desktop-shell-window-maximized");
+    vi.restoreAllMocks();
+  });
+
+  it("renders Windows controls and invokes window actions", async () => {
+    await act(async () => root.render(<DesktopWindowControls />));
+
+    const minimize = document.body.querySelector<HTMLButtonElement>('button[aria-label="Minimize"]');
+    const maximize = document.body.querySelector<HTMLButtonElement>('button[aria-label="Maximize"]');
+    const close = document.body.querySelector<HTMLButtonElement>('button[aria-label="Close"]');
+
+    expect(minimize).not.toBeNull();
+    expect(maximize).not.toBeNull();
+    expect(close).not.toBeNull();
+
+    await act(async () => {
+      minimize?.click();
+      maximize?.click();
+      close?.click();
+    });
+
+    expect(mockState.desktopShell.minimizeWindow).toHaveBeenCalledTimes(1);
+    expect(mockState.desktopShell.toggleMaximizeWindow).toHaveBeenCalledTimes(1);
+    expect(mockState.desktopShell.closeWindow).toHaveBeenCalledTimes(1);
+    expect(document.documentElement.classList.contains("desktop-shell-window-maximized")).toBe(true);
+  });
+
+  it.each(["darwin", "linux"] as const)("does not render custom controls on %s", async (platform) => {
+    mockState.desktopShell.platform = platform;
+
+    await act(async () => root.render(<DesktopWindowControls />));
+
+    expect(document.body.querySelector(".desktop-caption-controls")).toBeNull();
+  });
+
+  it("portals the controls outside the clipped React root", async () => {
+    await act(async () => root.render(<DesktopWindowControls />));
+
+    const controls = document.body.querySelector(".desktop-caption-controls");
+    expect(controls).not.toBeNull();
+    expect(container.contains(controls)).toBe(false);
+  });
+});

--- a/ui/src/components/DesktopWindowControls.tsx
+++ b/ui/src/components/DesktopWindowControls.tsx
@@ -1,0 +1,102 @@
+import { readDesktopShell } from "@/lib/desktop-shell";
+import { Minus, Square, X } from "lucide-react";
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+
+function syncMaximizedClass(maximized: boolean) {
+  document.documentElement.classList.toggle("desktop-shell-window-maximized", maximized);
+  document.body?.classList.toggle("desktop-shell-window-maximized", maximized);
+}
+
+export function DesktopWindowControls() {
+  const [visible, setVisible] = useState(false);
+  const [maximized, setMaximized] = useState(false);
+
+  useEffect(() => {
+    const desktopShell = readDesktopShell();
+    const shouldShow = desktopShell?.platform === "win32"
+      && typeof desktopShell.minimizeWindow === "function"
+      && typeof desktopShell.toggleMaximizeWindow === "function"
+      && typeof desktopShell.closeWindow === "function";
+
+    setVisible(shouldShow);
+    if (!shouldShow || typeof desktopShell?.isWindowMaximized !== "function") {
+      syncMaximizedClass(false);
+      return;
+    }
+
+    let canceled = false;
+    const updateMaximized = (value: boolean) => {
+      if (canceled) return;
+      setMaximized(value);
+      syncMaximizedClass(value);
+    };
+
+    void desktopShell.isWindowMaximized()
+      .then(updateMaximized)
+      .catch(() => updateMaximized(false));
+
+    const syncOnResize = () => {
+      void desktopShell.isWindowMaximized?.()
+        .then(updateMaximized)
+        .catch(() => updateMaximized(false));
+    };
+    window.addEventListener("resize", syncOnResize);
+    return () => {
+      canceled = true;
+      window.removeEventListener("resize", syncOnResize);
+      syncMaximizedClass(false);
+    };
+  }, []);
+
+  if (!visible) return null;
+
+  const desktopShell = readDesktopShell();
+
+  return createPortal(
+    <div className="desktop-caption-controls desktop-window-no-drag" aria-label="Window controls">
+      <button
+        type="button"
+        className="desktop-caption-control"
+        aria-label="Minimize"
+        title="Minimize"
+        onClick={() => {
+          void desktopShell?.minimizeWindow?.();
+        }}
+      >
+        <Minus aria-hidden="true" size={14} strokeWidth={1.8} />
+      </button>
+      <button
+        type="button"
+        className="desktop-caption-control"
+        aria-label={maximized ? "Restore" : "Maximize"}
+        title={maximized ? "Restore" : "Maximize"}
+        onClick={() => {
+          void desktopShell?.toggleMaximizeWindow?.()
+            .then((value) => {
+              setMaximized(value);
+              syncMaximizedClass(value);
+            })
+            .catch(() => {
+              setMaximized(false);
+              syncMaximizedClass(false);
+            });
+        }}
+      >
+        <Square aria-hidden="true" size={12} strokeWidth={1.8} />
+      </button>
+      <button
+        type="button"
+        className="desktop-caption-control desktop-caption-control--close"
+        aria-label="Close"
+        title="Close"
+        onClick={() => {
+          void desktopShell?.closeWindow?.();
+        }}
+      >
+        <X aria-hidden="true" size={14} strokeWidth={1.8} />
+      </button>
+    </div>,
+    document.body,
+  );
+}

--- a/ui/src/components/Layout.tsx
+++ b/ui/src/components/Layout.tsx
@@ -368,11 +368,6 @@ function isMacDesktopShell(): boolean {
   return readDesktopShell()?.platform === "darwin";
 }
 
-function isDesktopChromeShell(): boolean {
-  const platform = readDesktopShell()?.platform;
-  return platform === "darwin" || platform === "win32";
-}
-
 function getWorkspaceColumnFamily(relativePath: string): WorkspaceColumnFamily | null {
   if (/^\/apps(?:\/|$)/.test(relativePath)) return "apps";
   if (/^\/workspaces\/backups(?:\/|$)/.test(relativePath)) return "backups";
@@ -977,7 +972,6 @@ export function Layout() {
   const navigationType = useNavigationType();
   const inAppBackStackRef = useRef<string[]>([]);
   const macDesktopShell = useMemo(() => isMacDesktopShell(), []);
-  const desktopChromeShell = useMemo(() => isDesktopChromeShell(), []);
   const isInstanceSettingsRoute = location.pathname.startsWith("/instance/");
   const relativeBoardPath = useMemo(
     () => toOrganizationRelativePath(location.pathname),
@@ -1644,7 +1638,7 @@ export function Layout() {
             isMobile ? "w-full" : desktopContentShellInsetClass,
           )}
         >
-          {!isMobile && desktopChromeShell ? <div className="desktop-window-drag h-[var(--desktop-content-top-gap)] shrink-0" /> : null}
+          {!isMobile && (macDesktopShell || readDesktopShell()?.platform === "win32") ? <div className="desktop-window-drag h-[var(--desktop-content-top-gap)] shrink-0" /> : null}
           {showDesktopSettingsModal ? (
             <DesktopSettingsModalFrame onClose={closeSettingsModal}>
               {hasUnknownOrganizationPrefix ? (
@@ -1671,7 +1665,7 @@ export function Layout() {
                     isMobile && "sticky top-0 z-20 bg-background/80 backdrop-blur-xl supports-[backdrop-filter]:bg-background/65",
                   )}
                 >
-                  <BreadcrumbBar desktopChrome={desktopChromeShell} />
+                  <BreadcrumbBar desktopChrome={macDesktopShell || readDesktopShell()?.platform === "win32"} />
                 </div>
               ) : null}
               <div className={cn(isMobile ? "block" : "flex min-h-0 min-w-0 flex-1")}>
@@ -1750,7 +1744,7 @@ export function Layout() {
                       >
                         {!useFramelessWorkspaceMain ? (
                           <div data-testid="workspace-main-header" className="shrink-0">
-                            <BreadcrumbBar desktopChrome={desktopChromeShell} variant="card" />
+                            <BreadcrumbBar desktopChrome={macDesktopShell || readDesktopShell()?.platform === "win32"} variant="card" />
                           </div>
                         ) : null}
                         <main

--- a/ui/src/components/Layout.tsx
+++ b/ui/src/components/Layout.tsx
@@ -28,6 +28,7 @@ import { useToast } from "../context/ToastContext";
 import { useKeyboardShortcuts } from "../hooks/useKeyboardShortcuts";
 import { useOrganizationPageMemory } from "../hooks/useOrganizationPageMemory";
 import { useScrollbarActivityRef } from "../hooks/useScrollbarActivityRef";
+import { readDesktopShell } from "../lib/desktop-shell";
 import {
   normalizeRememberedSettingsPath,
   resolveDefaultSettingsPath,
@@ -364,9 +365,12 @@ export function DesktopSettingsModalFrame({
 }
 
 function isMacDesktopShell(): boolean {
-  if (typeof window === "undefined") return false;
-  if (!("desktopShell" in window) || !window.desktopShell) return false;
-  return /Mac/i.test(window.navigator.userAgent);
+  return readDesktopShell()?.platform === "darwin";
+}
+
+function isDesktopChromeShell(): boolean {
+  const platform = readDesktopShell()?.platform;
+  return platform === "darwin" || platform === "win32";
 }
 
 function getWorkspaceColumnFamily(relativePath: string): WorkspaceColumnFamily | null {
@@ -973,6 +977,7 @@ export function Layout() {
   const navigationType = useNavigationType();
   const inAppBackStackRef = useRef<string[]>([]);
   const macDesktopShell = useMemo(() => isMacDesktopShell(), []);
+  const desktopChromeShell = useMemo(() => isDesktopChromeShell(), []);
   const isInstanceSettingsRoute = location.pathname.startsWith("/instance/");
   const relativeBoardPath = useMemo(
     () => toOrganizationRelativePath(location.pathname),
@@ -1639,7 +1644,7 @@ export function Layout() {
             isMobile ? "w-full" : desktopContentShellInsetClass,
           )}
         >
-          {!isMobile && macDesktopShell ? <div className="desktop-window-drag h-[var(--desktop-content-top-gap)] shrink-0" /> : null}
+          {!isMobile && desktopChromeShell ? <div className="desktop-window-drag h-[var(--desktop-content-top-gap)] shrink-0" /> : null}
           {showDesktopSettingsModal ? (
             <DesktopSettingsModalFrame onClose={closeSettingsModal}>
               {hasUnknownOrganizationPrefix ? (
@@ -1666,7 +1671,7 @@ export function Layout() {
                     isMobile && "sticky top-0 z-20 bg-background/80 backdrop-blur-xl supports-[backdrop-filter]:bg-background/65",
                   )}
                 >
-                  <BreadcrumbBar desktopChrome={macDesktopShell} />
+                  <BreadcrumbBar desktopChrome={desktopChromeShell} />
                 </div>
               ) : null}
               <div className={cn(isMobile ? "block" : "flex min-h-0 min-w-0 flex-1")}>
@@ -1745,7 +1750,7 @@ export function Layout() {
                       >
                         {!useFramelessWorkspaceMain ? (
                           <div data-testid="workspace-main-header" className="shrink-0">
-                            <BreadcrumbBar desktopChrome={macDesktopShell} variant="card" />
+                            <BreadcrumbBar desktopChrome={desktopChromeShell} variant="card" />
                           </div>
                         ) : null}
                         <main

--- a/ui/src/components/PrimaryRail.test.tsx
+++ b/ui/src/components/PrimaryRail.test.tsx
@@ -397,6 +397,7 @@ describe("PrimaryRail active motion indicator", () => {
 
     expect(rail?.getAttribute("data-desktop-shell")).toBe("true");
     expect(rail?.getAttribute("data-desktop-platform")).toBe("windows");
+    expect(rail?.className).toContain("primary-rail-shell");
     expect(rail?.className).toContain("w-[52px]");
     expect(rail?.className).toContain("[--primary-rail-item-width:52px]");
     expect(rail?.className).toContain("[--primary-rail-item-shift:0px]");

--- a/ui/src/components/PrimaryRail.tsx
+++ b/ui/src/components/PrimaryRail.tsx
@@ -458,7 +458,7 @@ export function PrimaryRail({
       data-desktop-shell={isDesktopShell ? "true" : undefined}
       data-desktop-platform={desktopRailPlatform ?? undefined}
       className={cn(
-        "my-2 flex h-[calc(100%-1rem)] shrink-0 flex-col items-center py-1.5 text-[color:color-mix(in_oklab,var(--foreground)_78%,white)]",
+        "primary-rail-shell my-2 flex h-[calc(100%-1rem)] shrink-0 flex-col items-center py-1.5 text-[color:color-mix(in_oklab,var(--foreground)_78%,white)]",
         desktopRailPlatform === "windows"
           ? "ml-1 mr-1 w-[52px] [--primary-rail-item-shift:0px] [--primary-rail-item-width:52px]"
           : isDesktopShell

--- a/ui/src/context/ThemeContext.tsx
+++ b/ui/src/context/ThemeContext.tsx
@@ -176,7 +176,7 @@ function applyTheme(theme: Theme, designStyle: DesignStyle, baseColor: BaseColor
   root.dataset.baseColor = baseColor;
   root.dataset.themeColor = accentTheme;
   root.style.colorScheme = isDark ? "dark" : "light";
-  root.style.backgroundColor = root.classList.contains("desktop-shell-macos")
+  root.style.backgroundColor = root.classList.contains("desktop-shell-glass")
     ? "transparent"
     : themeColor;
   const themeColorMeta = document.querySelector('meta[name="theme-color"]');

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -69,6 +69,7 @@
   --desktop-content-surface-light-alt: #f8f4ee;
   --desktop-content-border-light: rgb(214 209 202 / 0.82);
   --desktop-workspace-radius: calc(var(--radius-sm) - 1px);
+  --desktop-window-radius: 0.625rem;
   --desktop-titlebar-top-gap: 0.625rem;
   --desktop-sidebar-top-clearance: 2.125rem;
   --desktop-content-top-gap: 0.375rem;
@@ -1055,14 +1056,40 @@
     height: 100%;
     overflow: hidden;
   }
-  body.desktop-shell-macos {
+  body.desktop-shell-glass {
     background-color: transparent;
     background-image: none;
   }
-  html.desktop-shell-macos,
-  html.desktop-shell-macos body,
-  html.desktop-shell-macos #root {
+  html.desktop-shell-glass,
+  html.desktop-shell-glass body,
+  html.desktop-shell-glass #root {
     background: transparent;
+  }
+  html.desktop-shell-windows,
+  html.desktop-shell-windows body,
+  html.desktop-shell-windows #root {
+    border-radius: var(--desktop-window-radius);
+    overflow: hidden;
+  }
+  html.desktop-shell-windows body {
+    clip-path: inset(0 round var(--desktop-window-radius));
+  }
+  html.desktop-shell-windows #root {
+    position: fixed;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    contain: paint;
+    clip-path: inset(0 round var(--desktop-window-radius));
+  }
+  html.desktop-shell-windows.desktop-shell-window-maximized,
+  html.desktop-shell-windows.desktop-shell-window-maximized body,
+  html.desktop-shell-windows.desktop-shell-window-maximized #root {
+    border-radius: 0;
+  }
+  html.desktop-shell-windows.desktop-shell-window-maximized body,
+  html.desktop-shell-windows.desktop-shell-window-maximized #root {
+    clip-path: none;
   }
   h1,
   h2,
@@ -1124,6 +1151,65 @@
 
   .desktop-chrome :is(a, button, input, select, textarea, [role="button"], [data-slot="input"], [data-slot="button"], [data-slot="select-trigger"]) {
     -webkit-app-region: no-drag;
+  }
+
+  .desktop-caption-controls {
+    position: fixed;
+    top: 0;
+    right: 0;
+    z-index: 2147483647;
+    display: flex;
+    height: 2.375rem;
+    overflow: hidden;
+    border-top-right-radius: var(--desktop-window-radius);
+    border-bottom-left-radius: 0.5rem;
+    background: color-mix(in oklab, var(--surface-shell) 56%, transparent);
+    color: color-mix(in oklab, var(--foreground) 76%, transparent);
+    pointer-events: auto;
+    -webkit-backdrop-filter: blur(18px) saturate(120%);
+    backdrop-filter: blur(18px) saturate(120%);
+  }
+
+  .desktop-caption-control {
+    display: inline-flex;
+    width: 2.875rem;
+    height: 2.375rem;
+    align-items: center;
+    justify-content: center;
+    border: 0;
+    border-radius: 0;
+    background: transparent;
+    color: inherit;
+    transition: background-color 120ms ease, color 120ms ease;
+  }
+
+  .desktop-caption-control:hover {
+    background: color-mix(in oklab, var(--surface-elevated) 82%, transparent);
+    color: var(--foreground);
+  }
+
+  .desktop-caption-control:focus-visible {
+    outline: 2px solid color-mix(in oklab, var(--ring) 72%, transparent);
+    outline-offset: -2px;
+  }
+
+  .desktop-caption-control--close:hover {
+    background: #c42b1c;
+    color: #fff;
+  }
+
+  .dark .desktop-caption-controls {
+    background: rgb(24 24 23 / 0.72);
+    color: rgb(232 229 222 / 0.72);
+  }
+
+  .dark .desktop-caption-control:hover {
+    background: rgb(255 255 255 / 0.1);
+    color: #fff;
+  }
+
+  .dark .desktop-caption-control--close:hover {
+    background: #c42b1c;
   }
 
   html.desktop-shell-macos .rudder-doc-editor-tab-drag-spacer {
@@ -1207,7 +1293,7 @@
     background: var(--background);
   }
 
-  html.desktop-shell-macos .app-shell-backdrop {
+  html.desktop-shell-glass .app-shell-backdrop {
     background:
       linear-gradient(
         180deg,
@@ -1218,7 +1304,16 @@
     backdrop-filter: blur(38px) saturate(122%);
   }
 
-  html.dark.desktop-shell-macos .app-shell-backdrop {
+  html.desktop-shell-windows .app-shell-backdrop {
+    border-radius: var(--desktop-window-radius);
+    overflow: hidden;
+  }
+
+  html.desktop-shell-windows.desktop-shell-window-maximized .app-shell-backdrop {
+    border-radius: 0;
+  }
+
+  html.dark.desktop-shell-glass .app-shell-backdrop {
     background:
       linear-gradient(
         180deg,
@@ -1227,6 +1322,27 @@
       );
     -webkit-backdrop-filter: blur(38px) saturate(138%);
     backdrop-filter: blur(38px) saturate(138%);
+  }
+
+  /* Windows transparent BrowserWindows do not provide macOS-style vibrancy.
+     Keep the shell translucent, but prevent readable windows behind Rudder
+     from bleeding through the navigation and workspace gutters. */
+  html.desktop-shell-windows.desktop-shell-glass .app-shell-backdrop {
+    background:
+      linear-gradient(
+        180deg,
+        rgb(250 248 245 / 0.9) 0%,
+        rgb(244 240 234 / 0.84) 100%
+      );
+  }
+
+  html.dark.desktop-shell-windows.desktop-shell-glass .app-shell-backdrop {
+    background:
+      linear-gradient(
+        180deg,
+        rgb(17 18 21 / 0.9) 0%,
+        rgb(12 14 17 / 0.86) 100%
+      );
   }
 
   .workspace-shell {
@@ -1249,7 +1365,7 @@
     backdrop-filter: blur(18px) saturate(116%);
   }
 
-  html.dark.desktop-shell-macos .messenger-main-workbench-surface {
+  html.dark.desktop-shell-glass .messenger-main-workbench-surface {
     background:
       linear-gradient(
         180deg,
@@ -1259,29 +1375,29 @@
     -webkit-backdrop-filter: blur(20px) saturate(124%);
     backdrop-filter: blur(20px) saturate(124%);
   }
-  html.desktop-shell-macos .workspace-shell {
+  html.desktop-shell-glass .workspace-shell {
     background: transparent;
     border: 0;
     box-shadow: none;
     -webkit-backdrop-filter: none;
     backdrop-filter: none;
   }
-  html.dark.desktop-shell-macos .workspace-shell {
+  html.dark.desktop-shell-glass .workspace-shell {
     background: transparent;
     border: 0;
     box-shadow: none;
     -webkit-backdrop-filter: none;
     backdrop-filter: none;
   }
-  html.desktop-shell-macos .workspace-shell--library-transparent,
-  html.dark.desktop-shell-macos .workspace-shell--library-transparent {
+  html.desktop-shell-glass .workspace-shell--library-transparent,
+  html.dark.desktop-shell-glass .workspace-shell--library-transparent {
     background: transparent;
   }
 
   .primary-rail-shell {
     background: transparent;
   }
-  html.desktop-shell-macos .primary-rail-shell {
+  html.desktop-shell-glass .primary-rail-shell {
     background:
       linear-gradient(
         180deg,
@@ -1292,7 +1408,7 @@
     -webkit-backdrop-filter: blur(22px) saturate(112%);
     backdrop-filter: blur(22px) saturate(112%);
   }
-  html.dark.desktop-shell-macos .primary-rail-shell {
+  html.dark.desktop-shell-glass .primary-rail-shell {
     background:
       linear-gradient(
         180deg,
@@ -1304,7 +1420,25 @@
     backdrop-filter: blur(20px) saturate(118%);
   }
 
-  html.desktop-shell-macos .workspace-shell .surface-shell {
+  html.desktop-shell-windows.desktop-shell-glass .primary-rail-shell {
+    background:
+      linear-gradient(
+        180deg,
+        rgb(244 242 239 / 0.74) 0%,
+        rgb(238 235 231 / 0.68) 100%
+      );
+  }
+
+  html.dark.desktop-shell-windows.desktop-shell-glass .primary-rail-shell {
+    background:
+      linear-gradient(
+        180deg,
+        rgb(18 20 23 / 0.72) 0%,
+        rgb(14 16 19 / 0.66) 100%
+      );
+  }
+
+  html.desktop-shell-glass .workspace-shell .surface-shell {
     background:
       linear-gradient(
         180deg,
@@ -1315,7 +1449,7 @@
     -webkit-backdrop-filter: blur(12px) saturate(104%);
     backdrop-filter: blur(12px) saturate(104%);
   }
-  html.dark.desktop-shell-macos .workspace-shell .surface-shell {
+  html.dark.desktop-shell-glass .workspace-shell .surface-shell {
     background:
       linear-gradient(
         180deg,
@@ -1349,7 +1483,7 @@
       0 10px 18px -16px rgb(0 0 0 / 0.2);
   }
 
-  html.desktop-shell-macos :is(.workspace-context-card, .workspace-main-card) {
+  html.desktop-shell-glass :is(.workspace-context-card, .workspace-main-card) {
     background: var(--desktop-content-surface-light);
     border-color: rgb(220 214 207 / 0.88);
     box-shadow:
@@ -1358,7 +1492,7 @@
       inset 0 1px 0 rgb(255 255 255 / 0.64);
   }
 
-  html.dark.desktop-shell-macos :is(.workspace-context-card, .workspace-main-card) {
+  html.dark.desktop-shell-glass :is(.workspace-context-card, .workspace-main-card) {
     background: var(--desktop-content-surface-dark);
     border-color: rgb(76 75 70 / 0.86);
     box-shadow:
@@ -1369,8 +1503,8 @@
 
   .workspace-main-card--frameless,
   .dark .workspace-main-card--frameless,
-  html.desktop-shell-macos .workspace-main-card--frameless,
-  html.dark.desktop-shell-macos .workspace-main-card--frameless {
+  html.desktop-shell-glass .workspace-main-card--frameless,
+  html.dark.desktop-shell-glass .workspace-main-card--frameless {
     background: transparent;
     border-width: 0;
     border-color: transparent;
@@ -1419,11 +1553,11 @@
   }
 
   @media (min-width: 768px) {
-    html.desktop-shell-macos [data-testid="chat-main-workspace-card"]:has(> [data-testid="chat-desktop-toolbar-clearance"]) {
+    html.desktop-shell-glass [data-testid="chat-main-workspace-card"]:has(> [data-testid="chat-desktop-toolbar-clearance"]) {
       isolation: isolate;
     }
 
-    html.desktop-shell-macos [data-testid="chat-main-workspace-card"] > [data-testid="chat-desktop-toolbar-clearance"] {
+    html.desktop-shell-glass [data-testid="chat-main-workspace-card"] > [data-testid="chat-desktop-toolbar-clearance"] {
       position: relative;
       z-index: 1;
       height: 2.75rem;
@@ -1440,7 +1574,7 @@
       backdrop-filter: blur(18px) saturate(128%);
     }
 
-    html.dark.desktop-shell-macos [data-testid="chat-main-workspace-card"] > [data-testid="chat-desktop-toolbar-clearance"] {
+    html.dark.desktop-shell-glass [data-testid="chat-main-workspace-card"] > [data-testid="chat-desktop-toolbar-clearance"] {
       border-bottom-color: color-mix(in oklab, var(--desktop-content-border-dark) 36%, transparent);
       background: color-mix(in oklab, var(--desktop-content-surface-dark) 24%, transparent);
       box-shadow:
@@ -1482,13 +1616,13 @@
     backdrop-filter: blur(30px) saturate(128%);
   }
 
-  html.desktop-shell-macos .settings-modal-backdrop {
+  html.desktop-shell-glass .settings-modal-backdrop {
     background: rgb(244 241 236 / 0.18);
     -webkit-backdrop-filter: blur(36px) saturate(118%);
     backdrop-filter: blur(36px) saturate(118%);
   }
 
-  html.dark.desktop-shell-macos .settings-modal-backdrop {
+  html.dark.desktop-shell-glass .settings-modal-backdrop {
     background: rgb(13 14 16 / 0.22);
     -webkit-backdrop-filter: blur(34px) saturate(112%);
     backdrop-filter: blur(34px) saturate(112%);
@@ -1507,7 +1641,7 @@
     }
   }
 
-  html.desktop-shell-macos .settings-modal-shell {
+  html.desktop-shell-glass .settings-modal-shell {
     border-color: rgb(218 212 205 / 0.9);
     background: rgb(242 240 237 / 0.996);
     box-shadow:
@@ -1516,7 +1650,7 @@
       inset 0 1px 0 rgb(255 255 255 / 0.62);
   }
 
-  html.dark.desktop-shell-macos .settings-modal-shell {
+  html.dark.desktop-shell-glass .settings-modal-shell {
     border-color: rgb(76 75 70 / 0.88);
     background: rgb(27 27 26 / 0.996);
     box-shadow:
@@ -1530,12 +1664,12 @@
     border-right: 1px solid color-mix(in oklab, var(--border-soft) 92%, transparent);
   }
 
-  html.desktop-shell-macos .settings-modal-sidebar {
+  html.desktop-shell-glass .settings-modal-sidebar {
     background: rgb(239 237 233 / 0.98);
     border-right-color: rgb(216 211 204 / 0.9);
   }
 
-  html.dark.desktop-shell-macos .settings-modal-sidebar {
+  html.dark.desktop-shell-glass .settings-modal-sidebar {
     background: rgb(34 34 32 / 0.98);
     border-right-color: rgb(75 74 70 / 0.88);
   }

--- a/ui/src/lib/desktop-shell.ts
+++ b/ui/src/lib/desktop-shell.ts
@@ -352,6 +352,7 @@ export type DesktopBrowserShortcutRequest = {
 };
 
 export type DesktopShellApi = {
+  platform?: NodeJS.Platform;
   getBootState(): Promise<DesktopBootState>;
   onBootState(listener: (state: DesktopBootState) => void): () => void;
   openPath(targetPath: string): Promise<void>;
@@ -369,6 +370,10 @@ export type DesktopShellApi = {
   copyImage?(payload: DesktopImageDataPayload): Promise<void>;
   showImageInFolder?(payload: DesktopImageDataPayload): Promise<void>;
   setAppearance(theme: "light" | "dark" | "system"): Promise<void>;
+  minimizeWindow?(): Promise<void>;
+  toggleMaximizeWindow?(): Promise<boolean>;
+  closeWindow?(): Promise<void>;
+  isWindowMaximized?(): Promise<boolean>;
   getUpdateChannel?(): Promise<DesktopUpdateChannel>;
   setUpdateChannel?(channel: DesktopUpdateChannel): Promise<DesktopUpdateChannel>;
   reloadApp?(): Promise<void>;

--- a/ui/src/lib/index-css.test.ts
+++ b/ui/src/lib/index-css.test.ts
@@ -484,25 +484,25 @@ describe("index.css motion rules", () => {
     expect(reducedMotion).toContain(".morph-popover[data-state=\"open\"]");
   });
 
-  it("keeps the macOS desktop shell translucent in light mode", () => {
-    const lightDesktopBackdrop = cssBlock("html.desktop-shell-macos .app-shell-backdrop");
+  it("keeps the desktop glass shell translucent in light mode", () => {
+    const lightDesktopBackdrop = cssBlock("html.desktop-shell-glass .app-shell-backdrop");
 
     expect(lightDesktopBackdrop).toContain("rgb(250 248 245 / 0.34)");
     expect(lightDesktopBackdrop).toContain("rgb(244 240 234 / 0.22)");
     expect(lightDesktopBackdrop).toContain("backdrop-filter: blur(38px) saturate(122%)");
   });
 
-  it("keeps macOS desktop glass on the app backdrop and active Chat header without adding a workspace wash", () => {
-    const lightDesktopBackdrop = cssBlock("html.desktop-shell-macos .app-shell-backdrop");
-    const darkDesktopBackdrop = cssBlock("html.dark.desktop-shell-macos .app-shell-backdrop");
-    const lightPrimaryRail = cssBlock("html.desktop-shell-macos .primary-rail-shell");
-    const lightWorkspaceShell = cssBlock("html.desktop-shell-macos .workspace-shell");
-    const darkWorkspaceShell = cssBlock("html.dark.desktop-shell-macos .workspace-shell");
-    const lightDesktopWorkspaceCards = cssBlock("html.desktop-shell-macos :is(.workspace-context-card, .workspace-main-card)");
-    const darkDesktopWorkspaceCards = cssBlock("html.dark.desktop-shell-macos :is(.workspace-context-card, .workspace-main-card)");
-    const activeChatCardSelector = 'html.desktop-shell-macos [data-testid="chat-main-workspace-card"]:has(> [data-testid="chat-desktop-toolbar-clearance"])';
-    const chatHeaderSelector = 'html.desktop-shell-macos [data-testid="chat-main-workspace-card"] > [data-testid="chat-desktop-toolbar-clearance"]';
-    const darkChatHeaderSelector = 'html.dark.desktop-shell-macos [data-testid="chat-main-workspace-card"] > [data-testid="chat-desktop-toolbar-clearance"]';
+  it("keeps cross-platform desktop glass on the app backdrop and active Chat header without adding a workspace wash", () => {
+    const lightDesktopBackdrop = cssBlock("html.desktop-shell-glass .app-shell-backdrop");
+    const darkDesktopBackdrop = cssBlock("html.dark.desktop-shell-glass .app-shell-backdrop");
+    const lightPrimaryRail = cssBlock("html.desktop-shell-glass .primary-rail-shell");
+    const lightWorkspaceShell = cssBlock("html.desktop-shell-glass .workspace-shell");
+    const darkWorkspaceShell = cssBlock("html.dark.desktop-shell-glass .workspace-shell");
+    const lightDesktopWorkspaceCards = cssBlock("html.desktop-shell-glass :is(.workspace-context-card, .workspace-main-card)");
+    const darkDesktopWorkspaceCards = cssBlock("html.dark.desktop-shell-glass :is(.workspace-context-card, .workspace-main-card)");
+    const activeChatCardSelector = 'html.desktop-shell-glass [data-testid="chat-main-workspace-card"]:has(> [data-testid="chat-desktop-toolbar-clearance"])';
+    const chatHeaderSelector = 'html.desktop-shell-glass [data-testid="chat-main-workspace-card"] > [data-testid="chat-desktop-toolbar-clearance"]';
+    const darkChatHeaderSelector = 'html.dark.desktop-shell-glass [data-testid="chat-main-workspace-card"] > [data-testid="chat-desktop-toolbar-clearance"]';
     const activeChatCard = cssBlock(activeChatCardSelector);
     const lightChatHeader = cssBlock(chatHeaderSelector);
     const darkChatHeader = cssBlock(darkChatHeaderSelector);
@@ -534,7 +534,7 @@ describe("index.css motion rules", () => {
     expect(chatLoadErrorOffset).toContain("margin-top: 1.5rem");
     expect(chatLoadingOffset).toContain("padding-top: 1rem");
     expect(chatLoadingOffset).toContain("padding-bottom: 1rem");
-    expect(indexCss).not.toContain("html.desktop-shell-macos :is(.workspace-context-header, .workspace-main-header)");
+    expect(indexCss).not.toContain("html.desktop-shell-glass :is(.workspace-context-header, .workspace-main-header)");
   });
 
   it("keeps frameless Library work surfaces transparent over the desktop shell", () => {
@@ -544,11 +544,11 @@ describe("index.css motion rules", () => {
     expect(framelessWorkspaceCard).toContain("box-shadow: none");
   });
 
-  it("keeps the Library workspace shell transparent on macOS desktop", () => {
-    const libraryWorkspaceShell = cssBlock("html.desktop-shell-macos .workspace-shell--library-transparent");
-    const darkLibraryWorkspaceShell = cssBlock("html.dark.desktop-shell-macos .workspace-shell--library-transparent");
+  it("keeps the Library workspace shell transparent in the desktop glass shell", () => {
+    const libraryWorkspaceShell = cssBlock("html.desktop-shell-glass .workspace-shell--library-transparent");
+    const darkLibraryWorkspaceShell = cssBlock("html.dark.desktop-shell-glass .workspace-shell--library-transparent");
 
-    expect(indexCss).toContain("html.dark.desktop-shell-macos .workspace-shell--library-transparent");
+    expect(indexCss).toContain("html.dark.desktop-shell-glass .workspace-shell--library-transparent");
     expect(libraryWorkspaceShell).toContain("background: transparent");
     expect(darkLibraryWorkspaceShell).toContain("background: transparent");
     expect(libraryWorkspaceShell).not.toContain("desktop-content-surface");
@@ -634,6 +634,39 @@ describe("index.css motion rules", () => {
     expect(rootTokens).toContain("--desktop-workspace-radius: calc(var(--radius-sm) - 1px)");
     expect(workspaceShell).toContain("border-radius: var(--desktop-workspace-radius)");
     expect(workspaceCards).toContain("border-radius: var(--desktop-workspace-radius)");
+  });
+
+  it("clips the Windows desktop shell to rounded transparent outer corners", () => {
+    const rootTokens = cssBlock(":root");
+    const windowsRootClip = cssBlock("html.desktop-shell-windows,");
+    const windowsBackdropClip = cssBlock("html.desktop-shell-windows .app-shell-backdrop");
+    const maximizedBackdropClip = cssBlock("html.desktop-shell-windows.desktop-shell-window-maximized .app-shell-backdrop");
+    const captionControls = cssBlock(".desktop-caption-controls");
+
+    expect(rootTokens).toContain("--desktop-window-radius: 0.625rem");
+    expect(windowsRootClip).toContain("border-radius: var(--desktop-window-radius)");
+    expect(windowsRootClip).toContain("overflow: hidden");
+    expect(indexCss).toMatch(/html\.desktop-shell-windows body\s*\{\s*clip-path: inset\(0 round var\(--desktop-window-radius\)\);/);
+    expect(indexCss).toMatch(/html\.desktop-shell-windows #root\s*\{\s*position: fixed;/);
+    expect(indexCss).toMatch(/html\.desktop-shell-windows\.desktop-shell-window-maximized body,\s*html\.desktop-shell-windows\.desktop-shell-window-maximized #root\s*\{\s*clip-path: none;/);
+    expect(windowsBackdropClip).toContain("border-radius: var(--desktop-window-radius)");
+    expect(maximizedBackdropClip).toContain("border-radius: 0");
+    expect(captionControls).toContain("border-top-right-radius: var(--desktop-window-radius)");
+    expect(captionControls).toContain("z-index: 2147483647");
+  });
+
+  it("keeps Windows glass tinted enough to prevent readable background bleed", () => {
+    const lightShell = cssBlock("html.desktop-shell-windows.desktop-shell-glass .app-shell-backdrop");
+    const darkShell = cssBlock("html.dark.desktop-shell-windows.desktop-shell-glass .app-shell-backdrop");
+    const lightRail = cssBlock("html.desktop-shell-windows.desktop-shell-glass .primary-rail-shell");
+    const darkRail = cssBlock("html.dark.desktop-shell-windows.desktop-shell-glass .primary-rail-shell");
+
+    expect(lightShell).toContain("rgb(250 248 245 / 0.9)");
+    expect(lightShell).toContain("rgb(244 240 234 / 0.84)");
+    expect(darkShell).toContain("rgb(17 18 21 / 0.9)");
+    expect(darkShell).toContain("rgb(12 14 17 / 0.86)");
+    expect(lightRail).toContain("rgb(244 242 239 / 0.74)");
+    expect(darkRail).toContain("rgb(18 20 23 / 0.72)");
   });
 
   it("keeps dashboard run previews compact even when transcripts contain markdown headings", () => {

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -1,4 +1,5 @@
 import { AppErrorBoundary } from "@/components/AppErrorBoundary";
+import { DesktopWindowControls } from "@/components/DesktopWindowControls";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { ConsoleRingBuffer } from "@/lib/console-ring-buffer";
 import { BrowserRouter } from "@/lib/router";
@@ -21,6 +22,7 @@ import { SidebarProvider } from "./context/SidebarContext";
 import { ThemeProvider } from "./context/ThemeContext";
 import { ToastProvider } from "./context/ToastContext";
 import "./index.css";
+import { readDesktopShell } from "./lib/desktop-shell";
 import "./motion.css";
 
 const E2E_CHILDREN_ONLY_ERROR_MESSAGE = "React.Children.only expected to receive a single React element child.";
@@ -42,19 +44,26 @@ declare global {
 ConsoleRingBuffer.install();
 
 function isDesktopShellWindow() {
-  return typeof window !== "undefined"
-    && "desktopShell" in window
-    && Boolean((window as typeof window & { desktopShell?: unknown }).desktopShell);
+  return readDesktopShell() !== null;
 }
 
 function syncDesktopShellClass() {
+  const isDesktopShell = isDesktopShellWindow();
+  const desktopPlatform = readDesktopShell()?.platform;
   const isMacDesktopShell =
-    isDesktopShellWindow()
-    && /Mac/i.test(window.navigator.userAgent);
+    isDesktopShell
+    && desktopPlatform === "darwin";
+  const isWindowsDesktopShell =
+    isDesktopShell
+    && desktopPlatform === "win32";
 
+  document.documentElement.classList.toggle("desktop-shell-glass", isDesktopShell);
   document.documentElement.classList.toggle("desktop-shell-macos", isMacDesktopShell);
+  document.documentElement.classList.toggle("desktop-shell-windows", isWindowsDesktopShell);
   if (document.body) {
+    document.body.classList.toggle("desktop-shell-glass", isDesktopShell);
     document.body.classList.toggle("desktop-shell-macos", isMacDesktopShell);
+    document.body.classList.toggle("desktop-shell-windows", isWindowsDesktopShell);
   }
 }
 
@@ -82,7 +91,7 @@ syncDesktopShellClass();
 
 if (typeof document !== "undefined") {
   const root = document.documentElement;
-  root.style.backgroundColor = root.classList.contains("desktop-shell-macos")
+  root.style.backgroundColor = root.classList.contains("desktop-shell-glass")
     ? "transparent"
     : "";
 }
@@ -119,6 +128,7 @@ createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
       <AppErrorBoundary>
+        <DesktopWindowControls />
         <I18nProvider>
           <ThemeProvider>
             <BrowserRouter>


### PR DESCRIPTION
Adds the Windows transparent paper-glass shell, custom caption controls, rounded restored-window clipping, and stronger Windows-only tinting so background text cannot bleed through the navigation. Fixes the missing primary-rail-shell class. Preserves macOS and Linux opaque defaults. Validation: Desktop/UI typecheck, 14 focused regressions, product-logic check, Windows Electron smoke glass assertions, independent reviewer accept, independent verifier PASS. Packaged verification is delegated to CI because this local host does not have Cargo.