### PR TITLE
fix: rename app finder action

### DIFF
--- a/doc/plans/2026-07-29-app-builder-prd.md
+++ b/doc/plans/2026-07-29-app-builder-prd.md
@@ -81,7 +81,7 @@ V1 delivers:
 - a Desktop-owned fixed runner that installs dependencies, runs typecheck,
   unit tests, production build, and a real loopback readiness check;
 - a reviewed, opaque installation-local App binding;
-- Start, Stop, Open, Copy App link, Continue in Chat, and Open source;
+- Start, Stop, Open, Copy App link, Continue in Chat, and Open in Finder;
 - development-data Backup, Export, Import, and Restore;
 - clear unavailable and failure states;
 - macOS, Linux, and Windows process-ownership adapters.
@@ -156,7 +156,7 @@ The Apps workspace shows durable build and binding state:
 
 - source work pending: `Continue in Chat`;
 - source exists: `Register & preview`;
-- running: `Open`, `Copy App link`, `Stop`, `Continue in Chat`, `Open source`;
+- running: `Open`, `Copy App link`, `Stop`, `Continue in Chat`, `Open in Finder`;
 - bound App: development-data Backup, Import, and Restore;
 - failed or unavailable: causal error and recovery direction.
 

--- a/tests/e2e/app-builder.spec.ts
+++ b/tests/e2e/app-builder.spec.ts
@@ -621,7 +621,7 @@ test.describe("Apps workspace", () => {
     });
     await expect(page.getByRole("heading", { name: "The App could not open" })).toBeVisible();
     await expect(page.getByTestId("apps-ask-ai")).toBeVisible();
-    await expect(page.getByRole("button", { name: "Open source" })).toHaveCount(0);
+    await expect(page.getByRole("button", { name: "Open in Finder" })).toHaveCount(0);
     await page.screenshot({
       path: `/tmp/rudder-apps-e2e-failure-${testInfo.workerIndex}.png`,
       fullPage: true,
@@ -1029,7 +1029,7 @@ test.describe("Apps workspace", () => {
     });
   });
 
-  test("preserves recovery when automatic App startup fails", async ({ page }) => {
+  test("preserves recovery when automatic App startup fails", async ({ page }, testInfo) => {
     const organization = await createOrganization(page.request, "App-Auto-Failure");
     await setPluginsEnabled(page.request, true);
     const createdResponse = await page.request.post(
@@ -1094,7 +1094,15 @@ test.describe("Apps workspace", () => {
       `${E2E_BASE_URL}/${organization.issuePrefix}/apps/view/managed%3A${created.id}`,
     );
     await expect(page.getByTestId("apps-retry-managed-app")).toBeVisible();
-    await expect(page.getByRole("button", { name: "Open source" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Open in Finder" })).toBeVisible();
+    const managedAppEntry = page.getByTestId(`apps-entry-managed:${created.id}`);
+    await managedAppEntry.hover();
+    await page.getByTestId(`apps-more-managed:${created.id}`).click();
+    await expect(page.getByRole("menuitem", { name: "Open in Finder" })).toBeVisible();
+    await page.screenshot({
+      path: `/tmp/rudder-app-builder-finder-menu-${testInfo.workerIndex}.png`,
+      fullPage: true,
+    });
   });
 
   test("keeps App Builder records organization-scoped", async ({ request }) => {

--- a/ui/src/components/AppsContextSidebar.tsx
+++ b/ui/src/components/AppsContextSidebar.tsx
@@ -314,7 +314,7 @@ function AppRowActions({
               if (definition) {
                 void desktopShell?.openPath(definition.cwd).catch((error) => {
                   pushToast({
-                    title: "Could not open App source",
+                    title: "Could not open App in Finder",
                     body: error instanceof Error ? error.message : undefined,
                     tone: "error",
                   });
@@ -327,7 +327,7 @@ function AppRowActions({
             }}
           >
             <FolderSearch aria-hidden />
-            Open source
+            Open in Finder
           </DropdownMenuItem>
         ) : null}
         {entry.kind === "managed" && entry.app.conversationId ? (

--- a/ui/src/pages/Apps.tsx
+++ b/ui/src/pages/Apps.tsx
@@ -486,7 +486,7 @@ function ManagedSetupPane({
                 `/library?directory=${encodeURIComponent(entry.app.sourceRoot)}`,
               )}
             >
-              Open source
+              Open in Finder
             </Button>
           </div>
           {retryMutation.error ? (


### PR DESCRIPTION
## Summary
- rename the App source action to `Open in Finder` across the Apps UI
- align the App Builder PRD and add menu-level E2E coverage

## Verification
- `pnpm --filter @rudderhq/ui typecheck`
- `pnpm --filter @rudderhq/ui build`
- `pnpm lint:changed`
- `pnpm exec playwright test tests/e2e/app-builder.spec.ts --config tests/e2e/playwright.config.ts --grep "preserves recovery when automatic App startup fails"`

The default shared dev instance was not reset; its existing migration mismatch remains outside this change.