### PR TITLE
fix(ci): bound PostgreSQL runtime downloads

### DIFF
--- a/desktop/scripts/postgres-runtime-download.mjs
+++ b/desktop/scripts/postgres-runtime-download.mjs
@@ -1,0 +1,76 @@
+import { createWriteStream } from "node:fs";
+import { copyFile } from "node:fs/promises";
+import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import { fileURLToPath } from "node:url";
+
+const DEFAULT_DOWNLOAD_TIMEOUT_MS = 600_000;
+const DEFAULT_MAX_ATTEMPTS = 3;
+const DEFAULT_RETRY_DELAY_MS = 2_000;
+const RETRYABLE_HTTP_STATUS = new Set([403, 429, 500, 502, 503, 504]);
+
+function resolvePositiveInteger(value, fallback) {
+  const parsed = Number.parseInt(String(value ?? ""), 10);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function resolveTimeoutMs(value) {
+  return resolvePositiveInteger(
+    value ?? process.env.RUDDER_POSTGRES_RUNTIME_DOWNLOAD_TIMEOUT_MS,
+    DEFAULT_DOWNLOAD_TIMEOUT_MS,
+  );
+}
+
+export async function downloadPostgresRuntimeArchive(url, targetPath, options = {}) {
+  if (url.startsWith("file://")) {
+    await copyFile(fileURLToPath(url), targetPath);
+    return;
+  }
+
+  const timeoutMs = resolveTimeoutMs(options.timeoutMs);
+  const maxAttempts = resolvePositiveInteger(options.maxAttempts, DEFAULT_MAX_ATTEMPTS);
+  const retryDelayMs = resolvePositiveInteger(options.retryDelayMs, DEFAULT_RETRY_DELAY_MS);
+  const fetchImpl = options.fetchImpl ?? globalThis.fetch;
+  let lastError;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+    let retryable = true;
+
+    try {
+      const response = await fetchImpl(url, {
+        signal: controller.signal,
+        headers: { "user-agent": "Rudder-PostgreSQL-Runtime/1.0" },
+      });
+      if (!response.ok) {
+        retryable = RETRYABLE_HTTP_STATUS.has(response.status);
+        await response.body?.cancel().catch(() => undefined);
+        throw new Error(`failed to download ${url}: ${response.status} ${response.statusText}`);
+      }
+      if (!response.body) {
+        throw new Error("PostgreSQL runtime archive response has no body");
+      }
+
+      await pipeline(
+        Readable.fromWeb(response.body),
+        createWriteStream(targetPath),
+        { signal: controller.signal },
+      );
+      return;
+    } catch (error) {
+      const finalError = controller.signal.aborted
+        ? new Error(`timed out downloading ${url} after ${timeoutMs}ms`, { cause: error })
+        : error;
+      if (attempt === maxAttempts || !retryable) throw finalError;
+      lastError = finalError;
+      const delayMs = retryDelayMs * attempt;
+      console.error(`[postgres-runtime] download attempt ${attempt}/${maxAttempts} failed; retrying in ${delayMs}ms: ${finalError.message}`);
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  throw lastError ?? new Error(`failed to download ${url}`);
+}

--- a/desktop/scripts/postgres-runtime-download.test.mjs
+++ b/desktop/scripts/postgres-runtime-download.test.mjs
@@ -1,0 +1,49 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { ReadableStream } from "node:stream/web";
+import { afterEach, describe, expect, it } from "vitest";
+import { downloadPostgresRuntimeArchive } from "./postgres-runtime-download.mjs";
+
+const roots = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })));
+});
+
+describe("PostgreSQL runtime archive download", () => {
+  it("streams a response body to the target archive", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "rudder-postgres-download-"));
+    roots.push(root);
+    const target = path.join(root, "archive.zip");
+    const body = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("archive contents"));
+        controller.close();
+      },
+    });
+
+    await downloadPostgresRuntimeArchive("https://example.test/archive.zip", target, {
+      fetchImpl: async () => ({ ok: true, status: 200, statusText: "OK", body }),
+    });
+
+    await expect(fs.readFile(target, "utf8")).resolves.toBe("archive contents");
+  });
+
+  it("aborts a response body that stalls after headers", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "rudder-postgres-download-timeout-"));
+    roots.push(root);
+    const target = path.join(root, "archive.zip");
+    const body = new ReadableStream({
+      start() {
+        // Simulate a server that sends headers but never finishes the archive.
+      },
+    });
+
+    await expect(downloadPostgresRuntimeArchive("https://example.test/archive.zip", target, {
+      timeoutMs: 20,
+      maxAttempts: 1,
+      fetchImpl: async () => ({ ok: true, status: 200, statusText: "OK", body }),
+    })).rejects.toThrow("timed out downloading https://example.test/archive.zip after 20ms");
+  });
+});

