### PR TITLE
fix(ci): cache native PostgreSQL runtime payload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -449,6 +449,13 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Cache PostgreSQL runtime payload
+        uses: actions/cache@v5
+        with:
+          path: ~/.rudder/runtime-payloads/postgres-18.4
+          key: postgres-runtime-18.4-${{ runner.os }}-${{ matrix.arch }}-${{ hashFiles('desktop/scripts/prepare-postgres-runtime.mjs') }}
+          restore-keys: postgres-runtime-18.4-${{ runner.os }}-${{ matrix.arch }}-
+
       - name: Prepare PostgreSQL test runtime
         if: matrix.target != 'x86_64-unknown-linux-gnu'
         run: |

--- a/scripts/ci-workflow-contract.test.mjs
+++ b/scripts/ci-workflow-contract.test.mjs
@@ -45,6 +45,14 @@ test("keeps the full graph behind planner outputs and affected checks separate",
   }
 });
 
+test("caches native PostgreSQL runtime payloads by runner and architecture", () => {
+  const native = workflowJob("native-foundations");
+  assert.match(native, /name: Cache PostgreSQL runtime payload/);
+  assert.match(native, /path: \~\/\.rudder\/runtime-payloads\/postgres-18\.4/);
+  assert.match(native, /key: postgres-runtime-18\.4-\$\{\{ runner\.os \}\}-\$\{\{ matrix\.arch \}\}-/);
+  assert.match(native, /restore-keys: postgres-runtime-18\.4-\$\{\{ runner\.os \}\}-\$\{\{ matrix\.arch \}\}-/);
+});
+
 test("prints the profile and identity tuple in the aggregate check", () => {
   const summary = workflowJob("qualification-summary");
   for (const field of ["PROFILE", "QUALIFICATION", "SOURCE_SHA", "COMPARISON_SHA", "PLAN_DIGEST"]) {


### PR DESCRIPTION
## Summary

- cache the PostgreSQL 18.4 runtime payload in the native-foundations matrix
- key the cache by runner OS, target architecture, and the runtime preparation script
- add a CI workflow contract test so native jobs cannot regress to downloading the payload on every run

## Root cause

The current main Test run `34237062962` failed in the Windows native-foundations job while preparing PostgreSQL 18.4. The step had no cache and remained in `node desktop/scripts/prepare-postgres-runtime.mjs` for approximately 53 minutes before the 60-minute job timeout. A separate successful Windows run showed the same cold preparation path takes about 9m45s when the external download/extraction is healthy.

The Desktop packaged job already cached this payload, but the native-foundations matrix did not. This change gives each OS/architecture its own cache while retaining the existing runtime completeness, PostgreSQL version, layout, and symlink checks on every invocation.

## Verification

- `node --test scripts/ci-workflow-contract.test.mjs` — 4/4 passed
- `git diff --check` — passed
- the workflow linter accepted the changed `.github/workflows/ci.yml`
- failed main run: `34237062962`, Windows `Prepare PostgreSQL test runtime`; no release publication occurred

No application data, migrations, package versions, release tags, or public artifacts were changed.
