### PR TITLE
fix(release): use packaged runtime for Windows browser smoke

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -578,6 +578,8 @@ jobs:
 
       - name: Smoke Windows Smart App Control browser fallback
         if: matrix.platform == 'windows'
+        env:
+          RUDDER_BROWSER_APP_RUNTIME_PACKAGE_DIR: ${{ github.workspace }}/desktop/.packaged/server-package
         run: pnpm --filter @rudderhq/cli smoke:browser-app
 
       - name: Smoke packaged App Builder

--- a/cli/scripts/browser-app-smoke.mjs
+++ b/cli/scripts/browser-app-smoke.mjs
@@ -17,10 +17,26 @@ const cliEntry = path.join(cliRoot, "dist", "index.js");
 const { version } = JSON.parse(await readFile(path.join(cliRoot, "package.json"), "utf8"));
 const testHome = await mkdtemp(path.join(tmpdir(), "rudder-browser-app-smoke."));
 const READY_TIMEOUT_MS = 300_000;
+const packagedRuntimePackageDirInput = process.env.RUDDER_BROWSER_APP_RUNTIME_PACKAGE_DIR?.trim();
+const packagedRuntimePackageDir = path.resolve(
+  packagedRuntimePackageDirInput || path.resolve(cliRoot, "..", "desktop", ".packaged", "server-package"),
+);
+const packagedRuntimePackageJsonPath = path.join(packagedRuntimePackageDir, "package.json");
 const postgresBinDir = process.env.RUDDER_POSTGRES_BIN_DIR?.trim()
   || path.join(process.env.USERPROFILE ?? "", ".rudder", "runtime-payloads", "postgres-18.4", "win32-x64", "bin");
 
 assert.ok(existsSync(cliEntry), "build @rudderhq/cli before running browser-app smoke");