--- a/desktop/scripts/prepare-postgres-runtime.mjs
+++ b/desktop/scripts/prepare-postgres-runtime.mjs
@@ -3,7 +3,7 @@ import { spawnSync } from "node:child_process";
 import { copyFile, cp, mkdir, readFile, readdir, realpath, rename, rm, stat, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import { downloadPostgresRuntimeArchive } from "./postgres-runtime-download.mjs";
 
 const POSTGRES_VERSION = "18.4";
 const runtimeDirName = `postgres-${POSTGRES_VERSION}`;
@@ -14,7 +14,6 @@ const cacheRoot = process.env.RUDDER_POSTGRES_RUNTIME_CACHE_DIR
   : path.join(os.homedir(), ".rudder", "runtime-payloads");
 const runtimeRoot = path.join(cacheRoot, runtimeDirName, `${platform}-${arch}`);
 const binDir = path.join(runtimeRoot, "bin");
-const downloadTimeoutMs = Number.parseInt(process.env.RUDDER_POSTGRES_RUNTIME_DOWNLOAD_TIMEOUT_MS ?? "600000", 10);
 const installLockPath = `${runtimeRoot}.install.lock`;
 const lifecycleLockPath = path.join(cacheRoot, ".postgres-runtime.lifecycle.lock");
 
@@ -210,33 +209,6 @@ async function materializeSymlinks(currentDir) {
   }
 }
 
