### PR TITLE
fix(chat): keep first sends responsive under load

### DIFF
--- a/doc/plans/2026-09-08-chat-responsiveness-under-load.md
+++ b/doc/plans/2026-09-08-chat-responsiveness-under-load.md
@@ -1,0 +1,119 @@
+---
+title: Chat responsiveness under load
+date: 2026-09-08
+kind: fix-plan
+status: in_progress
+area: ui
+entities:
+  - messenger_chat
+  - live_updates
+related_code:
+  - ui/src/pages/Chat.tsx
+  - ui/src/context/LiveUpdatesProvider.tsx
+  - ui/src/lib/messenger-query-cache.ts
+  - tests/e2e/chat-first-turn-responsiveness.spec.ts
+---
+
+# Intent and bounded delivery
+
+The operator reports that submitting a new chat can leave the new-chat screen
+stuck, with delayed or incorrect navigation, especially under machine load.
+The broader goal is responsive interaction under slow CPU and slow I/O, not
+merely a faster spinner on an idle machine.
+
+This slice removes confirmed foreground/background coupling and overlapping
+query invalidations, and preserves first-turn operation state across responsive
+page remounts. It does not claim whole-app performance qualification or
+parity with Hermes Studio. No data migration, runtime protocol rewrite, fake
+successful persistence, paid-agent benchmark, or Desktop packaging change is
+part of this slice.
+
+## Confirmed source-level causes
+
+- The first-turn acknowledgement seeds the conversation/message caches, then
+  awaits list/group refreshes before setting stream state and navigating.
+  The NDJSON consumer awaits that callback, so unrelated GETs also block
+  processing subsequent stream events.
+- The same acknowledgement navigates unconditionally; a late response can
+  override a newer user navigation and clear a different composer draft.
+- Live updates and Messenger reconciliation invalidate overlapping parent and
+  child query keys. Existing cached queries can be restarted repeatedly by a
+  single event. Preserve event freshness while removing within-event duplicates;
+  do not suppress a later authoritative event with a blanket in-flight guard.
+- Independent black-box acceptance found that switching desktop/mobile layout
+  remounts the routed Chat page while its first POST is unresolved. Local pending
+  content and the send lock disappear, and a component-lifetime navigation guard
+  cannot distinguish that remount from actual user navigation. First-turn
+  operation ownership must outlive the presentation component.
+
+## State inventory and acceptance packet
+
+| State | Current job / visible controls | Safety and continuity |
+| --- | --- | --- |
+| Draft | Choose agent/context and Send | Existing agent preflight and draft semantics remain |
+| Submitted, not acknowledged | Immediately show local outgoing content and explicit sending feedback | Not represented as persisted; duplicate submission disabled; navigation remains available |
+| Acknowledged | Show accepted conversation, one user message, stream/loading state | Seed caches and navigate without waiting for sidebar GETs; server owns the canonical ID |
+| User navigated elsewhere | Continue the chosen conversation/workflow | Late acknowledgement must not navigate back or clear the new draft; accepted work remains discoverable |
+| Pre-ack failure | Visible error and recoverable original text/files | No fake success; retain existing recovery semantics |
+| Streaming/final | Read output or send next turn when allowed | Sidebar synchronization must not stop stream consumption; preserve queue/stop protocol |
+
+Primary tests use an isolated local API and PostgreSQL with the repository's
+explicit no-cost agent process fixture. Hold real sidebar GET requests after
+initial loading. Independently observe the real NDJSON response and require
+navigation plus rendered output while those GETs remain unresolved. Include
+4x renderer CPU throttling, late acknowledgement after SPA navigation, failure
+recovery, duplicate send, and desktop/mobile pre-ack feedback. Read persisted
+messages back to assert one user turn. Runtime-fixture output is not live model
+quality evidence.
+
+The acceptance matrix also requires crossing the responsive breakpoint in both
+directions while the initial POST is unresolved, retaining text/attachment
+feedback and the duplicate-send lock, then opening the acknowledged conversation.
+Test failed delivery after remount and successful retry; actual navigation and
+organization switches must still supersede foreground handoff. An older final
+callback must not clear a newer first-turn operation.
+If a first-turn failure arrives after leaving its source, retain the source
+draft without replacing a newer draft. A conflicting recovery uses a separate
+recoverable draft and an explicit source-organization-scoped toast action; no
+automatic navigation. Release recovered attachment references after successful
+retry. Test the recovery action through the browser, not only store contents.
+
+## Integration ownership
+
+The operator explicitly assigned integration to this task after concurrent Chat
+edits were detected. Preserve unrelated shared-worktree changes. Reconcile the
+overlapping first-send implementation against the current user requirement;
+retain useful parallel attachment/reload/failure regression coverage instead of
+discarding the other work wholesale. Verify the final integrated source, not just
+an earlier isolated diff. The initial independent receipt was FAIL, so neither
+the previous stage accept nor passing focused tests count as final acceptance.
+
+For invalidations, use actual QueryClient/QueryObserver with deferred query
+functions and existing cache, not only mocked invalidateQueries call counts.
+Check descendant coverage, organization isolation, and later-event freshness.
+
+Stage review precedes independent black-box acceptance; final review reads the
+verifier receipt and exact candidate fingerprint. Screenshots belong outside
+the repository. Do not overwrite concurrent edits in the shared checkout.
+
+## Next performance work, not delivered by this slice
+
+1. Capture a production-renderer trace with representative long histories and
+   concurrent runs. Record input-to-paint, navigation-to-content, long tasks,
+   request counts and bytes. Separate browser CPU, API latency, DB wait, and
+   agent startup rather than inferring server performance from a screenshot.
+2. Narrow ChatGeneration subscriptions: sidebar activity consumers should not
+   subscribe to full streaming bodies. Verify actual render counts before
+   choosing selectors or external-store seams.
+3. Profile expensive history/Markdown work and stabilize row props; introduce
+   windowing only with scroll anchoring, search/jump, selection and accessibility
+   regression coverage. Do not apply memoization indiscriminately.
+4. Inventory mutation journeys and remove nonessential refetches from UI critical
+   paths. Keep optimistic pending, acknowledged, failed and retry states explicit.
+   Destructive/governed operations still require authoritative confirmation.
+5. If event bursts remain expensive after deduplication, design per-key bounded
+   coalescing with a trailing refresh so events arriving during an in-flight
+   snapshot are not lost. Blind cancelRefetch:false is not a freshness strategy.
+
+No percentage speedup or whole-app latency guarantee is claimed until measured
+against a frozen production build and representative workload.

--- a/tests/e2e/chat-first-turn-recovery.spec.ts
+++ b/tests/e2e/chat-first-turn-recovery.spec.ts
@@ -1,0 +1,63 @@
+import { expect, test } from "@playwright/test";
+import { createE2EChatAgent } from "./support/chat-agent";
+import { E2E_CODEX_STUB } from "./support/e2e-env";
+
+test("recovers a failed first turn without replacing a newer draft", async ({ page }) => {
+  const orgResponse = await page.request.post("/api/orgs", { data: { name: `First-turn-recovery-${Date.now()}` } });
+  expect(orgResponse.ok()).toBe(true);
+  const org = await orgResponse.json();
+  const agent = await createE2EChatAgent(page.request, org.id, { command: E2E_CODEX_STUB });
+  await page.addInitScript((id) => localStorage.setItem("rudder.selectedOrganizationId", id), org.id);
+  await page.setViewportSize({ width: 1440, height: 960 });
+  await page.goto(`/${org.urlKey}/messenger/chat?agentId=${agent.id}`);
+  const editor = () => page.locator(".rudder-mdxeditor-content").first();
+  await expect(editor()).toBeVisible({ timeout: 20_000 });
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => { release = resolve; });
+  let posts = 0;
+  await page.route(`**/api/orgs/${org.id}/chats/messages/stream`, async (route) => {
+    posts += 1;
+    if (posts === 1) { await gate; await route.abort("failed"); return; }
+    await route.continue();
+  });
+  const original = "Recover the original failed turn with its attachment";
+  const replacement = "Do not replace this newer draft";
+  try {
+    await editor().fill(original);
+    await page.locator('input[type="file"]').setInputFiles({
+      name: "recovered-note.txt", mimeType: "text/plain", buffer: Buffer.from("Keep this file through failure"),
+    });
+    await page.getByRole("button", { name: "Send", exact: true }).click();
+    await expect.poll(() => posts).toBe(1);
+    await expect(page.getByTestId("chat-pending-first-turn")).toContainText(original);
+    await page.getByRole("link", { name: "New chat", exact: true }).click();
+    await editor().fill(replacement);
+    release();
+    const recoveredLink = page.getByRole("link", { name: "Open recovered draft", exact: true });
+    await expect(recoveredLink).toBeVisible();
+    await expect(editor()).toContainText(replacement);
+    await expect(recoveredLink).toHaveAttribute("href", new RegExp(`/${org.urlKey}/messenger/chat\\?firstTurnRecovery=`));
+    await recoveredLink.click();
+    await expect(editor()).toContainText(original);
+    await expect(page.getByTestId("chat-pending-attachment")).toContainText("recovered-note.txt");
+    await page.getByRole("button", { name: "Send", exact: true }).click();
+    await expect(page).toHaveURL(/\/messenger\/chat\/[a-f0-9-]+$/, { timeout: 20_000 });
+    const bubble = page.getByTestId("chat-user-message-bubble").filter({ hasText: original });
+    await expect(bubble).toHaveCount(1);
+    await expect(bubble.getByText("recovered-note.txt", { exact: true }).filter({ visible: true }).first()).toBeVisible();
+    const chatsResponse = await page.request.get(`/api/orgs/${org.id}/chats?status=all`);
+    expect(chatsResponse.ok()).toBe(true);
+    const chats = await chatsResponse.json();
+    expect(chats).toHaveLength(1);
+    const messagesResponse = await page.request.get(`/api/chats/${chats[0].id}/messages`);
+    expect(messagesResponse.ok()).toBe(true);
+    const messages = await messagesResponse.json();
+    expect(messages.filter((message: { role: string; body: string }) => message.role === "user" && message.body === original)).toHaveLength(1);
+    await page.getByRole("link", { name: "New chat", exact: true }).click();
+    await expect(editor()).toContainText(replacement);
+    expect(posts).toBe(2);
+  } finally {
+    release();
+    await page.unrouteAll({ behavior: "wait" });
+  }
+});

--- a/tests/e2e/chat-first-turn-resize.spec.ts
+++ b/tests/e2e/chat-first-turn-resize.spec.ts
@@ -1,0 +1,64 @@
+import { expect, test } from "@playwright/test";
+import { createE2EChatAgent } from "./support/chat-agent";
+import { E2E_CODEX_STUB } from "./support/e2e-env";
+
+for (const startMobile of [false, true]) {
+  for (const failFirst of [false, true]) {
+    test(`first send survives ${startMobile ? "mobile to desktop" : "desktop to mobile"} resize${failFirst ? " and failed retry" : ""}`, async ({ page }) => {
+      const orgResponse = await page.request.post("/api/orgs", { data: { name: `Resize-${Date.now()}` } });
+      expect(orgResponse.ok()).toBe(true);
+      const org = await orgResponse.json();
+      const agent = await createE2EChatAgent(page.request, org.id, { name: "Resize agent", command: E2E_CODEX_STUB });
+      await page.addInitScript((id) => localStorage.setItem("rudder.selectedOrganizationId", id), org.id);
+      const desktop = { width: 1440, height: 960 };
+      const mobile = { width: 390, height: 844 };
+      await page.setViewportSize(startMobile ? mobile : desktop);
+      await page.goto(`/${org.issuePrefix}/messenger/chat?agentId=${agent.id}`);
+      const editor = () => page.locator(".rudder-mdxeditor-content").first();
+      await expect(editor()).toBeVisible({ timeout: 20_000 });
+      await expect(page.getByRole("button", { name: "Send", exact: true })).toBeVisible();
+      let release!: () => void;
+      const gate = new Promise<void>((resolve) => { release = resolve; });
+      let posts = 0;
+      await page.route(`**/api/orgs/${org.id}/chats/messages/stream`, async (route) => {
+        posts += 1;
+        if (posts === 1) {
+          await gate;
+          if (failFirst) { await route.abort("failed"); return; }
+        }
+        await route.continue();
+      });
+      const body = `Keep one first turn across resize ${startMobile}-${failFirst}`;
+      try {
+        await editor().fill(body);
+        await page.locator('input[type="file"]').setInputFiles({ name: "resize-note.txt", mimeType: "text/plain", buffer: Buffer.from("retain this attachment") });
+        await page.getByRole("button", { name: "Send", exact: true }).click();
+        await expect.poll(() => posts).toBe(1);
+        await expect(page.getByTestId("chat-pending-first-turn")).toContainText(body);
+        await page.setViewportSize(startMobile ? desktop : mobile);
+        await expect(page.getByTestId("chat-pending-first-turn")).toContainText(body);
+        await expect(page.getByTestId("chat-pending-first-turn")).toContainText("resize-note.txt");
+        await editor().press("Enter");
+        await expect(page.getByRole("button", { name: "Sending", exact: true })).toBeDisabled();
+        expect(posts).toBe(1);
+        release();
+        if (failFirst) {
+          await expect(editor()).toContainText(body);
+          await expect(page.getByTestId("chat-pending-first-turn")).toHaveCount(0);
+          await page.getByRole("button", { name: "Send", exact: true }).click();
+        }
+        await expect(page).toHaveURL(/\/messenger\/chat\/[a-f0-9-]+$/, { timeout: 20_000 });
+        const chatId = new URL(page.url()).pathname.split("/").pop();
+        await expect(page.getByTestId("chat-main-workspace-card")).toContainText("Streaming reply", { timeout: 25_000 });
+        const response = await page.request.get(`/api/chats/${chatId}/messages`);
+        expect(response.ok()).toBe(true);
+        const messages = await response.json();
+        expect(messages.filter((message: { role: string; body: string }) => message.role === "user" && message.body === body)).toHaveLength(1);
+        expect(posts).toBe(failFirst ? 2 : 1);
+      } finally {
+        release();
+        await page.unrouteAll({ behavior: "wait" });
+      }
+    });
+  }
+}

