### PR TITLE
fix(desktop): honor Windows listener ownership budget

### DIFF
--- a/desktop/src/local-apps-runtime.test.ts
+++ b/desktop/src/local-apps-runtime.test.ts
@@ -968,7 +968,7 @@ describe("Desktop Local App runtime", { timeout: localAppRuntimeTestTimeoutMs },
   it("allows a bounded slow Windows process snapshot to prove listener ownership", async () => {
     const owned = await approvedFixture({ readinessTimeoutMs: 30_000 });
     const verifyListenerOwnership = vi.fn(async (input: { timeoutMs: number }) => {
-      expect(input.timeoutMs).toBeGreaterThan(20_000);
+      expect(input.timeoutMs).toBe(60_000);
       await new Promise((resolve) => setTimeout(resolve, 900));
       return true;
     });
@@ -978,6 +978,7 @@ describe("Desktop Local App runtime", { timeout: localAppRuntimeTestTimeoutMs },
       ...(windowsFixtureProcessPlatform ? { processPlatform: windowsFixtureProcessPlatform } : {}),
       ...(windowsFixtureWatchdogSpawner ? { spawnWatchdog: windowsFixtureWatchdogSpawner } : {}),
       verifyListenerOwnership,
+      listenerOwnershipRetryTimeoutMs: 60_000,
     });
     try {
       await expect(manager.start(owned.definition.id)).resolves.toMatchObject({ status: "running" });
@@ -1342,7 +1343,10 @@ describe("Desktop Local App runtime", { timeout: localAppRuntimeTestTimeoutMs },
     },
   );
 
-  it("keeps watchdog startup and cleanup deadlines referenced while start is pending", async () => {
+  it(
+    "keeps watchdog startup and cleanup deadlines referenced while start is pending",
+    { timeout: 15_000 },
+    async () => {
     const { registry, definition } = await approvedFixture({ readinessTimeoutMs: 250 });
     const helper = watchdogEmitting({ type: "ignored" });
     helper.send = vi.fn((_payload: unknown, callback?: (error: Error | null) => void) => {
@@ -1352,25 +1356,25 @@ describe("Desktop Local App runtime", { timeout: localAppRuntimeTestTimeoutMs },
     const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
     const manager = new LocalAppRuntimeManager({
       registry,
-      platform: process.platform,
+      platform: "win32",
       spawnWatchdog,
-      watchdogStartTimeoutMs: 60_001,
-      cleanupTimeoutMs: 60_002,
+      watchdogStartTimeoutMs: 1_001,
+      cleanupTimeoutMs: 1_002,
     });
 
     try {
       const pendingStart = manager.start(definition.id);
       await vi.waitFor(() => expect(spawnWatchdog).toHaveBeenCalledOnce());
-      const startupCallIndex = timeoutSpy.mock.calls.findIndex(([, delay]) => delay === 60_001);
+      const startupCallIndex = timeoutSpy.mock.calls.findIndex(([, delay]) => delay === 1_001);
       expect(startupCallIndex).toBeGreaterThanOrEqual(0);
       const startupTimer = timeoutSpy.mock.results[startupCallIndex]?.value as NodeJS.Timeout;
       expect(startupTimer.hasRef()).toBe(true);
 
       helper.emit("error", new Error("watchdog fixture failed"));
       await vi.waitFor(() => {
-        expect(timeoutSpy.mock.calls.some(([, delay]) => delay === 60_002)).toBe(true);
-      });
-      const cleanupCallIndex = timeoutSpy.mock.calls.findIndex(([, delay]) => delay === 60_002);
+        expect(timeoutSpy.mock.calls.some(([, delay]) => delay === 1_002)).toBe(true);
+      }, { timeout: 5_000 });
+      const cleanupCallIndex = timeoutSpy.mock.calls.findIndex(([, delay]) => delay === 1_002);
       const cleanupTimer = timeoutSpy.mock.results[cleanupCallIndex]?.value as NodeJS.Timeout;
       expect(cleanupTimer.hasRef()).toBe(true);
 
@@ -1381,7 +1385,8 @@ describe("Desktop Local App runtime", { timeout: localAppRuntimeTestTimeoutMs },
       timeoutSpy.mockRestore();
       await manager.shutdown();
     }
-  });
+    },
+  );
 
   it.runIf(process.platform !== "win32")(
     "keeps ownership orphaned when a running watchdog exits without acknowledging cleanup",

--- a/desktop/src/local-apps-runtime.ts
+++ b/desktop/src/local-apps-runtime.ts
@@ -404,7 +404,8 @@ export class LocalAppRuntimeManager {
     this.watchdogStartTimeoutMs = Math.max(1, options.watchdogStartTimeoutMs ?? 10_000);
     this.listenerOwnershipRetryTimeoutMs = Math.max(
       1,
-      options.listenerOwnershipRetryTimeoutMs ?? LISTENER_OWNERSHIP_RETRY_TIMEOUT_MS,
+      options.listenerOwnershipRetryTimeoutMs
+        ?? (platform === "win32" ? WINDOWS_LISTENER_OWNERSHIP_RETRY_TIMEOUT_MS : LISTENER_OWNERSHIP_RETRY_TIMEOUT_MS),
     );
     this.cleanupTimeoutMs = Math.max(
       1,
@@ -1062,12 +1063,7 @@ export class LocalAppRuntimeManager {
   }
 
   private async waitForListenerOwnership(record: RuntimeRecord): Promise<void> {
-    const deadline = Date.now() + Math.min(
-      record.definition.readiness.timeoutMs,
-      this.processPlatform.platform === "win32"
-        ? WINDOWS_LISTENER_OWNERSHIP_RETRY_TIMEOUT_MS
-        : this.listenerOwnershipRetryTimeoutMs,
-    );
+    const deadline = Date.now() + this.listenerOwnershipRetryTimeoutMs;
     while (Date.now() < deadline) {
       if (
         !record.helper


### PR DESCRIPTION
## Summary

- honor the configured Windows listener-ownership retry budget instead of truncating it to the readiness timeout
- keep the default Windows ownership budget at 30 seconds while respecting explicit shorter or longer test/runtime budgets
- make the Windows watchdog deadline-reference regression test deterministic and bounded

## Root cause

The Windows listener ownership deadline was computed as:

`min(readinessTimeoutMs, WINDOWS_LISTENER_OWNERSHIP_RETRY_TIMEOUT_MS)`

This discarded an explicit `listenerOwnershipRetryTimeoutMs: 60_000` and capped the real watchdog test at 30 seconds. Under CI load, PowerShell process snapshots and `netstat` observation could consume that entire window; cleanup then failed closed and a later deadline test timed out behind the first failure.

The manager now uses its configured ownership budget directly. Windows receives a 30-second default, while callers can explicitly choose a bounded budget. The deadline-reference test uses short sentinel durations and explicitly exercises the Windows platform path, preserving the assertion that lifecycle timers remain referenced without waiting a full minute.

No process ownership checks, fail-closed behavior, or Windows-only real watchdog test was removed or skipped.

## Verification

- `env -u NODE_ENV -u ELECTRON_RUN_AS_NODE CI=true NODE_ENV=test RUDDER_NATIVE_MODE=node corepack pnpm exec vitest run desktop/src/local-apps-runtime.test.ts --pool=forks --maxWorkers=1 --minWorkers=1 --no-file-parallelism` — 59/59 run tests passed; 5 Windows-only cases skipped on macOS
- `env -u NODE_ENV -u ELECTRON_RUN_AS_NODE CI=true corepack pnpm --filter @rudderhq/desktop typecheck` — passed
- `node --check desktop/src/local-app-watchdog-runner.mjs` — passed
- `git diff --check` — passed

The source is based on current main `3dbd6897f904b11005bb33212ba44715fb0577d1`. No application data, migrations, release tags, packages, or public artifacts were changed.
