### PR TITLE
test(db): extend migration cleanup timeout

### DIFF
--- a/packages/db/src/client.test.ts
+++ b/packages/db/src/client.test.ts
@@ -266,7 +266,7 @@ afterEach(async () => {
       retryDelay: 250,
     });
   }
-}, migrationTestTimeout(10_000));
+}, migrationTestTimeout(30_000));
 
 describe("applyPendingMigrations", () => {
   it(


### PR DESCRIPTION
## Summary
- extend the migration test cleanup hook budget for slower Linux CI runners
- prevent embedded PostgreSQL teardown from timing out after a successful migration test

## Validation
- pnpm --filter @rudderhq/db exec vitest run src/client.test.ts --maxWorkers=2
- 19/19 tests passed

Release context: this is a [skip release] stability repair for the 0.7.20 candidate qualification.