### PR TITLE
fix(release): unblock Windows browser-app runtime smoke

### DIFF
--- a/cli/scripts/browser-app-smoke.mjs
+++ b/cli/scripts/browser-app-smoke.mjs
@@ -64,6 +64,7 @@ function startBrowserApp(label) {
     env: {
       ...process.env,
       RUDDER_POSTGRES_BIN_DIR: postgresBinDir,
+      RUDDER_RUNTIME_INSTALL_OMIT_OPTIONAL: "true",
     },
     stdio: ["ignore", "pipe", "pipe"],
     windowsHide: true,
@@ -93,6 +94,7 @@ function startBrowserAppParent() {
     env: {
       ...process.env,
       RUDDER_POSTGRES_BIN_DIR: postgresBinDir,
+      RUDDER_RUNTIME_INSTALL_OMIT_OPTIONAL: "true",
     },
     stdio: ["ignore", "pipe", "pipe"],
     windowsHide: true,

--- a/cli/src/__tests__/start.test.ts
+++ b/cli/src/__tests__/start.test.ts
@@ -110,6 +110,29 @@ function writeRuntimePackageSync(cacheDir: string, packageName: string, version 
   writeFileSync(path.join(packageDir, "index.js"), "", "utf8");
 }
 
+function writeRuntimePackageManifestSync(
+  cacheDir: string,
+  packageName: string,
+  manifest: Record<string, unknown>,
+): void {
+  const packageDir = path.join(cacheDir, "node_modules", ...packageName.split("/"));
+  mkdirSync(packageDir, { recursive: true });
+  writeFileSync(path.join(packageDir, "package.json"), JSON.stringify(manifest), "utf8");
+  writeFileSync(path.join(packageDir, "index.js"), "", "utf8");
+}
+
+function currentSharpPlatformPackage(): string | null {
+  if (process.platform === "darwin" && process.arch === "arm64") return "@img/sharp-darwin-arm64";
+  if (process.platform === "darwin" && process.arch === "x64") return "@img/sharp-darwin-x64";
+  if (process.platform === "linux" && process.arch === "arm64") return "@img/sharp-linux-arm64";
+  if (process.platform === "linux" && process.arch === "arm") return "@img/sharp-linux-arm";
+  if (process.platform === "linux" && process.arch === "ia32") return "@img/sharp-linux-ia32";
+  if (process.platform === "linux" && process.arch === "ppc64") return "@img/sharp-linux-ppc64";
+  if (process.platform === "linux" && process.arch === "x64") return "@img/sharp-linux-x64";
+  if (process.platform === "win32" && process.arch === "x64") return "@img/sharp-win32-x64";
+  return null;
+}
+
 async function writeFakePostgresRuntime(
   root: string,
   options: { nestedTimezone?: boolean } = {},
@@ -2600,6 +2623,109 @@ describe("runtime install helpers", () => {
         },
       );
     } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("can skip embedded PostgreSQL optional dependencies while retaining native runtime packages", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "rudder-runtime-install-external-postgres-flags-test."));
+    const previousPostgresBinDir = process.env.RUDDER_POSTGRES_BIN_DIR;
+    const previousOmitOptional = process.env.RUDDER_RUNTIME_INSTALL_OMIT_OPTIONAL;
+    try {
+      process.env.RUDDER_POSTGRES_BIN_DIR = await writeFakePostgresRuntime(path.join(root, "external"));
+      process.env.RUDDER_RUNTIME_INSTALL_OMIT_OPTIONAL = "true";
+      const sharpPlatformPackage = currentSharpPlatformPackage();
+      if (!sharpPlatformPackage) throw new Error(`Unsupported test platform: ${process.platform}/${process.arch}`);
+      const embeddedPostgresPlatformPackage = currentEmbeddedPostgresPlatformPackage();
+      const sharpTarball = `${sharpPlatformPackage.replace("@", "").replace("/", "-")}-0.34.5.tgz`;
+      let sharpRepairPrefix = "";
+      const spawnSyncImpl = vi
+        .fn()
+        .mockImplementationOnce((_command, args: string[]) => {
+          const runtimeCacheDir = args[args.indexOf("--prefix") + 1];
+          writeRuntimePackageSync(runtimeCacheDir, "@rudderhq/server", "1.2.3");
+          writeRuntimePackageManifestSync(runtimeCacheDir, "embedded-postgres", {
+            name: "embedded-postgres",
+            version: "18.1.0-beta.16",
+            optionalDependencies: embeddedPostgresPlatformPackage
+              ? { [embeddedPostgresPlatformPackage]: "18.1.0-beta.16" }
+              : {},
+          });
+          writeRuntimePackageManifestSync(runtimeCacheDir, "sharp", {
+            name: "sharp",
+            version: "0.34.5",
+            optionalDependencies: { [sharpPlatformPackage]: "0.34.5" },
+          });
+          return { status: 0, stdout: "added runtime", stderr: "" };
+        })
+        .mockImplementationOnce((_command, args: string[]) => {
+          sharpRepairPrefix = args[args.indexOf("--pack-destination") + 1];
+          return { status: 0, stdout: `${sharpTarball}\n`, stderr: "" };
+        })
+        .mockImplementationOnce((_command, args: string[]) => {
+          const targetDir = args[args.indexOf("-C") + 1];
+          mkdirSync(targetDir, { recursive: true });
+          writeFileSync(path.join(targetDir, "package.json"), JSON.stringify({
+            name: sharpPlatformPackage,
+            version: "0.34.5",
+          }), "utf8");
+          writeFileSync(path.join(targetDir, "index.js"), "", "utf8");
+          return { status: 0, stdout: "extracted native package", stderr: "" };
+        });
+
+      await expect(
+        ensureRuntimeInstalled({
+          version: "1.2.3",
+          homeDir: root,
+          spawnSyncImpl: spawnSyncImpl as never,
+          postgresVersionProbe: () => "PostgreSQL 18.4",
+          preparePostgresPayload: true,
+          pruneRuntimeCache: false,
+        }),
+      ).resolves.toMatchObject({
+        status: "installed",
+        command: expect.stringContaining("--omit=optional"),
+      });
+
+      expect(spawnSyncImpl).toHaveBeenCalledTimes(3);
+      expect(spawnSyncImpl).toHaveBeenCalledWith(
+        npmInstallInvocation.command,
+        [
+          ...npmInstallInvocation.args,
+          "install",
+          "--prefix",
+          resolveRuntimeCacheDir("1.2.3", root),
+          "--omit=dev",
+          "--omit=optional",
+          "--no-audit",
+          "--no-fund",
+          "@rudderhq/server@1.2.3",
+        ],
+        expect.any(Object),
+      );
+      expect(spawnSyncImpl.mock.calls[1]?.[1]).toEqual(expect.arrayContaining([
+        "pack",
+        `${sharpPlatformPackage}@0.34.5`,
+        "--registry",
+        NPM_PUBLIC_REGISTRY_URL,
+        "--silent",
+      ]));
+      expect(spawnSyncImpl.mock.calls[2]?.[1]).toEqual([
+        "-xzf",
+        path.join(sharpRepairPrefix, sharpTarball),
+        "-C",
+        path.join(resolveRuntimeCacheDir("1.2.3", root), "node_modules", ...sharpPlatformPackage.split("/")),
+        "--strip-components",
+        "1",
+      ]);
+      if (embeddedPostgresPlatformPackage) {
+        expect(spawnSyncImpl.mock.calls.flatMap(([, args]) => args)).not.toContain(embeddedPostgresPlatformPackage);
+      }
+    } finally {
+      if (previousPostgresBinDir === undefined) delete process.env.RUDDER_POSTGRES_BIN_DIR;
+      else process.env.RUDDER_POSTGRES_BIN_DIR = previousPostgresBinDir;
+      if (previousOmitOptional === undefined) delete process.env.RUDDER_RUNTIME_INSTALL_OMIT_OPTIONAL;
+      else process.env.RUDDER_RUNTIME_INSTALL_OMIT_OPTIONAL = previousOmitOptional;
       await rm(root, { recursive: true, force: true });
     }
   });

