### PR TITLE
test(e2e): wait for workspace restore response

### DIFF
--- a/tests/e2e/workspace-backups.spec.ts
+++ b/tests/e2e/workspace-backups.spec.ts
@@ -78,7 +78,16 @@ test("browses, restores, and deletes workspace backup versions", async ({ page }
   await page.getByRole("button", { name: "Restore" }).click();
   const restoreDialog = page.getByRole("dialog", { name: "Restore workspace backup" });
   await expect(restoreDialog).toBeVisible();
-  await restoreDialog.getByRole("button", { name: "Restore" }).click();
+  const restoreResponse = page.waitForResponse((response) =>
+    response.request().method() === "POST"
+      && response.url().includes("/workspace/backups/")
+      && response.url().endsWith("/restore")
+      && response.ok(),
+  );
+  await Promise.all([
+    restoreResponse,
+    restoreDialog.getByRole("button", { name: "Restore" }).click(),
+  ]);
   await expect.poll(async () => fs.readFile(path.join(workspaceRoot, "plans", "roadmap.md"), "utf8"))
     .toBe("# Roadmap\n");
   await expect(page.getByText("2 backups")).toBeVisible();


### PR DESCRIPTION
## Summary

- wait for the concrete workspace-backup restore HTTP response before asserting restored files in the E2E workflow

## Root cause

The workspace-backup restore service performs the atomic workspace replacement before returning its response, while the UI triggers the mutation asynchronously with React Query. The E2E clicked the confirmation button and immediately started a five-second filesystem poll without waiting for the `POST /api/orgs/:orgId/workspace/backups/:backupId/restore` request. Under CI load, the pre-restore safety backup could still be running, so the test observed `ENOENT` even though the restore was still in flight.

The test now waits for the matching successful restore response and then verifies the restored file and UI state. This preserves the real workflow and does not weaken the restore contract.

## Verification

- `RUDDER_E2E_RUN_ID=workspace-backups-fix-... CI=true corepack pnpm test:e2e tests/e2e/workspace-backups.spec.ts` — 2/2 passed (1.3m)
- `git diff --check` — passed

The source branch is based on current main `ede59f91b789785e6524e8ad3f674026fd8a4676`. No application data, migrations, release tags, packages, or public artifacts were changed.