+assert.ok(
+  existsSync(packagedRuntimePackageJsonPath),
+  "build the packaged Desktop server runtime before running browser-app smoke",
+);
+const runtimePackage = JSON.parse(await readFile(packagedRuntimePackageJsonPath, "utf8"));
+assert.equal(runtimePackage.name, "@rudderhq/server", "packaged browser-app smoke runtime must be the Rudder server");
+assert.equal(
+  runtimePackage.version,
+  version,
+  "packaged browser-app smoke runtime must match the CLI candidate version",
+);
 assert.ok(
   existsSync(path.join(postgresBinDir, "postgres.exe")),
   `prepared PostgreSQL 18.4 runtime is required at ${postgresBinDir}`,
@@ -63,6 +79,7 @@ function startBrowserApp(label) {
   ], {
     env: {
       ...process.env,
+      RUDDER_BROWSER_APP_RUNTIME_PACKAGE_DIR: packagedRuntimePackageDir,
       RUDDER_POSTGRES_BIN_DIR: postgresBinDir,
       RUDDER_RUNTIME_INSTALL_OMIT_OPTIONAL: "true",
     },
@@ -93,6 +110,7 @@ function startBrowserAppParent() {
   ], {
     env: {
       ...process.env,
+      RUDDER_BROWSER_APP_RUNTIME_PACKAGE_DIR: packagedRuntimePackageDir,
       RUDDER_POSTGRES_BIN_DIR: postgresBinDir,
       RUDDER_RUNTIME_INSTALL_OMIT_OPTIONAL: "true",
     },

--- a/cli/src/commands/browser-app.test.ts
+++ b/cli/src/commands/browser-app.test.ts
@@ -32,6 +32,7 @@ describe("Windows browser-app compatibility", () => {
     const previousInstanceId = process.env.RUDDER_INSTANCE_ID;
     const previousPort = process.env.PORT;
     const previousPostgresPort = process.env.RUDDER_EMBEDDED_POSTGRES_PORT;
+    const previousRuntimePackageDir = process.env.RUDDER_BROWSER_APP_RUNTIME_PACKAGE_DIR;
     const home = await mkdtemp(path.join(tmpdir(), "rudder-browser-app-runtime-guard."));
     const readyFile = path.join(home, "ready.json");
     const activeRunPid = 42_424;
@@ -40,6 +41,7 @@ describe("Windows browser-app compatibility", () => {
 
     process.env.RUDDER_HOME = home;
     process.env.RUDDER_LOCAL_ENV = "prod_local";
+    process.env.RUDDER_BROWSER_APP_RUNTIME_PACKAGE_DIR = path.join(home, "candidate-server-package");
     Object.defineProperty(process, "platform", { configurable: true, value: "win32" });
     startRuntimeMock.mockImplementation(async (options) => {
       if (options.takeoverOnVersionMismatch) process.kill(activeRunPid, "SIGTERM");
@@ -59,6 +61,7 @@ describe("Windows browser-app compatibility", () => {
 
       expect(startRuntimeMock).toHaveBeenCalledWith({
         version: "0.7.19",
+        runtimePackageDir: path.join(home, "candidate-server-package"),
         takeoverOnVersionMismatch: false,
       });
       expect(killSpy).not.toHaveBeenCalled();
@@ -80,6 +83,8 @@ describe("Windows browser-app compatibility", () => {
       else process.env.PORT = previousPort;
       if (previousPostgresPort === undefined) delete process.env.RUDDER_EMBEDDED_POSTGRES_PORT;
       else process.env.RUDDER_EMBEDDED_POSTGRES_PORT = previousPostgresPort;
+      if (previousRuntimePackageDir === undefined) delete process.env.RUDDER_BROWSER_APP_RUNTIME_PACKAGE_DIR;
+      else process.env.RUDDER_BROWSER_APP_RUNTIME_PACKAGE_DIR = previousRuntimePackageDir;
       await rm(home, { recursive: true, force: true });
     }
   });

--- a/cli/src/commands/browser-app.ts
+++ b/cli/src/commands/browser-app.ts
@@ -406,10 +406,12 @@ async function runBrowserAppChild(options: BrowserAppCommandOptions): Promise<vo
   let startedServer: StartedServer | null = null;
   let readyWritten = false;
   let releaseDesktopTakeoverLease: (() => void) | null = null;
+  const runtimePackageDir = process.env.RUDDER_BROWSER_APP_RUNTIME_PACKAGE_DIR?.trim();
   try {
     while (true) {
       startedServer = await startManagedServerFromRuntime({
         version: runtimeVersion,
+        ...(runtimePackageDir ? { runtimePackageDir } : {}),
         // A native Desktop runtime owns the process while it is alive. Never
         // terminate it just to replace a mismatched browser-app version.
         takeoverOnVersionMismatch: false,

--- a/cli/src/runtime/server-entry.test.ts
+++ b/cli/src/runtime/server-entry.test.ts
@@ -1,9 +1,33 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { startServerFromModule } from "./server-entry.js";
+
+const runtimeModuleMocks = vi.hoisted(() => ({
+  ensureRuntimeInstalled: vi.fn(),
+  importRuntimeServerModule: vi.fn(),
+}));
+
+vi.mock("./install.js", () => runtimeModuleMocks);
+
+import { loadServerRuntimeModule, startServerFromModule } from "./server-entry.js";
 
 describe("server runtime startup policy", () => {
   afterEach(() => {
     vi.restoreAllMocks();
+    runtimeModuleMocks.ensureRuntimeInstalled.mockReset();
+    runtimeModuleMocks.importRuntimeServerModule.mockReset();
+  });
+
+  it("uses an explicit packaged runtime before the repository development entry", async () => {
+    const runtimeModule = { startManagedLocalServer: vi.fn() };
+    const runtimePackageDir = "/tmp/rudder-candidate-server-package";
+    runtimeModuleMocks.importRuntimeServerModule.mockResolvedValue(runtimeModule);
+
+    await expect(loadServerRuntimeModule({
+      version: "0.7.20",
+      runtimePackageDir,
+    })).resolves.toBe(runtimeModule);
+
+    expect(runtimeModuleMocks.importRuntimeServerModule).toHaveBeenCalledWith(runtimePackageDir);
+    expect(runtimeModuleMocks.ensureRuntimeInstalled).not.toHaveBeenCalled();
   });
 
   it("preserves takeover for ordinary CLI runtime starts by default", async () => {

--- a/cli/src/runtime/server-entry.ts
+++ b/cli/src/runtime/server-entry.ts
@@ -26,6 +26,7 @@ export interface StartedServer {
 export interface LoadServerRuntimeOptions {
   version: string;
   homeDir?: string;
+  runtimePackageDir?: string;
   onRuntimeInstalled?: (result: Awaited<ReturnType<typeof ensureRuntimeInstalled>>) => void;
   takeoverOnVersionMismatch?: boolean;
 }
@@ -59,6 +60,11 @@ function resolveDevServerEntry(): string {
 }
 
 export async function loadServerRuntimeModule(options: LoadServerRuntimeOptions): Promise<unknown> {
+  const runtimePackageDir = options.runtimePackageDir?.trim();
+  if (runtimePackageDir) {
+    return await importRuntimeServerModule(path.resolve(runtimePackageDir));
+  }
+
   const devEntry = resolveDevServerEntry();
   if (fs.existsSync(devEntry)) {
     maybeEnableUiDevMiddleware(devEntry);

--- a/scripts/release-workflow-contract.test.mjs
+++ b/scripts/release-workflow-contract.test.mjs
@@ -109,6 +109,8 @@ describe("unified delivery workflows", () => {
     expect(releaseWorkflow).toContain("Smoke packaged account gate");
     expect(preflight).toContain("Verify migration compatibility manifest");
     expect(preflight).toContain("scripts/release-compatibility-matrix.mjs");
+    expect(desktop).toContain("RUDDER_BROWSER_APP_RUNTIME_PACKAGE_DIR");
+    expect(desktop).toContain("desktop/.packaged/server-package");
     expect(desktop).toContain("timeout-minutes: 25");
     expect(desktop).toContain("pnpm --filter @rudderhq/db exec tsx ../../scripts/release-compatibility-runtime.ts");
     expect(desktop.indexOf("pnpm --filter @rudderhq/db exec tsx ../../scripts/release-compatibility-runtime.ts"))


### PR DESCRIPTION
## Summary

- run the Windows browser-app Release smoke against the exact packaged server runtime built in the candidate
- pass that runtime directory through both the child and parent browser-app smoke modes
- require the packaged runtime package name/version to match the CLI candidate before starting the smoke

## Root cause

The 0.7.20 Release candidate built `desktop/.packaged/server-package`, but the Windows browser-app smoke could resolve a development or unpublished runtime instead. That left the first ready handoff waiting until the 25-minute Desktop job timeout. This change binds the smoke to the packaged runtime from the same candidate and makes the runtime loader explicit.

## Verification

- `pnpm exec vitest run cli/src/commands/browser-app.test.ts cli/src/runtime/server-entry.test.ts scripts/release-workflow-contract.test.mjs` (39/39 passed)
- `pnpm --filter @rudderhq/cli typecheck`
- `pnpm --filter @rudderhq/desktop typecheck`
- `node --check cli/scripts/browser-app-smoke.mjs`
- `git diff --check`