--- a/cli/src/runtime/install.ts
+++ b/cli/src/runtime/install.ts
@@ -10,6 +10,17 @@ import { pathToFileURL } from "node:url";
 import { resolveRudderHomeDir } from "../config/home.js";
 import { resolveNpmCommandInvocation } from "../npm-command.js";
 import { tryInstallNativePayload } from "./native-payload.js";
+import {
+  canResolveRuntimePackage,
+  ensureRuntimeNativeDependencies,
+  hasRequiredRuntimeNativeDependencies,
+  installRuntimePackageInStaging,
+  normalizeOptionalDependencyVersion,
+  packageNameFromSpec,
+  readRuntimePackageJson,
+  removeRuntimeInstallLocks,
+  type SpawnSyncResultLike,
+} from "./platform-dependencies.js";
 import { downloadRuntimePostgresArchive } from "./postgres-runtime-download.js";
 import { resolvePostgresRuntimeArchiveSource } from "./postgres-runtime-source.js";
 export const RUNTIME_NPM_PACKAGE_NAME = "@rudderhq/server";
@@ -23,9 +34,7 @@ export const DEFAULT_RUNTIME_CACHE_KEEP_PREVIOUS = 0;
 const RUNTIME_NPM_INSTALL_BASE_FLAGS = ["--omit=dev"];
 const RUNTIME_NPM_INSTALL_OPTIONAL_FLAGS = ["--include=optional"];
 const RUNTIME_NPM_INSTALL_SUFFIX_FLAGS = ["--no-audit", "--no-fund"];
-const RUNTIME_NPM_PACK_FLAGS = ["--registry", NPM_PUBLIC_REGISTRY_URL, "--silent"];
 const EMBEDDED_POSTGRES_PACKAGE_NAME = "embedded-postgres";
-const SHARP_PACKAGE_NAME = "sharp";
 const RUDDER_DESKTOP_MANAGED_POSTGRES_BIN_DIR_ENV = "RUDDER_DESKTOP_MANAGED_POSTGRES_BIN_DIR";
 const RUDDER_POSTGRES_BIN_DIR_ENV = "RUDDER_POSTGRES_BIN_DIR";
 const RUDDER_POSTGRES_RUNTIME_ARCHIVE_MAX_BYTES_ENV = "RUDDER_POSTGRES_RUNTIME_ARCHIVE_MAX_BYTES";
@@ -36,12 +45,6 @@ const RUNTIME_CACHE_PACKAGE_JSON = {
   private: true,
   type: "module",
 };
-const NPM_PLATFORM_REPAIR_ENV = {
-  npm_config_registry: NPM_PUBLIC_REGISTRY_URL,
-  npm_config_update_notifier: "false",
-  NO_UPDATE_NOTIFIER: "1",
-};
-
 function omitOptionalRuntimeDependencies(): boolean {
   return process.env.RUDDER_RUNTIME_INSTALL_OMIT_OPTIONAL === "true";
 }
@@ -53,13 +56,6 @@ function runtimeNpmInstallFlags(): string[] {
     ...RUNTIME_NPM_INSTALL_SUFFIX_FLAGS,
   ];
 }
-
-type PackageJsonLike = {
-  name?: string;
-  version?: string;
-  dependencies?: Record<string, string>;
-  optionalDependencies?: Record<string, string>;
-};
 
 export interface RuntimeInstallMetadata {
   version: 1;
@@ -148,7 +144,6 @@ export class RuntimeInstallError extends Error {
   }
 }
 