--- a/tests/e2e/chat-first-turn-responsiveness.spec.ts
+++ b/tests/e2e/chat-first-turn-responsiveness.spec.ts
@@ -1,0 +1,248 @@
+import { expect, test, type Page, type Request } from "@playwright/test";
+import { createE2EChatAgent } from "./support/chat-agent";
+import { E2E_CODEX_STUB } from "./support/e2e-env";
+
+type WireEvent = {
+  type: string;
+  conversation?: { id: string };
+};
+
+type ObservedWindow = Window & { firstTurnWireEvents: WireEvent[] };
+
+function deferred() {
+  let release!: () => void;
+  const promise = new Promise<void>((resolve) => { release = resolve; });
+  return { promise, release };
+}
+
+/** Observe a clone of the real NDJSON response, without replacing ack or output. */
+async function observeFirstTurn(page: Page, orgId: string) {
+  await page.addInitScript((path) => {
+    const observed = window as ObservedWindow;
+    observed.firstTurnWireEvents = [];
+    const originalFetch = window.fetch.bind(window);
+    window.fetch = async (...args) => {
+      const response = await originalFetch(...args);
+      if (new URL(response.url).pathname === path && response.ok) {
+        const reader = response.clone().body!.getReader();
+        void (async () => {
+          const decoder = new TextDecoder();
+          let buffer = "";
+          while (true) {
+            const { value, done } = await reader.read();
+            buffer += decoder.decode(value, { stream: !done });
+            const lines = buffer.split("\n");
+            buffer = lines.pop() ?? "";
+            if (done && buffer.trim()) lines.push(buffer);
+            for (const line of lines) {
+              if (line.trim()) observed.firstTurnWireEvents.push(JSON.parse(line));
+            }
+            if (done) break;
+          }
+        })().catch(() => undefined); // Browser teardown may abort the observer.
+      }
+      return response;
+    };
+  }, `/api/orgs/${orgId}/chats/messages/stream`);
+}
+
+async function wireEvents(page: Page) {
+  return page.evaluate(() => (window as ObservedWindow).firstTurnWireEvents);
+}
+
+async function createFixture(page: Page, suffix: string) {
+  const orgResponse = await page.request.post("/api/orgs", {
+    data: { name: `First-turn-responsiveness-${suffix}-${Date.now()}` },
+  });
+  expect(orgResponse.ok()).toBe(true);
+  const organization = await orgResponse.json();
+  const agent = await createE2EChatAgent(page.request, organization.id, {
+    name: "Responsiveness Agent",
+    command: E2E_CODEX_STUB,
+  });
+  const existingResponse = await page.request.post(`/api/orgs/${organization.id}/chats`, {
+    data: {
+      title: "Existing conversation stays selected",
+      preferredAgentId: agent.id,
+      issueCreationMode: "manual_approval",
+      planMode: false,
+      initialMessage: { body: "This is the existing conversation." },
+    },
+  });
+  expect(existingResponse.ok(), await existingResponse.text()).toBe(true);
+  const existing = await existingResponse.json();
+  await observeFirstTurn(page, organization.id);
+  await page.setViewportSize({ width: 1440, height: 960 });
+  await page.goto("/");
+  await page.evaluate((orgId) => {
+    window.localStorage.setItem("rudder.selectedOrganizationId", orgId);
+  }, organization.id);
+  await page.goto(`/${organization.issuePrefix}/messenger/chat?agentId=${agent.id}`);
+  await expect(page.locator(".rudder-mdxeditor-content").first()).toBeVisible({ timeout: 20_000 });
+  const existingLink = page.locator(`a[href$="/messenger/chat/${existing.id}"]`).first();
+  await expect(existingLink).toBeVisible({ timeout: 15_000 });
+  return { organization, existing, existingLink };
+}
+
+/** Gate only real sidebar GETs, after initial data is already on screen. */
+async function holdSidebar(page: Page, orgId: string, kind: "lists" | "groups" | "both") {
+  const gate = deferred();
+  const held: string[] = [];
+  const heldRequests = new Set<Request>();
+  let released = false;
+  let completed = 0;
+  const matches = (url: URL) => {
+    const base = `/api/orgs/${orgId}`;
+    return (kind !== "groups" && [
+      `${base}/chats`, `${base}/messenger/threads`,
+    ].includes(url.pathname)) || (kind !== "lists" && url.pathname === `${base}/messenger/groups`);
+  };
+  await page.route(matches, async (route) => {
+    if (route.request().method() === "GET" && !released) {
+      held.push(route.request().url());
+      heldRequests.add(route.request());
+      await gate.promise;
+    }
+    await route.continue();
+  });
+  page.on("response", (response) => {
+    if (heldRequests.has(response.request())) completed += 1;
+  });
+  return {
+    held,
+    isReleased: () => released,
+    completed: () => completed,
+    release: () => { released = true; gate.release(); },
+    dispose: async () => {
+      released = true;
+      gate.release();
+      await page.unrouteAll({ behavior: "wait" });
+    },
+  };
+}
+
+async function acceptedChatId(page: Page) {
+  await expect.poll(async () => (await wireEvents(page)).some((event) => event.type === "ack"), {
+    message: "the real first-turn stream must acknowledge the persisted chat",
+    timeout: 15_000,
+  }).toBe(true);
+  const ack = (await wireEvents(page)).find((event) => event.type === "ack");
+  expect(ack?.conversation?.id).toBeTruthy();
+  return ack!.conversation!.id;
+}
+
+async function assertPersistedTurn(page: Page, chatId: string, body: string) {
+  const response = await page.request.get(`/api/chats/${chatId}/messages`);
+  expect(response.ok()).toBe(true);
+  const messages = await response.json() as Array<{ role: string; body: string }>;
+  expect(messages.filter((message) => message.role === "user" && message.body === body)).toHaveLength(1);
+}
+
+for (const kind of ["lists", "groups"] as const) {
+  test(`accepted first chat navigates and renders stream progress while sidebar ${kind} GETs are held`, async ({ page }, testInfo) => {
+    const { organization } = await createFixture(page, kind);
+    const sidebar = await holdSidebar(page, organization.id, kind);
+    const cdp = kind === "lists" ? await page.context().newCDPSession(page) : null;
+    // Exercise a slow renderer without making startup/module compilation the benchmark.
+    if (cdp) await cdp.send("Emulation.setCPUThrottlingRate", { rate: 4 });
+    const body = `Accepted turn must not wait for sidebar ${kind}`;
+    try {
+      await page.locator(".rudder-mdxeditor-content").first().fill(body);
+      await page.getByRole("button", { name: "Send", exact: true }).click();
+      const chatId = await acceptedChatId(page);
+      await expect.poll(() => sidebar.held.length, { timeout: 10_000 }).toBeGreaterThan(0);
+      await assertPersistedTurn(page, chatId, body);
+      await expect.poll(async () => (await wireEvents(page)).some((event) =>
+        event.type === "assistant_delta" || event.type === "transcript_entry"), {
+        message: "real runtime progress must reach the browser independently of sidebar GETs",
+        timeout: 15_000,
+      }).toBe(true);
+
+      // Soft assertions collect both symptoms of the same blocked acknowledgement.
+      await expect.soft(page, "accepted conversation navigation must not await sidebar refresh").toHaveURL(
+        new RegExp(`/messenger/chat/${chatId}$`), { timeout: 3_000 },
+      );
+      await expect.soft(page.getByTestId("chat-user-message-bubble").filter({ hasText: body })).toHaveCount(1, {
+        timeout: 2_000,
+      });
+      await expect.soft(page.getByTestId("chat-main-workspace-card"),
+        "received assistant progress must render while sidebar GETs remain blocked").toContainText("Streaming reply", {
+        timeout: 3_000,
+      });
+      expect(sidebar.isReleased()).toBe(false);
+      expect(sidebar.completed()).toBe(0);
+      await page.screenshot({ path: testInfo.outputPath(`sidebar-${kind}-held.png`), fullPage: true });
+      await testInfo.attach("held-sidebar-wire-evidence", {
+        body: JSON.stringify({ url: page.url(), held: sidebar.held, events: await wireEvents(page), cpuRate: cdp ? 4 : 1 }),
+        contentType: "application/json",
+      });
+
+      sidebar.release();
+      await expect(page).toHaveURL(new RegExp(`/messenger/chat/${chatId}$`), { timeout: 15_000 });
+      await expect(page.getByTestId("chat-assistant-message").last()).toContainText("Streaming reply for chat.", {
+        timeout: 30_000,
+      });
+      await assertPersistedTurn(page, chatId, body);
+    } finally {
+      await sidebar.dispose();
+      if (cdp) { await cdp.send("Emulation.setCPUThrottlingRate", { rate: 1 }); await cdp.detach(); }
+    }
+  });
+}
+
+test("selecting an existing conversation before first ack is not stolen by late ack or sidebar completion", async ({ page }, testInfo) => {
+  const { organization, existing, existingLink } = await createFixture(page, "navigation");
+  const streamGate = deferred();
+  let streamReached = false;
+  const streamPath = `**/api/orgs/${organization.id}/chats/messages/stream`;
+  await page.route(streamPath, async (route) => {
+    streamReached = true;
+    await streamGate.promise;
+    await route.continue();
+  });
+  const sidebar = await holdSidebar(page, organization.id, "both");
+  const body = "Finish this turn without taking me away from my selected conversation";
+  try {
+    await page.locator(".rudder-mdxeditor-content").first().fill(body);
+    await page.getByRole("button", { name: "Send", exact: true }).click();
+    await expect.poll(() => streamReached).toBe(true);
+    await expect(page.getByTestId("chat-pending-first-turn")).toContainText(body);
+    expect((await wireEvents(page)).some((event) => event.type === "ack")).toBe(false);
+    // A real SPA link keeps the in-flight component callback alive, unlike page.goto.
+    await existingLink.click();
+    const selectedUrl = page.url();
+    expect(selectedUrl).toMatch(new RegExp(`/messenger/chat/${existing.id}$`));
+    await expect(page.locator(".rudder-mdxeditor-content").first()).toBeVisible();
+    const nextDraft = "Keep the draft I typed after switching conversations";
+    await page.locator(".rudder-mdxeditor-content").first().fill(nextDraft);
+    const navigations: string[] = [];
+    page.on("framenavigated", (frame) => { if (frame === page.mainFrame()) navigations.push(frame.url()); });
+    streamGate.release();
+    const acceptedId = await acceptedChatId(page);
+    expect(acceptedId).not.toBe(existing.id);
+    await expect.poll(() => sidebar.held.length).toBeGreaterThan(0);
+    await assertPersistedTurn(page, acceptedId, body);
+    await expect.poll(async () => (await wireEvents(page)).some((event) => event.type === "final"), {
+      timeout: 30_000,
+    }).toBe(true);
+    await expect.soft(page, "late acknowledgement must preserve the user's selected chat").toHaveURL(selectedUrl);
+    await page.screenshot({ path: testInfo.outputPath("existing-chat-before-sidebar-release.png"), fullPage: true });
+    sidebar.release();
+    await expect.poll(() => sidebar.completed(), { timeout: 15_000 }).toBeGreaterThan(0);
+    // Observe the callback continuation, not an immediate URL assertion that passes before it runs.
+    await page.waitForTimeout(2_000);
+    await expect.soft(page, "sidebar completion must never navigate back to the background accepted chat").toHaveURL(selectedUrl);
+    await expect(page.locator(".rudder-mdxeditor-content").first()).toContainText(nextDraft);
+    expect.soft(navigations.filter((url) => url !== selectedUrl), "no transient route theft after explicit selection").toEqual([]);
+    await page.screenshot({ path: testInfo.outputPath("existing-chat-after-sidebar-release.png"), fullPage: true });
+    await testInfo.attach("late-ack-navigation-evidence", {
+      body: JSON.stringify({ selectedUrl, acceptedId, finalUrl: page.url(), navigations, held: sidebar.held, events: await wireEvents(page) }),
+      contentType: "application/json",
+    });
+    await assertPersistedTurn(page, acceptedId, body);
+  } finally {
+    streamGate.release();
+    await sidebar.dispose();
+    await page.unroute(streamPath);
+  }
+});

