### PR TITLE
fix(release): verify packaged browser smoke runtime

### DIFF
--- a/cli/scripts/browser-app-smoke.mjs
+++ b/cli/scripts/browser-app-smoke.mjs
@@ -203,17 +203,8 @@ try {
   assert.equal(health.localEnv, "e2e");
   assert.equal(health.runtimeOwnerKind, "cli");
   assert.equal(health.deploymentMode, "local_trusted");
-  const runtimeCacheKey = health.version === version ? version : "latest";
-  const installedRuntimePackage = JSON.parse(await readFile(path.join(
-    testHome,
-    "runtimes",
-    runtimeCacheKey,
-    "node_modules",
-    "@rudderhq",
-    "server",
-    "package.json",
-  ), "utf8"));
-  assert.equal(health.version, installedRuntimePackage.version);
+  const activeRuntimePackage = JSON.parse(await readFile(packagedRuntimePackageJsonPath, "utf8"));
+  assert.equal(health.version, activeRuntimePackage.version);
   if (health.version !== version) {
     console.log(
       `[browser-app-smoke] requested prepublish runtime ${version}; observed intentional latest fallback ${health.version}`,

--- a/scripts/release-workflow-contract.test.mjs
+++ b/scripts/release-workflow-contract.test.mjs
@@ -11,6 +11,7 @@ const releaseWorkflow = readFileSync(join(workflowDir, "release.yml"), "utf8");
 const docsWorkflow = readFileSync(join(workflowDir, "docs-production.yml"), "utf8");
 const releaseSetup = readFileSync(join(repoRoot, "doc/engineering/RELEASE-AUTOMATION-SETUP.md"), "utf8");
 const nextReleaseScript = readFileSync(join(repoRoot, "scripts/prepare-next-release.mjs"), "utf8");
+const browserAppSmoke = readFileSync(join(repoRoot, "cli/scripts/browser-app-smoke.mjs"), "utf8");
 const releaseMirrorPolicy = join(repoRoot, "scripts/release-mirror-policy.mjs");
 
 function workflowJob(source, jobName) {
@@ -111,6 +112,7 @@ describe("unified delivery workflows", () => {
     expect(preflight).toContain("scripts/release-compatibility-matrix.mjs");
     expect(desktop).toContain("RUDDER_BROWSER_APP_RUNTIME_PACKAGE_DIR");
     expect(desktop).toContain("desktop/.packaged/server-package");
+    expect(browserAppSmoke).toContain("readFile(packagedRuntimePackageJsonPath");
     expect(desktop).toContain("timeout-minutes: 25");
     expect(desktop).toContain("pnpm --filter @rudderhq/db exec tsx ../../scripts/release-compatibility-runtime.ts");
     expect(desktop.indexOf("pnpm --filter @rudderhq/db exec tsx ../../scripts/release-compatibility-runtime.ts"))


### PR DESCRIPTION
## Summary
- verify browser-app smoke against the packaged server runtime selected by the candidate
- prevent the smoke from reading a non-existent temporary runtime cache after packaged-runtime startup
- add a release contract assertion for the packaged runtime verification path

## Validation
- CLI typecheck
- release workflow contract: 23 passed
- CLI build
- browser smoke syntax and diff checks

Fixes the stable candidate failure in run 34292757816.