### PR TITLE
docs(release): prepare v0.7.20 notes

### DIFF
--- a/docs/releases.mdx
+++ b/docs/releases.mdx
@@ -18,6 +18,33 @@ Rudder publishes stable releases for the default install path:
 npx @rudderhq/cli@latest start
 ```
 
+<Update label="September 9, 2026" description="v0.7.20" tags={["New","Improved","Fixed"]}>
+
+## v0.7.20
+
+[GitHub Release](https://github.com/Undertone0809/rudder/releases/tag/v0.7.20)
+
+Rudder 0.7.20 makes local agent work easier to start and recover, keeps Chat activity in sync with live runs, and strengthens workspace and Desktop reliability across platforms.
+
+### New
+
+- Windows installations now have a browser-app compatibility path. When Smart App Control would block the unsigned Desktop executable, `rudder start` can open the same local workspace in Microsoft Edge app mode and create a Start Menu shortcut.
+- Added a dedicated `rudder browser-app` command for opening and managing the loopback-only browser workspace.
+
+### Improved
+
+- Chat now refreshes queued work after live activity and reconnects, while avoiding repeated polling for hidden terminal states and keeping failure previews bounded and useful.
+- Desktop and CLI update flows now report progress more consistently, recover terminal and local-app handoffs more reliably, and preserve runtime ownership across retries.
+- Embedded PostgreSQL recovery now verifies process ownership and reuses a live runtime port when appropriate, improving relaunch and recovery behavior.
+
+### Fixed
+
+- Workspace folder mappings now accept valid dotted names while continuing to reject malformed and escaping paths.
+- Fixed Chat website icons being clipped in transcript content.
+- Improved cross-platform local-app readiness and cleanup behavior, including Windows browser-app startup and packaged Desktop restart coverage.
+
+</Update>
+
 <Update label="September 7, 2026" description="v0.7.19" tags={["New","Improved","Fixed"]}>
 
 ## v0.7.19

--- a/docs/zh/releases.mdx
+++ b/docs/zh/releases.mdx
@@ -18,6 +18,33 @@ Rudder 稳定版本对应默认安装路径：
 npx @rudderhq/cli@latest start
 ```
 
+<Update label="2026年9月9日" description="v0.7.20" tags={["新功能","改进","问题修复"]}>
+
+## v0.7.20
+
+[GitHub Release](https://github.com/Undertone0809/rudder/releases/tag/v0.7.20)
+
+Rudder 0.7.20 让本地 Agent 工作更容易启动和恢复，让 Chat 活动与实时运行保持同步，并提升跨平台工作区和 Desktop 的可靠性。
+
+### 新功能
+
+- Windows 安装现在提供浏览器应用兼容模式。当 Smart App Control 可能阻止未签名的 Desktop 可执行文件时，`rudder start` 可以在 Microsoft Edge 应用模式中打开同一个本地工作区，并创建开始菜单快捷方式。
+- 增加专用的 `rudder browser-app` 命令，用于打开和管理仅限本机回环访问的浏览器工作区。
+
+### 改进
+
+- Chat 现在会在实时活动和重新连接后刷新排队工作，同时避免反复轮询已隐藏的终止状态，并保留有界且有用的失败预览。
+- Desktop 和 CLI 更新流程现在会更一致地报告进度，更可靠地恢复 Terminal 和本地应用交接，并在重试时保留运行时所有权。
+- 内置 PostgreSQL 恢复现在会校验进程所有权，并在适当时复用仍在运行的运行时端口，改善重启和恢复行为。
+
+### 问题修复
+
+- 工作区文件夹映射现在接受有效的点号名称，同时继续拒绝格式错误和越界路径。
+- 修复 Chat Transcript 内容中的网站图标被裁切的问题。
+- 改进跨平台本地应用的就绪和清理行为，包括 Windows 浏览器应用启动和打包 Desktop 重启覆盖。
+
+</Update>
+
 <Update label="2026年9月7日" description="v0.7.19" tags={["新功能","改进","问题修复"]}>
 
 ## v0.7.19

--- a/releases/v0.7.20.md
+++ b/releases/v0.7.20.md
@@ -1,0 +1,18 @@
+Rudder 0.7.20 makes local agent work easier to start and recover, keeps Chat activity in sync with live runs, and strengthens workspace and Desktop reliability across platforms.
+
+## New
+
+- Added a browser-app compatibility path for Windows installations. When Smart App Control would block the unsigned Desktop executable, `rudder start` can open the same local workspace in Microsoft Edge app mode and create a Start Menu shortcut.
+- Added a dedicated `rudder browser-app` command for opening and managing the loopback-only browser workspace.
+
+## Improved
+
+- Chat now refreshes queued work after live activity and reconnects, while avoiding repeated polling for hidden terminal states and keeping failure previews bounded and useful.
+- Desktop and CLI update flows now report progress more consistently, recover terminal and local-app handoffs more reliably, and preserve runtime ownership across retries.
+- Embedded PostgreSQL recovery now verifies process ownership and reuses a live runtime port when appropriate, improving relaunch and recovery behavior.
+
+## Fixed
+
+- Workspace folder mappings now accept valid dotted names while continuing to reject malformed and escaping paths.
+- Fixed Chat website icons being clipped in transcript content.
+- Improved cross-platform local-app readiness and cleanup behavior, including Windows browser-app startup and packaged Desktop restart coverage.

--- a/tests/docs-search/docs-search.spec.ts
+++ b/tests/docs-search/docs-search.spec.ts
@@ -121,8 +121,8 @@ test("renders and filters the localized changelog timeline", async ({ page }) =>
     {
       route: "/releases",
       title: "Changelog",
-      latestDate: "August 28, 2026",
-      latestVersion: "v0.7.15",
+      latestDate: "September 9, 2026",
+      latestVersion: "v0.7.20",
       filterTag: "New",
       statusTag: "Status",
       tags: ["Improved", "New", "Fixed", "Status"],
@@ -130,8 +130,8 @@ test("renders and filters the localized changelog timeline", async ({ page }) =>
     {
       route: "/zh/releases",
       title: "更新日志",
-      latestDate: "2026年8月28日",
-      latestVersion: "v0.7.15",
+      latestDate: "2026年9月9日",
+      latestVersion: "v0.7.20",
       filterTag: "新功能",
       statusTag: "版本状态",
       tags: ["改进", "新功能", "问题修复", "版本状态"],
@@ -148,7 +148,7 @@ test("renders and filters the localized changelog timeline", async ({ page }) =>
         "xpath=ancestor::div[contains(@class, 'update-container')]",
       );
     await expect(page.locator(`h2#${item.latestVersion.replaceAll(".", "-")}`)).toBeVisible();
-    await expect(page.locator('h2[id^="v0-"]')).toHaveCount(49);
+    await expect(page.locator('h2[id^="v0-"]')).toHaveCount(50);
     const latestUpdate = page.locator(`h2#${item.latestVersion.replaceAll(".", "-")}`).locator(
       "xpath=ancestor::div[contains(@class, 'update-container')]",
     );


### PR DESCRIPTION
## Summary
- add v0.7.20 GitHub release notes
- add English and Chinese public changelog entries

## Verification
- node scripts/verify-stable-changelog.mjs --version 0.7.20
- git diff --check

This PR is release preparation for the authorized 0.7.20 stable release.