--- a/tests/e2e/chat-send-dedup.spec.ts
+++ b/tests/e2e/chat-send-dedup.spec.ts
@@ -20,7 +20,7 @@ async function createStreamingOrg(page: Page, name: string) {
 test("deduplicates rapid send clicks when starting a new chat", async ({ page }) => {
   const organization = await createStreamingOrg(page, `Dedup-Chat-${Date.now()}`);
 
-  await page.route(`**/api/orgs/${organization.id}/chats`, async (route, request) => {
+  await page.route(`**/api/orgs/${organization.id}/chats/messages/stream`, async (route, request) => {
     if (request.method() !== "POST") {
       await route.continue();
       return;
@@ -87,6 +87,10 @@ async function exerciseOptimisticFirstTurn(page: Page, viewport: { width: number
 
     const composer = page.locator(".rudder-mdxeditor-content").first();
     const body = `Immediate first-turn feedback ${suffix}`;
+    const fileName = `first-turn-${suffix}.txt`;
+    await page.locator('input[type="file"]').setInputFiles({
+      name: fileName, mimeType: "text/plain", buffer: Buffer.from("First-turn attachment evidence"),
+    });
     await expect(composer).toBeVisible({ timeout: 15_000 });
     await composer.fill(body);
     await page.getByRole("button", { name: "Send" }).click();
@@ -94,7 +98,9 @@ async function exerciseOptimisticFirstTurn(page: Page, viewport: { width: number
     await expect.poll(() => streamRouteReached).toBe(true);
     await expect(page.getByTestId("chat-pending-first-turn")).toContainText(body);
     await expect(page.getByTestId("chat-pending-first-turn-status")).toContainText("Sending message...");
+    await expect(page.getByTestId("chat-pending-first-turn")).toContainText(fileName);
     await expect(composer).toHaveText("");
+    await expect(composer).toHaveAttribute("contenteditable", "false");
     await expect(page.getByRole("button", { name: "Sending" })).toBeDisabled();
 
     releaseStream();
@@ -106,16 +112,30 @@ async function exerciseOptimisticFirstTurn(page: Page, viewport: { width: number
     await expect(page.getByTestId("chat-assistant-message").last()).toContainText("Streaming reply for chat.", {
       timeout: 30_000,
     });
+    const bubble = page.getByTestId("chat-user-message-bubble").filter({ hasText: body });
+    await expect(bubble.getByText(fileName, { exact: true }).filter({ visible: true }).first()).toBeVisible();
+    const chatsRes = await page.request.get(`/api/orgs/${organization.id}/chats?status=all`);
+    expect(chatsRes.ok()).toBe(true);
+    const chats = await chatsRes.json();
+    expect(chats).toHaveLength(1);
+    expect(new URL(page.url()).pathname).toContain(`/chat/${chats[0].id}`);
+    await page.reload();
+    await expect(bubble).toHaveCount(1);
+    await expect(bubble.getByText(fileName, { exact: true }).filter({ visible: true }).first()).toBeVisible();
   } finally {
     releaseStream();
     await page.unroute(streamRoute);
   }
 }
 
-test("shows first-turn sending feedback on desktop and mobile before acknowledgement", async ({ page }) => {
-  await exerciseOptimisticFirstTurn(page, { width: 1440, height: 960 }, "desktop");
-  await exerciseOptimisticFirstTurn(page, { width: 390, height: 844 }, "mobile");
-});
+for (const { viewport, suffix } of [
+  { viewport: { width: 1440, height: 960 }, suffix: "desktop" },
+  { viewport: { width: 390, height: 844 }, suffix: "mobile" },
+]) {
+  test(`shows first-turn sending feedback and preserves attachments on ${suffix}`, async ({ page }) => {
+    await exerciseOptimisticFirstTurn(page, viewport, suffix);
+  });
+}
 
 test("restores a failed first-turn draft and clears the sending state", async ({ page }) => {
   await page.setViewportSize({ width: 1440, height: 960 });
@@ -145,6 +165,10 @@ test("restores a failed first-turn draft and clears the sending state", async ({
 
     const composer = page.locator(".rudder-mdxeditor-content").first();
     const body = "Keep this first-turn draft after failure";
+    const fileName = "retry-first-turn.txt";
+    await page.locator('input[type="file"]').setInputFiles({
+      name: fileName, mimeType: "text/plain", buffer: Buffer.from("Keep this attachment after failure"),
+    });
     await expect(composer).toBeVisible({ timeout: 15_000 });
     await composer.fill(body);
     await page.getByRole("button", { name: "Send" }).click();
@@ -157,6 +181,17 @@ test("restores a failed first-turn draft and clears the sending state", async ({
     await expect(composer).toContainText(body);
     await expect(page.getByRole("button", { name: "Send" })).toBeEnabled();
     await expect(page.getByText("provider stack trace", { exact: false })).toHaveCount(0);
+    await expect(page.getByTestId("chat-pending-attachment")).toContainText(fileName);
+    await expect(composer).toHaveAttribute("contenteditable", "true");
+    await page.unroute(streamRoute);
+    await page.getByRole("button", { name: "Send" }).click();
+    await expect(page).toHaveURL(/\/chat\/[^/?]+$/, { timeout: 15_000 });
+    const bubble = page.getByTestId("chat-user-message-bubble").filter({ hasText: body });
+    await expect(bubble).toHaveCount(1);
+    await expect(bubble.getByText(fileName, { exact: true }).filter({ visible: true }).first()).toBeVisible();
+    const chatsRes = await page.request.get(`/api/orgs/${organization.id}/chats?status=all`);
+    expect(chatsRes.ok()).toBe(true);
+    expect(await chatsRes.json()).toHaveLength(1);
   } finally {
     releaseFailure();
     await page.unroute(streamRoute);

--- a/ui/src/context/ChatGenerationContext.tsx
+++ b/ui/src/context/ChatGenerationContext.tsx
@@ -1,5 +1,6 @@
 import type { TranscriptEntry } from "@/agent-runtimes";
 import { useActivityCoordinator } from "@/context/ActivityCoordinatorContext";
+import { FirstChatTurnProvider } from "@/context/FirstChatTurnContext";
 import { setChatFlagState, setChatScopedState } from "@/lib/chat-stream-state";
 import { createContext, startTransition, useCallback, useContext, useEffect, useMemo, useRef, useState, useSyncExternalStore, type ReactNode } from "react";
 
@@ -516,7 +517,7 @@ export function ChatGenerationProvider({ children }: { children: ReactNode }) {
   return (
     <ChatGenerationStatusStoreContext.Provider value={statusStore}>
       <ChatGenerationActionsContext.Provider value={actions}>
-        <ChatGenerationContext.Provider value={value}>{children}</ChatGenerationContext.Provider>
+        <ChatGenerationContext.Provider value={value}><FirstChatTurnProvider>{children}</FirstChatTurnProvider></ChatGenerationContext.Provider>
       </ChatGenerationActionsContext.Provider>
     </ChatGenerationStatusStoreContext.Provider>
   );

--- a/ui/src/context/FirstChatTurnContext.tsx
+++ b/ui/src/context/FirstChatTurnContext.tsx
@@ -1,0 +1,35 @@
+import { useOrganization } from "@/context/OrganizationContext";
+import { FirstChatTurnStore } from "@/lib/chat-first-turn-store";
+import { createContext, useContext, useLayoutEffect, useState, type ReactNode } from "react";
+import { useInRouterContext, useLocation } from "react-router-dom";
+
+const FirstChatTurnContext = createContext<FirstChatTurnStore | null>(null);
+
+export function firstChatTurnOwner(orgId: string | null, locationKey: string) {
+  return `${orgId ?? "__none__"}:${locationKey}`;
+}
+
+function RouteOwner({ store }: { store: FirstChatTurnStore }) {
+  const location = useLocation();
+  const { selectedOrganizationId } = useOrganization();
+  useLayoutEffect(() => {
+    store.setOwner(firstChatTurnOwner(selectedOrganizationId, location.key));
+  }, [store, selectedOrganizationId, location.key]);
+  return null;
+}
+
+/** Above Layout's responsive Outlet trees, so only committed navigation revokes ownership. */
+export function FirstChatTurnProvider({ children }: { children: ReactNode }) {
+  const [store] = useState(() => new FirstChatTurnStore());
+  const inRouter = useInRouterContext();
+  return <FirstChatTurnContext.Provider value={store}>
+    {inRouter && <RouteOwner store={store} />}
+    {children}
+  </FirstChatTurnContext.Provider>;
+}
+
+export function useFirstChatTurnStore() {
+  const store = useContext(FirstChatTurnContext);
+  if (!store) throw new Error("FirstChatTurnProvider is required");
+  return store;
+}

--- a/ui/src/context/LiveUpdatesProvider.invalidation.test.ts
+++ b/ui/src/context/LiveUpdatesProvider.invalidation.test.ts
@@ -1,0 +1,116 @@
+// @vitest-environment node
+
+import type { LiveEvent } from "@rudderhq/shared";
+import { QueryClient, QueryObserver, type QueryKey } from "@tanstack/react-query";
+import { describe, expect, it, vi } from "vitest";
+import { queryKeys } from "../lib/queryKeys";
+import { __liveUpdatesTestUtils } from "./LiveUpdatesProvider";
+
+function observeDeferredQueries(keys: QueryKey[]) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false, staleTime: Infinity } } });
+  const queries = keys.map((queryKey) => {
+    const requests: Array<(value: unknown[]) => void> = [];
+    client.setQueryData(queryKey, []);
+    const observer = new QueryObserver(client, {
+      queryKey,
+      // Deliberately non-abortable, like API calls that do not consume signal.
+      queryFn: () => new Promise<unknown[]>((resolve) => requests.push(resolve)),
+    });
+    const unsubscribe = observer.subscribe(() => {});
+    return { queryKey, requests, unsubscribe };
+  });
+  return {
+    client,
+    queries,
+    counts: () => queries.map(({ requests }) => requests.length),
+    dispose: () => {
+      queries.forEach(({ requests, unsubscribe }) => {
+        requests.forEach((resolve) => resolve([]));
+        unsubscribe();
+      });
+      client.clear();
+    },
+  };
+}
+
+function deliver(client: QueryClient, type: LiveEvent["type"], payload: Record<string, unknown>, orgId = "org-1") {
+  __liveUpdatesTestUtils.handleLiveEvent(
+    client,
+    "org-1",
+    "/ORG/messenger",
+    { type, orgId, payload } as LiveEvent,
+    () => null,
+    { cooldownHits: new Map(), suppressUntil: 0 },
+    { userId: "user-1", agentId: null },
+    { issueNotifications: false, chatNotifications: false },
+  );
+}
+
+function issueListKeys(orgId: string) {
+  return [
+    queryKeys.issues.list(orgId),
+    queryKeys.issues.listTouchedByMe(orgId),
+    queryKeys.issues.listUnreadTouchedByMe(orgId),
+    queryKeys.issues.listPreview(orgId, 10),
+    queryKeys.messenger.threads(orgId),
+    queryKeys.messenger.threadPages(orgId, false),
+    queryKeys.messenger.threadPages(orgId, true),
+    queryKeys.messenger.threadPreview(orgId),
+    queryKeys.messenger.issues(orgId),
+    queryKeys.chats.workManifests(orgId),
+    queryKeys.sidebarBadges(orgId),
+  ];
+}
+
+describe("live invalidation with active QueryObservers", () => {
+  it("invalidates heartbeat descendants once per event and preserves a later authoritative terminal read", async () => {
+    const keys = [
+      queryKeys.agentRuns("org-1"),
+      queryKeys.agentRuns("org-1", "agent-1"),
+      queryKeys.agentRunsOverview("org-1"),
+      queryKeys.sidebarBadges("org-1"),
+      queryKeys.runDetail("run-1"),
+      queryKeys.runEvents("run-1"),
+    ];
+    const fixture = observeDeferredQueries(keys);
+    try {
+      const payload = { runId: "run-1", agentId: "agent-1" };
+      deliver(fixture.client, "heartbeat.run.status", { ...payload, status: "running" });
+      expect(fixture.counts()).toEqual(keys.map(() => 1));
+      deliver(fixture.client, "heartbeat.run.status", { ...payload, status: "succeeded" });
+      expect(fixture.counts()).toEqual(keys.map(() => 2));
+      fixture.queries.forEach(({ requests }) => requests[1](["succeeded"]));
+      await vi.waitFor(() => expect(fixture.client.isFetching()).toBe(0));
+      fixture.queries.forEach(({ requests }) => requests[0](["running"]));
+      await Promise.resolve();
+      keys.forEach((key) => expect(fixture.client.getQueryData(key)).toEqual(["succeeded"]));
+    } finally {
+      fixture.dispose();
+    }
+  });
+
+  it.each(["activity.logged", "issue.content_updated"] as const)("%s starts one request per issue/list descendant and leaves other organizations untouched", async (eventType) => {
+    const ownKeys = issueListKeys("org-1");
+    const otherKeys = issueListKeys("org-2");
+    const fixture = observeDeferredQueries([...ownKeys, ...otherKeys]);
+    try {
+      const payload = { entityType: "issue", entityId: "issue-1", action: "issue.updated" };
+      deliver(fixture.client, eventType, payload, "org-2");
+      expect(fixture.counts()).toEqual([...ownKeys, ...otherKeys].map(() => 0));
+      deliver(fixture.client, eventType, payload);
+      expect(fixture.counts()).toEqual([...ownKeys.map(() => 1), ...otherKeys.map(() => 0)]);
+      // Keep original cancellation semantics across distinct authoritative events.
+      for (let index = 0; index < 9; index += 1) {
+        deliver(fixture.client, eventType, payload);
+      }
+      expect(fixture.counts()).toEqual([...ownKeys.map(() => 10), ...otherKeys.map(() => 0)]);
+      fixture.queries.forEach(({ requests }) => requests.at(-1)?.(["latest"]));
+      await vi.waitFor(() => expect(fixture.client.isFetching()).toBe(0));
+      fixture.queries.forEach(({ requests }) => requests.slice(0, -1).forEach((resolve) => resolve(["stale"])));
+      await Promise.resolve();
+      ownKeys.forEach((key) => expect(fixture.client.getQueryData(key)).toEqual(["latest"]));
+    } finally {
+      fixture.dispose();
+    }
+  });
+});

--- a/ui/src/context/LiveUpdatesProvider.test.ts
+++ b/ui/src/context/LiveUpdatesProvider.test.ts
@@ -39,11 +39,10 @@ describe("LiveUpdatesProvider issue invalidation", () => {
       },
     );
 
+    // This prefix covers touched and unread lists (real observer coverage lives
+    // in LiveUpdatesProvider.invalidation.test.ts).
     expect(invalidations).toContainEqual({
-      queryKey: queryKeys.issues.listTouchedByMe("organization-1"),
-    });
-    expect(invalidations).toContainEqual({
-      queryKey: queryKeys.issues.listUnreadTouchedByMe("organization-1"),
+      queryKey: queryKeys.issues.list("organization-1"),
     });
     expect(invalidations).toContainEqual({
       queryKey: queryKeys.chats.workManifests("organization-1"),
@@ -316,7 +315,7 @@ describe("LiveUpdatesProvider notification preferences", () => {
       queryKey: queryKeys.activityRoot("organization-1"),
     });
     expect(invalidations).toContainEqual({
-      queryKey: queryKeys.messenger.threadPreview("organization-1"),
+      queryKey: queryKeys.messenger.threads("organization-1"),
     });
   });
 
@@ -366,12 +365,6 @@ describe("LiveUpdatesProvider notification preferences", () => {
     });
     expect(invalidations).toContainEqual({
       queryKey: queryKeys.messenger.threads("organization-1"),
-    });
-    expect(invalidations).toContainEqual({
-      queryKey: queryKeys.messenger.threadPages("organization-1"),
-    });
-    expect(invalidations).toContainEqual({
-      queryKey: queryKeys.messenger.threadPreview("organization-1"),
     });
     expect(invalidations).toContainEqual({
       queryKey: queryKeys.messenger.issues("organization-1"),
@@ -424,12 +417,6 @@ describe("LiveUpdatesProvider notification preferences", () => {
     });
     expect(invalidations).toContainEqual({
       queryKey: queryKeys.messenger.threads("organization-1"),
-    });
-    expect(invalidations).toContainEqual({
-      queryKey: queryKeys.messenger.threadPages("organization-1"),
-    });
-    expect(invalidations).toContainEqual({
-      queryKey: queryKeys.messenger.threadPreview("organization-1"),
     });
     expect(invalidations).toContainEqual({
       queryKey: queryKeys.messenger.issues("organization-1"),

--- a/ui/src/context/LiveUpdatesProvider.tsx
+++ b/ui/src/context/LiveUpdatesProvider.tsx
@@ -638,7 +638,6 @@ function invalidateHeartbeatQueries(
   const agentId = readString(payload.agentId);
   if (agentId) {
     queryClient.invalidateQueries({ queryKey: queryKeys.agents.detail(agentId) });
-    queryClient.invalidateQueries({ queryKey: queryKeys.agentRuns(orgId, agentId) });
   }
 }
 
@@ -664,12 +663,10 @@ function invalidateActivityQueries(
   }
 
   if (entityType === "issue") {
+    // Prefixes include touched/unread lists and thread pages/previews.
+    // Re-invalidating their children would restart the just-started requests.
     queryClient.invalidateQueries({ queryKey: queryKeys.issues.list(orgId) });
-    queryClient.invalidateQueries({ queryKey: queryKeys.issues.listTouchedByMe(orgId) });
-    queryClient.invalidateQueries({ queryKey: queryKeys.issues.listUnreadTouchedByMe(orgId) });
     queryClient.invalidateQueries({ queryKey: queryKeys.messenger.threads(orgId) });
-    queryClient.invalidateQueries({ queryKey: queryKeys.messenger.threadPages(orgId) });
-    queryClient.invalidateQueries({ queryKey: queryKeys.messenger.threadPreview(orgId) });
     queryClient.invalidateQueries({ queryKey: queryKeys.messenger.issues(orgId) });
     queryClient.invalidateQueries({ queryKey: queryKeys.chats.workManifests(orgId) });
     if (entityId) {

--- a/ui/src/lib/chat-first-turn-store.test.ts
+++ b/ui/src/lib/chat-first-turn-store.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { readChatDraft, saveChatDraft } from "./chat-draft-storage";
+import { FirstChatTurnStore } from "./chat-first-turn-store";
+import { readChatPendingAttachmentsForScope, resetChatPendingAttachmentsForTests, updateChatPendingAttachmentsForScope } from "./chat-pending-attachments";
+
+beforeEach(() => {
+  const values = new Map<string, string>();
+  vi.stubGlobal("localStorage", { getItem: (key: string) => values.get(key) ?? null, setItem: (key: string, value: string) => values.set(key, value) });
+  resetChatPendingAttachmentsForTests();
+});
+afterEach(() => vi.unstubAllGlobals());
+
+const turn = { streamKey: "one", body: "keep my draft", files: [] as File[], createdAt: new Date() };
+
+describe("first chat operation lifetime", () => {
+  it("does not restore over a newer submitted turn whose source was cleared", () => {
+    const store = new FirstChatTurnStore();
+    store.setOwner("org-a:route-1");
+    store.begin("org-a:route-1", turn, "org-a:__new__");
+    store.setOwner("org-a:route-2");
+    store.begin("org-a:route-2", { ...turn, streamKey: "newer" }, "org-a:__new__");
+    expect(store.recoverDraft("org-a:route-1", "one", "org-a", null)?.conversationId).toBe("first-turn-recovery:one");
+    expect(readChatDraft("org-a", null)).toBe("");
+    expect(store.getSnapshot().pending?.streamKey).toBe("newer");
+  });
+  it.each(["org-a:route-2", "org-b:route-1"])("recovers an inactive operation without touching %s", (destination) => {
+    const store = new FirstChatTurnStore();
+    const file = new File(["original"], "original.txt");
+    store.setOwner("org-a:route-1");
+    store.begin("org-a:route-1", { ...turn, files: [file] });
+    store.setOwner(destination);
+    store.begin(destination, { ...turn, streamKey: "newer" });
+    const snapshot = store.getSnapshot();
+    const recovery = store.recoverDraft("org-a:route-1", "one", "org-a", null);
+    expect(recovery?.conversationId).toBeNull();
+    expect(readChatDraft("org-a", null)).toBe(turn.body);
+    expect(readChatPendingAttachmentsForScope("org-a:__new__")).toEqual([file]);
+    expect(store.getSnapshot()).toBe(snapshot);
+    expect(store.recoverDraft("org-a:route-1", "one", "org-a", null)).toBeNull();
+  });
+  it.each(["text", "attachment"])("keeps original recovery separately when a newer source %s exists", (kind) => {
+    const store = new FirstChatTurnStore();
+    const original = new File(["old"], "old.txt");
+    const newer = new File(["new"], "new.txt");
+    store.setOwner("org-a:route-1");
+    store.begin("org-a:route-1", { ...turn, files: [original] });
+    store.setOwner("org-a:route-2");
+    if (kind === "text") saveChatDraft("org-a", null, "new draft");
+    else updateChatPendingAttachmentsForScope("org-a:__new__", () => [newer]);
+    const recovered = store.recoverDraft("org-a:route-1", "one", "org-a", null)!;
+    expect(recovered.conversationId).toBe("first-turn-recovery:one");
+    expect(readChatDraft("org-a", recovered.conversationId)).toBe(turn.body);
+    expect(readChatPendingAttachmentsForScope(`org-a:${recovered.conversationId}`)).toEqual([original]);
+    expect(readChatDraft("org-a", null)).toBe(kind === "text" ? "new draft" : "");
+    expect(readChatPendingAttachmentsForScope("org-a:__new__")).toEqual(kind === "attachment" ? [newer] : []);
+    expect(store.readRecoveredTurn("org-a", recovered.conversationId)?.files[0]).toBe(original);
+    const recoveryScope = `org-a:${recovered.conversationId}`;
+    store.begin("org-a:route-2", { ...turn, streamKey: "retry" }, recoveryScope);
+    store.finish("org-a:route-2", "retry");
+    expect(store.readRecoveredTurn("org-a", recovered.conversationId)).toBeUndefined();
+  });
+  it("retains content and the synchronous send claim across page subscriptions", () => {
+    const store = new FirstChatTurnStore();
+    store.setOwner("org-a:route-1");
+    const detach = store.subscribe(() => {});
+    expect(store.begin("org-a:route-1", turn)).toBe(true);
+    detach();
+    const remounted = store.subscribe(() => {});
+    expect(store.getSnapshot().pending).toEqual(turn);
+    expect(store.begin("org-a:route-1", { ...turn, streamKey: "duplicate" })).toBe(false);
+    expect(store.owns("org-a:route-1", "one")).toBe(true);
+    remounted();
+  });
+  it.each(["org-a:route-2", "org-b:route-1"])("revokes ownership at boundary %s", (destination) => {
+    const store = new FirstChatTurnStore();
+    store.setOwner("org-a:route-1");
+    store.begin("org-a:route-1", turn);
+    store.setOwner(destination);
+    expect(store.getSnapshot().pending).toBeNull();
+    expect(store.owns("org-a:route-1", "one")).toBe(false);
+    store.begin(destination, { ...turn, streamKey: "newer" });
+    expect(store.finish("org-a:route-1", "one", true)).toBe(false);
+    expect(store.getSnapshot().pending?.streamKey).toBe("newer");
+    expect(store.getSnapshot().recovery).toBe(0);
+  });
+  it("publishes original recovery state after failure and permits one retry", () => {
+    const store = new FirstChatTurnStore();
+    store.setOwner("org-a:route-1");
+    store.begin("org-a:route-1", turn);
+    expect(store.finish("org-a:route-1", "one", true)).toBe(true);
+    expect(store.getSnapshot().recoveredTurn).toEqual(turn);
+    expect(store.begin("org-a:route-1", { ...turn, streamKey: "retry" })).toBe(true);
+    expect(store.finish("org-a:route-1", "one")).toBe(false);
+    expect(store.getSnapshot().pending?.streamKey).toBe("retry");
+  });
+});

--- a/ui/src/lib/chat-first-turn-store.ts
+++ b/ui/src/lib/chat-first-turn-store.ts
@@ -1,0 +1,79 @@
+import { CHAT_COMPOSER_DRAFT_VERSION, readChatComposerDraft, saveChatComposerDraft } from "./chat-draft-storage";
+import { readChatPendingAttachmentsForScope, resolveChatPendingAttachmentScopeKey, updateChatPendingAttachmentsForScope } from "./chat-pending-attachments";
+import { chatResponseAnnotationsForDraft, type ChatResponseAnnotationState } from "./chat-response-annotations";
+
+export type PendingFirstChatTurn = {
+  streamKey: string;
+  body: string;
+  files: File[];
+  createdAt: Date;
+  annotationState?: ChatResponseAnnotationState;
+};
+
+/** Provider-owned, memory-only operation state; subscribing is not navigation. */
+export class FirstChatTurnStore {
+  private owner: string | null = null;
+  private operations = new Map<string, { owner: string; turn: PendingFirstChatTurn; draftScope?: string }>();
+  private recoveredByScope = new Map<string, PendingFirstChatTurn>();
+  private snapshot: { pending: PendingFirstChatTurn | null; recovery: number; recoveredTurn: PendingFirstChatTurn | null } = { pending: null, recovery: 0, recoveredTurn: null };
+  private listeners = new Set<() => void>();
+  getSnapshot = () => this.snapshot;
+  subscribe = (listener: () => void) => {
+    this.listeners.add(listener);
+    return () => { this.listeners.delete(listener); };
+  };
+  private publish(pending: PendingFirstChatTurn | null, recovery = this.snapshot.recovery, recoveredTurn: PendingFirstChatTurn | null = null) {
+    this.snapshot = { pending, recovery, recoveredTurn };
+    this.listeners.forEach((listener) => listener());
+  }
+  setOwner(owner: string | null) {
+    if (this.owner === owner) return;
+    this.owner = owner;
+    this.publish(null);
+  }
+  begin(owner: string, turn: PendingFirstChatTurn, draftScope?: string) {
+    if (owner !== this.owner || this.snapshot.pending) return false;
+    this.operations.set(turn.streamKey, { owner, turn, draftScope });
+    if (draftScope) this.recoveredByScope.delete(draftScope);
+    this.publish(turn);
+    return true;
+  }
+  owns(owner: string, streamKey: string) {
+    return this.owner === owner && this.snapshot.pending?.streamKey === streamKey;
+  }
+  finish(owner: string, streamKey: string, recover = false) {
+    if (!recover && this.operations.get(streamKey)?.owner === owner) this.operations.delete(streamKey);
+    if (!this.owns(owner, streamKey)) return false;
+    this.publish(null, this.snapshot.recovery + (recover ? 1 : 0), recover ? this.snapshot.pending : null);
+    return true;
+  }
+  readRecoveredTurn(orgId: string, conversationId: string | null) {
+    return this.recoveredByScope.get(resolveChatPendingAttachmentScopeKey(orgId, conversationId));
+  }
+  /** Operation recovery survives route revocation; only the current claim may publish to the composer. */
+  recoverDraft(owner: string, streamKey: string, orgId: string, sourceConversationId: string | null) {
+    const operation = this.operations.get(streamKey);
+    if (!operation || operation.owner !== owner) return null;
+    const { turn } = operation;
+    const sourceScope = resolveChatPendingAttachmentScopeKey(orgId, sourceConversationId);
+    const current = readChatComposerDraft(orgId, sourceConversationId);
+    const conflict = current.body.length > 0 || current.inlineAnnotations.length > 0
+      || readChatPendingAttachmentsForScope(sourceScope).length > 0
+      || [...this.operations.values()].some((other) => other !== operation && other.draftScope === sourceScope);
+    const conversationId = conflict ? `first-turn-recovery:${streamKey}` : sourceConversationId;
+    const scope = resolveChatPendingAttachmentScopeKey(orgId, conversationId);
+    saveChatComposerDraft(orgId, conversationId, {
+      version: CHAT_COMPOSER_DRAFT_VERSION,
+      body: turn.body,
+      inlineAnnotations: turn.annotationState ? chatResponseAnnotationsForDraft(turn.annotationState) : [],
+    });
+    updateChatPendingAttachmentsForScope(scope, () => turn.files);
+    // File objects (including annotation attachments) deliberately remain memory-only.
+    this.recoveredByScope.set(scope, turn);
+    this.operations.delete(streamKey);
+    if (this.owns(owner, streamKey)) {
+      this.publish(null, this.snapshot.recovery + (conflict ? 0 : 1), conflict ? null : turn);
+    }
+    return { conversationId, turn };
+  }
+}

--- a/ui/src/lib/messenger-query-cache.test.ts
+++ b/ui/src/lib/messenger-query-cache.test.ts
@@ -2,11 +2,12 @@
 
 import { queryKeys } from "@/lib/queryKeys";
 import type { ChatConversation, MessengerCustomGroupsResponse, MessengerThreadSummary, SidebarBadges } from "@rudderhq/shared";
-import { QueryClient } from "@tanstack/react-query";
+import { QueryClient, QueryObserver } from "@tanstack/react-query";
 import { describe, expect, it } from "vitest";
 import {
   archiveMessengerChatInCache,
   cancelMessengerChatRenameQueries,
+  invalidateMessengerThreadSummaryQueries,
   markMessengerChatPinnedInCache,
   markMessengerChatReadInCache,
   markMessengerThreadPinnedInCache,
@@ -70,6 +71,50 @@ function conversation(overrides: Partial<ChatConversation> & Pick<ChatConversati
     ...overrides,
   };
 }
+
+describe("invalidateMessengerThreadSummaryQueries", () => {
+  it("refreshes each descendant and custom groups once without touching another organization", async () => {
+    const client = new QueryClient({ defaultOptions: { queries: { staleTime: Infinity, retry: false } } });
+    const keys = (orgId: string) => [
+      queryKeys.messenger.threads(orgId),
+      queryKeys.messenger.threadPages(orgId, false),
+      queryKeys.messenger.threadPages(orgId, true),
+      queryKeys.messenger.threadPreview(orgId),
+      queryKeys.messenger.customGroups(orgId),
+    ];
+    const ownKeys = keys("org-1");
+    const otherKeys = keys("org-2");
+    const queries = [...ownKeys, ...otherKeys].map((queryKey) => {
+      const requests: ReturnType<typeof deferred<string[]>>[] = [];
+      client.setQueryData(queryKey, []);
+      const observer = new QueryObserver(client, {
+        queryKey,
+        queryFn: () => {
+          const request = deferred<string[]>();
+          requests.push(request);
+          return request.promise;
+        },
+      });
+      return { requests, unsubscribe: observer.subscribe(() => {}) };
+    });
+    try {
+      const refresh = invalidateMessengerThreadSummaryQueries(client, "org-1");
+      expect(queries.map(({ requests }) => requests.length)).toEqual([
+        ...ownKeys.map(() => 1), ...otherKeys.map(() => 0),
+      ]);
+      queries.forEach(({ requests }) => requests.forEach((request) => request.resolve(["fresh"])));
+      await refresh;
+      ownKeys.forEach((key) => expect(client.getQueryData(key)).toEqual(["fresh"]));
+      otherKeys.forEach((key) => expect(client.getQueryData(key)).toEqual([]));
+    } finally {
+      queries.forEach(({ requests, unsubscribe }) => {
+        requests.forEach((request) => request.resolve([]));
+        unsubscribe();
+      });
+      client.clear();
+    }
+  });
+});
 
 describe("upsertMessengerThreadSummaryQueries", () => {
   it("updates every paged Messenger thread cache variant used by the sidebar", () => {

--- a/ui/src/lib/messenger-query-cache.ts
+++ b/ui/src/lib/messenger-query-cache.ts
@@ -283,8 +283,8 @@ function getCachedMessengerThreadUnreadCount(queryClient: QueryClient, orgId: st
 
 export function invalidateMessengerThreadSummaryQueries(queryClient: QueryClient, orgId: string) {
   return Promise.all([
+    // threads is the prefix for both page variants and previews; groups is a sibling.
     queryClient.invalidateQueries({ queryKey: queryKeys.messenger.threads(orgId) }),
-    queryClient.invalidateQueries({ queryKey: queryKeys.messenger.threadPages(orgId) }),
     queryClient.invalidateQueries({ queryKey: queryKeys.messenger.customGroups(orgId) }),
   ]);
 }

--- a/ui/src/pages/Chat.attachment-preview.test.tsx
+++ b/ui/src/pages/Chat.attachment-preview.test.tsx
@@ -13,6 +13,7 @@ import { SidePanelProvider, useSidePanel } from "@/context/SidePanelContext";
 import { ThemeProvider } from "@/context/ThemeContext";
 import { readChatAskUserDraft } from "@/lib/chat-draft-storage";
 import { requestChatFileAnnotation } from "@/lib/chat-file-annotation-events";
+import { FirstChatTurnStore } from "@/lib/chat-first-turn-store";
 import {
   resetChatPendingAttachmentsForTests,
   resolveChatPendingAttachmentScopeKey,
@@ -37,6 +38,13 @@ import { ChatSidePanel } from "./Chat.side-panel";
 
 const nativeGetBoundingClientRect =
   HTMLElement.prototype.getBoundingClientRect;
+let firstTurnStore: FirstChatTurnStore;
+
+vi.mock("@/context/FirstChatTurnContext", async (importOriginal) => ({
+  ...await importOriginal<typeof import("@/context/FirstChatTurnContext")>(),
+  // Keep the real subscription/operation seam while this fixture mocks its router.
+  useFirstChatTurnStore: () => firstTurnStore,
+}));
 
 function makeLiveSurfaceAnchorsVisible() {
   HTMLElement.prototype.getBoundingClientRect = function getBoundingClientRect() {
@@ -1579,6 +1587,8 @@ async function renderPersistedSideChatPanel(conversationId: string) {
 }
 
 beforeEach(() => {
+  firstTurnStore = new FirstChatTurnStore();
+  firstTurnStore.setOwner("org-1:chat");
   mockState.chatGenerationScopes.clear();
   mockState.sitesEnabled = false;
   installLocalStorageMock();
@@ -8591,7 +8601,7 @@ describe("Atomic new-chat drafts", () => {
     });
   });
 
-  it("shows the first-turn draft immediately and commits the accepted chat after acknowledgement", async () => {
+  it.each(["stalled", "rejected"])("opens the accepted first chat without waiting for %s sidebar refreshes", async (refreshOutcome) => {
     mockState.conversationId = null;
     mockState.conversations = [];
     mockState.messagesByChatId = {};
@@ -8628,6 +8638,12 @@ describe("Atomic new-chat drafts", () => {
     expect(container.querySelector("[data-testid='chat-pending-first-turn-status']")?.textContent)
       .toContain("Sending message...");
 
+    let releaseRefresh!: () => void;
+    const refreshGate = new Promise<void>((resolve) => { releaseRefresh = resolve; });
+    mockState.invalidateQueries.mockImplementation(() => refreshOutcome === "stalled"
+      ? refreshGate
+      : Promise.reject(new Error("Sidebar refresh failed")));
+
     const acceptedConversation = chat({
       id: "atomic-chat-1",
       title: "Create exactly one accepted chat",
@@ -8654,6 +8670,9 @@ describe("Atomic new-chat drafts", () => {
 
     expect(editor?.value).toBe("");
     expect(mockState.navigate).toHaveBeenCalledWith("/chat/atomic-chat-1");
+    expect(mockState.pushToast).not.toHaveBeenCalledWith(expect.objectContaining({ title: "Could not send message" }));
+    releaseRefresh();
+    mockState.invalidateQueries.mockResolvedValue(undefined);
     expect(mockState.setQueryData).toHaveBeenCalledWith(
       expect.arrayContaining(["chats", "org-1", "detail", "atomic-chat-1"]),
       expect.objectContaining({ id: "atomic-chat-1" }),

--- a/ui/src/pages/Chat.first-turn.test.ts
+++ b/ui/src/pages/Chat.first-turn.test.ts
@@ -1,0 +1,21 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+import { firstChatTurnRecoveryToast } from "./Chat.first-turn";
+
+describe("first-turn recovery presentation", () => {
+  it("does not add an action without a recovered draft", () => {
+    expect(firstChatTurnRecoveryToast("/source-org/messenger/chat", null)).toEqual({});
+  });
+
+  it.each([
+    [null, "/source-org/messenger/chat"],
+    ["first-turn-recovery:new:123", "/source-org/messenger/chat?firstTurnRecovery=new%3A123"],
+    ["local-app-recovery:recovered", "/source-org/messenger/chat?localAppRecoveryDraft=recovered"],
+  ])("keeps recovery %s in the originating organization", (conversationId, href) => {
+    expect(firstChatTurnRecoveryToast("/source-org/messenger/chat", { conversationId })).toEqual({
+      persistent: true,
+      action: { label: "Open recovered draft", href },
+    });
+  });
+});

--- a/ui/src/pages/Chat.first-turn.tsx
+++ b/ui/src/pages/Chat.first-turn.tsx
@@ -1,0 +1,43 @@
+import { Loader2 } from "lucide-react";
+import type { ComponentProps } from "react";
+import { OptimisticUserDraftItem } from "./Chat.messages";
+
+/** Presentation only: operation ownership belongs to FirstChatTurnStore. */
+export function ChatPendingFirstTurn(props: ComponentProps<typeof OptimisticUserDraftItem>) {
+  return (
+    <div
+      data-testid="chat-pending-first-turn"
+      className="flex w-full max-w-3xl flex-col items-end gap-1 px-1"
+    >
+      <OptimisticUserDraftItem {...props} />
+      <div
+        data-testid="chat-pending-first-turn-status"
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        className="flex items-center gap-1.5 px-1 text-[11px] text-muted-foreground"
+      >
+        <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden />
+        <span>Sending message...</span>
+      </div>
+    </div>
+  );
+}
+
+export function firstChatTurnRecoveryToast(
+  sourcePath: string,
+  recovery: { conversationId: string | null } | null,
+) {
+  if (!recovery) return {};
+  return {
+    persistent: true,
+    action: {
+      label: "Open recovered draft",
+      href: recovery.conversationId?.startsWith("first-turn-recovery:")
+        ? `${sourcePath}?firstTurnRecovery=${encodeURIComponent(recovery.conversationId.slice("first-turn-recovery:".length))}`
+        : recovery.conversationId?.startsWith("local-app-recovery:")
+          ? `${sourcePath}?localAppRecoveryDraft=${encodeURIComponent(recovery.conversationId.slice("local-app-recovery:".length))}`
+          : sourcePath,
+    },
+  };
+}

--- a/ui/src/pages/Chat.tsx
+++ b/ui/src/pages/Chat.tsx
@@ -53,6 +53,7 @@ import { VirtualizedActivityTimeline } from "@/components/VirtualizedActivityTim
 import { useBreadcrumbs } from "@/context/BreadcrumbContext";
 import { useChatGenerations } from "@/context/ChatGenerationContext";
 import { useDialog } from "@/context/DialogContext";
+import { firstChatTurnOwner, useFirstChatTurnStore } from "@/context/FirstChatTurnContext";
 import { useI18n } from "@/context/I18nContext";
 import { useImagePreview } from "@/context/ImagePreviewContext";
 import { useOrganization } from "@/context/OrganizationContext";
@@ -207,7 +208,7 @@ import {
   Square,
   Trash2
 } from "lucide-react";
-import { Fragment, useCallback, useEffect, useLayoutEffect, useMemo, useReducer, useRef, useState, type CSSProperties, type KeyboardEvent as ReactKeyboardEvent } from "react";
+import { Fragment, useCallback, useEffect, useLayoutEffect, useMemo, useReducer, useRef, useState, useSyncExternalStore, type CSSProperties, type KeyboardEvent as ReactKeyboardEvent } from "react";
 import { createPortal } from "react-dom";
 import { useCurrentUserAvatar } from "../hooks/useCurrentUserAvatar";
 import { PendingAttachmentPreview } from "./Chat.attachments";
@@ -239,6 +240,11 @@ export { applyChatStreamProgressEvent } from "./Chat.workspace-helpers";
 
 export function Chat() { const { selectedOrganizationId } = useOrganization(); return selectedOrganizationId ? <ChatWorkspace key={selectedOrganizationId} /> : <div className="text-sm text-muted-foreground">Select a organization first.</div>; }
 function ChatWorkspace() { const { conversationId } = useParams<{ conversationId?: string }>(); const location = useLocation(); const navigate = useNavigate(); const [searchParams] = useSearchParams(); const queryClient = useQueryClient(); const { selectedOrganization, selectedOrganizationId } = useOrganization(); const { viewedOrganizationId } = useViewedOrganization(); const { locale, t } = useI18n(); const { setBreadcrumbs } = useBreadcrumbs(); const { pushToast } = useToast(); const { confirm, openNewProject } = useDialog();
+  const firstTurnStore = useFirstChatTurnStore();
+  const firstTurnOwner = firstChatTurnOwner(selectedOrganizationId, location.key);
+  const firstTurnState = useSyncExternalStore(firstTurnStore.subscribe, firstTurnStore.getSnapshot);
+  const pendingFirstTurn = firstTurnState.pending;
+  const newConversationSendInFlight = Boolean(pendingFirstTurn);
   const localizeChatProcessText = useCallback((text: string) => {
     // "Thinking" is a live Chat state here; keep it distinct from the model's reasoning setting.
     if (text === "Thinking" && locale === "zh-CN") return "思考中";
@@ -252,7 +258,7 @@ function ChatWorkspace() { const { conversationId } = useParams<{ conversationId
     setChatSendInFlight,
     setStreamAbortController,
     setStreamDraftForChat,
-    streamDrafts, } = useChatGenerations(); const draftStorageOrgId = selectedOrganizationId!; const draftStorageConversationId = conversationId ?? localAppRecoveryDraftStorageScope(searchParams.get("localAppRecoveryDraft")) ?? null; const draftStorageScopeKey = resolveChatPendingAttachmentScopeKey(draftStorageOrgId, draftStorageConversationId); const activeDraftScopeRef = useRef(draftStorageScopeKey);
+    streamDrafts, } = useChatGenerations(); const draftStorageOrgId = selectedOrganizationId!; const draftStorageConversationId = conversationId ?? (searchParams.get("firstTurnRecovery") ? `first-turn-recovery:${searchParams.get("firstTurnRecovery")}` : null) ?? localAppRecoveryDraftStorageScope(searchParams.get("localAppRecoveryDraft")) ?? null; const draftStorageScopeKey = resolveChatPendingAttachmentScopeKey(draftStorageOrgId, draftStorageConversationId); const activeDraftScopeRef = useRef(draftStorageScopeKey);
   const stopRecoveryImmediateRetryKeysRef = useRef(new Set<string>());
   const stopRecoveryStreamKeysRef = useRef<Record<string, string>>({});
   const streamOwnershipRef = useRef<Record<string, { streamKey: string; controller: AbortController }>>({});
@@ -283,7 +289,7 @@ function ChatWorkspace() { const { conversationId } = useParams<{ conversationId
   const [responseAnnotationState, dispatchResponseAnnotation] = useReducer(
     responseAnnotationReducer,
     initialComposerDraftRef.current?.inlineAnnotations ?? [],
-    createChatResponseAnnotationState,
+    (annotations) => firstTurnStore.readRecoveredTurn(draftStorageOrgId, draftStorageConversationId)?.annotationState ?? createChatResponseAnnotationState(annotations),
   );
   const responseAnnotationStateByScopeRef = useRef<Record<string, ChatResponseAnnotationState>>({});
   const [responseAnnotationsExpanded, setResponseAnnotationsExpanded] = useState(false);
@@ -300,13 +306,9 @@ function ChatWorkspace() { const { conversationId } = useParams<{ conversationId
   }, []);
   const [, refreshPendingFiles] = useState(0);
   const pendingFiles = readChatPendingAttachmentsForScope(draftStorageScopeKey);
-  const setPendingFilesForCurrentScope = useCallback((updater: (current: File[]) => File[]) => { updateChatPendingAttachmentsForScope(draftStorageScopeKey, updater); refreshPendingFiles((version) => version + 1); }, [draftStorageScopeKey]); const clearPendingFilesForCurrentScope = useCallback(() => { setPendingFilesForCurrentScope(() => []); }, [setPendingFilesForCurrentScope]); const [newConversationSendInFlight, setNewConversationSendInFlight] = useState(false); const [openProcessMessageIds, setOpenProcessMessageIds] = useState<Record<string, boolean>>({}); const [loadingTranscriptMessageIds, setLoadingTranscriptMessageIds] = useState<Record<string, true>>({}); const [loadedTranscriptsByMessageId, setLoadedTranscriptsByMessageId] = useState<Record<string, TranscriptEntry[]>>({}); const [draftPreferredAgentId, setDraftPreferredAgentId] = useState<string>(NO_CHAT_AGENT_ID); const [draftProjectId, setDraftProjectId] = useState<string>(NO_PROJECT_ID);
-  const [pendingFirstTurn, setPendingFirstTurn] = useState<{
-    body: string;
-    files: File[];
-    createdAt: Date;
-  } | null>(null);
-  const [pendingProjectContextOverride, setPendingProjectContextOverride] = useState<{ chatId: string; projectId: string | null; } | null>(null); const [draftPlanMode, setDraftPlanMode] = useState(false); const [pendingPlanModeOverride, setPendingPlanModeOverride] = useState<boolean | null>(null); const [decisionNotesByMessageId, setDecisionNotesByMessageId] = useState<Record<string, string>>({}); const [issueProposalOverridesByMessageId, setIssueProposalOverridesByMessageId] = useState<Record<string, Record<string, unknown>>>({}); const [plusMenuOpen, setPlusMenuOpen] = useState(false); const [agentMenuOpen, setAgentMenuOpen] = useState(false); const [projectMenuOpen, setProjectMenuOpen] = useState(false); const [skillMenuOpen, setSkillMenuOpen] = useState(false); const [skillSearchQuery, setSkillSearchQuery] = useState(""); const [libraryFileMentionQuery, setLibraryFileMentionQuery] = useState<string | null>(null); const [composerMenuPosition, setComposerMenuPosition] = useState<CSSProperties | null>(null); const [sideChatSlashMenuPosition, setSideChatSlashMenuPosition] = useState<CSSProperties | null>(null); const [inlineEditUserMessageId, setInlineEditUserMessageId] = useState<string | null>(null); const [inlineEditDraft, setInlineEditDraft] = useState(""); const [editingQueuedItem, setEditingQueuedItem] = useState<{ itemId: string; value: string; version: number } | null>(null); const [stoppingChatIds, setStoppingChatIds] = useState<Set<string>>(() => new Set()); const [steeringQueuedItemIds, setSteeringQueuedItemIds] = useState<Set<string>>(() => new Set()); const [branchPreview, setBranchPreview] = useState<ChatBranchPreview | null>(null); const [emptyStateActiveTab, setEmptyStateActiveTab] = useState<"recent" | "use-cases">("use-cases"); const [emptyStateActiveSuggestionIndex, setEmptyStateActiveSuggestionIndex] = useState(0); const [dismissedEmptyStatePromptQuery, setDismissedEmptyStatePromptQuery] = useState<string | null>(null); const [retainedEmptyStatePromptSuggestions, setRetainedEmptyStatePromptSuggestions] = useState<readonly EmptyStatePromptSuggestion[]>([]); const [recentProjectConversationLimit, setRecentProjectConversationLimit] = useState(RECENT_PROJECT_CONVERSATION_INITIAL_LIMIT); const [recentAskUserAnswerMessageId, setRecentAskUserAnswerMessageId] = useState<string | null>(null); const [renamingConversationId, setRenamingConversationId] = useState<string | null>(null); const [renameDraft, setRenameDraft] = useState(""); const [generatingChatTitleIds, setGeneratingChatTitleIds] = useState<Set<string>>(() => new Set()); const [workManifestWideOpen, setWorkManifestWideOpen] = useState(true); const fileInputRef = useRef<HTMLInputElement>(null); const composerSurfaceRef = useRef<HTMLDivElement>(null); const composerEditorRef = useRef<MarkdownEditorRef>(null); const inlineEditSurfaceRef = useRef<HTMLDivElement>(null); const inlineEditEditorRef = useRef<MarkdownEditorRef>(null); const composerContextMenuRef = useRef<HTMLDivElement>(null); const composerEditorScrollRef = useScrollbarActivityRef(); const skillSearchInputRef = useRef<HTMLInputElement>(null); const manuallyMarkedUnreadKeyRef = useRef<string | null>(null); const newConversationSendLockRef = useRef(false); const chatSendLocksRef = useRef<Record<string, true>>({}); const stoppingChatIdsRef = useRef(new Set<string>()); const steeringQueuedItemIdsRef = useRef(new Set<string>()); const lastAppliedPrefillRef = useRef<string | null>(null); const lastAppliedAgentPrefillRef = useRef<string | null>(null); const lastAppliedProjectPrefillRef = useRef<string | null>(null); const draftProjectScopeKeyRef = useRef<string | null>(null); const draftProjectDefaultKeyRef = useRef<string | null>(null); const draftProjectManuallySelectedRef = useRef(false); const chatMessagesScrollElementRef = useRef<HTMLDivElement | null>(null); const chatMainWorkspaceRef = useRef<HTMLElement | null>(null); const initialScrolledConversationRef = useRef<string | null>(null); const { isMobile, sidebarOpen, setSidebarOpen } = useSidebar(); const { open: sidePanelOpen, openTarget: openSidePanelTarget, openTargetForContext: openSidePanelTargetForContext, showPanelForContext: showSidePanelForContext } = useSidePanel(); const chatMessagesActivityRef = useScrollbarActivityRef(); const chatMessagesScrollRef = useCallback((element: HTMLDivElement | null) => { chatMessagesScrollElementRef.current = element; chatMessagesActivityRef(element); }, [chatMessagesActivityRef]); const pendingPrefill = searchParams.get("prefill") ?? ""; const pendingAgentPrefill = searchParams.get("agentId")?.trim() ?? ""; const pendingProjectPrefill = searchParams.get("projectId")?.trim() ?? ""; const pendingIssueId = searchParams.get("issueId")?.trim() ?? ""; const pendingTargetMessageId = (searchParams.get("messageId") ?? searchParams.get("targetMessageId") ?? "").trim(); const isMessengerChatRoute = /^\/(?:[^/]+\/)?messenger\/chat(?:\/|$)/.test(location.pathname); const relativePath = toOrganizationRelativePath(location.pathname); const chatRouteBase = relativePath.startsWith("/messenger/chat") ? "/messenger/chat" : "/chat"; const chatRootPath = chatRouteBase; const chatConversationPath = useCallback((id: string) => `${chatRouteBase}/${id}`, [chatRouteBase]); const resolveCurrentSidePanelChatContextKey = useCallback(() => { const activePath = typeof window === "undefined" ? relativePath : toOrganizationRelativePath(window.location.pathname); const match = activePath.match(/^\/(?:messenger\/)?chat\/([^/?#]+)/); const chatId = match?.[1] ?? conversationId ?? null; return chatId ? `chat:${chatId}` : null; }, [conversationId, relativePath]); const openLocalFile = useCallback((targetPath: string) => { const desktopShell = readDesktopShell();
+  const setPendingFilesForCurrentScope = useCallback((updater: (current: File[]) => File[]) => { updateChatPendingAttachmentsForScope(draftStorageScopeKey, updater); refreshPendingFiles((version) => version + 1); }, [draftStorageScopeKey]); const clearPendingFilesForCurrentScope = useCallback(() => { setPendingFilesForCurrentScope(() => []); }, [setPendingFilesForCurrentScope]);  const [openProcessMessageIds, setOpenProcessMessageIds] = useState<Record<string, boolean>>({}); const [loadingTranscriptMessageIds, setLoadingTranscriptMessageIds] = useState<Record<string, true>>({}); const [loadedTranscriptsByMessageId, setLoadedTranscriptsByMessageId] = useState<Record<string, TranscriptEntry[]>>({}); const [draftPreferredAgentId, setDraftPreferredAgentId] = useState<string>(NO_CHAT_AGENT_ID); const [draftProjectId, setDraftProjectId] = useState<string>(NO_PROJECT_ID);
+
+  const [pendingProjectContextOverride, setPendingProjectContextOverride] = useState<{ chatId: string; projectId: string | null; } | null>(null); const [draftPlanMode, setDraftPlanMode] = useState(false); const [pendingPlanModeOverride, setPendingPlanModeOverride] = useState<boolean | null>(null); const [decisionNotesByMessageId, setDecisionNotesByMessageId] = useState<Record<string, string>>({}); const [issueProposalOverridesByMessageId, setIssueProposalOverridesByMessageId] = useState<Record<string, Record<string, unknown>>>({}); const [plusMenuOpen, setPlusMenuOpen] = useState(false); const [agentMenuOpen, setAgentMenuOpen] = useState(false); const [projectMenuOpen, setProjectMenuOpen] = useState(false); const [skillMenuOpen, setSkillMenuOpen] = useState(false); const [skillSearchQuery, setSkillSearchQuery] = useState(""); const [libraryFileMentionQuery, setLibraryFileMentionQuery] = useState<string | null>(null); const [composerMenuPosition, setComposerMenuPosition] = useState<CSSProperties | null>(null); const [sideChatSlashMenuPosition, setSideChatSlashMenuPosition] = useState<CSSProperties | null>(null); const [inlineEditUserMessageId, setInlineEditUserMessageId] = useState<string | null>(null); const [inlineEditDraft, setInlineEditDraft] = useState(""); const [editingQueuedItem, setEditingQueuedItem] = useState<{ itemId: string; value: string; version: number } | null>(null); const [stoppingChatIds, setStoppingChatIds] = useState<Set<string>>(() => new Set()); const [steeringQueuedItemIds, setSteeringQueuedItemIds] = useState<Set<string>>(() => new Set()); const [branchPreview, setBranchPreview] = useState<ChatBranchPreview | null>(null); const [emptyStateActiveTab, setEmptyStateActiveTab] = useState<"recent" | "use-cases">("use-cases"); const [emptyStateActiveSuggestionIndex, setEmptyStateActiveSuggestionIndex] = useState(0); const [dismissedEmptyStatePromptQuery, setDismissedEmptyStatePromptQuery] = useState<string | null>(null); const [retainedEmptyStatePromptSuggestions, setRetainedEmptyStatePromptSuggestions] = useState<readonly EmptyStatePromptSuggestion[]>([]); const [recentProjectConversationLimit, setRecentProjectConversationLimit] = useState(RECENT_PROJECT_CONVERSATION_INITIAL_LIMIT); const [recentAskUserAnswerMessageId, setRecentAskUserAnswerMessageId] = useState<string | null>(null); const [renamingConversationId, setRenamingConversationId] = useState<string | null>(null); const [renameDraft, setRenameDraft] = useState(""); const [generatingChatTitleIds, setGeneratingChatTitleIds] = useState<Set<string>>(() => new Set()); const [workManifestWideOpen, setWorkManifestWideOpen] = useState(true); const fileInputRef = useRef<HTMLInputElement>(null); const composerSurfaceRef = useRef<HTMLDivElement>(null); const composerEditorRef = useRef<MarkdownEditorRef>(null); const inlineEditSurfaceRef = useRef<HTMLDivElement>(null); const inlineEditEditorRef = useRef<MarkdownEditorRef>(null); const composerContextMenuRef = useRef<HTMLDivElement>(null); const composerEditorScrollRef = useScrollbarActivityRef(); const skillSearchInputRef = useRef<HTMLInputElement>(null); const manuallyMarkedUnreadKeyRef = useRef<string | null>(null); const chatSendLocksRef = useRef<Record<string, true>>({}); const stoppingChatIdsRef = useRef(new Set<string>()); const steeringQueuedItemIdsRef = useRef(new Set<string>()); const lastAppliedPrefillRef = useRef<string | null>(null); const lastAppliedAgentPrefillRef = useRef<string | null>(null); const lastAppliedProjectPrefillRef = useRef<string | null>(null); const draftProjectScopeKeyRef = useRef<string | null>(null); const draftProjectDefaultKeyRef = useRef<string | null>(null); const draftProjectManuallySelectedRef = useRef(false); const chatMessagesScrollElementRef = useRef<HTMLDivElement | null>(null); const chatMainWorkspaceRef = useRef<HTMLElement | null>(null); const initialScrolledConversationRef = useRef<string | null>(null); const { isMobile, sidebarOpen, setSidebarOpen } = useSidebar(); const { open: sidePanelOpen, openTarget: openSidePanelTarget, openTargetForContext: openSidePanelTargetForContext, showPanelForContext: showSidePanelForContext } = useSidePanel(); const chatMessagesActivityRef = useScrollbarActivityRef(); const chatMessagesScrollRef = useCallback((element: HTMLDivElement | null) => { chatMessagesScrollElementRef.current = element; chatMessagesActivityRef(element); }, [chatMessagesActivityRef]); const pendingPrefill = searchParams.get("prefill") ?? ""; const pendingAgentPrefill = searchParams.get("agentId")?.trim() ?? ""; const pendingProjectPrefill = searchParams.get("projectId")?.trim() ?? ""; const pendingIssueId = searchParams.get("issueId")?.trim() ?? ""; const pendingTargetMessageId = (searchParams.get("messageId") ?? searchParams.get("targetMessageId") ?? "").trim(); const isMessengerChatRoute = /^\/(?:[^/]+\/)?messenger\/chat(?:\/|$)/.test(location.pathname); const relativePath = toOrganizationRelativePath(location.pathname); const chatRouteBase = relativePath.startsWith("/messenger/chat") ? "/messenger/chat" : "/chat"; const chatRootPath = chatRouteBase; const chatConversationPath = useCallback((id: string) => `${chatRouteBase}/${id}`, [chatRouteBase]); const resolveCurrentSidePanelChatContextKey = useCallback(() => { const activePath = typeof window === "undefined" ? relativePath : toOrganizationRelativePath(window.location.pathname); const match = activePath.match(/^\/(?:messenger\/)?chat\/([^/?#]+)/); const chatId = match?.[1] ?? conversationId ?? null; return chatId ? `chat:${chatId}` : null; }, [conversationId, relativePath]); const openLocalFile = useCallback((targetPath: string) => { const desktopShell = readDesktopShell();
     if (!desktopShell) {
       pushToast({
         title: "Open from Desktop",
@@ -392,7 +394,8 @@ function ChatWorkspace() { const { conversationId } = useParams<{ conversationId
       draftStorageOrgId,
       draftStorageConversationId,
     );
-    const inMemoryAnnotations = responseAnnotationStateByScopeRef.current[draftStorageScopeKey];
+    const inMemoryAnnotations = responseAnnotationStateByScopeRef.current[draftStorageScopeKey]
+      ?? firstTurnStore.readRecoveredTurn(draftStorageOrgId, draftStorageConversationId)?.annotationState;
     setDraftState({
       scopeKey: draftStorageScopeKey,
       value: storedDraft.body,
@@ -436,8 +439,17 @@ function ChatWorkspace() { const { conversationId } = useParams<{ conversationId
     draftStorageScopeKey,
     responseAnnotationState,
   ]);
+  const recoveredFirstTurnRef = useRef(firstTurnState.recovery);
+  useEffect(() => {
+    if (recoveredFirstTurnRef.current === firstTurnState.recovery) return;
+    recoveredFirstTurnRef.current = firstTurnState.recovery;
+    const recovered = readChatComposerDraft(draftStorageOrgId, draftStorageConversationId);
+    setDraftState({ scopeKey: draftStorageScopeKey, value: recovered.body });
+    dispatchResponseAnnotation({ type: "reset", annotations: recovered.inlineAnnotations, pendingFilesByAnnotationId: firstTurnState.recoveredTurn?.annotationState?.pendingFilesByAnnotationId });
+    refreshPendingFiles((version) => version + 1);
+  }, [firstTurnState.recovery, draftStorageOrgId, draftStorageConversationId, draftStorageScopeKey]);
   const pendingGroupId = searchParams.get("groupId")?.trim() ?? "";
-  useEffect(() => { if (!pendingPrefill) return; if (pendingPrefill === lastAppliedPrefillRef.current) return; if (draft.trim().length > 0) return; lastAppliedPrefillRef.current = pendingPrefill; setDraft(pendingPrefill);
+  useEffect(() => { if (newConversationSendInFlight || !pendingPrefill) return; if (pendingPrefill === lastAppliedPrefillRef.current) return; if (draft.trim().length > 0) return; lastAppliedPrefillRef.current = pendingPrefill; setDraft(pendingPrefill);
     requestAnimationFrame(() => { composerEditorRef.current?.focus(); }); const nextSearch = new URLSearchParams(searchParams); nextSearch.delete("prefill");
     navigate( {
         pathname: conversationId ? chatConversationPath(conversationId) : chatRootPath,
@@ -518,7 +530,7 @@ function ChatWorkspace() { const { conversationId } = useParams<{ conversationId
     }), enabled: !!selectedOrganizationId, }); const profileQuery = useQuery({
     queryKey: queryKeys.instance.profileSettings, queryFn: () => instanceSettingsApi.getProfile(), }); const generalSettingsQuery = useQuery({
     queryKey: queryKeys.instance.generalSettings, queryFn: () => instanceSettingsApi.getGeneral(), }); const showDeveloperDiagnostics = generalSettingsQuery.data?.showDeveloperDiagnostics === true;
-  useEffect(() => { if (pendingPrefill) return; const hasAgentPrefill = pendingAgentPrefill.length > 0; const hasProjectPrefill = pendingProjectPrefill.length > 0; if (!hasAgentPrefill && !hasProjectPrefill) return;
+  useEffect(() => { if (pendingPrefill || newConversationSendInFlight) return; const hasAgentPrefill = pendingAgentPrefill.length > 0; const hasProjectPrefill = pendingProjectPrefill.length > 0; if (!hasAgentPrefill && !hasProjectPrefill) return;
     const agentAlreadyApplied = !hasAgentPrefill || pendingAgentPrefill === lastAppliedAgentPrefillRef.current;
     const projectAlreadyApplied = !hasProjectPrefill || pendingProjectPrefill === lastAppliedProjectPrefillRef.current; if (agentAlreadyApplied && projectAlreadyApplied) return;
     if (!conversationId) { if (hasAgentPrefill && !agentAlreadyApplied && !agents) return; if (hasProjectPrefill && !projectAlreadyApplied && !projects) return;
@@ -643,7 +655,7 @@ function ChatWorkspace() { const { conversationId } = useParams<{ conversationId
   } = useQuery({
     queryKey: queryKeys.agents.skills(activeSkillAgentId ?? "__none__"),
     queryFn: () => agentsApi.skills(activeSkillAgentId!, selectedOrganizationId!), enabled: Boolean(selectedOrganizationId) && Boolean(activeSkillAgentId), });
-  useEffect(() => { setInlineEditUserMessageId(null); setInlineEditDraft(""); setBranchPreview(null); setRecentAskUserAnswerMessageId(null); setIssueProposalOverridesByMessageId({}); setPendingFirstTurn(null); }, [conversationId]);
+  useEffect(() => { setInlineEditUserMessageId(null); setInlineEditDraft(""); setBranchPreview(null); setRecentAskUserAnswerMessageId(null); setIssueProposalOverridesByMessageId({}); }, [conversationId]);
   useEffect(() => { setSkillMenuOpen(false); setSkillSearchQuery(""); }, [activeSkillAgentId]);
   useEffect(() => {
     if (isMobile) {
@@ -746,7 +758,7 @@ function ChatWorkspace() { const { conversationId } = useParams<{ conversationId
     upsertMessengerThreadSummary(optimisticConversation, {
       latestActivityAt: sentAt, preview: body, }); return optimisticConversation; }; const upsertMessages = (chatId: string, incoming: ChatMessage[]) => {
     queryClient.setQueryData<ChatMessage[]>(
-      queryKeys.chats.messages(selectedOrganizationId ?? "__none__", chatId), (current) => mergeChatMessages(current ?? [], incoming), ); }; const acquireNewConversationSendLock = useCallback(() => { if (newConversationSendLockRef.current) return false; newConversationSendLockRef.current = true; setNewConversationSendInFlight(true); return true; }, []); const releaseNewConversationSendLock = useCallback(() => { if (!newConversationSendLockRef.current) return; newConversationSendLockRef.current = false; setNewConversationSendInFlight(false); }, []); const acquireChatSendLock = useCallback((chatId: string) => { if (chatSendLocksRef.current[chatId]) return false;
+      queryKeys.chats.messages(selectedOrganizationId ?? "__none__", chatId), (current) => mergeChatMessages(current ?? [], incoming), ); }; const acquireChatSendLock = useCallback((chatId: string) => { if (chatSendLocksRef.current[chatId]) return false;
     chatSendLocksRef.current = { ...chatSendLocksRef.current, [chatId]: true, }; return true; }, []); const releaseChatSendLock = useCallback((chatId: string) => { if (!(chatId in chatSendLocksRef.current)) return; const { [chatId]: _removed, ...rest } = chatSendLocksRef.current; chatSendLocksRef.current = rest; }, []); const setProcessOpenForMessage = useCallback((messageId: string, open: boolean) => {
     setOpenProcessMessageIds((current) => {
       if (messageId in current && current[messageId] === open) return current;
@@ -1367,15 +1379,13 @@ function ChatWorkspace() { const { conversationId } = useParams<{ conversationId
         return;
       }
       if (!conversation) {
-        if (!acquireNewConversationSendLock()) return;
-        newConversationLockAcquired = true;
+        if (firstTurnStore.getSnapshot().pending) return;
         const selectedDraftAgentId = draftPreferredAgentId === NO_CHAT_AGENT_ID ? null : draftPreferredAgentId;
         if (!selectedDraftAgentId) {
           pushToast({
             title: "No chat agent available",
             body: "Create or activate an agent before sending.", tone: "error",
           });
-          releaseNewConversationSendLock();
           newConversationLockAcquired = false;
           return;
         }
@@ -1385,7 +1395,6 @@ function ChatWorkspace() { const { conversationId } = useParams<{ conversationId
             body: draftPreflightQuery.data?.error ?? "Check the selected agent configuration and try again.",
             tone: "error",
           });
-          releaseNewConversationSendLock();
           newConversationLockAcquired = false;
           return;
         }
@@ -1395,11 +1404,14 @@ function ChatWorkspace() { const { conversationId } = useParams<{ conversationId
         const streamKey = `new:${startedAt.getTime()}:${Math.random().toString(36).slice(2)}`;
         const acceptedConversation = { current: null as ChatConversation | null };
         activeStreamKey = streamKey;
-        setPendingFirstTurn({
+        if (!firstTurnStore.begin(firstTurnOwner, {
+          streamKey,
+          annotationState: responseAnnotationState,
           body,
           files: regularFilesToUpload,
           createdAt: startedAt,
-        });
+        }, draftStorageScopeKey)) return;
+        newConversationLockAcquired = true;
         if (usesComposerState) {
           setBranchPreview(null);
           setDraft("");
@@ -1429,7 +1441,7 @@ function ChatWorkspace() { const { conversationId } = useParams<{ conversationId
                 throw new Error("First chat acknowledgement did not include the accepted conversation");
               }
               userMessageAcknowledged = true;
-              setPendingFirstTurn(null);
+              const ownsFirstTurn = firstTurnStore.owns(firstTurnOwner, streamKey);
               conversation = event.conversation;
               acceptedConversation.current = event.conversation;
               activeChatId = conversation.id;
@@ -1448,35 +1460,17 @@ function ChatWorkspace() { const { conversationId } = useParams<{ conversationId
                 preview: event.userMessage.body,
               });
               upsertMessages(conversation.id, [event.userMessage]);
-              await Promise.all([
-                queryClient.invalidateQueries({
-                  queryKey: queryKeys.messenger.customGroups(selectedOrganizationId),
-                }),
-                ...(["active", "all"] as const).flatMap((status) => [
-                  queryClient.invalidateQueries({
-                    queryKey: queryKeys.chats.list(selectedOrganizationId, status),
-                  }),
-                  queryClient.invalidateQueries({
-                    queryKey: queryKeys.chats.listPreview(
-                      selectedOrganizationId,
-                      status,
-                      CHAT_LIST_PREVIEW_LIMIT,
-                    ),
-                  }),
-                ]),
-                invalidateMessengerThreadSummaryQueries(queryClient, selectedOrganizationId),
-              ]);
               rememberChatAgentId(selectedOrganizationId, selectedDraftAgentId);
               rememberChatProjectIdForAgent(
                 selectedOrganizationId,
                 selectedDraftAgentId,
                 draftProjectId === NO_PROJECT_ID ? null : draftProjectId,
               );
-              if (usesComposerState) {
+              if (usesComposerState && ownsFirstTurn) {
                 setBranchPreview(null);
                 setDraft("");
                 setDraftRuntimeOverrides({ modelOverride: null, effortOverride: null });
-                if (draftStorageConversationId?.startsWith("local-app-recovery:")) {
+                if (draftStorageConversationId?.startsWith("local-app-recovery:") || draftStorageConversationId?.startsWith("first-turn-recovery:")) {
                   clearChatDraft(draftStorageOrgId, draftStorageConversationId);
                 }
                 clearPendingFilesForCurrentScope();
@@ -1509,9 +1503,23 @@ function ChatWorkspace() { const { conversationId } = useParams<{ conversationId
                 transcript: [],
                 replyingAgentId: conversation.chatRuntime.runtimeAgentId ?? conversation.preferredAgentId ?? null,
               });
-              navigate(chatConversationPath(conversation.id));
-              releaseNewConversationSendLock();
+              // Acknowledgement owns the caches, not the user's subsequent navigation.
+              if (ownsFirstTurn) {
+                navigate(chatConversationPath(conversation.id));
+              }
+              firstTurnStore.finish(firstTurnOwner, streamKey);
               newConversationLockAcquired = false;
+              // These caches were seeded above. Reconcile in the background so slow
+              // sidebar GETs cannot block navigation or consumption of stream events.
+              // List prefix invalidation includes its preview descendants.
+              void Promise.all([
+                ...(["active", "all"] as const).map((status) => (
+                  queryClient.invalidateQueries({
+                    queryKey: queryKeys.chats.list(selectedOrganizationId, status),
+                  })
+                )),
+                invalidateMessengerThreadSummaryQueries(queryClient, selectedOrganizationId),
+              ]).catch(() => undefined);
               return;
             }
             if (!conversation) {
@@ -1559,7 +1567,7 @@ function ChatWorkspace() { const { conversationId } = useParams<{ conversationId
         if (!networkWaiting) {
           setStreamDraftForChat(activeStreamScopeKey ?? chatGenerationScopeKey(selectedOrganizationId, createdConversation), (current) => current?.streamKey === streamKey ? null : current);
         }
-        setPendingFirstTurn(null);
+        firstTurnStore.finish(firstTurnOwner, streamKey);
         return;
       }
       const chatId = conversation.id; const streamScopeKey = chatGenerationScopeKey(selectedOrganizationId, conversation); const activeDraftForChat = readChatScopedState(streamDrafts, streamScopeKey);
@@ -1585,7 +1593,7 @@ function ChatWorkspace() { const { conversationId } = useParams<{ conversationId
       } if (!acquireChatSendLock(chatId)) return; chatSendLockAcquired = true; activeChatId = chatId; activeStreamScopeKey = streamScopeKey; const selectedAgentId = activeAgentId === NO_CHAT_AGENT_ID ? null : activeAgentId;
       if (!conversation.preferredAgentId && selectedAgentId) { conversation = await chatsApi.update(conversation.id, { preferredAgentId: selectedAgentId }); setDraftPreferredAgentId(selectedAgentId); rememberChatAgentId(selectedOrganizationId, selectedAgentId); upsertConversation(conversation);
         upsertMessengerThreadSummary(conversation); }
-      if (newConversationLockAcquired || newConversationSendLockRef.current) { releaseNewConversationSendLock();
+      if (newConversationLockAcquired && activeStreamKey) { firstTurnStore.finish(firstTurnOwner, activeStreamKey);
         newConversationLockAcquired = false; }
       if (usesComposerState) { setBranchPreview(null); setDraft("");
         clearPendingFilesForCurrentScope(); } setChatSendInFlight(streamScopeKey, true); const abortController = new AbortController(); const startedAt = new Date(); const streamKey = `${chatId}:${startedAt.getTime()}:${Math.random().toString(36).slice(2)}`; activeStreamKey = streamKey; streamOwnershipRef.current[chatId] = { streamKey, controller: abortController }; setStreamAbortController(streamScopeKey, abortController); conversation = upsertOptimisticConversation(conversation, body, startedAt);
@@ -1726,7 +1734,8 @@ function ChatWorkspace() { const { conversationId } = useParams<{ conversationId
         setStreamDraftForChat(streamScopeKey, (current) => current?.streamKey === streamKey ? null : current);
       }
     } catch (error) {
-      if (activeStreamKey?.startsWith("new:")) setPendingFirstTurn(null);
+      const isFirstTurn = activeStreamKey?.startsWith("new:") === true;
+
       const pendingStop = conversation
         ? readPendingChatStopRecovery(selectedOrganizationId, conversation.id)
         : null;
@@ -1759,7 +1768,10 @@ function ChatWorkspace() { const { conversationId } = useParams<{ conversationId
         if (!streamScopeKey) return;
         setStreamDraftForChat(
           streamScopeKey, (current) => (current?.streamKey === activeStreamKey ? null : current), ); }
-      if (submittedComposerDraft && !userMessageAcknowledged) { const restoreConversationId = conversation?.id ?? submittedComposerDraft.conversationId; const restoreScopeKey = resolveChatPendingAttachmentScopeKey(
+      const firstTurnRecovery = isFirstTurn && activeStreamKey && submittedComposerDraft && !userMessageAcknowledged
+        ? firstTurnStore.recoverDraft(firstTurnOwner, activeStreamKey, submittedComposerDraft.orgId, submittedComposerDraft.conversationId)
+        : null;
+      if (submittedComposerDraft && !userMessageAcknowledged && !isFirstTurn) { const restoreConversationId = conversation?.id ?? submittedComposerDraft.conversationId; const restoreScopeKey = resolveChatPendingAttachmentScopeKey(
           submittedComposerDraft.orgId, restoreConversationId, ); saveChatComposerDraft(
           submittedComposerDraft.orgId,
           restoreConversationId,
@@ -1784,7 +1796,20 @@ function ChatWorkspace() { const { conversationId } = useParams<{ conversationId
         setInlineEditDraft(body);
         requestAnimationFrame(() => { inlineEditEditorRef.current?.focus(); });
       }
-      pushToast({ ...chatErrorToast(error, "send"), tone: "error" });
+      pushToast({
+        ...chatErrorToast(error, "send"), tone: "error",
+        ...(firstTurnRecovery ? {
+          persistent: true,
+          action: {
+            label: "Open recovered draft",
+            href: firstTurnRecovery.conversationId?.startsWith("first-turn-recovery:")
+              ? `${location.pathname}?firstTurnRecovery=${encodeURIComponent(firstTurnRecovery.conversationId.slice("first-turn-recovery:".length))}`
+              : firstTurnRecovery.conversationId?.startsWith("local-app-recovery:")
+                ? `${location.pathname}?localAppRecoveryDraft=${encodeURIComponent(firstTurnRecovery.conversationId.slice("local-app-recovery:".length))}`
+                : location.pathname,
+          },
+        } : {}),
+      });
       if (conversation) {
         void refreshChat(conversation.id).catch(() => null);
       }
@@ -1805,7 +1830,7 @@ function ChatWorkspace() { const { conversationId } = useParams<{ conversationId
       if (activeChatId && chatSendLockAcquired) {
         releaseChatSendLock(activeChatId);
       }
-      if (newConversationLockAcquired) { releaseNewConversationSendLock(); } } }; const conversations = useMemo(() => { const items = conversationsQuery.data ?? [];
+      if (newConversationLockAcquired && activeStreamKey) { firstTurnStore.finish(firstTurnOwner, activeStreamKey); } } }; const conversations = useMemo(() => { const items = conversationsQuery.data ?? [];
     return [...items].sort((a, b) => { if (a.isPinned !== b.isPinned) return a.isPinned ? -1 : 1; return new Date(b.lastMessageAt ?? b.updatedAt).getTime() - new Date(a.lastMessageAt ?? a.updatedAt).getTime(); }); }, [conversationsQuery.data]);
   const rawMessages = messagesQuery.data ?? [];
   useEffect(() => {
@@ -3449,6 +3474,7 @@ function ChatWorkspace() { const { conversationId } = useParams<{ conversationId
           ref={composerEditorRef}
           scrollRef={composerEditorScrollRef}
           value={draft}
+          readOnly={newConversationSendInFlight}
           onChange={handleComposerDraftChange}
           mentions={mentionOptions}
           onMentionQueryChange={setLibraryFileMentionQuery}
@@ -4263,6 +4289,6 @@ function ChatWorkspace() { const { conversationId } = useParams<{ conversationId
                     ) : renderEmptyStatePromptFlow()}
                   </>
                 )}
-                <div className="w-full max-w-3xl">
-                  {renderComposer(true)} </div> </div> </div> )} </main>
+                <fieldset className="w-full min-w-0 max-w-3xl" disabled={newConversationSendInFlight}>
+                  {renderComposer(true)} </fieldset> </div> </div> )} </main>
               </div> </div> ); }

--- a/ui/src/pages/Chat.tsx
+++ b/ui/src/pages/Chat.tsx
@@ -217,6 +217,7 @@ import {
   useChatComposerFileDrop,
   useChatComposerPasteAttachments,
 } from "./Chat.file-drop";
+import { ChatPendingFirstTurn, firstChatTurnRecoveryToast } from "./Chat.first-turn";
 import { AskUserPanel, AssistantDraftItem, ChatMessageItem, ChatMessagesLoadingState, LazyStreamTranscriptItem, OptimisticUserDraftItem, StreamTranscriptItem, chatIssueApprovalPayloadWithProposalOverride, type ChatTurnBranchControls } from "./Chat.messages";
 import {
   ChatAgentMenuContent,
@@ -1798,17 +1799,7 @@ function ChatWorkspace() { const { conversationId } = useParams<{ conversationId
       }
       pushToast({
         ...chatErrorToast(error, "send"), tone: "error",
-        ...(firstTurnRecovery ? {
-          persistent: true,
-          action: {
-            label: "Open recovered draft",
-            href: firstTurnRecovery.conversationId?.startsWith("first-turn-recovery:")
-              ? `${location.pathname}?firstTurnRecovery=${encodeURIComponent(firstTurnRecovery.conversationId.slice("first-turn-recovery:".length))}`
-              : firstTurnRecovery.conversationId?.startsWith("local-app-recovery:")
-                ? `${location.pathname}?localAppRecoveryDraft=${encodeURIComponent(firstTurnRecovery.conversationId.slice("local-app-recovery:".length))}`
-                : location.pathname,
-          },
-        } : {}),
+        ...firstChatTurnRecoveryToast(location.pathname, firstTurnRecovery),
       });
       if (conversation) {
         void refreshChat(conversation.id).catch(() => null);
@@ -3663,35 +3654,6 @@ function ChatWorkspace() { const { conversationId } = useParams<{ conversationId
       </div>
     );
   };
-  const renderPendingFirstTurn = () => {
-    if (!pendingFirstTurn) return null;
-    return (
-      <div
-        data-testid="chat-pending-first-turn"
-        className="flex w-full max-w-3xl flex-col items-end gap-1 px-1"
-      >
-        <OptimisticUserDraftItem
-          body={pendingFirstTurn.body}
-          files={pendingFirstTurn.files}
-          createdAt={pendingFirstTurn.createdAt}
-          onCopyMessageText={copyChatMessageText}
-          onEditDraftOnly={editDraftOnly}
-          skillReferences={chatSkillReferences}
-          onMarkdownLinkClick={handleChatMarkdownLinkClick}
-        />
-        <div
-          data-testid="chat-pending-first-turn-status"
-          role="status"
-          aria-live="polite"
-          aria-atomic="true"
-          className="flex items-center gap-1.5 px-1 text-[11px] text-muted-foreground"
-        >
-          <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden />
-          <span>Sending message...</span>
-        </div>
-      </div>
-    );
-  };
   return (
     <div className="chat-shell relative flex min-h-[calc(100dvh-8rem)] flex-col overflow-hidden text-foreground md:h-full md:min-h-0">
       <input ref={fileInputRef} type="file" className="hidden"
@@ -4251,7 +4213,13 @@ function ChatWorkspace() { const { conversationId } = useParams<{ conversationId
                 )} </div> </> ) : (
             <div className="flex min-h-0 flex-1 items-center justify-center overflow-y-auto px-6 py-8">
               <div className="mx-auto flex w-full max-w-4xl flex-col items-center justify-center">
-                {pendingFirstTurn ? renderPendingFirstTurn() : (
+                {pendingFirstTurn ? <ChatPendingFirstTurn
+                  {...pendingFirstTurn}
+                  onCopyMessageText={copyChatMessageText}
+                  onEditDraftOnly={editDraftOnly}
+                  skillReferences={chatSkillReferences}
+                  onMarkdownLinkClick={handleChatMarkdownLinkClick}
+                /> : (
                   <>
                     <div className="mb-5 w-full max-w-3xl px-1 text-center">
                       <h1 key={emptyStateHeadingKey} className="motion-chat-empty-heading max-w-full text-[2rem] leading-[1.1] tracking-normal text-foreground [overflow-wrap:anywhere] md:text-[2.3rem]" >


### PR DESCRIPTION
## Summary

- Keep first-chat acknowledgement, cache seeding, navigation, and stream consumption independent of sidebar/list refetches.
- Keep pending first-turn content and synchronous submission ownership above responsive page remounts; actual route/organization changes still supersede foreground navigation.
- Preserve text/files on failure, including late failure after navigating away. Recover conflicting older drafts through an explicit source-organization-scoped action instead of overwriting newer work.
- Remove overlapping parent/child query invalidations without changing cross-event freshness semantics.
- Reconcile the parallel first-send work: retain pending composer protection and attachment/reload/retry regression coverage.
- Extract pending first-turn presentation and recovery-toast construction out of the oversized Chat page rather than relaxing the architecture ratchet.

## Verification

- 361 related unit/component tests across 13 files passed on the final task branch.
- 12 author E2E cases passed against a real local API/PostgreSQL instance and a frozen production UI build, using the repository's no-cost agent process fixture.
- Production UI build/typecheck and changed-import lint passed. After the presentation extraction, the complete related suite and all 12 E2Es were rerun.
- Independent black-box verifier PASS: 4× renderer CPU, genuine held POST/sidebar GET requests, both responsive directions, failure/retry, newer drafts, actual organization switching, late acknowledgement, old final versus newer pending turn, and persisted attachment-byte readback.
- Separate final-renderer delta verification PASS: responsive pending/lock, real streaming with sidebar I/O held, and conflicting draft recovery with byte-exact attachments. The unchanged broader state-machine cases retain the previous full independent evidence, not a claim that they were rerun under a different hash.

The E2E cases are `chat-first-turn-responsiveness.spec.ts`, `chat-first-turn-resize.spec.ts`, `chat-first-turn-recovery.spec.ts`, and `chat-send-dedup.spec.ts`. These do not require a paid model.

## Scope and limits

This is a bounded interaction-reliability/performance slice, not a whole-app throughput benchmark or an installed Desktop release. No percentage speedup is claimed. Canonical conversation IDs remain server-owned: pending UI appears locally before acknowledgement; the real conversation route is selected after acknowledgement without waiting for unrelated refreshes.

No schema/API protocol, startup, migration, or packaging changes. Packaged Desktop verification was not run. Recovered File objects are memory-only and do not have browser-restart durability.

The shared checkout was concurrently switched to another task's branch. This branch isolates only the responsiveness work and preserves the already-integrated shared changes without committing unrelated staged files. The tested local baseline was `634aab5bb`; upstream queue freshness/active-polling changes are separate and must remain intact when integrating with current main. No merge or deployment is requested by this draft.