-async function downloadArchive(url, targetPath) {
-  if (url.startsWith("file://")) {
-    await copyFile(fileURLToPath(url), targetPath);
-    return;
-  }
-
-  const abortController = new AbortController();
-  const timeout = Number.isFinite(downloadTimeoutMs) && downloadTimeoutMs > 0
-    ? setTimeout(() => abortController.abort(), downloadTimeoutMs)
-    : null;
-  let response;
-  try {
-    response = await fetch(url, { signal: abortController.signal });
-  } catch (error) {
-    if (error?.name === "AbortError") {
-      throw new Error(`timed out downloading ${url} after ${downloadTimeoutMs}ms`);
-    }
-    throw error;
-  } finally {
-    if (timeout) clearTimeout(timeout);
-  }
-  if (!response.ok) {
-    throw new Error(`failed to download ${url}: ${response.status} ${response.statusText}`);
-  }
-  await writeFile(targetPath, Buffer.from(await response.arrayBuffer()));
-}
-
 function extractArchive(archivePath, extractDir) {
   const result = platform === "win32"
     ? spawnSync("powershell.exe", [
@@ -281,7 +253,7 @@ async function main() {
       try {
         console.error(`[postgres-runtime] downloading PostgreSQL ${POSTGRES_VERSION} runtime for ${platform}-${arch} from ${url}`);
         console.error(`[postgres-runtime] first download can be several hundred MB; cache target: ${binDir}`);
-        await downloadArchive(url, archivePath);
+        await downloadPostgresRuntimeArchive(url, archivePath);
         extractArchive(archivePath, extractDir);
 
         const extractedBinDir = await findBinDir(extractDir);

--- a/server/src/__tests__/log-store-offsets.test.ts
+++ b/server/src/__tests__/log-store-offsets.test.ts
@@ -46,7 +46,10 @@ describe("log store offsets", () => {
 import fs from "node:fs";
 import crypto from "node:crypto";
 const args = process.argv.slice(2);
-if (${JSON.stringify(mode)} === "hang" && args[1] === "read") { setInterval(() => {}, 1000); }
+if (${JSON.stringify(mode)} === "hang" && args[1] === "read") {
+  setInterval(() => {}, 1000);
+  await new Promise(() => {});
+}
 if (["not-found", "invalid-utf8"].includes(${JSON.stringify(mode)}) && args[1] === "read") {
   const errorCode = ${JSON.stringify(mode)} === "not-found" ? "evidence_read_not_found" : "evidence_read_invalid_utf8";
   console.log(JSON.stringify({ ok: false, capability: "evidence.read", protocolVersion: 1, errorCode, accepted: false }));

--- a/server/src/__tests__/workspace-backups.test.ts
+++ b/server/src/__tests__/workspace-backups.test.ts
@@ -28,6 +28,8 @@ import {
 
 import workspaceBackupReadParity from "../../../native/fixtures/workspace-backup-read-parity.json";
 
+vi.setConfig({ hookTimeout: 30_000, testTimeout: 30_000 });
+
 it("uses the portable Unicode scalar filename order shared with native browsing", () => {
   expect([...workspaceBackupReadParity.ordering.input].sort(compareWorkspaceBackupFilenames))
     .toEqual(workspaceBackupReadParity.ordering.expected);
@@ -224,6 +226,7 @@ describe("workspace backup service", () => {
   });
 
   afterAll(async () => {
+    await db?.$client.end({ timeout: 5 });
     await instance?.stop();
     if (dataDir) await fs.rm(dataDir, { recursive: true, force: true });
     if (rudderHome) await fs.rm(rudderHome, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

- keep the PostgreSQL runtime download timeout active while the response body is streamed
- retry transient download failures without retrying permanent HTTP errors
- add regression coverage for a response that stalls after headers
- give the Windows native workspace-backup sparse-recovery tests an explicit bounded 30-second test/hook budget
- close the workspace-backup database client before stopping embedded PostgreSQL in that suite
- make the native log-read cancellation fixture actually remain suspended instead of logging a response and exiting immediately

## Root causes fixed

1. `prepare-postgres-runtime.mjs` cleared its 10-minute AbortController timer as soon as `fetch()` returned headers. If the archive body then stopped arriving, `response.arrayBuffer()` could block until the Windows job timed out. The new helper streams the response through an AbortController-backed pipeline, keeping the timeout active for the body and retrying transient failures.

2. The main Test run `34275957971` reached the Windows native policy test set and timed out two realistic workspace-backup tests at the default 5-second Vitest timeout. Those tests create and inspect backup archives and need a bounded but larger CI budget. The suite now uses a 30-second test/hook budget and closes its DB client before stopping embedded PostgreSQL.

3. The same main Test run exposed a faulty `log-store-offsets.test.ts` hang fixture: it scheduled an interval but then still emitted a successful read response and called `process.exit(0)`. The cancellation test therefore raced a normal response instead of exercising cancellation. The fixture now awaits a never-resolving promise after starting the interval, so the parent must terminate it as intended.

## Verification

- `env -u NODE_ENV -u ELECTRON_RUN_AS_NODE -u PORT -u RUDDER_API_URL -u RUDDER_LISTEN_PORT CI=true corepack pnpm exec vitest run desktop/scripts/postgres-runtime-download.test.mjs desktop/scripts/stage-server.test.mjs --pool=forks --maxWorkers=1 --minWorkers=1 --no-file-parallelism` — 11/11 passed
- `env -u NODE_ENV -u ELECTRON_RUN_AS_NODE -u PORT -u RUDDER_API_URL -u RUDDER_LISTEN_PORT CI=true corepack pnpm exec vitest run server/src/__tests__/workspace-backups.test.ts` — 50/50 passed
- `env -u NODE_ENV -u ELECTRON_RUN_AS_NODE -u PORT -u RUDDER_API_URL -u RUDDER_LISTEN_PORT CI=true corepack pnpm exec vitest run server/src/__tests__/log-store-offsets.test.ts` — 10/10 passed
- `env -u NODE_ENV -u ELECTRON_RUN_AS_NODE -u PORT -u RUDDER_API_URL -u RUDDER_LISTEN_PORT CI=true corepack pnpm --filter @rudderhq/server typecheck` — passed
- `node --check desktop/scripts/prepare-postgres-runtime.mjs` — passed
- `node --check desktop/scripts/postgres-runtime-download.mjs` — passed
- `git diff --check` — passed

No application data, migrations, package versions, release tags, or public artifacts were changed.
