### PR TITLE
fix(ui): remove redundant all issues loaded state

### DIFF
--- a/tests/e2e/issue-auto-refresh.spec.ts
+++ b/tests/e2e/issue-auto-refresh.spec.ts
@@ -185,11 +185,10 @@ test.describe("Issue auto refresh", () => {
     await page.goto(`${E2E_BASE_URL}/${organization.issuePrefix}/issues`, { waitUntil: "domcontentloaded" });
     await page.getByTitle("List view").click();
 
-    const listSentinel = page.getByTestId("issues-list-load-more-sentinel");
-    await expect(listSentinel).toBeAttached({ timeout: 30_000 });
     await expect(page.getByRole("button", { name: "Load more", exact: true })).toHaveCount(0);
-    await listSentinel.scrollIntoViewIfNeeded();
-    await expect(page.getByTestId("issues-end-state")).toBeVisible({ timeout: 20_000 });
+    await expect(page.getByText("Paginated refresh issue 200", { exact: true })).toBeVisible({ timeout: 20_000 });
+    await expect(page.getByTestId("issues-list-load-more-sentinel")).toHaveCount(0);
+    await expect(page.getByTestId("issues-end-state")).toHaveCount(0);
 
     const anchor = page.getByText("Paginated refresh issue 000", { exact: true });
     await anchor.scrollIntoViewIfNeeded();
@@ -248,7 +247,7 @@ test.describe("Issue auto refresh", () => {
     });
     await expect(doneLane.locator('[data-testid^="kanban-card-"]')).toHaveCount(201, { timeout: 20_000 });
     await expect(page.getByRole("button", { name: "Load more", exact: true })).toHaveCount(0);
-    await expect(doneLane.getByTestId("kanban-end-state-done")).toBeVisible({ timeout: 20_000 });
+    await expect(doneLane.getByTestId("kanban-end-state-done")).toHaveCount(0);
   });
 
   test("discovers a filtered lane when the first page has no matching issues", async ({ page }) => {

--- a/ui/src/components/IssuesList.test.tsx
+++ b/ui/src/components/IssuesList.test.tsx
@@ -383,7 +383,7 @@ describe("IssuesList", () => {
     }
   });
 
-  it("shows a terminal state after the final page", () => {
+  it("removes the terminal state and pagination footer after the final page", () => {
     window.localStorage.setItem("test:issues:org-1", JSON.stringify({ viewMode: "list" }));
     const container = document.createElement("div");
     document.body.appendChild(container);
@@ -406,7 +406,9 @@ describe("IssuesList", () => {
       );
     });
 
-    expect(container.querySelector('[data-testid="issues-end-state"]')?.textContent).toBe("All issues loaded");
+    expect(container.querySelector('[data-testid="issues-end-state"]')).toBeNull();
+    expect(container.querySelector('[data-testid="issues-list-load-more-sentinel"]')).toBeNull();
+    expect(container.querySelector(".flex.justify-center.border-t")).toBeNull();
   });
 
   it("keeps a button fallback when IntersectionObserver is unavailable", () => {

--- a/ui/src/components/IssuesList.tsx
+++ b/ui/src/components/IssuesList.tsx
@@ -1445,7 +1445,7 @@ export function IssuesList({
         </>
       )}
 
-      {!isLoading && !searchActive && viewState.viewMode !== "board" ? (
+      {!isLoading && !searchActive && viewState.viewMode !== "board" && hasMoreIssues && onLoadMoreIssues ? (
         <div
           ref={listLoadMoreRef}
           data-testid="issues-list-load-more-sentinel"
@@ -1458,7 +1458,6 @@ export function IssuesList({
         isLoadingMoreIssues
         || paginationError
         || (hasMoreIssues && !infiniteScrollSupported)
-        || (!hasMoreIssues && activeHasData)
       ) ? (
         <div className="flex justify-center border-t border-[color:var(--border-soft)] py-3">
           {isLoadingMoreIssues ? (
@@ -1501,10 +1500,6 @@ export function IssuesList({
               {isLoadingMoreIssues ? <Loader2 className="h-4 w-4 animate-spin sm:mr-1" /> : null}
               <span>{isLoadingMoreIssues ? "Loading..." : "Load more"}</span>
             </Button>
-          ) : !hasMoreIssues && activeHasData ? (
-            <span data-testid="issues-end-state" className="text-xs text-muted-foreground">
-              All issues loaded
-            </span>
           ) : null}
         </div>
       ) : null}

--- a/ui/src/components/KanbanBoard.test.tsx
+++ b/ui/src/components/KanbanBoard.test.tsx
@@ -225,7 +225,7 @@ describe("KanbanBoard", () => {
     );
 
     expect(container.querySelector('[data-testid="kanban-load-more-loading-todo"]')).toBeTruthy();
-    expect(container.querySelector('[data-testid="kanban-end-state-done"]')?.textContent).toBe("All issues loaded");
+    expect(container.querySelector('[data-testid="kanban-end-state-done"]')).toBeNull();
     expect(container.querySelector('[data-testid="kanban-load-more-loading-done"]')).toBeNull();
   });
 
@@ -250,7 +250,7 @@ describe("KanbanBoard", () => {
     expect(onLoadMoreIssues).toHaveBeenCalledWith("board");
   });
 
-  it("shows a terminal state after the final board page", () => {
+  it("removes the terminal state and footer after the final board page", () => {
     const container = render(
       <KanbanBoard
         issues={[issue]}
@@ -259,7 +259,8 @@ describe("KanbanBoard", () => {
       />,
     );
 
-    expect(container.querySelector('[data-testid="kanban-end-state"]')?.textContent).toBe("All issues loaded");
+    expect(container.querySelector('[data-testid="kanban-end-state"]')).toBeNull();
+    expect(container.querySelector(".flex.justify-center.border-t")).toBeNull();
   });
 
   it("projects the dropped card order before the server refetch settles", () => {

--- a/ui/src/components/KanbanBoard.tsx
+++ b/ui/src/components/KanbanBoard.tsx
@@ -430,11 +430,6 @@ function KanbanColumn({
             </Button>
           </div>
         ) : null}
-        {showPaginationState && pagination.hasLoaded && !pagination.hasMore && !pagination.isLoading && !pagination.error ? (
-          <div data-testid={`kanban-end-state-${status}`} className="py-2 text-center text-[11px] text-muted-foreground">
-            All issues loaded
-          </div>
-        ) : null}
       </div>
     </div>
   );
@@ -444,11 +439,8 @@ function KanbanPaginationFooter({
   hasMoreIssues,
   isLoadingMoreIssues,
   loadMoreError,
-  showAggregateEndState = true,
   onLoadMoreIssues,
-}: Pick<KanbanBoardProps, "hasMoreIssues" | "isLoadingMoreIssues" | "loadMoreError" | "onLoadMoreIssues"> & {
-  showAggregateEndState?: boolean;
-}) {
+}: Pick<KanbanBoardProps, "hasMoreIssues" | "isLoadingMoreIssues" | "loadMoreError" | "onLoadMoreIssues">) {
   if (!onLoadMoreIssues) return null;
 
   const infiniteScrollSupported = typeof IntersectionObserver !== "undefined";
@@ -497,16 +489,6 @@ function KanbanPaginationFooter({
         <Button type="button" variant="outline" size="sm" onClick={() => void onLoadMoreIssues("board")}>
           Load more
         </Button>
-      </div>
-    );
-  }
-
-  if (!hasMoreIssues && showAggregateEndState) {
-    return (
-      <div className="flex shrink-0 justify-center border-t border-[color:var(--border-soft)] py-3">
-        <span data-testid="kanban-end-state" className="text-xs text-muted-foreground">
-          All issues loaded
-        </span>
       </div>
     );
   }
@@ -1034,7 +1016,6 @@ export function KanbanBoard({
           hasMoreIssues={hasMoreIssues}
           isLoadingMoreIssues={isLoadingMoreIssues}
           loadMoreError={loadMoreError}
-          showAggregateEndState={!paginationByStatus}
           onLoadMoreIssues={onLoadMoreIssues}
         />
       </div>


### PR DESCRIPTION
## Summary
- remove the redundant "All issues loaded" terminal labels and footer space from Issues list and Kanban views
- preserve infinite-scroll, retry, and fallback loading behavior
- update component and issue auto-refresh E2E coverage

## Validation
- component tests: 35/35
- UI typecheck
- UI production build
- changed-file lint
- git diff --check
- issue auto-refresh E2E: 4/4 (plus focused rerun: 1/1)

R6Z-207

Co-Authored-By: Rudder <285064165+Rudderhq@users.noreply.github.com>