-type SpawnSyncResultLike = ReturnType<typeof spawnSync>;
 export type RuntimePostgresVersionProbe = (postgresBinary: string) => string;
 
 type RuntimeInstallDeadline = {
@@ -289,15 +284,6 @@ function resolveEmbeddedPostgresPlatformPackage(
   if (platform === "linux" && arch === "x64") return "@embedded-postgres/linux-x64";
   if (platform === "win32" && arch === "x64") return "@embedded-postgres/windows-x64";
   return null;
-}
-
-async function canResolveRuntimePackage(cacheDir: string, packageName: string): Promise<boolean> {
-  try {
-    await readFile(path.join(cacheDir, "node_modules", ...packageName.split("/"), "package.json"), "utf8");
-    return true;
-  } catch {
-    return false;
-  }
 }
 
 async function hasRequiredRuntimePlatformDependencies(
@@ -589,7 +575,7 @@ async function ensureRuntimeInstalledUnlocked(
         fallbackOutput = collectOutputParts(
           fallbackOutput,
           await ensureRequiredEmbeddedPostgresPlatformPackage(spawnSyncImpl, fallbackCacheDir, deadline),
-          await ensureRequiredRuntimeNativeDependencies(spawnSyncImpl, fallbackCacheDir, deadline),
+          await ensureRuntimeNativeDependenciesForCache(spawnSyncImpl, fallbackCacheDir, deadline),
         );
         const postgresPayload = await stageRuntimePostgresPayload(
           fallbackCacheDir,
@@ -635,7 +621,7 @@ async function ensureRuntimeInstalledUnlocked(
   output = collectOutputParts(
     output,
     await ensureRequiredEmbeddedPostgresPlatformPackage(spawnSyncImpl, cacheDir, deadline),
-    await ensureRequiredRuntimeNativeDependencies(spawnSyncImpl, cacheDir, deadline),
+    await ensureRuntimeNativeDependenciesForCache(spawnSyncImpl, cacheDir, deadline),
   );
   const postgresPayload = await stageRuntimePostgresPayload(
     cacheDir,
@@ -757,18 +743,6 @@ function withPostgresPayload<T extends Omit<RuntimeInstallResult, "postgresPaylo
   };
 }
 
-function runtimePackageJsonPath(cacheDir: string, packageName: string): string {
-  return path.join(cacheDir, "node_modules", ...packageName.split("/"), "package.json");
-}
-
-async function readRuntimePackageJson(cacheDir: string, packageName: string): Promise<PackageJsonLike | null> {
-  try {
-    return JSON.parse(await readFile(runtimePackageJsonPath(cacheDir, packageName), "utf8")) as PackageJsonLike;
-  } catch {
-    return null;
-  }
-}
-
 async function tryRepairExistingRuntimePackage(options: {
   spawnSyncImpl: typeof spawnSync;
   cacheDir: string;
@@ -785,7 +759,7 @@ async function tryRepairExistingRuntimePackage(options: {
     options.cacheDir,
     options.deadline,
   );
-  const nativeOutput = await ensureRequiredRuntimeNativeDependencies(
+  const nativeOutput = await ensureRuntimeNativeDependenciesForCache(
     options.spawnSyncImpl,
     options.cacheDir,
     options.deadline,
@@ -796,6 +770,20 @@ async function tryRepairExistingRuntimePackage(options: {
   return !platformPackage || await canResolveRuntimePackage(options.cacheDir, platformPackage)
     ? combinedOutput
     : null;
+}
+
+async function ensureRuntimeNativeDependenciesForCache(
+  spawnSyncImpl: typeof spawnSync,
+  cacheDir: string,
+  deadline?: RuntimeInstallDeadline,
+): Promise<string> {
+  return ensureRuntimeNativeDependencies({
+    spawnSyncImpl,
+    cacheDir,
+    deadline,
+    remainingMs: remainingRuntimeInstallMs,
+    createError: (message, command, output) => new RuntimeInstallError(message, { cacheDir, command, output }),
+  });
 }
 
 export function embeddedPostgresPlatformPackageName(
@@ -835,7 +823,7 @@ async function ensureRequiredEmbeddedPostgresPlatformPackage(
     cacheDir,
     packageSpec,
     packageName,
-    deadline,
+    { cacheDir, deadline, remainingMs: remainingRuntimeInstallMs },
   );
   const output = collectSpawnOutput(result);
   if (result.status === 0 && packageName && await canResolveRuntimePackage(cacheDir, packageName)) {
@@ -847,250 +835,6 @@ async function ensureRequiredEmbeddedPostgresPlatformPackage(
     `Rudder runtime installation is missing required platform package ${packageName || packageSpec}. Re-run manually: ${command}`,
     { cacheDir, command, output },
   );
-}
-
-function resolveSharpPlatformPackageName(sharpPackage: PackageJsonLike): string | null {
-  const platformPrefixes = process.platform === "linux"
-    ? [
-        isLinuxGlibcRuntime() ? "linux" : "linuxmusl",
-        "linux",
-        "linuxmusl",
-      ]
-    : [process.platform];
-  for (const platformPrefix of platformPrefixes) {
-    const packageName = `@img/sharp-${platformPrefix}-${process.arch}`;
-    if (sharpPackage.optionalDependencies?.[packageName]) return packageName;
-  }
-  return null;
-}
-
-function isLinuxGlibcRuntime(): boolean {
-  try {
-    const report = process.report?.getReport() as { header?: { glibcVersionRuntime?: string } };
-    return typeof report.header?.glibcVersionRuntime === "string";
-  } catch {
-    return true;
-  }
-}
-
-async function hasRequiredRuntimeNativeDependencies(cacheDir: string): Promise<boolean> {
-  const sharpPackage = await readRuntimePackageJson(cacheDir, SHARP_PACKAGE_NAME);
-  if (!sharpPackage) return true;
-  const platformPackageName = resolveSharpPlatformPackageName(sharpPackage);
-  if (!platformPackageName) return true;
-
-  const requiredPackages = [{
-    name: platformPackageName,
-    version: normalizeOptionalDependencyVersion(sharpPackage.optionalDependencies?.[platformPackageName]),
-  }];
-  for (let index = 0; index < requiredPackages.length; index += 1) {
-    const requiredPackage = requiredPackages[index];
-    const packageJson = await readRuntimePackageJson(cacheDir, requiredPackage.name);
-    if (!packageJson || (
-      requiredPackage.version !== null
-      && packageJson.version !== requiredPackage.version
-    )) return false;
-    for (const [dependencyName, versionRange] of Object.entries(packageJson.optionalDependencies ?? {})) {
-      if (!requiredPackages.some(({ name }) => name === dependencyName)) {
-        requiredPackages.push({
-          name: dependencyName,
-          version: normalizeOptionalDependencyVersion(versionRange),
-        });
-      }
-    }
-  }
-  return true;
-}
-
-async function ensureRequiredRuntimeNativeDependencies(
-  spawnSyncImpl: typeof spawnSync,
-  cacheDir: string,
-  deadline?: RuntimeInstallDeadline,
-): Promise<string> {
-  if (!omitOptionalRuntimeDependencies()) return "";
-  const sharpPackage = await readRuntimePackageJson(cacheDir, SHARP_PACKAGE_NAME);
-  if (!sharpPackage) return "";
-  const platformPackageName = resolveSharpPlatformPackageName(sharpPackage);
-  if (!platformPackageName) return "";
-
-  const requiredPackageVersions = new Map<string, string | null>([
-    [platformPackageName, normalizeOptionalDependencyVersion(sharpPackage.optionalDependencies?.[platformPackageName])],
-  ]);
-  const requiredPackages = new Set([platformPackageName]);
-  let output = "";
-  for (let pass = 0; pass < 8; pass += 1) {
-    const missingSpecs: string[] = [];
-    for (const packageName of requiredPackages) {
-      const version = requiredPackageVersions.get(packageName) ?? null;
-      const packageJson = await readRuntimePackageJson(cacheDir, packageName);
-      if (packageJson && (version === null || packageJson.version === version)) continue;
-      missingSpecs.push(version ? `${packageName}@${version}` : packageName);
-    }
-
-    if (missingSpecs.length > 0) {
-      await removeRuntimeInstallLocks(cacheDir);
-      for (const packageSpec of missingSpecs) {
-        const packageName = packageNameFromSpec(packageSpec);
-        const result = await installRuntimePackageInStaging(
-          spawnSyncImpl,
-          cacheDir,
-          packageSpec,
-          packageName,
-          deadline,
-        );
-        output = collectOutputParts(output, collectSpawnOutput(result));
-        if (result.status === 0 && await canResolveRuntimePackage(cacheDir, packageName)) continue;
-        const command = formatRuntimePlatformRepairCommand(cacheDir, packageSpec);
-        throw new RuntimeInstallError(
-          `Rudder runtime installation is missing required native package ${packageName}. Re-run manually: ${command}`,
-          { cacheDir, command, output },
-        );
-      }
-    }
-
-    let discoveredNewPackage = false;
-    for (const packageName of [...requiredPackages]) {
-      const packageJson = await readRuntimePackageJson(cacheDir, packageName);
-      for (const [dependencyName, versionRange] of Object.entries(packageJson?.optionalDependencies ?? {})) {
-        if (requiredPackages.has(dependencyName)) continue;
-        requiredPackages.add(dependencyName);
-        requiredPackageVersions.set(dependencyName, normalizeOptionalDependencyVersion(versionRange));
-        discoveredNewPackage = true;
-      }
-    }
-    if (!discoveredNewPackage && await hasRequiredRuntimeNativeDependencies(cacheDir)) return output;
-  }
-
-  const command = [...requiredPackages]
-    .map((packageName) => formatRuntimePlatformRepairCommand(
-      cacheDir,
-      requiredPackageVersions.get(packageName)
-        ? `${packageName}@${requiredPackageVersions.get(packageName)}`
-        : packageName,
-    ))
-    .join("; ");
-  throw new RuntimeInstallError(
-    `Rudder runtime native dependency preparation did not converge. Re-run manually: ${command}`,
-    { cacheDir, command, output },
-  );
-}
-
-async function installRuntimePackageInStaging(
-  spawnSyncImpl: typeof spawnSync,
-  cacheDir: string,
-  packageSpec: string,
-  packageName: string,
-  deadline?: RuntimeInstallDeadline,
-): Promise<SpawnSyncResultLike> {
-  const stagingDir = path.join(cacheDir, `.platform-repair-${process.pid}-${Date.now()}`);
-  await mkdir(stagingDir, { recursive: true });
-
-  try {
-    const packResult = runNpmPack(spawnSyncImpl, packageSpec, stagingDir, cacheDir, deadline);
-    if (packResult.status !== 0) return packResult;
-
-    const packFilename = parseNpmPackFilename(packResult.stdout);
-    if (!packFilename) {
-      return createSyntheticSpawnResult(1, "", `Unable to parse npm pack output for ${packageSpec}.`);
-    }
-
-    const archivePath = path.join(stagingDir, packFilename);
-    const targetDir = path.dirname(runtimePackageJsonPath(cacheDir, packageName));
-    await mkdir(path.dirname(targetDir), { recursive: true });
-    await rm(targetDir, { recursive: true, force: true });
-    await mkdir(targetDir, { recursive: true });
-
-    const extractResult = runTarExtract(spawnSyncImpl, archivePath, targetDir, cacheDir, deadline);
-    return combineSpawnResults(packResult, extractResult);
-  } finally {
-    await rm(stagingDir, { recursive: true, force: true });
-  }
-}
-
-function runNpmPack(
-  spawnSyncImpl: typeof spawnSync,
-  packageSpec: string,
-  destinationDir: string,
-  cacheDir: string,
-  deadline?: RuntimeInstallDeadline,
-): SpawnSyncResultLike {
-  const timeout = remainingRuntimeInstallMs(deadline, cacheDir, `npm pack ${packageSpec}`);
-  const npm = resolveNpmCommandInvocation();
-  return spawnSyncImpl(
-    npm.command,
-    [...npm.args, "pack", packageSpec, "--pack-destination", destinationDir, ...RUNTIME_NPM_PACK_FLAGS],
-    {
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "pipe"],
-      env: { ...process.env, ...NPM_PLATFORM_REPAIR_ENV },
-      ...(timeout === undefined ? {} : { timeout }),
-      ...(process.platform === "win32" ? { windowsHide: true } : {}),
-    },
-  );
-}
-
-function runTarExtract(
-  spawnSyncImpl: typeof spawnSync,
-  archivePath: string,
-  targetDir: string,
-  cacheDir: string,
-  deadline?: RuntimeInstallDeadline,
-): SpawnSyncResultLike {
-  const timeout = remainingRuntimeInstallMs(deadline, cacheDir, "extract runtime platform package");
-  return spawnSyncImpl(
-    "tar",
-    ["-xzf", archivePath, "-C", targetDir, "--strip-components", "1"],
-    {
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "pipe"],
-      ...(timeout === undefined ? {} : { timeout }),
-      ...(process.platform === "win32" ? { windowsHide: true } : {}),
-    },
-  );
-}
-
-function parseNpmPackFilename(stdout: unknown): string | null {
-  if (typeof stdout !== "string") return null;
-  const filename = stdout.trim().split(/\r?\n/).filter(Boolean).at(-1);
-  return filename?.endsWith(".tgz") ? filename : null;
-}
-
-function createSyntheticSpawnResult(status: number, stdout: string, stderr: string): SpawnSyncResultLike {
-  return { status, stdout, stderr } as SpawnSyncResultLike;
-}
-
-function combineSpawnResults(...results: SpawnSyncResultLike[]): SpawnSyncResultLike {
-  const last = results.at(-1);
-  return {
-    status: last?.status ?? 0,
-    stdout: results.map((result) => result.stdout).filter(Boolean).join("\n"),
-    stderr: results.map((result) => result.stderr).filter(Boolean).join("\n"),
-    error: results.find((result) => result.error)?.error,
-  } as SpawnSyncResultLike;
-}
-
-async function removeRuntimeInstallLocks(cacheDir: string): Promise<void> {
-  await Promise.all([
-    rm(path.join(cacheDir, "package-lock.json"), { force: true }),
-    rm(path.join(cacheDir, "node_modules", ".package-lock.json"), { force: true }),
-  ]);
-}
-
-function packageNameFromSpec(packageSpec: string): string {
-  if (!packageSpec.startsWith("@")) {
-    const versionSeparator = packageSpec.indexOf("@");
-    return versionSeparator === -1 ? packageSpec : packageSpec.slice(0, versionSeparator);
-  }
-
-  const versionSeparator = packageSpec.indexOf("@", 1);
-  return versionSeparator === -1 ? packageSpec : packageSpec.slice(0, versionSeparator);
-}
-
-function normalizeOptionalDependencyVersion(versionRange: string | undefined): string | null {
-  const trimmed = versionRange?.trim();
-  if (!trimmed) return null;
-  const exactVersion = /^[~^]\s*([0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?)$/.exec(trimmed);
-  return exactVersion?.[1] ?? trimmed;
 }
 
 function runtimePostgresPlatformSegment(

--- a/cli/src/runtime/install.ts
+++ b/cli/src/runtime/install.ts
@@ -20,9 +20,12 @@ export const DEFAULT_RUNTIME_CACHE_MAX_ENTRIES = 2;
 export const DEFAULT_RUNTIME_CACHE_MAX_AGE_MS = 14 * 24 * 60 * 60 * 1000;
 export const DEFAULT_RUNTIME_CACHE_MAX_BYTES = 2 * 1024 * 1024 * 1024;
 export const DEFAULT_RUNTIME_CACHE_KEEP_PREVIOUS = 0;
-const RUNTIME_NPM_INSTALL_FLAGS = ["--omit=dev", "--include=optional", "--no-audit", "--no-fund"];
+const RUNTIME_NPM_INSTALL_BASE_FLAGS = ["--omit=dev"];
+const RUNTIME_NPM_INSTALL_OPTIONAL_FLAGS = ["--include=optional"];
+const RUNTIME_NPM_INSTALL_SUFFIX_FLAGS = ["--no-audit", "--no-fund"];
 const RUNTIME_NPM_PACK_FLAGS = ["--registry", NPM_PUBLIC_REGISTRY_URL, "--silent"];
 const EMBEDDED_POSTGRES_PACKAGE_NAME = "embedded-postgres";
+const SHARP_PACKAGE_NAME = "sharp";
 const RUDDER_DESKTOP_MANAGED_POSTGRES_BIN_DIR_ENV = "RUDDER_DESKTOP_MANAGED_POSTGRES_BIN_DIR";
 const RUDDER_POSTGRES_BIN_DIR_ENV = "RUDDER_POSTGRES_BIN_DIR";
 const RUDDER_POSTGRES_RUNTIME_ARCHIVE_MAX_BYTES_ENV = "RUDDER_POSTGRES_RUNTIME_ARCHIVE_MAX_BYTES";
@@ -38,6 +41,18 @@ const NPM_PLATFORM_REPAIR_ENV = {
   npm_config_update_notifier: "false",
   NO_UPDATE_NOTIFIER: "1",
 };
+
+function omitOptionalRuntimeDependencies(): boolean {
+  return process.env.RUDDER_RUNTIME_INSTALL_OMIT_OPTIONAL === "true";
+}
+
+function runtimeNpmInstallFlags(): string[] {
+  return [
+    ...RUNTIME_NPM_INSTALL_BASE_FLAGS,
+    ...(omitOptionalRuntimeDependencies() ? ["--omit=optional"] : RUNTIME_NPM_INSTALL_OPTIONAL_FLAGS),
+    ...RUNTIME_NPM_INSTALL_SUFFIX_FLAGS,
+  ];
+}
 
 type PackageJsonLike = {
   name?: string;
@@ -291,6 +306,7 @@ async function hasRequiredRuntimePlatformDependencies(
   postgresVersionProbe: RuntimePostgresVersionProbe,
   deadline?: RuntimeInstallDeadline,
 ): Promise<boolean> {
+  if (omitOptionalRuntimeDependencies()) return hasRequiredRuntimeNativeDependencies(cacheDir);
   if (!await canResolveRuntimePackage(cacheDir, EMBEDDED_POSTGRES_PACKAGE_NAME)) return true;
   const platformPackage = resolveEmbeddedPostgresPlatformPackage();
   if (!platformPackage) return true;
@@ -312,6 +328,7 @@ async function hasRequiredRuntimePlatformDependencies(
 
 async function assertRequiredRuntimePlatformDependencies(cacheDir: string, command: string, output: string): Promise<void> {
   if (!await canResolveRuntimePackage(cacheDir, EMBEDDED_POSTGRES_PACKAGE_NAME)) return;
+  if (omitOptionalRuntimeDependencies()) return;
   const platformPackage = resolveEmbeddedPostgresPlatformPackage();
   if (!platformPackage || await canResolveRuntimePackage(cacheDir, platformPackage)) return;
 
@@ -572,6 +589,7 @@ async function ensureRuntimeInstalledUnlocked(
         fallbackOutput = collectOutputParts(
           fallbackOutput,
           await ensureRequiredEmbeddedPostgresPlatformPackage(spawnSyncImpl, fallbackCacheDir, deadline),
+          await ensureRequiredRuntimeNativeDependencies(spawnSyncImpl, fallbackCacheDir, deadline),
         );
         const postgresPayload = await stageRuntimePostgresPayload(
           fallbackCacheDir,
@@ -617,6 +635,7 @@ async function ensureRuntimeInstalledUnlocked(
   output = collectOutputParts(
     output,
     await ensureRequiredEmbeddedPostgresPlatformPackage(spawnSyncImpl, cacheDir, deadline),
+    await ensureRequiredRuntimeNativeDependencies(spawnSyncImpl, cacheDir, deadline),
   );
   const postgresPayload = await stageRuntimePostgresPayload(
     cacheDir,
@@ -691,7 +710,7 @@ function runNpmRuntimeInstall(
   const npm = resolveNpmCommandInvocation();
   return spawnSyncImpl(
     npm.command,
-    [...npm.args, "install", "--prefix", cacheDir, ...RUNTIME_NPM_INSTALL_FLAGS, packageSpec],
+    [...npm.args, "install", "--prefix", cacheDir, ...runtimeNpmInstallFlags(), packageSpec],
     {
       encoding: "utf8",
       stdio: ["ignore", "pipe", "pipe"],
@@ -702,7 +721,7 @@ function runNpmRuntimeInstall(
 }
 
 function formatRuntimeInstallCommand(cacheDir: string, packageSpec: string): string {
-  return `npm install --prefix ${cacheDir} ${RUNTIME_NPM_INSTALL_FLAGS.join(" ")} ${packageSpec}`;
+  return `npm install --prefix ${cacheDir} ${runtimeNpmInstallFlags().join(" ")} ${packageSpec}`;
 }
 
 function formatRuntimePlatformRepairCommand(cacheDir: string, packageSpec: string): string {
@@ -766,10 +785,16 @@ async function tryRepairExistingRuntimePackage(options: {
     options.cacheDir,
     options.deadline,
   );
-  if (!await canResolveRuntimePackage(options.cacheDir, EMBEDDED_POSTGRES_PACKAGE_NAME)) return output;
+  const nativeOutput = await ensureRequiredRuntimeNativeDependencies(
+    options.spawnSyncImpl,
+    options.cacheDir,
+    options.deadline,
+  );
+  const combinedOutput = collectOutputParts(output, nativeOutput);
+  if (!await canResolveRuntimePackage(options.cacheDir, EMBEDDED_POSTGRES_PACKAGE_NAME)) return combinedOutput;
   const platformPackage = resolveEmbeddedPostgresPlatformPackage();
   return !platformPackage || await canResolveRuntimePackage(options.cacheDir, platformPackage)
-    ? output
+    ? combinedOutput
     : null;
 }
 
@@ -797,6 +822,7 @@ async function ensureRequiredEmbeddedPostgresPlatformPackage(
   cacheDir: string,
   deadline?: RuntimeInstallDeadline,
 ): Promise<string> {
+  if (omitOptionalRuntimeDependencies()) return "";
   const packageSpec = await resolveEmbeddedPostgresPlatformPackageSpec(cacheDir);
   if (!packageSpec) return "";
 
@@ -819,6 +845,132 @@ async function ensureRequiredEmbeddedPostgresPlatformPackage(
   const command = formatRuntimePlatformRepairCommand(cacheDir, packageSpec);
   throw new RuntimeInstallError(
     `Rudder runtime installation is missing required platform package ${packageName || packageSpec}. Re-run manually: ${command}`,
+    { cacheDir, command, output },
+  );
+}
+
+function resolveSharpPlatformPackageName(sharpPackage: PackageJsonLike): string | null {
+  const platformPrefixes = process.platform === "linux"
+    ? [
+        isLinuxGlibcRuntime() ? "linux" : "linuxmusl",
+        "linux",
+        "linuxmusl",
+      ]
+    : [process.platform];
+  for (const platformPrefix of platformPrefixes) {
+    const packageName = `@img/sharp-${platformPrefix}-${process.arch}`;
+    if (sharpPackage.optionalDependencies?.[packageName]) return packageName;
+  }
+  return null;
+}
+
+function isLinuxGlibcRuntime(): boolean {
+  try {
+    const report = process.report?.getReport() as { header?: { glibcVersionRuntime?: string } };
+    return typeof report.header?.glibcVersionRuntime === "string";
+  } catch {
+    return true;
+  }
+}
+
+async function hasRequiredRuntimeNativeDependencies(cacheDir: string): Promise<boolean> {
+  const sharpPackage = await readRuntimePackageJson(cacheDir, SHARP_PACKAGE_NAME);
+  if (!sharpPackage) return true;
+  const platformPackageName = resolveSharpPlatformPackageName(sharpPackage);
+  if (!platformPackageName) return true;
+
+  const requiredPackages = [{
+    name: platformPackageName,
+    version: normalizeOptionalDependencyVersion(sharpPackage.optionalDependencies?.[platformPackageName]),
+  }];
+  for (let index = 0; index < requiredPackages.length; index += 1) {
+    const requiredPackage = requiredPackages[index];
+    const packageJson = await readRuntimePackageJson(cacheDir, requiredPackage.name);
+    if (!packageJson || (
+      requiredPackage.version !== null
+      && packageJson.version !== requiredPackage.version
+    )) return false;
+    for (const [dependencyName, versionRange] of Object.entries(packageJson.optionalDependencies ?? {})) {
+      if (!requiredPackages.some(({ name }) => name === dependencyName)) {
+        requiredPackages.push({
+          name: dependencyName,
+          version: normalizeOptionalDependencyVersion(versionRange),
+        });
+      }
+    }
+  }
+  return true;
+}
+
+async function ensureRequiredRuntimeNativeDependencies(
+  spawnSyncImpl: typeof spawnSync,
+  cacheDir: string,
+  deadline?: RuntimeInstallDeadline,
+): Promise<string> {
+  if (!omitOptionalRuntimeDependencies()) return "";
+  const sharpPackage = await readRuntimePackageJson(cacheDir, SHARP_PACKAGE_NAME);
+  if (!sharpPackage) return "";
+  const platformPackageName = resolveSharpPlatformPackageName(sharpPackage);
+  if (!platformPackageName) return "";
+
+  const requiredPackageVersions = new Map<string, string | null>([
+    [platformPackageName, normalizeOptionalDependencyVersion(sharpPackage.optionalDependencies?.[platformPackageName])],
+  ]);
+  const requiredPackages = new Set([platformPackageName]);
+  let output = "";
+  for (let pass = 0; pass < 8; pass += 1) {
+    const missingSpecs: string[] = [];
+    for (const packageName of requiredPackages) {
+      const version = requiredPackageVersions.get(packageName) ?? null;
+      const packageJson = await readRuntimePackageJson(cacheDir, packageName);
+      if (packageJson && (version === null || packageJson.version === version)) continue;
+      missingSpecs.push(version ? `${packageName}@${version}` : packageName);
+    }
+
+    if (missingSpecs.length > 0) {
+      await removeRuntimeInstallLocks(cacheDir);
+      for (const packageSpec of missingSpecs) {
+        const packageName = packageNameFromSpec(packageSpec);
+        const result = await installRuntimePackageInStaging(
+          spawnSyncImpl,
+          cacheDir,
+          packageSpec,
+          packageName,
+          deadline,
+        );
+        output = collectOutputParts(output, collectSpawnOutput(result));
+        if (result.status === 0 && await canResolveRuntimePackage(cacheDir, packageName)) continue;
+        const command = formatRuntimePlatformRepairCommand(cacheDir, packageSpec);
+        throw new RuntimeInstallError(
+          `Rudder runtime installation is missing required native package ${packageName}. Re-run manually: ${command}`,
+          { cacheDir, command, output },
+        );
+      }
+    }
+
+    let discoveredNewPackage = false;
+    for (const packageName of [...requiredPackages]) {
+      const packageJson = await readRuntimePackageJson(cacheDir, packageName);
+      for (const [dependencyName, versionRange] of Object.entries(packageJson?.optionalDependencies ?? {})) {
+        if (requiredPackages.has(dependencyName)) continue;
+        requiredPackages.add(dependencyName);
+        requiredPackageVersions.set(dependencyName, normalizeOptionalDependencyVersion(versionRange));
+        discoveredNewPackage = true;
+      }
+    }
+    if (!discoveredNewPackage && await hasRequiredRuntimeNativeDependencies(cacheDir)) return output;
+  }
+
+  const command = [...requiredPackages]
+    .map((packageName) => formatRuntimePlatformRepairCommand(
+      cacheDir,
+      requiredPackageVersions.get(packageName)
+        ? `${packageName}@${requiredPackageVersions.get(packageName)}`
+        : packageName,
+    ))
+    .join("; ");
+  throw new RuntimeInstallError(
+    `Rudder runtime native dependency preparation did not converge. Re-run manually: ${command}`,
     { cacheDir, command, output },
   );
 }

--- a/cli/src/runtime/platform-dependencies.ts
+++ b/cli/src/runtime/platform-dependencies.ts
@@ -1,0 +1,322 @@
+import { spawnSync } from "node:child_process";
+import { mkdir, readFile, rm } from "node:fs/promises";
+import path from "node:path";
+import { resolveNpmCommandInvocation } from "../npm-command.js";
+
+const NPM_PUBLIC_REGISTRY_URL = "https://registry.npmjs.org";
+const NPM_PLATFORM_REPAIR_ENV = {
+  npm_config_registry: NPM_PUBLIC_REGISTRY_URL,
+  npm_config_update_notifier: "false",
+  NO_UPDATE_NOTIFIER: "1",
+};
+
+export type SpawnSyncResultLike = ReturnType<typeof spawnSync>;
+
+export type PackageJsonLike = {
+  name?: string;
+  version?: string;
+  dependencies?: Record<string, string>;
+  optionalDependencies?: Record<string, string>;
+};
+
+type RuntimePackageDeadline<T> = {
+  deadline?: T;
+  cacheDir: string;
+  remainingMs: (deadline: T | undefined, cacheDir: string, command: string) => number | undefined;
+};
+
+export function runtimePackageJsonPath(cacheDir: string, packageName: string): string {
+  return path.join(cacheDir, "node_modules", ...packageName.split("/"), "package.json");
+}
+
+export async function readRuntimePackageJson(cacheDir: string, packageName: string): Promise<PackageJsonLike | null> {
+  try {
+    return JSON.parse(await readFile(runtimePackageJsonPath(cacheDir, packageName), "utf8")) as PackageJsonLike;
+  } catch {
+    return null;
+  }
+}
+
+export async function canResolveRuntimePackage(cacheDir: string, packageName: string): Promise<boolean> {
+  try {
+    await readFile(runtimePackageJsonPath(cacheDir, packageName), "utf8");
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function removeRuntimeInstallLocks(cacheDir: string): Promise<void> {
+  await Promise.all([
+    rm(path.join(cacheDir, "package-lock.json"), { force: true }),
+    rm(path.join(cacheDir, "node_modules", ".package-lock.json"), { force: true }),
+  ]);
+}
+
+export function packageNameFromSpec(packageSpec: string): string {
+  if (!packageSpec.startsWith("@")) {
+    const versionSeparator = packageSpec.indexOf("@");
+    return versionSeparator === -1 ? packageSpec : packageSpec.slice(0, versionSeparator);
+  }
+
+  const versionSeparator = packageSpec.indexOf("@", 1);
+  return versionSeparator === -1 ? packageSpec : packageSpec.slice(0, versionSeparator);
+}
+
+export function normalizeOptionalDependencyVersion(versionRange: string | undefined): string | null {
+  const trimmed = versionRange?.trim();
+  if (!trimmed) return null;
+  const exactVersion = /^[~^]\s*([0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?)$/.exec(trimmed);
+  return exactVersion?.[1] ?? trimmed;
+}
+
+export async function installRuntimePackageInStaging<TDeadline>(
+  spawnSyncImpl: typeof spawnSync,
+  cacheDir: string,
+  packageSpec: string,
+  packageName: string,
+  options: RuntimePackageDeadline<TDeadline>,
+): Promise<SpawnSyncResultLike> {
+  const stagingDir = path.join(cacheDir, `.platform-repair-${process.pid}-${Date.now()}`);
+  await mkdir(stagingDir, { recursive: true });
+
+  try {
+    const packResult = runNpmPack(spawnSyncImpl, packageSpec, stagingDir, options);
+    if (packResult.status !== 0) return packResult;
+
+    const packFilename = parseNpmPackFilename(packResult.stdout);
+    if (!packFilename) {
+      return createSyntheticSpawnResult(1, "", `Unable to parse npm pack output for ${packageSpec}.`);
+    }
+
+    const archivePath = path.join(stagingDir, packFilename);
+    const targetDir = path.dirname(runtimePackageJsonPath(cacheDir, packageName));
+    await mkdir(path.dirname(targetDir), { recursive: true });
+    await rm(targetDir, { recursive: true, force: true });
+    await mkdir(targetDir, { recursive: true });
+
+    const extractResult = runTarExtract(spawnSyncImpl, archivePath, targetDir, options);
+    return combineSpawnResults(packResult, extractResult);
+  } finally {
+    await rm(stagingDir, { recursive: true, force: true });
+  }
+}
+
+function runNpmPack<TDeadline>(
+  spawnSyncImpl: typeof spawnSync,
+  packageSpec: string,
+  destinationDir: string,
+  options: RuntimePackageDeadline<TDeadline>,
+): SpawnSyncResultLike {
+  const timeout = options.remainingMs(options.deadline, options.cacheDir, `npm pack ${packageSpec}`);
+  const npm = resolveNpmCommandInvocation();
+  return spawnSyncImpl(
+    npm.command,
+    [
+      ...npm.args,
+      "pack",
+      packageSpec,
+      "--pack-destination",
+      destinationDir,
+      "--registry",
+      NPM_PUBLIC_REGISTRY_URL,
+      "--silent",
+    ],
+    {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+      env: { ...process.env, ...NPM_PLATFORM_REPAIR_ENV },
+      ...(timeout === undefined ? {} : { timeout }),
+      ...(process.platform === "win32" ? { windowsHide: true } : {}),
+    },
+  );
+}
+
+function runTarExtract<TDeadline>(
+  spawnSyncImpl: typeof spawnSync,
+  archivePath: string,
+  targetDir: string,
+  options: RuntimePackageDeadline<TDeadline>,
+): SpawnSyncResultLike {
+  const timeout = options.remainingMs(options.deadline, options.cacheDir, "extract runtime platform package");
+  return spawnSyncImpl(
+    "tar",
+    ["-xzf", archivePath, "-C", targetDir, "--strip-components", "1"],
+    {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+      ...(timeout === undefined ? {} : { timeout }),
+      ...(process.platform === "win32" ? { windowsHide: true } : {}),
+    },
+  );
+}
+
+function parseNpmPackFilename(stdout: unknown): string | null {
+  if (typeof stdout !== "string") return null;
+  const filename = stdout.trim().split(/\r?\n/).filter(Boolean).at(-1);
+  return filename?.endsWith(".tgz") ? filename : null;
+}
+
+function createSyntheticSpawnResult(status: number, stdout: string, stderr: string): SpawnSyncResultLike {
+  return { status, stdout, stderr } as SpawnSyncResultLike;
+}
+
+function combineSpawnResults(...results: SpawnSyncResultLike[]): SpawnSyncResultLike {
+  const last = results.at(-1);
+  return {
+    status: last?.status ?? 0,
+    stdout: results.map((result) => result.stdout).filter(Boolean).join("\n"),
+    stderr: results.map((result) => result.stderr).filter(Boolean).join("\n"),
+    error: results.find((result) => result.error)?.error,
+  } as SpawnSyncResultLike;
+}
+
+function isLinuxGlibcRuntime(): boolean {
+  try {
+    const report = process.report?.getReport() as { header?: { glibcVersionRuntime?: string } };
+    return typeof report.header?.glibcVersionRuntime === "string";
+  } catch {
+    return true;
+  }
+}
+
+function resolveSharpPlatformPackageName(sharpPackage: PackageJsonLike): string | null {
+  const platformPrefixes = process.platform === "linux"
+    ? [
+        isLinuxGlibcRuntime() ? "linux" : "linuxmusl",
+        "linux",
+        "linuxmusl",
+      ]
+    : [process.platform];
+  for (const platformPrefix of platformPrefixes) {
+    const packageName = `@img/sharp-${platformPrefix}-${process.arch}`;
+    if (sharpPackage.optionalDependencies?.[packageName]) return packageName;
+  }
+  return null;
+}
+
+export async function hasRequiredRuntimeNativeDependencies(cacheDir: string): Promise<boolean> {
+  const sharpPackage = await readRuntimePackageJson(cacheDir, "sharp");
+  if (!sharpPackage) return true;
+  const platformPackageName = resolveSharpPlatformPackageName(sharpPackage);
+  if (!platformPackageName) return true;
+
+  const requiredPackages = [{
+    name: platformPackageName,
+    version: normalizeOptionalDependencyVersion(sharpPackage.optionalDependencies?.[platformPackageName]),
+  }];
+  for (let index = 0; index < requiredPackages.length; index += 1) {
+    const requiredPackage = requiredPackages[index];
+    const packageJson = await readRuntimePackageJson(cacheDir, requiredPackage.name);
+    if (!packageJson || (
+      requiredPackage.version !== null
+      && packageJson.version !== requiredPackage.version
+    )) return false;
+    for (const [dependencyName, versionRange] of Object.entries(packageJson.optionalDependencies ?? {})) {
+      if (!requiredPackages.some(({ name }) => name === dependencyName)) {
+        requiredPackages.push({
+          name: dependencyName,
+          version: normalizeOptionalDependencyVersion(versionRange),
+        });
+      }
+    }
+  }
+  return true;
+}
+
+export async function ensureRuntimeNativeDependencies<TDeadline>(options: {
+  spawnSyncImpl: typeof spawnSync;
+  cacheDir: string;
+  deadline?: TDeadline;
+  remainingMs: (deadline: TDeadline | undefined, cacheDir: string, command: string) => number | undefined;
+  createError: (message: string, command: string, output: string) => Error;
+}): Promise<string> {
+  if (process.env.RUDDER_RUNTIME_INSTALL_OMIT_OPTIONAL !== "true") return "";
+  const sharpPackage = await readRuntimePackageJson(options.cacheDir, "sharp");
+  if (!sharpPackage) return "";
+  const platformPackageName = resolveSharpPlatformPackageName(sharpPackage);
+  if (!platformPackageName) return "";
+
+  const installOptions = {
+    deadline: options.deadline,
+    cacheDir: options.cacheDir,
+    remainingMs: options.remainingMs,
+  };
+  const requiredPackageVersions = new Map<string, string | null>([
+    [platformPackageName, normalizeOptionalDependencyVersion(sharpPackage.optionalDependencies?.[platformPackageName])],
+  ]);
+  const requiredPackages = new Set([platformPackageName]);
+  let output = "";
+  for (let pass = 0; pass < 8; pass += 1) {
+    const missingSpecs: string[] = [];
+    for (const packageName of requiredPackages) {
+      const version = requiredPackageVersions.get(packageName) ?? null;
+      const packageJson = await readRuntimePackageJson(options.cacheDir, packageName);
+      if (packageJson && (version === null || packageJson.version === version)) continue;
+      missingSpecs.push(version ? `${packageName}@${version}` : packageName);
+    }
+
+    if (missingSpecs.length > 0) {
+      await removeRuntimeInstallLocks(options.cacheDir);
+      for (const packageSpec of missingSpecs) {
+        const packageName = packageNameFromSpec(packageSpec);
+        const result = await installRuntimePackageInStaging(
+          options.spawnSyncImpl,
+          options.cacheDir,
+          packageSpec,
+          packageName,
+          installOptions,
+        );
+        output = collectOutputParts(output, collectSpawnOutput(result));
+        if (result.status === 0 && await canResolveRuntimePackage(options.cacheDir, packageName)) continue;
+        const command = formatRuntimePlatformRepairCommand(options.cacheDir, packageSpec);
+        throw options.createError(
+          `Rudder runtime installation is missing required native package ${packageName}. Re-run manually: ${command}`,
+          command,
+          output,
+        );
+      }
+    }
+
+    let discoveredNewPackage = false;
+    for (const packageName of [...requiredPackages]) {
+      const packageJson = await readRuntimePackageJson(options.cacheDir, packageName);
+      for (const [dependencyName, versionRange] of Object.entries(packageJson?.optionalDependencies ?? {})) {
+        if (requiredPackages.has(dependencyName)) continue;
+        requiredPackages.add(dependencyName);
+        requiredPackageVersions.set(dependencyName, normalizeOptionalDependencyVersion(versionRange));
+        discoveredNewPackage = true;
+      }
+    }
+    if (!discoveredNewPackage && await hasRequiredRuntimeNativeDependencies(options.cacheDir)) return output;
+  }
+
+  const command = [...requiredPackages]
+    .map((packageName) => formatRuntimePlatformRepairCommand(
+      options.cacheDir,
+      requiredPackageVersions.get(packageName)
+        ? `${packageName}@${requiredPackageVersions.get(packageName)}`
+        : packageName,
+    ))
+    .join("; ");
+  throw options.createError(
+    "Rudder runtime native dependency preparation did not converge. Re-run manually: " + command,
+    command,
+    output,
+  );
+}
+
+function formatRuntimePlatformRepairCommand(cacheDir: string, packageSpec: string): string {
+  return `npm pack ${packageSpec} --registry=${NPM_PUBLIC_REGISTRY_URL} --silent, then extract it into ${path.join(cacheDir, "node_modules")}`;
+}
+
+function collectSpawnOutput(result: SpawnSyncResultLike): string {
+  return [result.stdout, result.stderr, result.error instanceof Error ? result.error.message : null]
+    .filter((value): value is string => typeof value === "string" && value.trim().length > 0)
+    .join("\n")
+    .trim();
+}
+
+function collectOutputParts(...parts: string[]): string {
+  return parts.filter((part) => part.trim().length > 0).join("\n").trim();
+}


### PR DESCRIPTION
## Summary
- skip `embedded-postgres` optional platform downloads in the Windows browser-app smoke when the workflow supplies a prepared PostgreSQL runtime
- retain and validate the current platform `sharp` native packages, including exact nested optional versions
- cover the optional dependency path and preserve the existing readiness timeout diagnostics

## Verification
- `pnpm --filter @rudderhq/cli typecheck`
- `pnpm --filter @rudderhq/cli exec vitest run src/__tests__/start.test.ts` (119 passed, 2 skipped)
- `pnpm --filter @rudderhq/cli build`
- real runtime install integration with `@rudderhq/server@0.7.19`: `sharp` loaded and embedded PostgreSQL platform package was absent
- global `pnpm lint` remains blocked by pre-existing import-order findings in five unrelated files

Release-only repair; `[skip release]` prevents an automatic canary publication.
