### PR TITLE
fix(server): accept dotted workspace mappings

### DIFF
--- a/server/src/__tests__/home-paths.test.ts
+++ b/server/src/__tests__/home-paths.test.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { buildAgentWorkspaceKey } from "../agent-workspace-key.js";
+import { syncFileHandle } from "../file-system-durability.js";
 import {
   ensureAgentWorkspaceLayout,
   ensureOrganizationWorkspaceLayout,
@@ -33,7 +34,6 @@ import {
   resolveProjectLibraryDir,
   resolveProjectLibraryRelativePath,
 } from "../home-paths.js";
-import { syncFileHandle } from "../file-system-durability.js";
 
 async function makeTempDir(prefix: string): Promise<string> {
   return fs.mkdtemp(path.join(os.tmpdir(), prefix));
@@ -486,7 +486,7 @@ describe("home paths", () => {
     );
   });
 
-  it("rejects a friendly workspace mapping that is not a single safe path segment", async () => {
+  it("rejects unsafe friendly workspace folder mappings", async () => {
     const rudderHome = await makeTempDir("rudder-home-paths-invalid-folder-map-");
     const workspaceHome = await makeTempDir("rudder-user-workspaces-invalid-folder-map-");
     cleanupDirs.add(rudderHome);
@@ -495,22 +495,36 @@ describe("home paths", () => {
     process.env.RUDDER_INSTANCE_ID = "test-instance";
     process.env.RUDDER_ORGANIZATION_WORKSPACE_HOME = workspaceHome;
 
-    await fs.writeFile(
-      resolveOrganizationWorkspaceMapPath(),
-      `${JSON.stringify({
-        version: 1,
-        organizations: [{
-          instanceId: "test-instance",
-          orgId,
-          folderName: "../outside",
-          createdAt: "2026-01-01T00:00:00.000Z",
-          updatedAt: "2026-01-01T00:00:00.000Z",
-        }],
-      }, null, 2)}\n`,
-      "utf8",
-    );
+    for (const folderName of [
+      "",
+      ".",
+      "..",
+      "../outside",
+      "nested/folder",
+      "nested\\folder",
+      " leading-space",
+      "trailing-space ",
+      "trailing-dot.",
+    ]) {
+      await fs.writeFile(
+        resolveOrganizationWorkspaceMapPath(),
+        `${JSON.stringify({
+          version: 1,
+          organizations: [{
+            instanceId: "test-instance",
+            orgId,
+            folderName,
+            createdAt: "2026-01-01T00:00:00.000Z",
+            updatedAt: "2026-01-01T00:00:00.000Z",
+          }],
+        }, null, 2)}\n`,
+        "utf8",
+      );
 
-    expect(() => resolveOrganizationWorkspaceRoot(orgId)).toThrow(/Invalid organization workspace folder mapping/);
+      expect(() => resolveOrganizationWorkspaceRoot(orgId), folderName).toThrow(
+        /Invalid organization workspace folder mapping/,
+      );
+    }
   });
 
   it("rejects reserved mappings before organization cleanup can remove sibling data", async () => {
@@ -1246,6 +1260,49 @@ describe("home paths", () => {
       /could not find the mapped organization Library folder/i,
     );
     await expect(fs.stat(layout.root)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("reconciles legacy mapped folders containing safe dots", async () => {
+    const rudderHome = await makeTempDir("rudder-home-paths-reconcile-dotted-");
+    const workspaceHome = await makeTempDir("rudder-user-workspaces-reconcile-dotted-");
+    cleanupDirs.add(rudderHome);
+    cleanupDirs.add(workspaceHome);
+    process.env.RUDDER_HOME = rudderHome;
+    process.env.RUDDER_INSTANCE_ID = "test-instance";
+    process.env.RUDDER_ORGANIZATION_WORKSPACE_HOME = workspaceHome;
+
+    const folderName = "rudder-eval-2026-08-11t20-15-09.137z";
+    const workspaceRoot = path.join(workspaceHome, folderName);
+    const sentinel = path.join(workspaceRoot, "projects", "demo", "README.md");
+    await fs.mkdir(path.dirname(sentinel), { recursive: true });
+    await fs.writeFile(sentinel, "# Preserve legacy mapping\n", "utf8");
+    await fs.writeFile(
+      resolveOrganizationWorkspaceMapPath(),
+      `${JSON.stringify({
+        version: 1,
+        organizations: [{
+          instanceId: "test-instance",
+          orgId,
+          folderName,
+          orgName: "Dotted Legacy Mapping",
+          createdAt: "2026-08-11T20:15:09.137Z",
+          updatedAt: "2026-08-11T20:15:09.137Z",
+        }],
+      }, null, 2)}\n`,
+      "utf8",
+    );
+
+    const result = await reconcileOrganizationStorageRoots([{
+      id: orgId,
+      name: "Dotted Legacy Mapping",
+      urlKey: "dotted-legacy-mapping",
+    }]);
+
+    expect(result.workspaceAvailableOrganizationIds).toEqual([orgId]);
+    expect(resolveOrganizationWorkspaceRoot(orgId)).toBe(workspaceRoot);
+    await expect(fs.readFile(sentinel, "utf8")).resolves.toBe("# Preserve legacy mapping\n");
+    await expect(fs.readFile(path.join(workspaceRoot, ".rudder-workspace.json"), "utf8"))
+      .resolves.toContain(`"orgId": "${orgId}"`);
   });
 
   it("keeps startup reconciliation available when macOS blocks the organization workspace map", async () => {

--- a/server/src/home-paths.ts
+++ b/server/src/home-paths.ts
@@ -11,6 +11,7 @@ import os from "node:os";
 import path from "node:path";
 import { type AgentWorkspaceLocator, resolveStoredOrDerivedAgentWorkspaceKey } from "./agent-workspace-key.js";
 import { syncDirectory, syncFileHandle } from "./file-system-durability.js";
+import { validateOrganizationWorkspaceFolderName } from "./organization-workspace-folder-name.js";
 
 const DEFAULT_INSTANCE_ID = "default";
 const INSTANCE_ID_RE = /^[a-zA-Z0-9_-]+$/;
@@ -1201,10 +1202,7 @@ function readOrganizationWorkspaceFolderName(orgId: string): string | null {
     if (typeof record.folderName !== "string") {
       throw new Error("Organization workspace folder mapping must contain a folder name.");
     }
-    const folderName = validatePathSegment(record.folderName, "organization workspace folder");
-    if (folderName !== record.folderName) {
-      throw new Error("Organization workspace folder mapping must not contain leading or trailing whitespace.");
-    }
+    const folderName = validateOrganizationWorkspaceFolderName(record.folderName);
     if (RESERVED_ORGANIZATION_WORKSPACE_NAMES.has(folderName.toLowerCase())) {
       throw new Error(`Organization workspace folder mapping uses reserved folder '${folderName}'.`);
     }

--- a/server/src/organization-workspace-folder-name.ts
+++ b/server/src/organization-workspace-folder-name.ts
@@ -1,0 +1,17 @@
+const ORGANIZATION_WORKSPACE_FOLDER_RE = /^[a-zA-Z0-9._-]+$/;
+
+export function validateOrganizationWorkspaceFolderName(value: string): string {
+  const folderName = value.trim();
+  if (folderName !== value) {
+    throw new Error("Organization workspace folder mapping must not contain leading or trailing whitespace.");
+  }
+  if (
+    !ORGANIZATION_WORKSPACE_FOLDER_RE.test(folderName)
+    || folderName === "."
+    || folderName === ".."
+    || folderName.endsWith(".")
+  ) {
+    throw new Error(`Invalid organization workspace folder for workspace path '${value}'.`);
+  }
+  return folderName;
+}


### PR DESCRIPTION
## Summary

- restore startup compatibility for friendly organization workspace folders containing safe internal dots
- validate workspace folder mappings with a dedicated single-segment policy instead of the stricter organization-ID policy
- preserve traversal, whitespace, trailing-dot, reserved-name, and missing-folder fail-closed behavior
- add a production-shaped upgrade regression that preserves existing workspace data

## Root cause

Rudder's canonical friendly-folder writer permits `[A-Za-z0-9._-]`, but v0.7.19 hardened the persisted mapping reader by reusing the organization storage-key validator, which permits only `[A-Za-z0-9_-]`. A folder generated from a name with an internal dot could therefore be written successfully and rejected on the next startup, after PostgreSQL was already healthy.

## Verification

- `NODE_ENV=test CI=true corepack pnpm exec vitest run server/src/__tests__/home-paths.test.ts` — 62/62 passed
- `CI=true corepack pnpm -r typecheck` — passed
- `CI=true corepack pnpm --filter @rudderhq/server build` — passed
- `CI=true corepack pnpm architecture:audit:check` — passed; no comparison regression
- `env -u NODE_ENV -u ELECTRON_RUN_AS_NODE CI=true corepack pnpm desktop:verify` — passed after preparing the documented dev-smoke debug process host
- independent installed-Desktop black-box verifier — PASS on the same `prod_local/default` data across a controlled restart; no workspace-path or migration-journal drift

## Baseline notes

- Full repository lint still reports eight pre-existing import-order failures on `origin/main`; the three changed files passed `lint:changed` before commit and are content-identical after rebase.
- A full `pnpm test:run` attempt reached `chat-routes.test.ts`, where all 189 assertions passed but Node reported one transient unhandled `HPE_INVALID_CONSTANT` HTTP parser rejection. An immediate isolated rerun of the unchanged file passed 189/189 with exit 0. The focused affected suite and packaged Desktop gate are green.

## Risk

- No database migration or schema change.
- No workspace rename, deletion, or mapping rewrite is required.
- The broader organization/agent storage-key validator remains unchanged; dots are accepted only at the friendly workspace-folder boundary.
