### PR TITLE
fix(ci): restore response annotation qualification

### DIFF
--- a/scripts/architecture-audit-baseline.json
+++ b/scripts/architecture-audit-baseline.json
@@ -386,6 +386,14 @@
       "expiry": "2027-03-31"
     },
     {
+      "path": "ui/src/components/chat/ResponseAnnotations.tsx",
+      "lines": 1501,
+      "owner": "collaboration-ui",
+      "rationale": "Response annotation rendering still combines selection, disclosure, editing, attachment, and source-navigation state after the initial interaction delivery.",
+      "target": "Extract annotation disclosure and editor controllers and reduce the component below 1500 lines.",
+      "expiry": "2026-12-31"
+    },
+    {
       "path": "server/src/services/runtime-kernel/heartbeat.execute.ts",
       "lines": 1501,
       "owner": "runtime-server",

--- a/ui/src/components/side-panel/SideChatPanelView.test.tsx
+++ b/ui/src/components/side-panel/SideChatPanelView.test.tsx
@@ -217,11 +217,21 @@ function GenerationProbe() {
   return null;
 }
 
+class ResizeObserverMock {
+  observe() {}
+
+  unobserve() {}
+
+  disconnect() {}
+}
+
 beforeAll(() => {
   notifyManager.setNotifyFunction((callback) => act(callback));
+  vi.stubGlobal("ResizeObserver", ResizeObserverMock);
 });
 
 afterAll(() => {
+  vi.unstubAllGlobals();
   notifyManager.setNotifyFunction((callback) => callback());
 });
 


### PR DESCRIPTION
## Summary
- register the newly oversized response-annotation component in the architecture debt baseline using the required sentinel contract
- provide a scoped ResizeObserver test double for SideChatPanelView annotation tests and restore the global afterward

## Why
Recent response-annotation work reached main while its deterministic qualification closeout was incomplete: Architecture ratchet failed on the missing debt record, and Ubuntu UI tests failed because jsdom has no ResizeObserver. No product behavior changes.

## Verification
- full SideChatPanelView.test.tsx: 22/22 passed
- UI typecheck
- lint:changed
- architecture:audit:check
- git diff --check
- independent final code review: ACCEPT
- independent acceptance verification: PASS