### PR TITLE
test: stabilize native spool overflow timeout

### DIFF
--- a/packages/agent-runtime-utils/src/native-process-runner.test.ts
+++ b/packages/agent-runtime-utils/src/native-process-runner.test.ts
@@ -142,7 +142,7 @@ describe("Rust Agent Run process host", () => {
     await expect(access(path.join(root, "receipts"))).resolves.toBeUndefined();
   });
 
-  it("fails closed when the log consumer cannot drain the bounded output spool", async () => {
+  it("fails closed when the log consumer cannot drain the bounded output spool", { timeout: 15_000 }, async () => {
     const root = await mkdtemp(path.join(os.tmpdir(), "rudder-native-agent-spool-overflow-"));
     const commandInput = new PassThrough();
     const lifecycle = new PassThrough();


### PR DESCRIPTION
## Summary
- give the bounded native output-spool regression test an explicit 15s Vitest budget
- keep product runtime timeouts unchanged

## Release context
This is a release-gate repair for v0.7.19. The exact main qualification run failed twice on macOS x64 because this test exceeded the default 5s test budget (5103ms); all other tests passed.

## Verification
- focused Vitest passed
- focused test repeated 10 times locally

[skip release]