### PR TITLE
fix(release): restore automatic Canary publication

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,6 +3,7 @@
 .github/** @Rudderhq
 scripts/release*.sh @Rudderhq
 scripts/release-*.mjs @Rudderhq
+scripts/update-release-compatibility-matrix.mjs @Rudderhq
 scripts/create-github-release.sh @Rudderhq
 scripts/collect-desktop-release-assets.mjs @Rudderhq
 scripts/mirror-desktop-release-to-cos.mjs @Rudderhq

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,13 @@ jobs:
             --report "$RUNNER_TEMP/ci-impact-plan.json"
           cat "$RUNNER_TEMP/ci-impact-plan.json" >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Verify canary migration compatibility declaration
+        run: |
+          candidate_version="$(node -p "require('./cli/package.json').version")-canary.0"
+          node scripts/release-compatibility-matrix.mjs \
+            --channel canary \
+            --candidate-version "$candidate_version"
+
       - name: Upload impact plan evidence
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -804,6 +804,7 @@ jobs:
       contents: write
       id-token: write
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     environment: npm-canary
     outputs:
       version: ${{ needs.preflight.outputs.version }}
@@ -874,7 +875,7 @@ jobs:
           package_map="$(mktemp)"
           awk -F '\t' 'NF == 4 { print ".\t" $1 "\t" $2 }' dist/npm-payloads/manifest.tsv > "$package_map"
           test "$(wc -l < "$package_map" | xargs)" = "15"
-          wait_for_npm_package_versions "$(cat "$package_map")" 60 5
+          wait_for_npm_package_versions "$(cat "$package_map")" 180 5
           git tag "$RELEASE_TAG" "$SOURCE_SHA"
           git push origin "refs/tags/$RELEASE_TAG"
           cd dist/desktop-assets
@@ -909,6 +910,7 @@ jobs:
       contents: write
       id-token: write
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     environment: npm-stable
     outputs:
       version: ${{ needs.preflight.outputs.version }}
@@ -988,7 +990,7 @@ jobs:
           package_map="$(mktemp)"
           awk -F '\t' 'NF == 4 { print ".\t" $1 "\t" $2 }' dist/npm-payloads/manifest.tsv > "$package_map"
           test "$(wc -l < "$package_map" | xargs)" = "15"
-          wait_for_npm_package_versions "$(cat "$package_map")" 60 5
+          wait_for_npm_package_versions "$(cat "$package_map")" 180 5
       - name: Create immutable Release and upload verified Desktop assets
         env:
           GH_TOKEN: ${{ github.token }}

--- a/doc/engineering/PUBLISHING.md
+++ b/doc/engineering/PUBLISHING.md
@@ -95,6 +95,8 @@ maintainer records rather than the public changelog.
 After both the stable and public changelog deploy succeed,
 `scripts/prepare-next-release.mjs` idempotently proposes the next patch base on
 `codex/release-vX.Y.Z` with one `[skip release]` maintenance commit and a PR.
+That handoff also records the next version's migration compatibility declaration
+from the published stable tag, so the next automatic Canary is release-ready.
 Release explicitly dispatches Test for that exact SHA because `GITHUB_TOKEN`
 PR creation does not trigger normal PR checks. Merge through protected `main`
 after required checks pass, then verify the merged commit's CI.

--- a/doc/engineering/RELEASE-AUTOMATION-SETUP.md
+++ b/doc/engineering/RELEASE-AUTOMATION-SETUP.md
@@ -295,7 +295,8 @@ The release agent merges reviewed preparation PRs under the existing release
 authority, then requires exact-source `main` Test before publishing. The
 generated `[skip release]` version commit is proposed on
 `codex/release-vX.Y.Z`; retries reuse its PR without force-pushing. The workflow
-reports the PR as pending integration and dispatches Test for its immutable SHA.
+reports the PR as pending integration, includes the next version's generated
+migration compatibility declaration, and dispatches Test for its immutable SHA.
 Complete the handoff by merging the PR normally and verifying merged `main` CI.
 
 ## 7.1. Configure progressive qualification and candidate promotion
@@ -345,6 +346,7 @@ These files should always trigger code owner review:
 - `scripts/release.sh`
 - `scripts/release-lib.sh`
 - `scripts/release-package-map.mjs`
+- `scripts/update-release-compatibility-matrix.mjs`
 - `scripts/create-github-release.sh`
 - `scripts/cleanup-obsolete-canaries.mjs`
 - `scripts/collect-desktop-release-assets.mjs`

--- a/doc/engineering/RELEASING.md
+++ b/doc/engineering/RELEASING.md
@@ -195,6 +195,9 @@ queue changes use the full family set. Pushes to `main` and trusted manual
 exact-source runs also produce a full qualification receipt. The required
 receipt is the successful `Qualification summary` job for the exact source,
 not merely a successful individual platform job.
+The `Test` plan also verifies the canary migration declaration before the
+qualification summary can turn green; `Release` repeats that check as a
+defense-in-depth preflight.
 
 Release builds are separated from publication. The candidate jobs build the 15
 npm payloads and seven Desktop assets once, then create the short-lived

--- a/scripts/prepare-next-release.mjs
+++ b/scripts/prepare-next-release.mjs
@@ -218,6 +218,11 @@ function main() {
     }
 
     run("node", ["scripts/release-package-map.mjs", "set-version", decision.nextVersion]);
+    run("node", [
+      "scripts/update-release-compatibility-matrix.mjs",
+      "--candidate-version", decision.nextVersion,
+      "--stable-version", options.stableVersion,
+    ]);
     run("git", ["add", "-u"]);
     run("git", ["commit", "-m", `chore(release): start v${decision.nextVersion} [skip release]`]);
 

--- a/scripts/release-compatibility-matrix.mjs
+++ b/scripts/release-compatibility-matrix.mjs
@@ -12,6 +12,36 @@ const journalPath = "packages/db/src/migrations/meta/_journal.json";
 const migrationsPath = "packages/db/src/migrations";
 
 export const migrationCompatibilityMatrix = {
+  "0.7.21": {
+    candidateFingerprint: "085c15c2a32685dbbddd775ee6fe21aea4ff5c151193f1711ad8c1c52a04a0db",
+    fixtures: [
+      {
+        version: "0.7.20",
+        ref: "v0.7.20",
+        fingerprint: "085c15c2a32685dbbddd775ee6fe21aea4ff5c151193f1711ad8c1c52a04a0db",
+      },
+      {
+        version: "0.7.19",
+        ref: "v0.7.19",
+        fingerprint: "085c15c2a32685dbbddd775ee6fe21aea4ff5c151193f1711ad8c1c52a04a0db",
+      },
+      {
+        version: "0.7.18",
+        ref: "v0.7.18",
+        fingerprint: "085c15c2a32685dbbddd775ee6fe21aea4ff5c151193f1711ad8c1c52a04a0db",
+      },
+      {
+        version: "0.7.16",
+        ref: "v0.7.16",
+        fingerprint: "085c15c2a32685dbbddd775ee6fe21aea4ff5c151193f1711ad8c1c52a04a0db",
+      },
+      {
+        version: "0.7.15",
+        ref: "v0.7.15",
+        fingerprint: "3fa86ccfeb959872e3d87af335928aff13880fc990c51f1dcf3c42baa6eb07ce",
+      },
+    ],
+  },
   "0.7.20": {
     candidateFingerprint: "085c15c2a32685dbbddd775ee6fe21aea4ff5c151193f1711ad8c1c52a04a0db",
     fixtures: [
@@ -594,7 +624,7 @@ export function buildMigrationManifest({ journalRaw, listSqlFiles, readSqlFile, 
   return { ...journal, entries, sqlFiles, fingerprint };
 }
 
-function readCandidateManifest(repoRoot) {
+export function readCandidateManifest(repoRoot = defaultRepoRoot) {
   return buildMigrationManifest({
     label: "candidate",
     journalRaw: readFileSync(join(repoRoot, journalPath), "utf8"),
@@ -650,7 +680,7 @@ function readGitFiles(repoRoot, ref, paths) {
   return files;
 }
 
-function readFixtureManifest(repoRoot, fixture) {
+export function readFixtureManifest(repoRoot, fixture) {
   try {
     execFileSync("git", ["-C", repoRoot, "rev-parse", "--verify", `${fixture.ref}^{commit}`], {
       encoding: "utf8",

--- a/scripts/release-compatibility-matrix.test.mjs
+++ b/scripts/release-compatibility-matrix.test.mjs
@@ -35,6 +35,26 @@ function manifest(tags, sqlByTag, label) {
 }
 
 describe("release migration compatibility matrix", () => {
+  it("accepts the checked-in 0.7.21 candidate against the previous stable fixtures", () => {
+    const result = runCompatibilityPreflight({
+      candidateVersion: "0.7.21-canary.0",
+      channel: "canary",
+    });
+
+    expect(result.candidateFingerprint).toBe(
+      "085c15c2a32685dbbddd775ee6fe21aea4ff5c151193f1711ad8c1c52a04a0db",
+    );
+    expect(result.candidateMigrations).toBe(163);
+    expect(result.candidateSqlFiles).toBe(165);
+    expect(result.fixtures.map((fixture) => fixture.version)).toEqual([
+      "0.7.20",
+      "0.7.19",
+      "0.7.18",
+      "0.7.16",
+      "0.7.15",
+    ]);
+  }, 60_000);
+
   it("accepts the checked-in 0.7.20 candidate against the previous stable fixture", () => {
     const result = runCompatibilityPreflight({
       candidateVersion: "0.7.20-canary.0",

--- a/scripts/release-next-version.test.mjs
+++ b/scripts/release-next-version.test.mjs
@@ -10,6 +10,7 @@ import {
   decideVersionHandoff,
   nextPatchVersion,
 } from "./prepare-next-release.mjs";
+import { buildMigrationManifest } from "./release-compatibility-matrix.mjs";
 
 const scriptsDir = dirname(fileURLToPath(import.meta.url));
 const tempRoots = [];
@@ -41,6 +42,69 @@ function exec(command, args, cwd) {
   return execFileSync(command, args, { cwd, encoding: "utf8" });
 }
 
+function compatibilityFingerprint() {
+  return buildMigrationManifest({
+    label: "test fixture",
+    journalRaw: JSON.stringify({
+      version: "7",
+      dialect: "postgresql",
+      entries: [{
+        idx: 0,
+        version: "7",
+        when: 1_700_000_000_000,
+        tag: "0000_base",
+        breakpoints: true,
+      }],
+    }),
+    listSqlFiles: () => ["0000_base.sql"],
+    readSqlFile: () => "SELECT 1;\n",
+  }).fingerprint;
+}
+
+function writeCompatibilityFixture(repo) {
+  const migrations = join(repo, "packages", "db", "src", "migrations");
+  mkdirSync(join(migrations, "meta"), { recursive: true });
+  const journalRaw = JSON.stringify({
+    version: "7",
+    dialect: "postgresql",
+    entries: [{
+      idx: 0,
+      version: "7",
+      when: 1_700_000_000_000,
+      tag: "0000_base",
+      breakpoints: true,
+    }],
+  });
+  const sql = "SELECT 1;\n";
+  const fingerprint = compatibilityFingerprint();
+
+  writeFileSync(join(migrations, "meta", "_journal.json"), `${journalRaw}\n`);
+  writeFileSync(join(migrations, "0000_base.sql"), sql);
+
+  const matrixPath = join(repo, "scripts", "release-compatibility-matrix.mjs");
+  const source = readFileSync(matrixPath, "utf8");
+  const declaration = [
+    '  "0.5.1": {',
+    `    candidateFingerprint: "${fingerprint}",`,
+    "    fixtures: [",
+    "      {",
+    '        version: "0.5.0",',
+    '        ref: "v0.5.0",',
+    `        fingerprint: "${fingerprint}",`,
+    "      },",
+    "    ],",
+    "  },",
+    "",
+  ].join("\n");
+  writeFileSync(
+    matrixPath,
+    source.replace(
+      "export const migrationCompatibilityMatrix = {\n",
+      `export const migrationCompatibilityMatrix = {\n${declaration}`,
+    ),
+  );
+}
+
 function createReleaseRepo() {
   const root = mkdtempSync(join(tmpdir(), "rudder-next-release-test-"));
   tempRoots.push(root);
@@ -50,6 +114,15 @@ function createReleaseRepo() {
   mkdirSync(join(repo, "cli"), { recursive: true });
   cpSync(join(scriptsDir, "prepare-next-release.mjs"), join(repo, "scripts", "prepare-next-release.mjs"));
   cpSync(join(scriptsDir, "release-package-map.mjs"), join(repo, "scripts", "release-package-map.mjs"));
+  cpSync(
+    join(scriptsDir, "release-compatibility-matrix.mjs"),
+    join(repo, "scripts", "release-compatibility-matrix.mjs"),
+  );
+  cpSync(
+    join(scriptsDir, "update-release-compatibility-matrix.mjs"),
+    join(repo, "scripts", "update-release-compatibility-matrix.mjs"),
+  );
+  writeCompatibilityFixture(repo);
   writeFileSync(join(repo, "cli", "package.json"), `${JSON.stringify({
     name: "@rudderhq/cli",
     version: "0.5.1",
@@ -62,6 +135,8 @@ function createReleaseRepo() {
   exec("git", ["config", "user.email", "release-test@example.com"], repo);
   exec("git", ["add", "."], repo);
   exec("git", ["commit", "-m", "fixture"], repo);
+  exec("git", ["tag", "v0.5.0"], repo);
+  exec("git", ["tag", "v0.5.1"], repo);
   exec("git", ["remote", "add", "origin", remote], repo);
   exec("git", ["push", "-u", "origin", "main"], repo);
   return repo;
@@ -208,6 +283,15 @@ describe("next release version handoff", () => {
       JSON.parse(exec("git", ["show", "origin/codex/release-v0.5.2:cli/package.json"], repo))
         .version,
     ).toBe("0.5.2");
+    const handoffMatrix = exec(
+      "git",
+      ["show", "origin/codex/release-v0.5.2:scripts/release-compatibility-matrix.mjs"],
+      repo,
+    );
+    expect(handoffMatrix).toContain('"0.5.2"');
+    expect(handoffMatrix).toContain('version: "0.5.1"');
+    expect(handoffMatrix).toContain(`candidateFingerprint: "${compatibilityFingerprint()}"`);
+    expect(handoffMatrix).toContain(`fingerprint: "${compatibilityFingerprint()}"`);
     expect(exec("git", ["show", "-s", "--format=%s", remoteHead], repo).trim()).toBe(
       "chore(release): start v0.5.2 [skip release]",
     );

--- a/scripts/release-workflow-contract.test.mjs
+++ b/scripts/release-workflow-contract.test.mjs
@@ -72,6 +72,12 @@ describe("unified delivery workflows", () => {
   });
 
   it("runs source, docs, platform, and fast packaged Desktop gates in Test", () => {
+    const plan = workflowJob(testWorkflow, "plan");
+    expect(plan).toContain("Verify canary migration compatibility declaration");
+    expect(plan).toContain("scripts/release-compatibility-matrix.mjs");
+    expect(plan).toContain("--channel canary");
+    expect(plan.indexOf("Verify canary migration compatibility declaration"))
+      .toBeLessThan(plan.indexOf("Upload impact plan evidence"));
     expect(testWorkflow).toContain("Architecture ratchet");
     expect(testWorkflow).toContain("pnpm test:run --maxWorkers=2");
     expect(testWorkflow).toContain("Ensure Electron runtime dependency");
@@ -140,6 +146,8 @@ describe("unified delivery workflows", () => {
       expect(publish).toContain("--source-tree-sha");
       expect(publish).toContain("--workflow-source-sha");
       expect(publish).toContain("--phase binaries");
+      expect(publish).toContain("timeout-minutes: 45");
+      expect(publish).toContain('wait_for_npm_package_versions "$(cat "$package_map")" 180 5');
       expect(publish).not.toContain("--phase checksum");
       expect(publish).not.toContain("gh release upload");
     }

--- a/scripts/update-release-compatibility-matrix.mjs
+++ b/scripts/update-release-compatibility-matrix.mjs
@@ -1,0 +1,167 @@
+#!/usr/bin/env node
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  migrationCompatibilityMatrix,
+  readCandidateManifest,
+  readFixtureManifest,
+  validateCompatibilityMatrix,
+} from "./release-compatibility-matrix.mjs";
+
+const scriptPath = fileURLToPath(import.meta.url);
+const scriptsDirectory = dirname(scriptPath);
+const repoRoot = resolve(scriptsDirectory, "..");
+const matrixPath = join(scriptsDirectory, "release-compatibility-matrix.mjs");
+const matrixMarker = "export const migrationCompatibilityMatrix = {\n";
+
+function parseStableVersion(version) {
+  const match = String(version ?? "").match(/^(\d+)\.(\d+)\.(\d+)$/);
+  if (!match) {
+    throw new Error(`expected a stable semver like 0.5.1, found: ${version || "<empty>"}`);
+  }
+  return match.slice(1).map(Number);
+}
+
+function compareStableVersions(left, right) {
+  const leftParts = parseStableVersion(left);
+  const rightParts = parseStableVersion(right);
+  for (let index = 0; index < leftParts.length; index += 1) {
+    if (leftParts[index] !== rightParts[index]) return leftParts[index] - rightParts[index];
+  }
+  return 0;
+}
+
+function parseArguments(argv) {
+  const options = { candidateVersion: "", stableVersion: "" };
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === "--candidate-version") {
+      options.candidateVersion = argv[index + 1] ?? "";
+      index += 1;
+    } else if (argument === "--stable-version") {
+      options.stableVersion = argv[index + 1] ?? "";
+      index += 1;
+    } else {
+      throw new Error(`unexpected argument ${argument}`);
+    }
+  }
+
+  parseStableVersion(options.candidateVersion);
+  parseStableVersion(options.stableVersion);
+  if (compareStableVersions(options.candidateVersion, options.stableVersion) <= 0) {
+    throw new Error(
+      `candidate version ${options.candidateVersion} must be newer than stable ${options.stableVersion}`,
+    );
+  }
+  return options;
+}
+
+function findPreviousDeclaration(stableVersion) {
+  const exact = migrationCompatibilityMatrix[stableVersion];
+  if (exact) return { version: stableVersion, declaration: exact };
+
+  const previous = Object.entries(migrationCompatibilityMatrix)
+    .filter(([version]) => compareStableVersions(version, stableVersion) < 0)
+    .sort(([left], [right]) => compareStableVersions(left, right))
+    .at(-1);
+  if (!previous) {
+    throw new Error(`no prior migration compatibility declaration exists before ${stableVersion}`);
+  }
+  return { version: previous[0], declaration: previous[1] };
+}
+
+function buildDeclaration({ candidateVersion, stableVersion }) {
+  const candidateManifest = readCandidateManifest(repoRoot);
+  const previous = findPreviousDeclaration(stableVersion);
+  const stableFixture = {
+    version: stableVersion,
+    ref: `v${stableVersion}`,
+  };
+  const stableManifest = readFixtureManifest(repoRoot, stableFixture);
+  const fixtures = [
+    { ...stableFixture, fingerprint: stableManifest.fingerprint },
+    ...(previous.declaration.fixtures ?? []),
+  ].filter((fixture, index, all) => (
+    all.findIndex((other) => other.version === fixture.version) === index
+  ));
+  const declaration = {
+    candidateFingerprint: candidateManifest.fingerprint,
+    fixtures,
+  };
+
+  validateCompatibilityMatrix({
+    candidateManifest,
+    candidateVersion: `${candidateVersion}-canary.0`,
+    channel: "canary",
+    matrix: {
+      ...migrationCompatibilityMatrix,
+      [candidateVersion]: declaration,
+    },
+    loadFixture: (fixture) => readFixtureManifest(repoRoot, fixture),
+  });
+
+  return { declaration, candidateManifest, previous };
+}
+
+function formatDeclaration(version, declaration) {
+  const fixtures = declaration.fixtures.map((fixture) => (
+    "      {\n"
+      + `        version: "${fixture.version}",\n`
+      + `        ref: "${fixture.ref}",\n`
+      + `        fingerprint: "${fixture.fingerprint}",\n`
+      + "      },"
+  )).join("\n");
+
+  return (
+    `  "${version}": {\n`
+    + `    candidateFingerprint: "${declaration.candidateFingerprint}",\n`
+    + "    fixtures: [\n"
+    + `${fixtures}\n`
+    + "    ],\n"
+    + "  },\n"
+  );
+}
+
+function updateMatrixFile(candidateVersion, declaration) {
+  const source = readFileSync(matrixPath, "utf8");
+  if (!source.includes(matrixMarker)) {
+    throw new Error(`migration compatibility matrix marker is missing from ${matrixPath}`);
+  }
+
+  const nextSource = source.replace(matrixMarker, `${matrixMarker}${formatDeclaration(candidateVersion, declaration)}`);
+  if (nextSource === source) {
+    throw new Error(`could not add migration compatibility declaration for ${candidateVersion}`);
+  }
+  writeFileSync(matrixPath, nextSource);
+}
+
+function main({ candidateVersion, stableVersion }) {
+  const existing = migrationCompatibilityMatrix[candidateVersion];
+  const { declaration, candidateManifest, previous } = buildDeclaration({ candidateVersion, stableVersion });
+  if (existing) {
+    if (JSON.stringify(existing) !== JSON.stringify(declaration)) {
+      throw new Error(
+        `migration compatibility declaration for ${candidateVersion} already exists with different content`,
+      );
+    }
+    console.log(`Migration compatibility declaration for ${candidateVersion} is already up to date.`);
+    return;
+  }
+
+  updateMatrixFile(candidateVersion, declaration);
+  console.log(
+    `Prepared migration compatibility declaration for ${candidateVersion} `
+    + `from ${previous.version} using ${candidateManifest.entries.length} migrations.`,
+  );
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === scriptPath) {
+  try {
+    main(parseArguments(process.argv.slice(2)));
+  } catch (error) {
+    console.error(`Error: ${error instanceof Error ? error.message : error}`);
+    process.exitCode = 1;
+  }
+}


### PR DESCRIPTION
## Summary
- Register the current 0.7.21 migration compatibility declaration so the automatic Canary preflight can proceed.
- Run the same declaration check in Test and generate the next declaration during the protected release-base handoff.
- Allow bounded npm registry propagation time before creating the Canary tag and GitHub Release.

## Validation
The focused release suite passes (3 files, 47 tests), along with the direct 0.7.21-canary.0 preflight, changed lint, Node syntax checks, and actionlint. The full repository baseline still has unrelated existing failures outside this PR.