### PR TITLE
fix(i18n): translate backlog as 积压 in Chinese

### DIFF
--- a/ui/src/context/I18nContext.test.ts
+++ b/ui/src/context/I18nContext.test.ts
@@ -70,6 +70,9 @@ describe("translateMessage", () => {
       "These preferences apply across the 控制台界面.",
     );
     expect(translateLegacyString("zh-CN", "All Agents")).toBe("全部智能体");
+    expect(translateLegacyString("zh-CN", "Backlog")).toBe("积压");
+    expect(translateLegacyString("zh-CN", "Issue status: backlog")).toBe("任务状态：积压");
+    expect(translateLegacyString("zh-CN", "backlog · medium · created by me")).toBe("积压 · 中 · 我创建的");
     expect(translateLegacyString("zh-CN", "Finished 2d ago")).toBe("2 天前完成");
     expect(translateLegacyString("zh-CN", "1 live")).toBe("1 个运行中");
     expect(translateLegacyString("zh-CN", "Messenger")).toBe("消息");

--- a/ui/src/i18n/legacyPhrases.ts
+++ b/ui/src/i18n/legacyPhrases.ts
@@ -78,7 +78,7 @@ const zhExactPhrases: Record<string, string> = {
   "Add instructions e.g. look for crashes in Sentry": "添加说明，例如检查 Sentry 里的崩溃问题",
   "Available Plugins": "可用插件",
   "Back": "返回",
-  "Backlog": "待办",
+  "Backlog": "积压",
   "Back to runs": "返回运行列表",
   "Base ref": "基准引用",
   "Beta": "测试版",
@@ -1055,7 +1055,7 @@ function translateIssueStatus(status: string) {
   if (normalized === "done") return "已完成";
   if (normalized === "blocked") return "阻塞";
   if (normalized === "cancelled") return "已取消";
-  if (normalized === "backlog") return "待整理";
+  if (normalized === "backlog") return "积压";
   return status;
 }
 


### PR DESCRIPTION
## Summary
- Translate the Chinese `Backlog` status as `积压` so it is distinct from `Todo` (`待办`).
- Keep exact and dynamic issue-status translations consistent.

## Validation
- `vitest run ui/src/context/I18nContext.test.ts` — 10 passed
- `@rudderhq/ui` typecheck — passed
- `pnpm lint:changed` — passed
- `@rudderhq/ui` production build — passed; existing CSS/chunk warnings only