### PR TITLE
fix: hide library source option for new projects

### DIFF
--- a/tests/e2e/new-project-sources-dialog.spec.ts
+++ b/tests/e2e/new-project-sources-dialog.spec.ts
@@ -61,7 +61,7 @@ test("adds recent local sources through the progressive Sources dialog", async (
 
   const sourcesDialog = page.getByTestId("new-project-add-sources-dialog");
   await expect(sourcesDialog).toBeVisible();
-  await expect(sourcesDialog.getByRole("button", { name: /Add from library/ })).toBeVisible();
+  await expect(sourcesDialog.getByRole("button", { name: /Add from library/ })).toHaveCount(0);
   await expect(sourcesDialog.getByRole("button", { name: /Select from local/ })).toBeVisible();
   await expect(sourcesDialog.getByRole("button", { name: /Add from URL/ })).toBeVisible();
   await expect(sourcesDialog.getByPlaceholder("Search Library or paste relative path")).toHaveCount(0);

--- a/tests/e2e/primary-rail-create-menu.spec.ts
+++ b/tests/e2e/primary-rail-create-menu.spec.ts
@@ -342,7 +342,7 @@ test.describe("Primary rail create menu", () => {
     ]);
   });
 
-  test("creates a project with a Library file attached as a path-based library resource", async ({ page }) => {
+  test("does not expose Library sources in the new project dialog", async ({ page }) => {
     const orgRes = await page.request.post("/api/orgs", {
       data: {
         name: `PrimaryRail-Project-Library-${Date.now()}`,
@@ -350,14 +350,6 @@ test.describe("Primary rail create menu", () => {
     });
     expect(orgRes.ok()).toBe(true);
     const organization = await orgRes.json() as { id: string; issuePrefix: string };
-
-    const fileRes = await page.request.post(`/api/orgs/${organization.id}/workspace/file`, {
-      data: {
-        filePath: "projects/create-menu/project-brief.md",
-        content: "# Project brief\n\nUse this as project context.",
-      },
-    });
-    expect(fileRes.ok()).toBe(true);
 
     await page.goto("/");
     await page.evaluate((orgId) => {
@@ -374,33 +366,9 @@ test.describe("Primary rail create menu", () => {
 
     await dialog.getByRole("button", { name: "Add sources", exact: true }).click();
     const sourcesDialog = page.getByTestId("new-project-add-sources-dialog");
-    await sourcesDialog.getByRole("button", { name: /Add from library/ }).click();
-    await sourcesDialog.getByRole("button", { name: /project-brief\.md/ }).click();
-    await expect(dialog.getByText("Library · File · projects/create-menu/project-brief.md")).toBeVisible();
-
-    const createResponse = page.waitForResponse((response) =>
-      response.request().method() === "POST"
-      && response.url().includes(`/api/orgs/${organization.id}/projects`)
-      && response.ok(),
-    );
-    await dialog.getByRole("button", { name: "Create project" }).click();
-    const created = await (await createResponse).json() as {
-      resources: Array<{
-        role: string;
-        resource: { name: string; kind: string; sourceType: string; locator: string };
-      }>;
-    };
-
-    expect(created.resources).toHaveLength(1);
-    expect(created.resources[0]).toEqual(expect.objectContaining({
-      role: "reference",
-      resource: expect.objectContaining({
-        name: "project-brief.md",
-        kind: "file",
-        sourceType: "library",
-        locator: "projects/create-menu/project-brief.md",
-      }),
-    }));
+    await expect(sourcesDialog.getByRole("button", { name: /Add from library/ })).toHaveCount(0);
+    await expect(sourcesDialog.getByRole("button", { name: /Select from local/ })).toBeVisible();
+    await expect(sourcesDialog.getByRole("button", { name: /Add from URL/ })).toBeVisible();
   });
 
   test("uses the local file picker from the new project Sources dialog", async ({ page }) => {

--- a/tests/e2e/smoke-real-work-loop.spec.ts
+++ b/tests/e2e/smoke-real-work-loop.spec.ts
@@ -301,7 +301,7 @@ test.describe("@smoke real work loop", () => {
       });
 
       await failedMessage.getByRole("button", { name: "Retry" }).click();
-      await expect(page.getByTestId("chat-user-message-bubble").filter({ hasText: task })).toBeVisible({
+      await expect(page.getByTestId("chat-user-message-bubble").filter({ hasText: task }).last()).toBeVisible({
         timeout: 15_000,
       });
       await expect(page.getByTestId("chat-assistant-message").last()).toContainText(

--- a/ui/src/components/AddSourcesDialog.tsx
+++ b/ui/src/components/AddSourcesDialog.tsx
@@ -38,6 +38,7 @@ type Props = {
   open: boolean;
   orgId: string;
   resources: OrganizationResource[];
+  allowLibrary?: boolean;
   excludedResourceIds?: Iterable<string>;
   excludedLibraryLocators?: Iterable<string>;
   testId?: string;
@@ -53,6 +54,7 @@ export function AddSourcesDialog({
   open,
   orgId,
   resources,
+  allowLibrary = true,
   excludedResourceIds = [],
   excludedLibraryLocators = [],
   testId = "add-sources-dialog",
@@ -78,7 +80,7 @@ export function AddSourcesDialog({
   const { data: libraryFiles } = useQuery({
     queryKey: queryKeys.organizations.workspaceMentionFiles(orgId, librarySearch),
     queryFn: () => organizationsApi.listWorkspaceMentionFiles(orgId, { query: librarySearch, limit: 24 }),
-    enabled: open && view === "library",
+    enabled: open && allowLibrary && view === "library",
   });
   const recentLocal = resources
     .filter((resource) => !excludedIds.has(resource.id) && resource.sourceType === "external" && ["file", "directory"].includes(resource.kind))
@@ -128,6 +130,11 @@ export function AddSourcesDialog({
   }
 
   const title = view === "library" ? "Add from library" : view === "local" ? "Select from local" : view === "url" ? "Add from URL" : "Add sources";
+  const sourceTypeOptions = [
+    ...(allowLibrary ? [{ view: "library" as const, label: "Add from library", detail: "Reuse files already in this organization", icon: LibraryBig }] : []),
+    { view: "local" as const, label: "Select from local", detail: "Reuse recent sources or choose a file", icon: FolderOpen },
+    { view: "url" as const, label: "Add from URL", detail: "Link a webpage or remote reference", icon: Globe2 },
+  ];
 
   return (
     <Dialog open={open} onOpenChange={reset}>
@@ -141,11 +148,7 @@ export function AddSourcesDialog({
           <Button type="button" variant="ghost" size="icon-xs" className="text-muted-foreground" aria-label="Close add sources" onClick={() => reset(false)}><X className="h-3.5 w-3.5" /></Button>
         </div>
 
-        {view === "choose" ? <div className="grid gap-2 p-4">{[
-          { view: "library" as const, label: "Add from library", detail: "Reuse files already in this organization", icon: LibraryBig },
-          { view: "local" as const, label: "Select from local", detail: "Reuse recent sources or choose a file", icon: FolderOpen },
-          { view: "url" as const, label: "Add from URL", detail: "Link a webpage or remote reference", icon: Globe2 },
-        ].map((option) => <button key={option.view} type="button" className="group flex w-full items-center gap-3 rounded-[var(--radius-sm)] border border-border/80 px-3 py-3 text-left transition-colors hover:border-border-strong hover:bg-accent/35 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring" onClick={() => setView(option.view)}>
+        {view === "choose" ? <div className="grid gap-2 p-4">{sourceTypeOptions.map((option) => <button key={option.view} type="button" className="group flex w-full items-center gap-3 rounded-[var(--radius-sm)] border border-border/80 px-3 py-3 text-left transition-colors hover:border-border-strong hover:bg-accent/35 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring" onClick={() => setView(option.view)}>
           <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-[calc(var(--radius-sm)-1px)] border border-border/70 bg-muted/40 text-muted-foreground group-hover:text-foreground"><option.icon className="h-4 w-4" /></span>
           <span className="min-w-0 flex-1"><span className="block text-sm font-medium">{option.label}</span><span className="mt-0.5 block text-xs text-muted-foreground">{option.detail}</span></span><span className="text-muted-foreground">&rsaquo;</span>
         </button>)}</div> : null}

--- a/ui/src/components/NewProjectDialog.test.tsx
+++ b/ui/src/components/NewProjectDialog.test.tsx
@@ -237,7 +237,7 @@ describe("NewProjectDialog", () => {
 
     const sourceDialog = container.querySelector('[data-testid="new-project-add-sources-dialog"]');
     expect(sourceDialog).not.toBeNull();
-    expect(sourceDialog?.textContent).toContain("Add from library");
+    expect(sourceDialog?.textContent).not.toContain("Add from library");
     expect(sourceDialog?.textContent).toContain("Select from local");
     expect(sourceDialog?.textContent).toContain("Add from URL");
     expect(sourceDialog?.textContent).not.toContain("Search Library");
@@ -294,38 +294,16 @@ describe("NewProjectDialog", () => {
     expect(submittedData).not.toHaveProperty("goalIds");
   });
 
-  it("keeps Library search inside its own source step", () => {
-    vi.useFakeTimers();
-    mockState.libraryEntries = [
-      {
-        name: "brief.md",
-        displayLabel: "Project brief",
-        path: "projects/rudder/brief.md",
-        isDirectory: false,
-      },
-    ];
+  it("does not expose the library source step when creating a project", () => {
     const container = renderDialog();
     const trigger = [...container.querySelectorAll<HTMLButtonElement>("button")]
       .find((button) => button.textContent?.includes("Add sources"));
 
     act(() => trigger!.click());
-    let sourceDialog = container.querySelector('[data-testid="new-project-add-sources-dialog"]')!;
-    const libraryButton = [...sourceDialog.querySelectorAll<HTMLButtonElement>("button")]
-      .find((button) => button.textContent?.includes("Add from library"));
-    act(() => libraryButton!.click());
-    sourceDialog = container.querySelector('[data-testid="new-project-add-sources-dialog"]')!;
+    const sourceDialog = container.querySelector('[data-testid="new-project-add-sources-dialog"]')!;
 
-    const libraryScroll = sourceDialog.querySelector<HTMLElement>("[data-testid='new-project-library-sources-scroll']");
-    expect(libraryScroll).not.toBeNull();
-    act(() => libraryScroll!.dispatchEvent(new Event("scroll")));
-    expect(libraryScroll?.classList.contains("is-scrolling")).toBe(true);
-    act(() => vi.advanceTimersByTime(700));
-    expect(libraryScroll?.classList.contains("is-scrolling")).toBe(false);
-    expect(sourceDialog.querySelector("input[placeholder='Search Library or paste relative path']")).not.toBeNull();
-    expect(sourceDialog.textContent).toContain("Project brief");
-    expect(sourceDialog.textContent).not.toContain("Recent sources");
-    expect(sourceDialog.querySelector("input[type='url']")).toBeNull();
-    vi.useRealTimers();
+    expect(sourceDialog.textContent).not.toContain("Add from library");
+    expect(sourceDialog.querySelector("[data-testid='new-project-library-sources-scroll']")).toBeNull();
   });
 
   it("reuses recent local sources and keeps direct file selection available", async () => {

--- a/ui/src/components/NewProjectDialog.tsx
+++ b/ui/src/components/NewProjectDialog.tsx
@@ -714,6 +714,7 @@ export function NewProjectDialog() {
         open={addSourcesOpen}
         orgId={selectedOrganizationId}
         resources={organizationResources ?? []}
+        allowLibrary={false}
         excludedResourceIds={selectedExistingResourceIds}
         excludedLibraryLocators={selectedLibraryLocators}
         testId="new-project-add-sources-dialog"


### PR DESCRIPTION
## Summary
- Hide Add from library in the New project > Add sources route.
- Preserve Add from library in existing project resource management.
- Update component and E2E coverage.

## Verification
- NewProjectDialog unit tests: 13 passed.
- UI typecheck passed.
- lint:changed passed.
- Focused real-browser E2E: 3 passed on disposable embedded-PostgreSQL instance.
- Independent verifier: PASS; final reviewer: accept.
- Desktop and mobile screenshots were inspected outside the repository.