### PR TITLE
test(desktop): allow Windows watchdog startup latency

### DIFF
--- a/desktop/src/local-apps-runtime.test.ts
+++ b/desktop/src/local-apps-runtime.test.ts
@@ -480,16 +480,16 @@ describe("Desktop Local App runtime", { timeout: localAppRuntimeTestTimeoutMs },
 
   it.runIf(process.platform === "win32")(
     "runs an approved Local App through the real Windows Node watchdog",
-    { timeout: 90_000 },
+    { timeout: 240_000 },
     async () => {
       const { registry, definition } = await approvedFixture({ readinessTimeoutMs: 30_000 });
       const manager = new LocalAppRuntimeManager({
         registry,
         platform: "win32",
         useNativeProcessHost: false,
-        watchdogStartTimeoutMs: 60_000,
-        listenerOwnershipRetryTimeoutMs: 30_000,
-        cleanupTimeoutMs: 30_000,
+        watchdogStartTimeoutMs: 120_000,
+        listenerOwnershipRetryTimeoutMs: 60_000,
+        cleanupTimeoutMs: 60_000,
       });
       try {
         const running = await manager.start(definition.id);


### PR DESCRIPTION
## Summary

- give the real Windows Node watchdog lifecycle test a 120-second startup budget
- extend the same test's bounded listener-ownership and cleanup budgets to 60 seconds
- extend only this Windows-only test's total timeout to 240 seconds

## Root cause

After the previous CI fixes, the merged main Test run `34234059030` reached the Windows native foundations job and failed only in the real Windows watchdog test:

`Local App watchdog did not start in time; cleanup could not be verified`

The failure occurred at the previous 60-second watchdog-start boundary while the real Windows process identity/cleanup path was active. This change keeps the real watchdog and ownership proof enabled; it only gives the Windows runner enough bounded time for PowerShell process inspection and cleanup under CI load. Production defaults are unchanged.

## Verification

- `env -u NODE_ENV -u ELECTRON_RUN_AS_NODE -u PORT -u RUDDER_API_URL -u RUDDER_LISTEN_PORT CI=true RUDDER_NATIVE_MODE=node corepack pnpm exec vitest run desktop/src/local-apps-runtime.test.ts` — 59/59 non-Windows tests passed; 5 Windows-only tests skipped on macOS
- `env -u NODE_ENV -u ELECTRON_RUN_AS_NODE CI=true corepack pnpm --filter @rudderhq/desktop typecheck` — passed
- `node --check desktop/src/local-app-watchdog-runner.mjs` — passed
- `git diff --check` — passed

No application data, migrations, release tags, npm packages, or GitHub Releases were changed.
