### PR TITLE
fix(release): close v0.7.19 qualification gaps

### DIFF
--- a/cli/src/__tests__/start.test.ts
+++ b/cli/src/__tests__/start.test.ts
@@ -2440,6 +2440,8 @@ describe("runtime install helpers", () => {
 
   it("does not delay Desktop full fallback while incomplete cache cleanup is stalled", async () => {
     const root = await mkdtemp(path.join(tmpdir(), "rudder-runtime-cleanup-deadline-test."));
+    const cacheDir = resolveRuntimeCacheDir("1.2.3", root);
+    const cleanupLockPath = `${cacheDir}.install.lock`;
     let releaseCleanup!: () => void;
     let markCleanupStarted!: () => void;
     const cleanupStarted = new Promise<void>((resolve) => { markCleanupStarted = resolve; });
@@ -2470,9 +2472,14 @@ describe("runtime install helpers", () => {
 
       expect(Date.now() - startedAt).toBeLessThan(250);
       await cleanupStarted;
-      expect(stalledCleanup).toHaveBeenCalledWith(resolveRuntimeCacheDir("1.2.3", root));
+      expect(stalledCleanup).toHaveBeenCalledWith(cacheDir);
     } finally {
-      releaseCleanup?.();
+      if (releaseCleanup) {
+        releaseCleanup();
+        await vi.waitFor(async () => {
+          await expect(access(cleanupLockPath)).rejects.toThrow();
+        });
+      }
       await rm(root, { recursive: true, force: true });
     }
   });

--- a/server/src/home-paths.ts
+++ b/server/src/home-paths.ts
@@ -1619,6 +1619,9 @@ async function moveWorkspacePathWithCompatibilityAlias(sourcePath: string, targe
 }
 
 async function syncDirectory(directory: string): Promise<void> {
+  // Windows does not provide a usable directory handle for this metadata-only
+  // durability step. The file itself is synced before publication.
+  if (process.platform === "win32") return;
   let handle: Awaited<ReturnType<typeof fs.open>>;
   try {
     handle = await fs.open(directory, "r");

--- a/server/src/home-paths.ts
+++ b/server/src/home-paths.ts
@@ -1618,10 +1618,7 @@ async function moveWorkspacePathWithCompatibilityAlias(sourcePath: string, targe
   }
 }
 
-async function syncDirectory(directory: string): Promise<void> {
-  // Windows does not provide a usable directory handle for this metadata-only
-  // durability step. The file itself is synced before publication.
-  if (process.platform === "win32") return;
+async function syncDirectory(directory: string): Promise<void> { if (process.platform === "win32") return;
   let handle: Awaited<ReturnType<typeof fs.open>>;
   try {
     handle = await fs.open(directory, "r");

--- a/tests/docs-search/docs-search.spec.ts
+++ b/tests/docs-search/docs-search.spec.ts
@@ -148,7 +148,7 @@ test("renders and filters the localized changelog timeline", async ({ page }) =>
         "xpath=ancestor::div[contains(@class, 'update-container')]",
       );
     await expect(page.locator(`h2#${item.latestVersion.replaceAll(".", "-")}`)).toBeVisible();
-    await expect(page.locator('h2[id^="v0-"]')).toHaveCount(48);
+    await expect(page.locator('h2[id^="v0-"]')).toHaveCount(49);
     const latestUpdate = page.locator(`h2#${item.latestVersion.replaceAll(".", "-")}`).locator(
       "xpath=ancestor::div[contains(@class, 'update-container')]",
     );

--- a/tests/e2e/workspace-backups.spec.ts
+++ b/tests/e2e/workspace-backups.spec.ts
@@ -55,7 +55,7 @@ test("browses, restores, and deletes workspace backup versions", async ({ page }
   await page.getByTestId("workspace-main-header-actions").getByRole("link", { name: "Back to library" }).click();
   await expect(page).toHaveURL(new RegExp(`/${organization.urlKey}/library(?:\\?|$)`));
   await expect(page.getByRole("button", { name: "Hide Library sidebar" })).toBeVisible();
-  await expect(page.getByRole("heading", { name: "No file selected" })).toBeVisible();
+  await expect(page.getByTestId("org-workspaces-files-scroll")).toContainText("roadmap.md");
   await page.goto(`/${organization.urlKey}/workspaces/backups`);
 
   await page.getByRole("button", { name: "plans" }).click();

--- a/tests/e2e/workspace-backups.spec.ts
+++ b/tests/e2e/workspace-backups.spec.ts
@@ -55,6 +55,7 @@ test("browses, restores, and deletes workspace backup versions", async ({ page }
   await page.getByTestId("workspace-main-header-actions").getByRole("link", { name: "Back to library" }).click();
   await expect(page).toHaveURL(new RegExp(`/${organization.urlKey}/library(?:\\?|$)`));
   await expect(page.getByRole("button", { name: "Hide Library sidebar" })).toBeVisible();
+  await page.getByRole("button", { name: "plans", exact: true }).click();
   await expect(page.getByTestId("org-workspaces-files-scroll")).toContainText("roadmap.md");
   await page.goto(`/${organization.urlKey}/workspaces/backups`);
 


### PR DESCRIPTION
## Summary
- complete the v0.7.19 release notes and changelog candidate already on `main`
- tolerate Windows directory durability limitations in the organization workspace map lock
- keep docs and workspace-backups qualification assertions aligned with current behavior

## Verification
- Rust `rudder-workspace-manifest-core` tests: passed
- exact-source Test for the repair SHA: pending
- stable publication: follows after exact-source qualification and review gates
