### PR TITLE
docs(release): announce stable releases on Discord by default

### DIFF
--- a/.agents/skills/maintainer/release-maintainer/SKILL.md
+++ b/.agents/skills/maintainer/release-maintainer/SKILL.md
@@ -32,11 +32,12 @@ Use a second branch only when the observed state genuinely crosses branches,
 such as a stable publish that needs partial recovery. Do not preload every
 reference for a readiness question.
 
-When the user explicitly requests a Discord announcement, or has already
-authorized that exact announcement in the conversation, read
-`references/announcement.md` after the release surfaces are verified. A release
-request alone does not authorize sending messages. Do not add announcements to
-Release CI or create a webhook unless explicitly requested.
+For a requested Rudder stable release, read `references/announcement.md` after
+the release surfaces are verified. Zeeland explicitly authorized this default
+on 2026-09-08: send one release announcement to Rudder / #announcements unless
+the user opts out. Reuse that standing authority without a second confirmation.
+Read-only checks, canaries, and publishing only a named non-release surface do
+not trigger it. Do not add announcements to Release CI or create a webhook.
 
 ## Authorization Boundary
 
@@ -52,7 +53,8 @@ Resolve a bare `publish` from context; do not expand it into a full version rele
 4. publish npm, tag, GitHub Release, Desktop, and production-docs surfaces;
 5. verify public installation, clean obsolete canary Releases/tags, and advance
    the next-version base through its protected-branch PR;
-6. when explicitly authorized, publish and read back the stable Discord announcement.
+6. publish and read back the stable Discord announcement under Zeeland's standing
+   authorization, unless the user explicitly opts out.
 
 Release and next-version PRs are part of this authorization. Never push directly
 to `main` or bypass its protection. Do not ask for routine second approval after validation.
@@ -124,8 +126,9 @@ exposing secrets, or expanding to another product/environment.
 8. For an authorized stable announcement, follow `references/announcement.md`: check for an existing
    version post, publish the bounded announcement with no default ping, read it
    back, and record its direct message URL.
-   Otherwise report the announcement as not requested; do not make it a new
-   permission question or a blocker for a release-only task.
+   Stable releases include this step by default. Record an explicit opt-out as
+   skipped by user; missing or unknown delivery means partial closeout. Do not
+   ask for routine second authorization.
 9. Report version/ref, workflow runs, npm tags, Release assets, install proof,
    changelog/docs state, announcement URL, cleanup, and remaining manual work.
 

--- a/.agents/skills/maintainer/release-maintainer/references/announcement.md
+++ b/.agents/skills/maintainer/release-maintainer/references/announcement.md
@@ -1,10 +1,12 @@
 # Stable Discord Announcement
 
-Use this reference when the user has explicitly authorized the stable Discord
-announcement, including earlier in the same conversation. Do not seek renewed
-approval for the same message scope. A release imperative alone does not grant
-messaging authority. Without an announcement request, complete the release and
-record `Announcement: not requested`; do not block it or ask a routine question.
+Zeeland explicitly requested on 2026-09-08 that Rudder stable releases include
+Discord announcements by default. This is standing user authorization for one
+English release post in the destination below after each requested stable release
+is verified. Do not ask again. An explicit opt-out overrides this default.
+Read-only checks, canaries, and publishing only named non-release surfaces do
+not trigger a post. Other destinations, pings, and follower cross-posts remain
+outside this standing authorization.
 
 An authorized announcement is a manual closeout surface, outside Release CI.
 Canary releases do not get a Discord announcement.

--- a/.agents/skills/maintainer/release-maintainer/references/shared.md
+++ b/.agents/skills/maintainer/release-maintainer/references/shared.md
@@ -170,7 +170,7 @@ Before completion, record:
 - obsolete canary cleanup and retained active line;
 - next-version PR URL, required checks, merged `main` SHA and its CI; report an
   unmerged PR as pending integration even when the Release workflow succeeded;
-- when announcement delivery is requested, its server, channel, direct message
+- for the default stable announcement, its server, channel, direct message
   URL, ping state, follower cross-post state, and rendered readback; otherwise
-  `Announcement: not requested`;
+  record an explicit user opt-out (read-only and canary runs do not announce);
 - preserved unrelated work or remaining blockers.

--- a/.agents/skills/maintainer/release-maintainer/references/stable.md
+++ b/.agents/skills/maintainer/release-maintainer/references/stable.md
@@ -109,8 +109,8 @@ Stable is complete only when:
 - npm `latest`, tag, Release, Desktop assets/checksum, docs, and public install
   resolve to the locked version;
 - the GitHub Release plus localized public changelogs are live;
-- if the user requested a Discord announcement, it has been posted and read
-  back according to `announcement.md`; otherwise it is `not requested`;
+- the default Discord announcement has been posted and read back according to
+  `announcement.md`, or the user's explicit opt-out is recorded;
 - post-stable cleanup is verified;
 - next-version `main` handoff and CI are verified;
 - unrelated later canaries are reported as separate overwrite risk rather than

--- a/doc/engineering/RELEASING.md
+++ b/doc/engineering/RELEASING.md
@@ -60,11 +60,17 @@ Every stable release has six separate surfaces:
 A stable release is done when all required surfaces are handled. The China
 mirror is required only for a release that explicitly enables `mirror_cos`.
 
-For the announcement surface, the public GitHub Release notes may be the
-announcement channel when there is no separate website post or social/customer
-announcement in scope. If a separate announcement or docs-site publish is
-expected, record the channel and owner in the release issue before closeout. If
-that surface is intentionally skipped, record who made that decision and why.
+Zeeland's explicit standing instruction (2026-09-08) includes a Discord
+announcement in every requested Rudder stable release unless the user opts out.
+After release verification and next-version handoff, send one English announcement
+to Rudder / #announcements at
+`https://discord.com/channels/1529148109748306051/1529151730200350953`.
+Check for an existing version post first and record its direct message URL after
+rendered readback. This standing authorization needs no second confirmation.
+It excludes canary releases, read-only readiness checks, other destinations,
+pings, and follower-server cross-posts. Keep delivery outside Release CI;
+follow the release skill's `references/announcement.md`. An explicit opt-out
+overrides the default; a missing or unknown delivery remains a partial closeout.
 
 Docs Release deploy failures caused by Vercel account or token access are an
 external release blocker for docs-site publishing. Do not silently count a


### PR DESCRIPTION
Stable releases previously treated Discord announcements as opt-in, so v0.7.19 completed without a channel post. Record Zeeland's explicit standing authorization to announce each verified stable release in Rudder / #announcements unless opted out, and synchronize the release skill and maintainer documentation.

Retain duplicate detection, rendered readback, login handoff, and the existing boundaries for canaries, pings, other destinations, and follower cross-posts. A missing or unknown announcement now remains a partial closeout.

Validation: skill quick_validate and git diff --check; checked stable release, explicit opt-out, read-only/canary, duplicate, and login-unavailable scenarios. Documentation-only change; no product runtime changes.
