### PR TITLE
fix(release): declare 0.7.20 migration compatibility

### DIFF
--- a/desktop/scripts/local-app-smoke-helpers.test.mjs
+++ b/desktop/scripts/local-app-smoke-helpers.test.mjs
@@ -77,6 +77,10 @@ describe("Local App smoke helpers", () => {
     expect(functionStart).toBeGreaterThanOrEqual(0);
     expect(functionEnd).toBeGreaterThan(functionStart);
     const probeSource = smokeSource.slice(functionStart, functionEnd);
+    expect(probeSource).toContain('const partition = webview.getAttribute("partition");');
+    expect(probeSource).toContain("const currentUrl = webview.getURL();");
+    expect(probeSource).toContain("partition !== expectedPartition");
+    expect(probeSource).toContain("url: currentUrl");
     expect(probeSource).toContain("expectedPartition,\n    expectedUrl,");
     expect(probeSource).not.toContain("attested.partition");
   });

--- a/desktop/scripts/smoke.mjs
+++ b/desktop/scripts/smoke.mjs
@@ -6800,10 +6800,11 @@ async function waitForLocalAppWebview(page, definition, expectedAttestation, exp
       .find((candidate) => candidate.getAttribute("data-local-binding-id") === bindingId
         && candidate.getAttribute("data-active") === "true");
     if (!webview
-      || webview.getAttribute("partition") !== expectedPartition
       || typeof webview.getURL !== "function"
-      || typeof webview.executeJavaScript !== "function"
-      || webview.getURL() !== url) return false;
+      || typeof webview.executeJavaScript !== "function") return false;
+    const partition = webview.getAttribute("partition");
+    const currentUrl = webview.getURL();
+    if (partition !== expectedPartition || currentUrl !== url) return false;
     try {
       const evidence = await webview.executeJavaScript(`(async () => {
         const response = await fetch(window.location.href, { cache: "no-store", credentials: "same-origin" });
@@ -6824,8 +6825,8 @@ async function waitForLocalAppWebview(page, definition, expectedAttestation, exp
         && evidence.bodyText.length > 0
         && (!bodyText || evidence.bodyText.includes(bodyText))) {
         return {
-          partition: webview.getAttribute("partition"),
-          url: webview.getURL(),
+          partition,
+          url: currentUrl,
           ...evidence,
           expectedUrl: url,
         };

--- a/scripts/release-compatibility-matrix.mjs
+++ b/scripts/release-compatibility-matrix.mjs
@@ -12,6 +12,31 @@ const journalPath = "packages/db/src/migrations/meta/_journal.json";
 const migrationsPath = "packages/db/src/migrations";
 
 export const migrationCompatibilityMatrix = {
+  "0.7.20": {
+    candidateFingerprint: "085c15c2a32685dbbddd775ee6fe21aea4ff5c151193f1711ad8c1c52a04a0db",
+    fixtures: [
+      {
+        version: "0.7.19",
+        ref: "v0.7.19",
+        fingerprint: "085c15c2a32685dbbddd775ee6fe21aea4ff5c151193f1711ad8c1c52a04a0db",
+      },
+      {
+        version: "0.7.18",
+        ref: "v0.7.18",
+        fingerprint: "085c15c2a32685dbbddd775ee6fe21aea4ff5c151193f1711ad8c1c52a04a0db",
+      },
+      {
+        version: "0.7.16",
+        ref: "v0.7.16",
+        fingerprint: "085c15c2a32685dbbddd775ee6fe21aea4ff5c151193f1711ad8c1c52a04a0db",
+      },
+      {
+        version: "0.7.15",
+        ref: "v0.7.15",
+        fingerprint: "3fa86ccfeb959872e3d87af335928aff13880fc990c51f1dcf3c42baa6eb07ce",
+      },
+    ],
+  },
   "0.7.19": {
     candidateFingerprint: "085c15c2a32685dbbddd775ee6fe21aea4ff5c151193f1711ad8c1c52a04a0db",
     fixtures: [

--- a/scripts/release-compatibility-matrix.test.mjs
+++ b/scripts/release-compatibility-matrix.test.mjs
@@ -35,6 +35,25 @@ function manifest(tags, sqlByTag, label) {
 }
 
 describe("release migration compatibility matrix", () => {
+  it("accepts the checked-in 0.7.20 candidate against the previous stable fixture", () => {
+    const result = runCompatibilityPreflight({
+      candidateVersion: "0.7.20-canary.0",
+      channel: "canary",
+    });
+
+    expect(result.candidateFingerprint).toBe(
+      "085c15c2a32685dbbddd775ee6fe21aea4ff5c151193f1711ad8c1c52a04a0db",
+    );
+    expect(result.candidateMigrations).toBe(163);
+    expect(result.candidateSqlFiles).toBe(165);
+    expect(result.fixtures.map((fixture) => fixture.version)).toEqual([
+      "0.7.19",
+      "0.7.18",
+      "0.7.16",
+      "0.7.15",
+    ]);
+  }, 60_000);
+
   it("accepts the checked-in 0.7.19 candidate against immutable release fixtures", () => {
     const result = runCompatibilityPreflight({
       candidateVersion: "0.7.19",

--- a/server/src/__tests__/heartbeat-paused-wakeups.test.ts
+++ b/server/src/__tests__/heartbeat-paused-wakeups.test.ts
@@ -149,6 +149,7 @@ describe("heartbeat paused wakeups", () => {
   });
 
   afterAll(async () => {
+    await db?.$client.end({ timeout: 5 });
     await instance?.stop();
     if (dataDir) {
       fs.rmSync(dataDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

- declare the 0.7.20 migration compatibility matrix entry required by the Release preflight
- cover the 0.7.20 canary candidate against the v0.7.19 and retained historical fixtures
- close the heartbeat paused-wakeups database client before stopping its embedded PostgreSQL fixture
- stabilize the packaged Local App smoke's WebView identity evidence across the asynchronous guest fetch

## Root causes fixed

1. The v0.7.20 package version was started without a corresponding entry in `scripts/release-compatibility-matrix.mjs`. The Release workflow correctly failed closed before any publish mutation with:

   `candidate 0.7.20-canary.0 has no old-version matrix declaration`

   The migration journal and SQL history are unchanged from v0.7.19, so the declaration uses the existing immutable fingerprint and adds v0.7.19 as the newest old-version fixture.

2. Ubuntu qualification intermittently failed in `server/src/__tests__/heartbeat-paused-wakeups.test.ts` after all 16 tests passed because `afterAll` stopped embedded PostgreSQL while the Drizzle/Postgres client was still open. The cleanup now closes the client with the same bounded timeout used by sibling suites before stopping PostgreSQL.

3. macOS packaged Local App smoke intermittently failed after the guest loaded because `waitForLocalAppWebview` re-read the WebView `partition` and URL after awaiting guest JavaScript. Electron/renderer reconciliation can clear or replace those DOM properties during that await. The helper now validates and snapshots the exact identity before the async guest probe, then returns the validated snapshot without weakening the expected-partition or URL checks.

## Verification

- `env -u NODE_ENV -u ELECTRON_RUN_AS_NODE CI=true corepack pnpm exec vitest run scripts/release-compatibility-matrix.test.mjs scripts/release-workflow-contract.test.mjs` — 36/36 passed
- `node scripts/release-compatibility-matrix.mjs --candidate-version 0.7.20-canary.0 --channel canary` — passed
- `node scripts/release-compatibility-matrix.mjs --candidate-version 0.7.20 --channel stable` — passed
- `env -u NODE_ENV -u ELECTRON_RUN_AS_NODE CI=true corepack pnpm exec vitest run desktop/scripts/local-app-smoke-helpers.test.mjs` — 11/11 passed
- `env -u NODE_ENV -u ELECTRON_RUN_AS_NODE CI=true corepack pnpm exec vitest run server/src/__tests__/heartbeat-paused-wakeups.test.ts` — 3 consecutive runs, each 16/16 passed
- `env -u NODE_ENV -u ELECTRON_RUN_AS_NODE CI=true corepack pnpm --filter @rudderhq/server typecheck` — passed
- `git diff --check` — passed

The original failed Release run was `34201319376`; no publication mutation occurred. No migrations, application data, or publication surfaces were changed.
