### PR TITLE
fix(release): declare 0.7.19 migration compatibility

### DIFF
--- a/scripts/release-compatibility-matrix.mjs
+++ b/scripts/release-compatibility-matrix.mjs
@@ -12,6 +12,26 @@ const journalPath = "packages/db/src/migrations/meta/_journal.json";
 const migrationsPath = "packages/db/src/migrations";
 
 export const migrationCompatibilityMatrix = {
+  "0.7.19": {
+    candidateFingerprint: "085c15c2a32685dbbddd775ee6fe21aea4ff5c151193f1711ad8c1c52a04a0db",
+    fixtures: [
+      {
+        version: "0.7.18",
+        ref: "v0.7.18",
+        fingerprint: "085c15c2a32685dbbddd775ee6fe21aea4ff5c151193f1711ad8c1c52a04a0db",
+      },
+      {
+        version: "0.7.16",
+        ref: "v0.7.16",
+        fingerprint: "085c15c2a32685dbbddd775ee6fe21aea4ff5c151193f1711ad8c1c52a04a0db",
+      },
+      {
+        version: "0.7.15",
+        ref: "v0.7.15",
+        fingerprint: "3fa86ccfeb959872e3d87af335928aff13880fc990c51f1dcf3c42baa6eb07ce",
+      },
+    ],
+  },
   "0.7.18": {
     candidateFingerprint: "085c15c2a32685dbbddd775ee6fe21aea4ff5c151193f1711ad8c1c52a04a0db",
     fixtures: [

--- a/scripts/release-compatibility-matrix.test.mjs
+++ b/scripts/release-compatibility-matrix.test.mjs
@@ -35,6 +35,24 @@ function manifest(tags, sqlByTag, label) {
 }
 
 describe("release migration compatibility matrix", () => {
+  it("accepts the checked-in 0.7.19 candidate against immutable release fixtures", () => {
+    const result = runCompatibilityPreflight({
+      candidateVersion: "0.7.19",
+      channel: "stable",
+    });
+
+    expect(result.candidateFingerprint).toBe(
+      "085c15c2a32685dbbddd775ee6fe21aea4ff5c151193f1711ad8c1c52a04a0db",
+    );
+    expect(result.candidateMigrations).toBe(163);
+    expect(result.candidateSqlFiles).toBe(165);
+    expect(result.fixtures.map((fixture) => fixture.version)).toEqual([
+      "0.7.18",
+      "0.7.16",
+      "0.7.15",
+    ]);
+  }, 60_000);
+
   it("accepts the checked-in 0.7.18 candidate against immutable release fixtures", () => {
     const result = runCompatibilityPreflight({
       candidateVersion: "0.7.18",


### PR DESCRIPTION
## Summary
- declare the 0.7.19 migration compatibility matrix entry
- cover v0.7.18, v0.7.16, and v0.7.15 immutable fixtures
- add focused regression coverage

## Verification
- node scripts/release-compatibility-matrix.mjs --candidate-version 0.7.19 --channel stable
- pnpm exec vitest run scripts/release-compatibility-matrix.test.mjs

This release-only repair uses [skip release] so it does not start a duplicate canary.