### PR TITLE
feat(native): add authority and auth contract cores

### DIFF
--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -1338,6 +1338,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rudder-auth-core"
+version = "0.7.20"
+dependencies = [
+ "hex",
+ "hmac",
+ "serde",
+ "serde_json",
+ "sha2",
+ "subtle",
+ "thiserror 2.0.20",
+ "zeroize",
+]
+
+[[package]]
 name = "rudder-authority-core"
 version = "0.7.20"
 dependencies = [

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -1339,7 +1339,7 @@ dependencies = [
 
 [[package]]
 name = "rudder-auth-core"
-version = "0.7.20"
+version = "0.7.21"
 dependencies = [
  "hex",
  "hmac",
@@ -1353,7 +1353,7 @@ dependencies = [
 
 [[package]]
 name = "rudder-authority-core"
-version = "0.7.20"
+version = "0.7.21"
 dependencies = [
  "serde",
  "serde_json",

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -1338,6 +1338,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rudder-authority-core"
+version = "0.7.20"
+dependencies = [
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror 2.0.20",
+]
+
+[[package]]
 name = "rudder-native"
 version = "0.7.21"
 dependencies = [

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -4,6 +4,7 @@ members = [
   "crates/agent-contract-core",
   "crates/archive-core",
   "crates/authority-core",
+  "crates/auth-core",
   "crates/native-protocol",
   "crates/plugin-archive-core",
   "crates/update-helper-core",

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
   "crates/agent-contract-core",
   "crates/archive-core",
+  "crates/authority-core",
   "crates/native-protocol",
   "crates/plugin-archive-core",
   "crates/update-helper-core",

--- a/native/crates/auth-core/Cargo.toml
+++ b/native/crates/auth-core/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "rudder-auth-core"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+
+[dependencies]
+hex = "0.4"
+hmac = "0.12"
+serde = { version = "1.0", features = ["derive"] }
+sha2 = "0.10"
+subtle = "2.6"
+thiserror = "2.0"
+zeroize = "1.8"
+
+[dev-dependencies]
+serde_json = "1.0"

--- a/native/crates/auth-core/src/lib.rs
+++ b/native/crates/auth-core/src/lib.rs
@@ -1,0 +1,643 @@
+//! Signed, short-lived actor envelopes for the private Node/Rust boundary.
+//!
+//! This crate owns only protocol data and verification. It does not persist
+//! credentials, contact an identity provider, write product state, or open a
+//! network listener. The caller supplies the current request and a process-local
+//! replay guard.
+
+#![forbid(unsafe_code)]
+
+use hmac::{Hmac, Mac};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::{collections::BTreeSet, fmt};
+use subtle::ConstantTimeEq;
+use thiserror::Error;
+use zeroize::Zeroizing;
+
+/// The only protocol version accepted by this crate.
+pub const PROTOCOL_VERSION: u16 = 1;
+/// Stable protocol name used as domain separation in the signing bytes.
+pub const PROTOCOL_SCHEMA: &str = "rudder.actor-envelope.v1";
+/// Maximum size of a textual protocol field in bytes.
+pub const MAX_FIELD_BYTES: usize = 256;
+/// Maximum lifetime of an envelope, in Unix seconds.
+pub const MAX_ENVELOPE_LIFETIME_SECONDS: u64 = 300;
+/// Number of bytes in a SHA-256 digest.
+pub const SHA256_BYTES: usize = 32;
+/// Number of hexadecimal characters in a SHA-256 digest or signature.
+pub const SHA256_HEX_LENGTH: usize = SHA256_BYTES * 2;
+
+/// Errors returned while constructing or verifying an actor envelope.
+#[derive(Clone, Debug, Error, Eq, PartialEq)]
+pub enum AuthError {
+    #[error("invalid {field}")]
+    InvalidField { field: &'static str },
+    #[error("unsupported actor envelope protocol version {actual}; expected {expected}")]
+    UnsupportedProtocolVersion { actual: u16, expected: u16 },
+    #[error("the signing key must not be empty")]
+    InvalidSecretKey,
+    #[error("actor envelope signature is invalid")]
+    InvalidSignature,
+    #[error("actor does not match the request")]
+    ActorMismatch,
+    #[error("organization does not match the request")]
+    OrganizationMismatch,
+    #[error("audience does not match the request")]
+    AudienceMismatch,
+    #[error("HTTP method does not match the request")]
+    MethodMismatch,
+    #[error("path does not match the request")]
+    PathMismatch,
+    #[error("action does not match the request")]
+    ActionMismatch,
+    #[error("request id does not match the request")]
+    RequestIdMismatch,
+    #[error("request body hash does not match the envelope")]
+    BodyHashMismatch,
+    #[error("envelope timestamp range is invalid")]
+    InvalidTimestamp,
+    #[error("actor envelope has expired")]
+    Expired,
+    #[error("actor envelope is not valid yet")]
+    NotYetValid,
+    #[error("actor envelope nonce has already been used")]
+    Replay,
+}
+
+/// Compatibility alias with a more descriptive name for downstream adapters.
+pub type ActorEnvelopeError = AuthError;
+
+/// The actor type and stable identifier bound into an envelope.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct ActorIdentity {
+    pub kind: String,
+    pub id: String,
+}
+
+/// A short alias for callers that refer to the claim as an actor.
+pub type Actor = ActorIdentity;
+
+impl ActorIdentity {
+    /// Create a validated actor identity.
+    pub fn new(kind: impl Into<String>, id: impl Into<String>) -> Result<Self, AuthError> {
+        let kind = kind.into();
+        let id = id.into();
+        validate_text(&kind, "actorKind")?;
+        validate_text(&id, "actorId")?;
+        Ok(Self { kind, id })
+    }
+
+    fn validate(&self) -> Result<(), AuthError> {
+        validate_text(&self.kind, "actorKind")?;
+        validate_text(&self.id, "actorId")
+    }
+}
+
+/// Request claims before an HMAC signature is attached.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct UnsignedActorEnvelope {
+    pub protocol_version: u16,
+    pub actor: ActorIdentity,
+    pub organization_id: String,
+    pub audience: String,
+    pub method: String,
+    pub path: String,
+    pub action: String,
+    pub body_sha256: String,
+    pub request_id: String,
+    pub nonce: String,
+    pub issued_at: u64,
+    pub expires_at: u64,
+}
+
+impl UnsignedActorEnvelope {
+    /// Attach an HMAC-SHA256 signature. The secret is used only for this call
+    /// and is never stored in or serialized with the returned envelope.
+    pub fn sign(self, secret: &[u8]) -> Result<ActorEnvelope, AuthError> {
+        self.validate()?;
+        let signature = hmac_signature(secret, &self.signing_bytes())?;
+        Ok(ActorEnvelope {
+            protocol_version: self.protocol_version,
+            actor: self.actor,
+            organization_id: self.organization_id,
+            audience: self.audience,
+            method: self.method,
+            path: self.path,
+            action: self.action,
+            body_sha256: self.body_sha256,
+            request_id: self.request_id,
+            nonce: self.nonce,
+            issued_at: self.issued_at,
+            expires_at: self.expires_at,
+            signature,
+        })
+    }
+
+    /// Sign using a non-serializable, zeroizing key wrapper.
+    pub fn sign_with_key(self, key: &SigningKey) -> Result<ActorEnvelope, AuthError> {
+        self.sign(key.as_bytes())
+    }
+
+    /// Return the exact bytes covered by the HMAC.
+    ///
+    /// The representation is a versioned domain separator followed by
+    /// length-prefixed UTF-8 fields and big-endian integer timestamps. It is
+    /// deterministic across Node and Rust implementations and excludes the
+    /// signature itself.
+    pub fn signing_bytes(&self) -> Vec<u8> {
+        canonical_signing_bytes(
+            self.protocol_version,
+            &self.actor,
+            &self.organization_id,
+            &self.audience,
+            &self.method,
+            &self.path,
+            &self.action,
+            &self.body_sha256,
+            &self.request_id,
+            &self.nonce,
+            self.issued_at,
+            self.expires_at,
+        )
+    }
+
+    fn validate(&self) -> Result<(), AuthError> {
+        validate_version(self.protocol_version)?;
+        validate_claims(
+            &self.actor,
+            &self.organization_id,
+            &self.audience,
+            &self.method,
+            &self.path,
+            &self.action,
+            &self.body_sha256,
+            &self.request_id,
+            &self.nonce,
+            self.issued_at,
+            self.expires_at,
+        )
+    }
+}
+
+/// A complete actor envelope. It contains claims and a signature, never the
+/// secret key used to produce that signature.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct ActorEnvelope {
+    pub protocol_version: u16,
+    pub actor: ActorIdentity,
+    pub organization_id: String,
+    pub audience: String,
+    pub method: String,
+    pub path: String,
+    pub action: String,
+    pub body_sha256: String,
+    pub request_id: String,
+    pub nonce: String,
+    pub issued_at: u64,
+    pub expires_at: u64,
+    pub signature: String,
+}
+
+impl ActorEnvelope {
+    /// Build validated unsigned claims for one HTTP/action request.
+    #[allow(clippy::new_ret_no_self, clippy::too_many_arguments)]
+    pub fn new(
+        actor: ActorIdentity,
+        organization_id: impl Into<String>,
+        audience: impl Into<String>,
+        method: impl Into<String>,
+        path: impl Into<String>,
+        action: impl Into<String>,
+        body: &[u8],
+        request_id: impl Into<String>,
+        nonce: impl Into<String>,
+        issued_at: u64,
+        expires_at: u64,
+    ) -> Result<UnsignedActorEnvelope, AuthError> {
+        let envelope = UnsignedActorEnvelope {
+            protocol_version: PROTOCOL_VERSION,
+            actor,
+            organization_id: organization_id.into(),
+            audience: audience.into(),
+            method: method.into(),
+            path: path.into(),
+            action: action.into(),
+            body_sha256: body_sha256(body),
+            request_id: request_id.into(),
+            nonce: nonce.into(),
+            issued_at,
+            expires_at,
+        };
+        envelope.validate()?;
+        Ok(envelope)
+    }
+
+    /// Sign an already-created unsigned envelope.
+    pub fn from_unsigned(
+        unsigned: UnsignedActorEnvelope,
+        secret: &[u8],
+    ) -> Result<Self, AuthError> {
+        unsigned.sign(secret)
+    }
+
+    /// Verify signature, freshness, request bindings, and then consume the
+    /// nonce exactly once. No state is changed when any earlier check fails.
+    pub fn verify(
+        &self,
+        secret: &[u8],
+        request: &RequestContext<'_>,
+        replay: &mut NonceReplayGuard,
+    ) -> Result<(), AuthError> {
+        self.validate()?;
+        if request.now < self.issued_at {
+            return Err(AuthError::NotYetValid);
+        }
+        if request.now >= self.expires_at {
+            return Err(AuthError::Expired);
+        }
+        self.verify_signature(secret)?;
+        self.verify_request_bindings(request)?;
+        replay.claim(&self.nonce)
+    }
+
+    /// Verify using a non-serializable, zeroizing key wrapper.
+    pub fn verify_with_key(
+        &self,
+        key: &SigningKey,
+        request: &RequestContext<'_>,
+        replay: &mut NonceReplayGuard,
+    ) -> Result<(), AuthError> {
+        self.verify(key.as_bytes(), request, replay)
+    }
+
+    /// Return the exact unsigned claims covered by the signature.
+    pub fn signing_bytes(&self) -> Vec<u8> {
+        canonical_signing_bytes(
+            self.protocol_version,
+            &self.actor,
+            &self.organization_id,
+            &self.audience,
+            &self.method,
+            &self.path,
+            &self.action,
+            &self.body_sha256,
+            &self.request_id,
+            &self.nonce,
+            self.issued_at,
+            self.expires_at,
+        )
+    }
+
+    fn validate(&self) -> Result<(), AuthError> {
+        validate_version(self.protocol_version)?;
+        validate_claims(
+            &self.actor,
+            &self.organization_id,
+            &self.audience,
+            &self.method,
+            &self.path,
+            &self.action,
+            &self.body_sha256,
+            &self.request_id,
+            &self.nonce,
+            self.issued_at,
+            self.expires_at,
+        )?;
+        if self.signature.is_empty() {
+            return Err(AuthError::InvalidSignature);
+        }
+        Ok(())
+    }
+
+    fn verify_signature(&self, secret: &[u8]) -> Result<(), AuthError> {
+        let provided = hex::decode(&self.signature).map_err(|_| AuthError::InvalidSignature)?;
+        if provided.len() != SHA256_BYTES {
+            return Err(AuthError::InvalidSignature);
+        }
+        let expected = hmac_bytes(secret, &self.signing_bytes())?;
+        if expected.as_slice().ct_eq(provided.as_slice()).unwrap_u8() != 1 {
+            return Err(AuthError::InvalidSignature);
+        }
+        Ok(())
+    }
+
+    fn verify_request_bindings(&self, request: &RequestContext<'_>) -> Result<(), AuthError> {
+        request.actor.validate()?;
+        validate_text(request.organization_id, "organizationId")?;
+        validate_text(request.audience, "audience")?;
+        validate_text(request.method, "method")?;
+        validate_path(request.path)?;
+        validate_text(request.action, "action")?;
+        validate_text(request.request_id, "requestId")?;
+
+        if self.actor != *request.actor {
+            return Err(AuthError::ActorMismatch);
+        }
+        if self.organization_id != request.organization_id {
+            return Err(AuthError::OrganizationMismatch);
+        }
+        if self.audience != request.audience {
+            return Err(AuthError::AudienceMismatch);
+        }
+        if self.method != request.method {
+            return Err(AuthError::MethodMismatch);
+        }
+        if self.path != request.path {
+            return Err(AuthError::PathMismatch);
+        }
+        if self.action != request.action {
+            return Err(AuthError::ActionMismatch);
+        }
+        if self.request_id != request.request_id {
+            return Err(AuthError::RequestIdMismatch);
+        }
+        if self.body_sha256 != body_sha256(request.body) {
+            return Err(AuthError::BodyHashMismatch);
+        }
+        Ok(())
+    }
+}
+
+/// The trusted request values that must match a signed envelope.
+///
+/// The caller owns these values and supplies the current clock. Keeping the
+/// context separate prevents verification from trusting claims copied out of
+/// the untrusted envelope.
+pub struct RequestContext<'a> {
+    pub actor: &'a ActorIdentity,
+    pub organization_id: &'a str,
+    pub audience: &'a str,
+    pub method: &'a str,
+    pub path: &'a str,
+    pub action: &'a str,
+    pub body: &'a [u8],
+    pub request_id: &'a str,
+    pub now: u64,
+}
+
+impl<'a> RequestContext<'a> {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        actor: &'a ActorIdentity,
+        organization_id: &'a str,
+        audience: &'a str,
+        method: &'a str,
+        path: &'a str,
+        action: &'a str,
+        body: &'a [u8],
+        request_id: &'a str,
+        now: u64,
+    ) -> Self {
+        Self {
+            actor,
+            organization_id,
+            audience,
+            method,
+            path,
+            action,
+            body,
+            request_id,
+            now,
+        }
+    }
+}
+
+/// A process-local single-use nonce guard.
+///
+/// This is deliberately an in-memory primitive. A caller that spans processes
+/// must provide an equivalent atomic store at its boundary; this crate does not
+/// create a database or credential store.
+#[derive(Clone, Debug, Default)]
+pub struct NonceReplayGuard {
+    used: BTreeSet<String>,
+}
+
+impl NonceReplayGuard {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn len(&self) -> usize {
+        self.used.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.used.is_empty()
+    }
+
+    pub fn contains(&self, nonce: &str) -> bool {
+        self.used.contains(nonce)
+    }
+
+    pub fn claim(&mut self, nonce: &str) -> Result<(), AuthError> {
+        validate_text(nonce, "nonce")?;
+        if !self.used.insert(nonce.to_owned()) {
+            return Err(AuthError::Replay);
+        }
+        Ok(())
+    }
+}
+
+/// A signing key that cannot be serialized and prints only a redacted debug
+/// representation. Its bytes are zeroized when the wrapper is dropped.
+pub struct SigningKey {
+    secret: Zeroizing<Vec<u8>>,
+}
+
+impl SigningKey {
+    pub fn new(secret: &[u8]) -> Result<Self, AuthError> {
+        if secret.is_empty() {
+            return Err(AuthError::InvalidSecretKey);
+        }
+        Ok(Self {
+            secret: Zeroizing::new(secret.to_vec()),
+        })
+    }
+
+    fn as_bytes(&self) -> &[u8] {
+        self.secret.as_slice()
+    }
+}
+
+impl Clone for SigningKey {
+    fn clone(&self) -> Self {
+        Self {
+            secret: Zeroizing::new(self.secret.to_vec()),
+        }
+    }
+}
+
+impl fmt::Debug for SigningKey {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("SigningKey(REDACTED)")
+    }
+}
+
+impl Serialize for SigningKey {
+    fn serialize<S>(&self, _serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        Err(serde::ser::Error::custom(
+            "signing key serialization is prohibited",
+        ))
+    }
+}
+
+/// Hash an HTTP request body using SHA-256 and return lowercase hexadecimal.
+pub fn body_sha256(body: &[u8]) -> String {
+    hex::encode(Sha256::digest(body))
+}
+
+/// Alias used by adapters that call the field a body hash.
+pub fn hash_body(body: &[u8]) -> String {
+    body_sha256(body)
+}
+
+type HmacSha256 = Hmac<Sha256>;
+
+fn hmac_signature(secret: &[u8], input: &[u8]) -> Result<String, AuthError> {
+    Ok(hex::encode(hmac_bytes(secret, input)?))
+}
+
+fn hmac_bytes(secret: &[u8], input: &[u8]) -> Result<Vec<u8>, AuthError> {
+    if secret.is_empty() {
+        return Err(AuthError::InvalidSecretKey);
+    }
+    let mut mac = HmacSha256::new_from_slice(secret).map_err(|_| AuthError::InvalidSecretKey)?;
+    mac.update(input);
+    Ok(mac.finalize().into_bytes().to_vec())
+}
+
+fn validate_version(version: u16) -> Result<(), AuthError> {
+    if version != PROTOCOL_VERSION {
+        return Err(AuthError::UnsupportedProtocolVersion {
+            actual: version,
+            expected: PROTOCOL_VERSION,
+        });
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn validate_claims(
+    actor: &ActorIdentity,
+    organization_id: &str,
+    audience: &str,
+    method: &str,
+    path: &str,
+    action: &str,
+    body_hash: &str,
+    request_id: &str,
+    nonce: &str,
+    issued_at: u64,
+    expires_at: u64,
+) -> Result<(), AuthError> {
+    actor.validate()?;
+    validate_text(organization_id, "organizationId")?;
+    validate_text(audience, "audience")?;
+    validate_text(method, "method")?;
+    validate_path(path)?;
+    validate_text(action, "action")?;
+    validate_body_hash(body_hash)?;
+    validate_text(request_id, "requestId")?;
+    validate_text(nonce, "nonce")?;
+    if issued_at == 0 || expires_at <= issued_at {
+        return Err(AuthError::InvalidTimestamp);
+    }
+    if expires_at - issued_at > MAX_ENVELOPE_LIFETIME_SECONDS {
+        return Err(AuthError::InvalidTimestamp);
+    }
+    Ok(())
+}
+
+fn validate_text(value: &str, field: &'static str) -> Result<(), AuthError> {
+    if value.is_empty()
+        || value.trim().is_empty()
+        || value.len() > MAX_FIELD_BYTES
+        || value
+            .bytes()
+            .any(|byte| byte == 0 || byte.is_ascii_control())
+    {
+        return Err(AuthError::InvalidField { field });
+    }
+    Ok(())
+}
+
+fn validate_path(path: &str) -> Result<(), AuthError> {
+    validate_text(path, "path")?;
+    if !path.starts_with('/') {
+        return Err(AuthError::InvalidField { field: "path" });
+    }
+    Ok(())
+}
+
+fn validate_body_hash(body_hash: &str) -> Result<(), AuthError> {
+    if body_hash.len() != SHA256_HEX_LENGTH
+        || !body_hash.bytes().all(|byte| byte.is_ascii_hexdigit())
+        || body_hash.bytes().any(|byte| byte.is_ascii_uppercase())
+    {
+        return Err(AuthError::InvalidField {
+            field: "bodySha256",
+        });
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn canonical_signing_bytes(
+    protocol_version: u16,
+    actor: &ActorIdentity,
+    organization_id: &str,
+    audience: &str,
+    method: &str,
+    path: &str,
+    action: &str,
+    body_hash: &str,
+    request_id: &str,
+    nonce: &str,
+    issued_at: u64,
+    expires_at: u64,
+) -> Vec<u8> {
+    let fields = [
+        actor.kind.as_bytes(),
+        actor.id.as_bytes(),
+        organization_id.as_bytes(),
+        audience.as_bytes(),
+        method.as_bytes(),
+        path.as_bytes(),
+        action.as_bytes(),
+        body_hash.as_bytes(),
+        request_id.as_bytes(),
+        nonce.as_bytes(),
+    ];
+    let mut output =
+        Vec::with_capacity(64 + fields.iter().map(|field| field.len() + 8).sum::<usize>());
+    output.extend_from_slice(PROTOCOL_SCHEMA.as_bytes());
+    output.push(0);
+    output.extend_from_slice(&protocol_version.to_be_bytes());
+    for field in fields {
+        output.extend_from_slice(&(field.len() as u64).to_be_bytes());
+        output.extend_from_slice(field);
+    }
+    output.extend_from_slice(&issued_at.to_be_bytes());
+    output.extend_from_slice(&expires_at.to_be_bytes());
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn signing_key_debug_is_redacted() {
+        let key = SigningKey::new(b"not-for-output").expect("key");
+        assert!(!format!("{key:?}").contains("not-for-output"));
+        let serialization_error = serde_json::to_string(&key).expect_err("key serialization");
+        assert!(!serialization_error.to_string().contains("not-for-output"));
+    }
+}

--- a/native/crates/auth-core/src/lib.rs
+++ b/native/crates/auth-core/src/lib.rs
@@ -10,15 +10,15 @@
 use hmac::{Hmac, Mac};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use std::{collections::BTreeSet, fmt};
+use std::{collections::BTreeMap, fmt};
 use subtle::ConstantTimeEq;
 use thiserror::Error;
 use zeroize::Zeroizing;
 
 /// The only protocol version accepted by this crate.
-pub const PROTOCOL_VERSION: u16 = 1;
+pub const PROTOCOL_VERSION: u16 = 2;
 /// Stable protocol name used as domain separation in the signing bytes.
-pub const PROTOCOL_SCHEMA: &str = "rudder.actor-envelope.v1";
+pub const PROTOCOL_SCHEMA: &str = "rudder.actor-envelope.v2";
 /// Maximum size of a textual protocol field in bytes.
 pub const MAX_FIELD_BYTES: usize = 256;
 /// Maximum lifetime of an envelope, in Unix seconds.
@@ -27,6 +27,10 @@ pub const MAX_ENVELOPE_LIFETIME_SECONDS: u64 = 300;
 pub const SHA256_BYTES: usize = 32;
 /// Number of hexadecimal characters in a SHA-256 digest or signature.
 pub const SHA256_HEX_LENGTH: usize = SHA256_BYTES * 2;
+/// Default number of live nonces retained by the process-local replay guard.
+pub const DEFAULT_REPLAY_CAPACITY: usize = 16 * 1024;
+/// Maximum replay-guard capacity accepted by this crate.
+pub const MAX_REPLAY_CAPACITY: usize = 64 * 1024;
 
 /// Errors returned while constructing or verifying an actor envelope.
 #[derive(Clone, Debug, Error, Eq, PartialEq)]
@@ -43,6 +47,10 @@ pub enum AuthError {
     ActorMismatch,
     #[error("organization does not match the request")]
     OrganizationMismatch,
+    #[error("authentication session does not match the request")]
+    SessionMismatch,
+    #[error("authentication epoch does not match the request")]
+    AuthEpochMismatch,
     #[error("audience does not match the request")]
     AudienceMismatch,
     #[error("HTTP method does not match the request")]
@@ -63,6 +71,10 @@ pub enum AuthError {
     NotYetValid,
     #[error("actor envelope nonce has already been used")]
     Replay,
+    #[error("actor envelope replay guard capacity is exhausted")]
+    ReplayCapacityExceeded,
+    #[error("replay guard capacity must be between one and {max} entries")]
+    InvalidReplayCapacity { max: usize },
 }
 
 /// Compatibility alias with a more descriptive name for downstream adapters.
@@ -102,6 +114,8 @@ pub struct UnsignedActorEnvelope {
     pub protocol_version: u16,
     pub actor: ActorIdentity,
     pub organization_id: String,
+    pub session_id: String,
+    pub auth_epoch: u64,
     pub audience: String,
     pub method: String,
     pub path: String,
@@ -123,6 +137,8 @@ impl UnsignedActorEnvelope {
             protocol_version: self.protocol_version,
             actor: self.actor,
             organization_id: self.organization_id,
+            session_id: self.session_id,
+            auth_epoch: self.auth_epoch,
             audience: self.audience,
             method: self.method,
             path: self.path,
@@ -152,6 +168,8 @@ impl UnsignedActorEnvelope {
             self.protocol_version,
             &self.actor,
             &self.organization_id,
+            &self.session_id,
+            self.auth_epoch,
             &self.audience,
             &self.method,
             &self.path,
@@ -169,6 +187,8 @@ impl UnsignedActorEnvelope {
         validate_claims(
             &self.actor,
             &self.organization_id,
+            &self.session_id,
+            self.auth_epoch,
             &self.audience,
             &self.method,
             &self.path,
@@ -190,6 +210,8 @@ pub struct ActorEnvelope {
     pub protocol_version: u16,
     pub actor: ActorIdentity,
     pub organization_id: String,
+    pub session_id: String,
+    pub auth_epoch: u64,
     pub audience: String,
     pub method: String,
     pub path: String,
@@ -208,6 +230,8 @@ impl ActorEnvelope {
     pub fn new(
         actor: ActorIdentity,
         organization_id: impl Into<String>,
+        session_id: impl Into<String>,
+        auth_epoch: u64,
         audience: impl Into<String>,
         method: impl Into<String>,
         path: impl Into<String>,
@@ -222,6 +246,8 @@ impl ActorEnvelope {
             protocol_version: PROTOCOL_VERSION,
             actor,
             organization_id: organization_id.into(),
+            session_id: session_id.into(),
+            auth_epoch,
             audience: audience.into(),
             method: method.into(),
             path: path.into(),
@@ -261,7 +287,7 @@ impl ActorEnvelope {
         }
         self.verify_signature(secret)?;
         self.verify_request_bindings(request)?;
-        replay.claim(&self.nonce)
+        replay.claim(&self.nonce, self.expires_at, request.now)
     }
 
     /// Verify using a non-serializable, zeroizing key wrapper.
@@ -280,6 +306,8 @@ impl ActorEnvelope {
             self.protocol_version,
             &self.actor,
             &self.organization_id,
+            &self.session_id,
+            self.auth_epoch,
             &self.audience,
             &self.method,
             &self.path,
@@ -297,6 +325,8 @@ impl ActorEnvelope {
         validate_claims(
             &self.actor,
             &self.organization_id,
+            &self.session_id,
+            self.auth_epoch,
             &self.audience,
             &self.method,
             &self.path,
@@ -328,6 +358,8 @@ impl ActorEnvelope {
     fn verify_request_bindings(&self, request: &RequestContext<'_>) -> Result<(), AuthError> {
         request.actor.validate()?;
         validate_text(request.organization_id, "organizationId")?;
+        validate_text(request.session_id, "sessionId")?;
+        validate_auth_epoch(request.auth_epoch)?;
         validate_text(request.audience, "audience")?;
         validate_text(request.method, "method")?;
         validate_path(request.path)?;
@@ -339,6 +371,12 @@ impl ActorEnvelope {
         }
         if self.organization_id != request.organization_id {
             return Err(AuthError::OrganizationMismatch);
+        }
+        if self.session_id != request.session_id {
+            return Err(AuthError::SessionMismatch);
+        }
+        if self.auth_epoch != request.auth_epoch {
+            return Err(AuthError::AuthEpochMismatch);
         }
         if self.audience != request.audience {
             return Err(AuthError::AudienceMismatch);
@@ -366,10 +404,14 @@ impl ActorEnvelope {
 ///
 /// The caller owns these values and supplies the current clock. Keeping the
 /// context separate prevents verification from trusting claims copied out of
-/// the untrusted envelope.
+/// the untrusted envelope. `session_id` and `auth_epoch` must be read from the
+/// currently active authentication state, so logout or credential revocation
+/// invalidates envelopes issued under the previous state.
 pub struct RequestContext<'a> {
     pub actor: &'a ActorIdentity,
     pub organization_id: &'a str,
+    pub session_id: &'a str,
+    pub auth_epoch: u64,
     pub audience: &'a str,
     pub method: &'a str,
     pub path: &'a str,
@@ -384,6 +426,8 @@ impl<'a> RequestContext<'a> {
     pub fn new(
         actor: &'a ActorIdentity,
         organization_id: &'a str,
+        session_id: &'a str,
+        auth_epoch: u64,
         audience: &'a str,
         method: &'a str,
         path: &'a str,
@@ -395,6 +439,8 @@ impl<'a> RequestContext<'a> {
         Self {
             actor,
             organization_id,
+            session_id,
+            auth_epoch,
             audience,
             method,
             path,
@@ -411,14 +457,31 @@ impl<'a> RequestContext<'a> {
 /// This is deliberately an in-memory primitive. A caller that spans processes
 /// must provide an equivalent atomic store at its boundary; this crate does not
 /// create a database or credential store.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct NonceReplayGuard {
-    used: BTreeSet<String>,
+    used: BTreeMap<String, u64>,
+    capacity: usize,
 }
 
 impl NonceReplayGuard {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    pub fn with_capacity(capacity: usize) -> Result<Self, AuthError> {
+        if capacity == 0 || capacity > MAX_REPLAY_CAPACITY {
+            return Err(AuthError::InvalidReplayCapacity {
+                max: MAX_REPLAY_CAPACITY,
+            });
+        }
+        Ok(Self {
+            used: BTreeMap::new(),
+            capacity,
+        })
+    }
+
+    pub fn capacity(&self) -> usize {
+        self.capacity
     }
 
     pub fn len(&self) -> usize {
@@ -430,15 +493,32 @@ impl NonceReplayGuard {
     }
 
     pub fn contains(&self, nonce: &str) -> bool {
-        self.used.contains(nonce)
+        self.used.contains_key(nonce)
     }
 
-    pub fn claim(&mut self, nonce: &str) -> Result<(), AuthError> {
+    pub fn claim(&mut self, nonce: &str, expires_at: u64, now: u64) -> Result<(), AuthError> {
         validate_text(nonce, "nonce")?;
-        if !self.used.insert(nonce.to_owned()) {
+        self.used.retain(|_, expiry| *expiry > now);
+        if expires_at <= now {
+            return Err(AuthError::Expired);
+        }
+        if self.used.contains_key(nonce) {
             return Err(AuthError::Replay);
         }
+        if self.used.len() >= self.capacity {
+            return Err(AuthError::ReplayCapacityExceeded);
+        }
+        self.used.insert(nonce.to_owned(), expires_at);
         Ok(())
+    }
+}
+
+impl Default for NonceReplayGuard {
+    fn default() -> Self {
+        Self {
+            used: BTreeMap::new(),
+            capacity: DEFAULT_REPLAY_CAPACITY,
+        }
     }
 }
 
@@ -527,6 +607,8 @@ fn validate_version(version: u16) -> Result<(), AuthError> {
 fn validate_claims(
     actor: &ActorIdentity,
     organization_id: &str,
+    session_id: &str,
+    auth_epoch: u64,
     audience: &str,
     method: &str,
     path: &str,
@@ -539,6 +621,8 @@ fn validate_claims(
 ) -> Result<(), AuthError> {
     actor.validate()?;
     validate_text(organization_id, "organizationId")?;
+    validate_text(session_id, "sessionId")?;
+    validate_auth_epoch(auth_epoch)?;
     validate_text(audience, "audience")?;
     validate_text(method, "method")?;
     validate_path(path)?;
@@ -551,6 +635,13 @@ fn validate_claims(
     }
     if expires_at - issued_at > MAX_ENVELOPE_LIFETIME_SECONDS {
         return Err(AuthError::InvalidTimestamp);
+    }
+    Ok(())
+}
+
+fn validate_auth_epoch(auth_epoch: u64) -> Result<(), AuthError> {
+    if auth_epoch == 0 {
+        return Err(AuthError::InvalidField { field: "authEpoch" });
     }
     Ok(())
 }
@@ -593,6 +684,8 @@ fn canonical_signing_bytes(
     protocol_version: u16,
     actor: &ActorIdentity,
     organization_id: &str,
+    session_id: &str,
+    auth_epoch: u64,
     audience: &str,
     method: &str,
     path: &str,
@@ -607,6 +700,7 @@ fn canonical_signing_bytes(
         actor.kind.as_bytes(),
         actor.id.as_bytes(),
         organization_id.as_bytes(),
+        session_id.as_bytes(),
         audience.as_bytes(),
         method.as_bytes(),
         path.as_bytes(),
@@ -624,6 +718,7 @@ fn canonical_signing_bytes(
         output.extend_from_slice(&(field.len() as u64).to_be_bytes());
         output.extend_from_slice(field);
     }
+    output.extend_from_slice(&auth_epoch.to_be_bytes());
     output.extend_from_slice(&issued_at.to_be_bytes());
     output.extend_from_slice(&expires_at.to_be_bytes());
     output

--- a/native/crates/auth-core/tests/protocol.rs
+++ b/native/crates/auth-core/tests/protocol.rs
@@ -1,0 +1,413 @@
+use rudder_auth_core::{ActorEnvelope, ActorIdentity, NonceReplayGuard, RequestContext};
+
+const SECRET: &[u8] = b"deterministic-test-secret";
+const BODY: &[u8] = br#"{"message":"hello"}"#;
+
+fn actor() -> ActorIdentity {
+    ActorIdentity::new("agent", "agent-1").expect("actor")
+}
+
+fn context<'a>(actor: &'a ActorIdentity) -> RequestContext<'a> {
+    RequestContext::new(
+        actor,
+        "org-1",
+        "rudder-node",
+        "POST",
+        "/api/agent-actions",
+        "agent.execute",
+        BODY,
+        "request-1",
+        1_005,
+    )
+}
+
+#[test]
+fn signed_envelope_round_trips_and_verifies() {
+    let unsigned = ActorEnvelope::new(
+        actor(),
+        "org-1",
+        "rudder-node",
+        "POST",
+        "/api/agent-actions",
+        "agent.execute",
+        BODY,
+        "request-1",
+        "nonce-1",
+        1_000,
+        1_010,
+    )
+    .expect("unsigned envelope");
+    let envelope = unsigned.sign(SECRET).expect("signed envelope");
+    let encoded = serde_json::to_string(&envelope).expect("serialize envelope");
+    let decoded: ActorEnvelope = serde_json::from_str(&encoded).expect("deserialize envelope");
+    let mut replay = NonceReplayGuard::new();
+
+    decoded
+        .verify(SECRET, &context(&actor()), &mut replay)
+        .expect("valid envelope");
+    assert_eq!(replay.len(), 1);
+    assert_eq!(decoded.body_sha256, rudder_auth_core::body_sha256(BODY));
+    assert_eq!(decoded.protocol_version, rudder_auth_core::PROTOCOL_VERSION);
+    assert_eq!(
+        decoded.signature,
+        "b9159201fa99b11f11b28c7da91b7f44abbdd08ce8a6af0b9f2d7fae168906a6"
+    );
+    assert!(!encoded.contains("deterministic-test-secret"));
+}
+
+#[test]
+fn signature_tampering_is_rejected_without_consuming_nonce() {
+    let unsigned = ActorEnvelope::new(
+        actor(),
+        "org-1",
+        "rudder-node",
+        "POST",
+        "/api/agent-actions",
+        "agent.execute",
+        BODY,
+        "request-1",
+        "nonce-2",
+        1_000,
+        1_010,
+    )
+    .expect("unsigned envelope");
+    let mut envelope = unsigned.sign(SECRET).expect("signed envelope");
+    let replacement = if envelope.signature.starts_with('0') {
+        '1'
+    } else {
+        '0'
+    };
+    envelope
+        .signature
+        .replace_range(..1, &replacement.to_string());
+    let mut replay = NonceReplayGuard::new();
+
+    let error = envelope
+        .verify(SECRET, &context(&actor()), &mut replay)
+        .expect_err("tampered signature");
+    assert_eq!(error, rudder_auth_core::AuthError::InvalidSignature);
+    assert!(replay.is_empty());
+}
+
+#[test]
+fn a_valid_envelope_nonce_is_single_use() {
+    let envelope = ActorEnvelope::new(
+        actor(),
+        "org-1",
+        "rudder-node",
+        "POST",
+        "/api/agent-actions",
+        "agent.execute",
+        BODY,
+        "request-1",
+        "nonce-3",
+        1_000,
+        1_010,
+    )
+    .expect("unsigned envelope")
+    .sign(SECRET)
+    .expect("signed envelope");
+    let request_actor = actor();
+    let request = context(&request_actor);
+    let mut replay = NonceReplayGuard::new();
+
+    envelope
+        .verify(SECRET, &request, &mut replay)
+        .expect("first use");
+    let error = envelope
+        .verify(SECRET, &request, &mut replay)
+        .expect_err("replay");
+    assert_eq!(error, rudder_auth_core::AuthError::Replay);
+    assert_eq!(replay.len(), 1);
+}
+
+#[test]
+fn expiry_and_not_yet_valid_envelopes_do_not_consume_nonce() {
+    let envelope = ActorEnvelope::new(
+        actor(),
+        "org-1",
+        "rudder-node",
+        "POST",
+        "/api/agent-actions",
+        "agent.execute",
+        BODY,
+        "request-1",
+        "nonce-4",
+        1_000,
+        1_010,
+    )
+    .expect("unsigned envelope")
+    .sign(SECRET)
+    .expect("signed envelope");
+    let request_actor = actor();
+    let mut replay = NonceReplayGuard::new();
+
+    let expired = RequestContext::new(
+        &request_actor,
+        "org-1",
+        "rudder-node",
+        "POST",
+        "/api/agent-actions",
+        "agent.execute",
+        BODY,
+        "request-1",
+        1_010,
+    );
+    assert_eq!(
+        envelope.verify(SECRET, &expired, &mut replay),
+        Err(rudder_auth_core::AuthError::Expired)
+    );
+
+    let early = RequestContext::new(
+        &request_actor,
+        "org-1",
+        "rudder-node",
+        "POST",
+        "/api/agent-actions",
+        "agent.execute",
+        BODY,
+        "request-1",
+        999,
+    );
+    assert_eq!(
+        envelope.verify(SECRET, &early, &mut replay),
+        Err(rudder_auth_core::AuthError::NotYetValid)
+    );
+    assert!(replay.is_empty());
+}
+
+#[test]
+fn body_binding_rejects_substitution_without_consuming_nonce() {
+    let envelope = ActorEnvelope::new(
+        actor(),
+        "org-1",
+        "rudder-node",
+        "POST",
+        "/api/agent-actions",
+        "agent.execute",
+        BODY,
+        "request-1",
+        "nonce-5",
+        1_000,
+        1_010,
+    )
+    .expect("unsigned envelope")
+    .sign(SECRET)
+    .expect("signed envelope");
+    let request_actor = actor();
+    let changed_body = RequestContext::new(
+        &request_actor,
+        "org-1",
+        "rudder-node",
+        "POST",
+        "/api/agent-actions",
+        "agent.execute",
+        b"changed body",
+        "request-1",
+        1_005,
+    );
+    let mut replay = NonceReplayGuard::new();
+
+    assert_eq!(
+        envelope.verify(SECRET, &changed_body, &mut replay),
+        Err(rudder_auth_core::AuthError::BodyHashMismatch)
+    );
+    assert!(replay.is_empty());
+
+    envelope
+        .verify(SECRET, &context(&request_actor), &mut replay)
+        .expect("original body remains valid");
+}
+
+#[test]
+fn cross_organization_actor_and_audience_bindings_are_rejected() {
+    let envelope = ActorEnvelope::new(
+        actor(),
+        "org-1",
+        "rudder-node",
+        "POST",
+        "/api/agent-actions",
+        "agent.execute",
+        BODY,
+        "request-1",
+        "nonce-6",
+        1_000,
+        1_010,
+    )
+    .expect("unsigned envelope")
+    .sign(SECRET)
+    .expect("signed envelope");
+    let request_actor = actor();
+    let mut replay = NonceReplayGuard::new();
+
+    let cross_org = RequestContext::new(
+        &request_actor,
+        "org-2",
+        "rudder-node",
+        "POST",
+        "/api/agent-actions",
+        "agent.execute",
+        BODY,
+        "request-1",
+        1_005,
+    );
+    assert_eq!(
+        envelope.verify(SECRET, &cross_org, &mut replay),
+        Err(rudder_auth_core::AuthError::OrganizationMismatch)
+    );
+
+    let other_actor = ActorIdentity::new("agent", "agent-2").expect("other actor");
+    let actor_mismatch = RequestContext::new(
+        &other_actor,
+        "org-1",
+        "rudder-node",
+        "POST",
+        "/api/agent-actions",
+        "agent.execute",
+        BODY,
+        "request-1",
+        1_005,
+    );
+    assert_eq!(
+        envelope.verify(SECRET, &actor_mismatch, &mut replay),
+        Err(rudder_auth_core::AuthError::ActorMismatch)
+    );
+
+    let audience_mismatch = RequestContext::new(
+        &request_actor,
+        "org-1",
+        "other-node",
+        "POST",
+        "/api/agent-actions",
+        "agent.execute",
+        BODY,
+        "request-1",
+        1_005,
+    );
+    assert_eq!(
+        envelope.verify(SECRET, &audience_mismatch, &mut replay),
+        Err(rudder_auth_core::AuthError::AudienceMismatch)
+    );
+    assert!(replay.is_empty());
+}
+
+#[test]
+fn path_mismatch_and_wrong_secret_are_rejected() {
+    let envelope = ActorEnvelope::new(
+        actor(),
+        "org-1",
+        "rudder-node",
+        "POST",
+        "/api/agent-actions",
+        "agent.execute",
+        BODY,
+        "request-1",
+        "nonce-7",
+        1_000,
+        1_010,
+    )
+    .expect("unsigned envelope")
+    .sign(SECRET)
+    .expect("signed envelope");
+    let request_actor = actor();
+    let wrong_path = RequestContext::new(
+        &request_actor,
+        "org-1",
+        "rudder-node",
+        "POST",
+        "/api/other-action",
+        "agent.execute",
+        BODY,
+        "request-1",
+        1_005,
+    );
+    let mut replay = NonceReplayGuard::new();
+
+    assert_eq!(
+        envelope.verify(SECRET, &wrong_path, &mut replay),
+        Err(rudder_auth_core::AuthError::PathMismatch)
+    );
+    assert_eq!(
+        envelope.verify(b"different-secret", &context(&request_actor), &mut replay),
+        Err(rudder_auth_core::AuthError::InvalidSignature)
+    );
+    assert!(replay.is_empty());
+}
+
+#[test]
+fn malformed_and_unknown_versions_are_rejected() {
+    let mut envelope = ActorEnvelope::new(
+        actor(),
+        "org-1",
+        "rudder-node",
+        "POST",
+        "/api/agent-actions",
+        "agent.execute",
+        BODY,
+        "request-1",
+        "nonce-8",
+        1_000,
+        1_010,
+    )
+    .expect("unsigned envelope")
+    .sign(SECRET)
+    .expect("signed envelope");
+    envelope.protocol_version = 99;
+    let mut replay = NonceReplayGuard::new();
+    assert_eq!(
+        envelope.verify(SECRET, &context(&actor()), &mut replay),
+        Err(rudder_auth_core::AuthError::UnsupportedProtocolVersion {
+            actual: 99,
+            expected: rudder_auth_core::PROTOCOL_VERSION,
+        })
+    );
+
+    assert!(serde_json::from_str::<ActorEnvelope>(
+        r#"{"protocolVersion":1,"actor":{"kind":"agent","id":"agent-1"},"organizationId":"org-1","audience":"rudder-node","method":"POST","path":"/api/agent-actions","action":"agent.execute","bodySha256":"not-a-hash","requestId":"request-1","nonce":"nonce-9","issuedAt":1000,"expiresAt":1010,"signature":"00"}"#
+    )
+    .expect("well-typed but malformed claims")
+    .verify(SECRET, &context(&actor()), &mut replay)
+    .is_err());
+    assert!(serde_json::from_str::<ActorEnvelope>(
+        r#"{"protocolVersion":1,"actor":{"kind":"agent","id":"agent-1"},"organizationId":"org-1","audience":"rudder-node","method":"POST","path":"/api/agent-actions","action":"agent.execute","bodySha256":"0000000000000000000000000000000000000000000000000000000000000000","requestId":"request-1","nonce":"nonce-9","issuedAt":1000,"expiresAt":1010,"signature":"00","secret":"must-not-be-accepted"}"#
+    )
+    .is_err());
+}
+
+#[test]
+fn constructor_rejects_long_lifetime_and_invalid_path() {
+    assert_eq!(
+        ActorEnvelope::new(
+            actor(),
+            "org-1",
+            "rudder-node",
+            "POST",
+            "not-an-http-path",
+            "agent.execute",
+            BODY,
+            "request-1",
+            "nonce-10",
+            1_000,
+            1_010,
+        )
+        .expect_err("path must be absolute"),
+        rudder_auth_core::AuthError::InvalidField { field: "path" }
+    );
+    assert_eq!(
+        ActorEnvelope::new(
+            actor(),
+            "org-1",
+            "rudder-node",
+            "POST",
+            "/api/agent-actions",
+            "agent.execute",
+            BODY,
+            "request-1",
+            "nonce-11",
+            1_000,
+            1_301,
+        )
+        .expect_err("envelopes are short-lived"),
+        rudder_auth_core::AuthError::InvalidTimestamp
+    );
+}

--- a/native/crates/auth-core/tests/protocol.rs
+++ b/native/crates/auth-core/tests/protocol.rs
@@ -11,6 +11,8 @@ fn context<'a>(actor: &'a ActorIdentity) -> RequestContext<'a> {
     RequestContext::new(
         actor,
         "org-1",
+        "session-1",
+        7,
         "rudder-node",
         "POST",
         "/api/agent-actions",
@@ -26,6 +28,8 @@ fn signed_envelope_round_trips_and_verifies() {
     let unsigned = ActorEnvelope::new(
         actor(),
         "org-1",
+        "session-1",
+        7,
         "rudder-node",
         "POST",
         "/api/agent-actions",
@@ -50,7 +54,7 @@ fn signed_envelope_round_trips_and_verifies() {
     assert_eq!(decoded.protocol_version, rudder_auth_core::PROTOCOL_VERSION);
     assert_eq!(
         decoded.signature,
-        "b9159201fa99b11f11b28c7da91b7f44abbdd08ce8a6af0b9f2d7fae168906a6"
+        "5714667f8666a5a88711c93bdc096c93eedc3b449c01aec04e5f954704e80135"
     );
     assert!(!encoded.contains("deterministic-test-secret"));
 }
@@ -60,6 +64,8 @@ fn signature_tampering_is_rejected_without_consuming_nonce() {
     let unsigned = ActorEnvelope::new(
         actor(),
         "org-1",
+        "session-1",
+        7,
         "rudder-node",
         "POST",
         "/api/agent-actions",
@@ -94,6 +100,8 @@ fn a_valid_envelope_nonce_is_single_use() {
     let envelope = ActorEnvelope::new(
         actor(),
         "org-1",
+        "session-1",
+        7,
         "rudder-node",
         "POST",
         "/api/agent-actions",
@@ -126,6 +134,8 @@ fn expiry_and_not_yet_valid_envelopes_do_not_consume_nonce() {
     let envelope = ActorEnvelope::new(
         actor(),
         "org-1",
+        "session-1",
+        7,
         "rudder-node",
         "POST",
         "/api/agent-actions",
@@ -145,6 +155,8 @@ fn expiry_and_not_yet_valid_envelopes_do_not_consume_nonce() {
     let expired = RequestContext::new(
         &request_actor,
         "org-1",
+        "session-1",
+        7,
         "rudder-node",
         "POST",
         "/api/agent-actions",
@@ -161,6 +173,8 @@ fn expiry_and_not_yet_valid_envelopes_do_not_consume_nonce() {
     let early = RequestContext::new(
         &request_actor,
         "org-1",
+        "session-1",
+        7,
         "rudder-node",
         "POST",
         "/api/agent-actions",
@@ -181,6 +195,8 @@ fn body_binding_rejects_substitution_without_consuming_nonce() {
     let envelope = ActorEnvelope::new(
         actor(),
         "org-1",
+        "session-1",
+        7,
         "rudder-node",
         "POST",
         "/api/agent-actions",
@@ -198,6 +214,8 @@ fn body_binding_rejects_substitution_without_consuming_nonce() {
     let changed_body = RequestContext::new(
         &request_actor,
         "org-1",
+        "session-1",
+        7,
         "rudder-node",
         "POST",
         "/api/agent-actions",
@@ -224,6 +242,8 @@ fn cross_organization_actor_and_audience_bindings_are_rejected() {
     let envelope = ActorEnvelope::new(
         actor(),
         "org-1",
+        "session-1",
+        7,
         "rudder-node",
         "POST",
         "/api/agent-actions",
@@ -243,6 +263,8 @@ fn cross_organization_actor_and_audience_bindings_are_rejected() {
     let cross_org = RequestContext::new(
         &request_actor,
         "org-2",
+        "session-1",
+        7,
         "rudder-node",
         "POST",
         "/api/agent-actions",
@@ -260,6 +282,8 @@ fn cross_organization_actor_and_audience_bindings_are_rejected() {
     let actor_mismatch = RequestContext::new(
         &other_actor,
         "org-1",
+        "session-1",
+        7,
         "rudder-node",
         "POST",
         "/api/agent-actions",
@@ -276,6 +300,8 @@ fn cross_organization_actor_and_audience_bindings_are_rejected() {
     let audience_mismatch = RequestContext::new(
         &request_actor,
         "org-1",
+        "session-1",
+        7,
         "other-node",
         "POST",
         "/api/agent-actions",
@@ -296,6 +322,8 @@ fn path_mismatch_and_wrong_secret_are_rejected() {
     let envelope = ActorEnvelope::new(
         actor(),
         "org-1",
+        "session-1",
+        7,
         "rudder-node",
         "POST",
         "/api/agent-actions",
@@ -313,6 +341,8 @@ fn path_mismatch_and_wrong_secret_are_rejected() {
     let wrong_path = RequestContext::new(
         &request_actor,
         "org-1",
+        "session-1",
+        7,
         "rudder-node",
         "POST",
         "/api/other-action",
@@ -339,6 +369,8 @@ fn malformed_and_unknown_versions_are_rejected() {
     let mut envelope = ActorEnvelope::new(
         actor(),
         "org-1",
+        "session-1",
+        7,
         "rudder-node",
         "POST",
         "/api/agent-actions",
@@ -361,15 +393,23 @@ fn malformed_and_unknown_versions_are_rejected() {
             expected: rudder_auth_core::PROTOCOL_VERSION,
         })
     );
+    envelope.protocol_version = 1;
+    assert_eq!(
+        envelope.verify(SECRET, &context(&actor()), &mut replay),
+        Err(rudder_auth_core::AuthError::UnsupportedProtocolVersion {
+            actual: 1,
+            expected: rudder_auth_core::PROTOCOL_VERSION,
+        })
+    );
 
     assert!(serde_json::from_str::<ActorEnvelope>(
-        r#"{"protocolVersion":1,"actor":{"kind":"agent","id":"agent-1"},"organizationId":"org-1","audience":"rudder-node","method":"POST","path":"/api/agent-actions","action":"agent.execute","bodySha256":"not-a-hash","requestId":"request-1","nonce":"nonce-9","issuedAt":1000,"expiresAt":1010,"signature":"00"}"#
+        r#"{"protocolVersion":2,"actor":{"kind":"agent","id":"agent-1"},"organizationId":"org-1","sessionId":"session-1","authEpoch":7,"audience":"rudder-node","method":"POST","path":"/api/agent-actions","action":"agent.execute","bodySha256":"not-a-hash","requestId":"request-1","nonce":"nonce-9","issuedAt":1000,"expiresAt":1010,"signature":"00"}"#
     )
     .expect("well-typed but malformed claims")
     .verify(SECRET, &context(&actor()), &mut replay)
     .is_err());
     assert!(serde_json::from_str::<ActorEnvelope>(
-        r#"{"protocolVersion":1,"actor":{"kind":"agent","id":"agent-1"},"organizationId":"org-1","audience":"rudder-node","method":"POST","path":"/api/agent-actions","action":"agent.execute","bodySha256":"0000000000000000000000000000000000000000000000000000000000000000","requestId":"request-1","nonce":"nonce-9","issuedAt":1000,"expiresAt":1010,"signature":"00","secret":"must-not-be-accepted"}"#
+        r#"{"protocolVersion":2,"actor":{"kind":"agent","id":"agent-1"},"organizationId":"org-1","sessionId":"session-1","authEpoch":7,"audience":"rudder-node","method":"POST","path":"/api/agent-actions","action":"agent.execute","bodySha256":"0000000000000000000000000000000000000000000000000000000000000000","requestId":"request-1","nonce":"nonce-9","issuedAt":1000,"expiresAt":1010,"signature":"00","secret":"must-not-be-accepted"}"#
     )
     .is_err());
 }
@@ -380,6 +420,8 @@ fn constructor_rejects_long_lifetime_and_invalid_path() {
         ActorEnvelope::new(
             actor(),
             "org-1",
+            "session-1",
+            7,
             "rudder-node",
             "POST",
             "not-an-http-path",
@@ -397,6 +439,8 @@ fn constructor_rejects_long_lifetime_and_invalid_path() {
         ActorEnvelope::new(
             actor(),
             "org-1",
+            "session-1",
+            7,
             "rudder-node",
             "POST",
             "/api/agent-actions",
@@ -410,4 +454,134 @@ fn constructor_rejects_long_lifetime_and_invalid_path() {
         .expect_err("envelopes are short-lived"),
         rudder_auth_core::AuthError::InvalidTimestamp
     );
+}
+
+#[test]
+fn authentication_session_and_epoch_are_bound_to_the_envelope() {
+    let envelope = ActorEnvelope::new(
+        actor(),
+        "org-1",
+        "session-1",
+        7,
+        "rudder-node",
+        "POST",
+        "/api/agent-actions",
+        "agent.execute",
+        BODY,
+        "request-session-binding",
+        "nonce-session-binding",
+        1_000,
+        1_010,
+    )
+    .expect("unsigned envelope")
+    .sign(SECRET)
+    .expect("signed envelope");
+    let request_actor = actor();
+    let mut replay = NonceReplayGuard::new();
+
+    let revoked_session = RequestContext::new(
+        &request_actor,
+        "org-1",
+        "session-2",
+        7,
+        "rudder-node",
+        "POST",
+        "/api/agent-actions",
+        "agent.execute",
+        BODY,
+        "request-session-binding",
+        1_005,
+    );
+    assert_eq!(
+        envelope.verify(SECRET, &revoked_session, &mut replay),
+        Err(rudder_auth_core::AuthError::SessionMismatch)
+    );
+
+    let advanced_epoch = RequestContext::new(
+        &request_actor,
+        "org-1",
+        "session-1",
+        8,
+        "rudder-node",
+        "POST",
+        "/api/agent-actions",
+        "agent.execute",
+        BODY,
+        "request-session-binding",
+        1_005,
+    );
+    assert_eq!(
+        envelope.verify(SECRET, &advanced_epoch, &mut replay),
+        Err(rudder_auth_core::AuthError::AuthEpochMismatch)
+    );
+    assert!(replay.is_empty());
+}
+
+#[test]
+fn replay_guard_evicts_expired_entries_and_rejects_active_overflow() {
+    let first = ActorEnvelope::new(
+        actor(),
+        "org-1",
+        "session-1",
+        7,
+        "rudder-node",
+        "POST",
+        "/api/agent-actions",
+        "agent.execute",
+        BODY,
+        "request-1",
+        "nonce-replay-1",
+        1_000,
+        1_010,
+    )
+    .expect("unsigned envelope")
+    .sign(SECRET)
+    .expect("signed envelope");
+    let second = ActorEnvelope::new(
+        actor(),
+        "org-1",
+        "session-1",
+        7,
+        "rudder-node",
+        "POST",
+        "/api/agent-actions",
+        "agent.execute",
+        BODY,
+        "request-1",
+        "nonce-replay-2",
+        1_000,
+        1_020,
+    )
+    .expect("unsigned envelope")
+    .sign(SECRET)
+    .expect("signed envelope");
+    let request_actor = actor();
+    let mut replay = NonceReplayGuard::with_capacity(1).expect("capacity");
+
+    first
+        .verify(SECRET, &context(&request_actor), &mut replay)
+        .expect("first request");
+    let error = second
+        .verify(SECRET, &context(&request_actor), &mut replay)
+        .expect_err("active replay entries must remain bounded");
+    assert_eq!(error, rudder_auth_core::AuthError::ReplayCapacityExceeded);
+    assert_eq!(replay.len(), 1);
+
+    let after_expiry = RequestContext::new(
+        &request_actor,
+        "org-1",
+        "session-1",
+        7,
+        "rudder-node",
+        "POST",
+        "/api/agent-actions",
+        "agent.execute",
+        BODY,
+        "request-1",
+        1_010,
+    );
+    second
+        .verify(SECRET, &after_expiry, &mut replay)
+        .expect("expired entries are evicted before a new claim");
+    assert_eq!(replay.len(), 1);
 }

--- a/native/crates/authority-core/Cargo.toml
+++ b/native/crates/authority-core/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "rudder-authority-core"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+sha2 = "0.10"
+thiserror = "2.0"
+
+[dev-dependencies]
+serde_json = "1.0"

--- a/native/crates/authority-core/src/lib.rs
+++ b/native/crates/authority-core/src/lib.rs
@@ -19,6 +19,11 @@ pub const LEGACY_OWNER: &str = "legacy";
 
 const MAX_IDENTIFIER_BYTES: usize = 256;
 const FENCING_TOKEN_BYTES: usize = 64;
+/// Maximum UTF-8 byte length of a bridge nonce. This retains the existing
+/// bounded text-field limit for protocol compatibility.
+pub const MAX_NONCE_BYTES: usize = MAX_IDENTIFIER_BYTES;
+/// Maximum lifetime of a bridge envelope in the caller's timestamp units.
+pub const MAX_BRIDGE_LIFETIME: u64 = 5 * 60;
 pub const DEFAULT_REPLAY_CAPACITY: usize = 16 * 1024;
 pub const MAX_REPLAY_CAPACITY: usize = 64 * 1024;
 
@@ -69,6 +74,10 @@ pub enum AuthorityError {
     BodyHashMismatch,
     #[error("bridge envelope has expired")]
     Expired,
+    #[error("bridge envelope is not yet valid")]
+    NotYetValid,
+    #[error("bridge envelope lifetime exceeds the maximum")]
+    LifetimeTooLong,
     #[error("bridge nonce has already been used")]
     Replay,
     #[error("bridge replay guard capacity is exhausted")]
@@ -524,6 +533,11 @@ pub struct LegacyBridgeRequestEnvelope {
     pub body_sha256: String,
     pub request_id: String,
     pub nonce: String,
+    /// Added without changing the protocol version. Missing legacy-wire values
+    /// default to zero for parsing compatibility, then fail validation rather
+    /// than being accepted without an issuance time.
+    #[serde(default)]
+    pub issued_at: u64,
     pub expires_at: u64,
 }
 
@@ -537,6 +551,7 @@ impl LegacyBridgeRequestEnvelope {
         body: &[u8],
         request_id: impl Into<String>,
         nonce: impl Into<String>,
+        issued_at: u64,
         expires_at: u64,
     ) -> Result<Self, AuthorityError> {
         authority.validate()?;
@@ -551,10 +566,8 @@ impl LegacyBridgeRequestEnvelope {
         validate_text(&organization_id, "organizationId")?;
         validate_text(&action, "action")?;
         validate_text(&request_id, "requestId")?;
-        validate_text(&nonce, "nonce")?;
-        if expires_at == 0 {
-            return Err(AuthorityError::InvalidField { field: "expiresAt" });
-        }
+        validate_nonce(&nonce)?;
+        validate_bridge_lifetime(issued_at, expires_at)?;
         Ok(Self {
             schema: LEGACY_BRIDGE_SCHEMA.to_owned(),
             protocol_version: AUTHORITY_PROTOCOL_VERSION,
@@ -568,6 +581,7 @@ impl LegacyBridgeRequestEnvelope {
             body_sha256: body_sha256(body),
             request_id,
             nonce,
+            issued_at,
             expires_at,
         })
     }
@@ -595,6 +609,7 @@ impl LegacyBridgeRequestEnvelope {
                 expected: AUTHORITY_PROTOCOL_VERSION,
             });
         }
+        validate_bridge_lifetime(self.issued_at, self.expires_at)?;
         if self.component != authority.component {
             return Err(AuthorityError::ComponentMismatch);
         }
@@ -632,15 +647,16 @@ impl LegacyBridgeRequestEnvelope {
         if self.request_id != request_id {
             return Err(AuthorityError::RequestIdMismatch);
         }
-        if self.expires_at == 0 || now >= self.expires_at {
+        if now < self.issued_at {
+            return Err(AuthorityError::NotYetValid);
+        }
+        if now >= self.expires_at {
             return Err(AuthorityError::Expired);
         }
         if self.body_sha256 != body_sha256(body) {
             return Err(AuthorityError::BodyHashMismatch);
         }
-        if self.nonce.is_empty() {
-            return Err(AuthorityError::InvalidField { field: "nonce" });
-        }
+        validate_nonce(&self.nonce)?;
         replay.claim(&self.nonce, self.expires_at, now)
     }
 }
@@ -684,6 +700,7 @@ impl NonceReplayGuard {
     }
 
     fn claim(&mut self, nonce: &str, expires_at: u64, now: u64) -> Result<(), AuthorityError> {
+        validate_nonce(nonce)?;
         self.used.retain(|_, expiry| *expiry > now);
         if expires_at <= now {
             return Err(AuthorityError::Expired);
@@ -742,13 +759,38 @@ fn validate_owner(owner: &OwnerId) -> Result<(), AuthorityError> {
 }
 
 fn validate_text(value: &str, field: &'static str) -> Result<(), AuthorityError> {
+    validate_text_bounded(value, field, MAX_IDENTIFIER_BYTES)
+}
+
+fn validate_nonce(nonce: &str) -> Result<(), AuthorityError> {
+    validate_text_bounded(nonce, "nonce", MAX_NONCE_BYTES)
+}
+
+fn validate_text_bounded(
+    value: &str,
+    field: &'static str,
+    max_bytes: usize,
+) -> Result<(), AuthorityError> {
     if value.is_empty()
-        || value.len() > MAX_IDENTIFIER_BYTES
+        || value.len() > max_bytes
         || value
             .bytes()
             .any(|byte| byte == 0 || byte.is_ascii_control())
     {
         return Err(AuthorityError::InvalidField { field });
+    }
+    Ok(())
+}
+
+fn validate_bridge_lifetime(issued_at: u64, expires_at: u64) -> Result<(), AuthorityError> {
+    if issued_at == 0 {
+        return Err(AuthorityError::InvalidField { field: "issuedAt" });
+    }
+    if expires_at == 0 || expires_at <= issued_at {
+        return Err(AuthorityError::InvalidField { field: "expiresAt" });
+    }
+    if expires_at - issued_at > MAX_BRIDGE_LIFETIME {
+        return Err(AuthorityError::LifetimeTooLong);
     }
     Ok(())
 }

--- a/native/crates/authority-core/src/lib.rs
+++ b/native/crates/authority-core/src/lib.rs
@@ -1,0 +1,734 @@
+//! Fail-closed authority and private legacy-bridge primitives for Rust cutover.
+//!
+//! This crate models the transaction boundary without opening a listener or
+//! owning product routes. A caller supplies its route inventory and uses the
+//! returned decision to dispatch to the one current writer. Epochs and fencing
+//! tokens make an old writer unusable after a handoff; bridge envelopes bind
+//! every request value that crosses to a private legacy process.
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::collections::{BTreeMap, BTreeSet};
+use thiserror::Error;
+
+pub const AUTHORITY_PROTOCOL_VERSION: u16 = 1;
+pub const AUTHORITY_SCHEMA: &str = "rudder.migration.authority.v1";
+pub const LEGACY_BRIDGE_SCHEMA: &str = "rudder.migration.legacy-bridge.v1";
+pub const RUST_OWNER: &str = "rust";
+pub const LEGACY_OWNER: &str = "legacy";
+
+const MAX_IDENTIFIER_BYTES: usize = 256;
+const FENCING_TOKEN_BYTES: usize = 64;
+
+/// Errors returned by authority construction, handoff, and bridge validation.
+#[derive(Clone, Debug, Error, PartialEq, Eq)]
+pub enum AuthorityError {
+    #[error("invalid {field}")]
+    InvalidField { field: &'static str },
+    #[error("unsupported authority protocol version {actual}; expected {expected}")]
+    UnsupportedProtocolVersion { actual: u16, expected: u16 },
+    #[error("unknown owner {owner}")]
+    UnknownOwner { owner: OwnerId },
+    #[error("unknown component {component}")]
+    UnknownComponent { component: String },
+    #[error("dual ownership at {scope}")]
+    DualOwnership { scope: String },
+    #[error("route {route} is bound to a different owner")]
+    RouteOwnerMismatch { route: String },
+    #[error("component {component} is bound to a different owner")]
+    ComponentOwnerMismatch { component: String },
+    #[error("route {route} is not registered")]
+    UnknownRoute { route: String },
+    #[error("stale epoch {provided}; current epoch is {current}")]
+    StaleEpoch { provided: u64, current: u64 },
+    #[error("future epoch {provided}; current epoch is {current}")]
+    FutureEpoch { provided: u64, current: u64 },
+    #[error("fencing token does not match the current authority")]
+    FencingTokenMismatch,
+    #[error("handoff must change the owner")]
+    SameOwnerHandoff,
+    #[error("authority epoch cannot increase further")]
+    EpochOverflow,
+    #[error("bridge envelope is not for the legacy owner")]
+    WrongAuthorityOwner,
+    #[error("bridge envelope component does not match the authority")]
+    ComponentMismatch,
+    #[error("bridge envelope component version does not match the authority")]
+    ComponentVersionMismatch,
+    #[error("bridge actor does not match the authenticated actor")]
+    ActorMismatch,
+    #[error("bridge organization does not match the request organization")]
+    OrganizationMismatch,
+    #[error("bridge action does not match the requested action")]
+    ActionMismatch,
+    #[error("bridge request id does not match the request")]
+    RequestIdMismatch,
+    #[error("bridge body hash does not match the request body")]
+    BodyHashMismatch,
+    #[error("bridge envelope has expired")]
+    Expired,
+    #[error("bridge nonce has already been used")]
+    Replay,
+}
+
+/// An owner identity is deliberately opaque; only the two migration owners
+/// are dispatchable by this crate.
+#[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(transparent)]
+pub struct OwnerId(String);
+
+impl OwnerId {
+    pub fn new(value: impl Into<String>) -> Result<Self, AuthorityError> {
+        let value = value.into();
+        validate_text(&value, "owner")?;
+        Ok(Self(value))
+    }
+
+    pub fn rust() -> Self {
+        Self(RUST_OWNER.to_owned())
+    }
+
+    pub fn legacy() -> Self {
+        Self(LEGACY_OWNER.to_owned())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    fn is_dispatchable(&self) -> bool {
+        matches!(self.as_str(), RUST_OWNER | LEGACY_OWNER)
+    }
+}
+
+impl AsRef<str> for OwnerId {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl std::fmt::Display for OwnerId {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+/// A component authority is the persisted one-writer record for a component.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct ComponentAuthority {
+    pub protocol_version: u16,
+    pub component: String,
+    pub component_version: String,
+    pub owner: OwnerId,
+    pub epoch: u64,
+    pub fencing_token: String,
+}
+
+impl ComponentAuthority {
+    /// Build the first authority record for a component at epoch one.
+    pub fn new(
+        component: impl Into<String>,
+        component_version: impl Into<String>,
+        owner: OwnerId,
+    ) -> Result<Self, AuthorityError> {
+        Self::at_epoch(component, component_version, owner, 1)
+    }
+
+    /// Build an authority at an explicit epoch for loading persisted state.
+    pub fn at_epoch(
+        component: impl Into<String>,
+        component_version: impl Into<String>,
+        owner: OwnerId,
+        epoch: u64,
+    ) -> Result<Self, AuthorityError> {
+        let component = component.into();
+        let component_version = component_version.into();
+        validate_text(&component, "component")?;
+        validate_text(&component_version, "componentVersion")?;
+        validate_owner(&owner)?;
+        if epoch == 0 {
+            return Err(AuthorityError::InvalidField { field: "epoch" });
+        }
+        let fencing_token = derive_fencing_token(&component, &component_version, &owner, epoch);
+        Ok(Self {
+            protocol_version: AUTHORITY_PROTOCOL_VERSION,
+            component,
+            component_version,
+            owner,
+            epoch,
+            fencing_token,
+        })
+    }
+
+    fn validate(&self) -> Result<(), AuthorityError> {
+        if self.protocol_version != AUTHORITY_PROTOCOL_VERSION {
+            return Err(AuthorityError::UnsupportedProtocolVersion {
+                actual: self.protocol_version,
+                expected: AUTHORITY_PROTOCOL_VERSION,
+            });
+        }
+        validate_text(&self.component, "component")?;
+        validate_text(&self.component_version, "componentVersion")?;
+        validate_owner(&self.owner)?;
+        if self.epoch == 0 {
+            return Err(AuthorityError::InvalidField { field: "epoch" });
+        }
+        if self.fencing_token.len() != FENCING_TOKEN_BYTES
+            || !self
+                .fencing_token
+                .bytes()
+                .all(|byte| byte.is_ascii_hexdigit())
+        {
+            return Err(AuthorityError::InvalidField {
+                field: "fencingToken",
+            });
+        }
+        Ok(())
+    }
+}
+
+/// One route's declared owner. Duplicate route claims are rejected as dual
+/// ownership rather than choosing an arbitrary declaration.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct RouteClaim {
+    pub route: String,
+    pub component: String,
+    pub owner: OwnerId,
+}
+
+impl RouteClaim {
+    pub fn new(
+        route: impl Into<String>,
+        component: impl Into<String>,
+        owner: OwnerId,
+    ) -> Result<Self, AuthorityError> {
+        let route = route.into();
+        let component = component.into();
+        validate_text(&route, "route")?;
+        validate_text(&component, "component")?;
+        validate_owner(&owner)?;
+        Ok(Self {
+            route,
+            component,
+            owner,
+        })
+    }
+
+    fn validate(&self) -> Result<(), AuthorityError> {
+        validate_text(&self.route, "route")?;
+        validate_text(&self.component, "component")?;
+        validate_owner(&self.owner)
+    }
+}
+
+/// The route result is a decision only. It does not bind a socket or perform
+/// a dispatch, so callers cannot accidentally create a second public listener.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase", tag = "kind")]
+pub enum RouteDecision {
+    Rust { authority: ComponentAuthority },
+    PrivateLegacyBridge { authority: ComponentAuthority },
+    Reject { reason: RouteRejection },
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum RouteRejection {
+    UnknownRoute { route: String },
+    UnknownComponent { component: String },
+    UnknownOwner { owner: OwnerId },
+    DualOwnership { scope: String },
+    OwnerMismatch { route: String },
+    InvalidAuthority { component: String },
+    UnsupportedProtocolVersion { actual: u16 },
+}
+
+/// A serializable authority inventory and its route ownership declarations.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct MigrationAuthority {
+    pub protocol_version: u16,
+    pub authorities: Vec<ComponentAuthority>,
+    pub routes: Vec<RouteClaim>,
+}
+
+impl MigrationAuthority {
+    pub fn from_parts(authorities: Vec<ComponentAuthority>, routes: Vec<RouteClaim>) -> Self {
+        Self {
+            protocol_version: AUTHORITY_PROTOCOL_VERSION,
+            authorities,
+            routes,
+        }
+    }
+
+    pub fn validate(&self) -> Result<(), AuthorityError> {
+        if self.protocol_version != AUTHORITY_PROTOCOL_VERSION {
+            return Err(AuthorityError::UnsupportedProtocolVersion {
+                actual: self.protocol_version,
+                expected: AUTHORITY_PROTOCOL_VERSION,
+            });
+        }
+
+        let mut components = BTreeMap::new();
+        for authority in &self.authorities {
+            authority.validate()?;
+            if !authority.owner.is_dispatchable() {
+                return Err(AuthorityError::UnknownOwner {
+                    owner: authority.owner.clone(),
+                });
+            }
+            if components
+                .insert(authority.component.clone(), authority)
+                .is_some()
+            {
+                return Err(AuthorityError::DualOwnership {
+                    scope: format!("component:{}", authority.component),
+                });
+            }
+        }
+
+        let mut routes = BTreeSet::new();
+        for claim in &self.routes {
+            claim.validate()?;
+            if !routes.insert(claim.route.clone()) {
+                return Err(AuthorityError::DualOwnership {
+                    scope: format!("route:{}", claim.route),
+                });
+            }
+            if !claim.owner.is_dispatchable() {
+                return Err(AuthorityError::UnknownOwner {
+                    owner: claim.owner.clone(),
+                });
+            }
+            let Some(authority) = components.get(&claim.component) else {
+                return Err(AuthorityError::UnknownComponent {
+                    component: claim.component.clone(),
+                });
+            };
+            if authority.owner != claim.owner {
+                return Err(AuthorityError::RouteOwnerMismatch {
+                    route: claim.route.clone(),
+                });
+            }
+        }
+        Ok(())
+    }
+
+    /// Return a route decision, rejecting the entire malformed inventory.
+    pub fn route_decision(&self, route: &str) -> RouteDecision {
+        if let Err(error) = self.validate() {
+            return RouteDecision::Reject {
+                reason: route_rejection(error),
+            };
+        }
+        let Some(claim) = self.routes.iter().find(|claim| claim.route == route) else {
+            return RouteDecision::Reject {
+                reason: RouteRejection::UnknownRoute {
+                    route: route.to_owned(),
+                },
+            };
+        };
+        let Some(authority) = self
+            .authorities
+            .iter()
+            .find(|authority| authority.component == claim.component)
+        else {
+            return RouteDecision::Reject {
+                reason: RouteRejection::UnknownComponent {
+                    component: claim.component.clone(),
+                },
+            };
+        };
+        match authority.owner.as_str() {
+            RUST_OWNER => RouteDecision::Rust {
+                authority: authority.clone(),
+            },
+            LEGACY_OWNER => RouteDecision::PrivateLegacyBridge {
+                authority: authority.clone(),
+            },
+            _ => RouteDecision::Reject {
+                reason: RouteRejection::UnknownOwner {
+                    owner: authority.owner.clone(),
+                },
+            },
+        }
+    }
+
+    pub fn current_authority(&self, component: &str) -> Option<&ComponentAuthority> {
+        let mut matches = self
+            .authorities
+            .iter()
+            .filter(|authority| authority.component == component);
+        let authority = matches.next()?;
+        if matches.next().is_some() {
+            None
+        } else {
+            Some(authority)
+        }
+    }
+
+    /// Atomically advance one component's epoch and update every route bound
+    /// to it. Validation happens on a cloned candidate before it replaces the
+    /// current state, so a rejected stale writer cannot partially cut over.
+    pub fn handoff(
+        &mut self,
+        request: HandoffRequest,
+    ) -> Result<ComponentAuthority, AuthorityError> {
+        self.validate()?;
+        validate_text(&request.component, "component")?;
+        validate_text(&request.to_component_version, "componentVersion")?;
+        validate_owner(&request.from_owner)?;
+        validate_owner(&request.to_owner)?;
+        if !request.to_owner.is_dispatchable() {
+            return Err(AuthorityError::UnknownOwner {
+                owner: request.to_owner,
+            });
+        }
+
+        let index = self
+            .authorities
+            .iter()
+            .position(|authority| authority.component == request.component)
+            .ok_or_else(|| AuthorityError::UnknownComponent {
+                component: request.component.clone(),
+            })?;
+        let current = &self.authorities[index];
+        if request.from_epoch < current.epoch {
+            return Err(AuthorityError::StaleEpoch {
+                provided: request.from_epoch,
+                current: current.epoch,
+            });
+        }
+        if request.from_epoch > current.epoch {
+            return Err(AuthorityError::FutureEpoch {
+                provided: request.from_epoch,
+                current: current.epoch,
+            });
+        }
+        if request.from_owner != current.owner {
+            return Err(AuthorityError::ComponentOwnerMismatch {
+                component: request.component,
+            });
+        }
+        if request.from_fencing_token != current.fencing_token {
+            return Err(AuthorityError::FencingTokenMismatch);
+        }
+        if request.to_owner == current.owner {
+            return Err(AuthorityError::SameOwnerHandoff);
+        }
+        let next_epoch = current
+            .epoch
+            .checked_add(1)
+            .ok_or(AuthorityError::EpochOverflow)?;
+        let next = ComponentAuthority::at_epoch(
+            current.component.clone(),
+            request.to_component_version,
+            request.to_owner,
+            next_epoch,
+        )?;
+
+        let mut candidate = self.clone();
+        candidate.authorities[index] = next.clone();
+        for claim in &mut candidate.routes {
+            if claim.component == current.component {
+                if claim.owner != current.owner {
+                    return Err(AuthorityError::DualOwnership {
+                        scope: format!("route:{}", claim.route),
+                    });
+                }
+                claim.owner = next.owner.clone();
+            }
+        }
+        candidate.validate()?;
+        *self = candidate;
+        Ok(next)
+    }
+}
+
+/// A request to replace the current writer for one component.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct HandoffRequest {
+    pub component: String,
+    pub from_owner: OwnerId,
+    pub from_epoch: u64,
+    pub from_fencing_token: String,
+    pub to_owner: OwnerId,
+    pub to_component_version: String,
+}
+
+impl HandoffRequest {
+    pub fn new(
+        component: impl Into<String>,
+        from_owner: OwnerId,
+        from_epoch: u64,
+        from_fencing_token: impl Into<String>,
+        to_owner: OwnerId,
+        to_component_version: impl Into<String>,
+    ) -> Self {
+        Self {
+            component: component.into(),
+            from_owner,
+            from_epoch,
+            from_fencing_token: from_fencing_token.into(),
+            to_owner,
+            to_component_version: to_component_version.into(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct ActorIdentity {
+    pub kind: String,
+    pub id: String,
+}
+
+impl ActorIdentity {
+    pub fn new(kind: impl Into<String>, id: impl Into<String>) -> Result<Self, AuthorityError> {
+        let kind = kind.into();
+        let id = id.into();
+        validate_text(&kind, "actorKind")?;
+        validate_text(&id, "actorId")?;
+        Ok(Self { kind, id })
+    }
+
+    fn validate(&self) -> Result<(), AuthorityError> {
+        validate_text(&self.kind, "actorKind")?;
+        validate_text(&self.id, "actorId")
+    }
+}
+
+/// A private legacy request envelope. It contains no credential; its fence is
+/// only useful when compared with the current authority record.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct LegacyBridgeRequestEnvelope {
+    pub schema: String,
+    pub protocol_version: u16,
+    pub component: String,
+    pub component_version: String,
+    pub authority_epoch: u64,
+    pub fencing_token: String,
+    pub actor: ActorIdentity,
+    pub organization_id: String,
+    pub action: String,
+    pub body_sha256: String,
+    pub request_id: String,
+    pub nonce: String,
+    pub expires_at: u64,
+}
+
+impl LegacyBridgeRequestEnvelope {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        authority: &ComponentAuthority,
+        actor: ActorIdentity,
+        organization_id: impl Into<String>,
+        action: impl Into<String>,
+        body: &[u8],
+        request_id: impl Into<String>,
+        nonce: impl Into<String>,
+        expires_at: u64,
+    ) -> Result<Self, AuthorityError> {
+        authority.validate()?;
+        if authority.owner != OwnerId::legacy() {
+            return Err(AuthorityError::WrongAuthorityOwner);
+        }
+        actor.validate()?;
+        let organization_id = organization_id.into();
+        let action = action.into();
+        let request_id = request_id.into();
+        let nonce = nonce.into();
+        validate_text(&organization_id, "organizationId")?;
+        validate_text(&action, "action")?;
+        validate_text(&request_id, "requestId")?;
+        validate_text(&nonce, "nonce")?;
+        if expires_at == 0 {
+            return Err(AuthorityError::InvalidField { field: "expiresAt" });
+        }
+        Ok(Self {
+            schema: LEGACY_BRIDGE_SCHEMA.to_owned(),
+            protocol_version: AUTHORITY_PROTOCOL_VERSION,
+            component: authority.component.clone(),
+            component_version: authority.component_version.clone(),
+            authority_epoch: authority.epoch,
+            fencing_token: authority.fencing_token.clone(),
+            actor,
+            organization_id,
+            action,
+            body_sha256: body_sha256(body),
+            request_id,
+            nonce,
+            expires_at,
+        })
+    }
+
+    /// Validate all request bindings before atomically consuming the nonce.
+    #[allow(clippy::too_many_arguments)]
+    pub fn validate(
+        &self,
+        authority: &ComponentAuthority,
+        actor: &ActorIdentity,
+        organization_id: &str,
+        action: &str,
+        body: &[u8],
+        request_id: &str,
+        now: u64,
+        replay: &mut NonceReplayGuard,
+    ) -> Result<(), AuthorityError> {
+        authority.validate()?;
+        if self.schema != LEGACY_BRIDGE_SCHEMA {
+            return Err(AuthorityError::InvalidField { field: "schema" });
+        }
+        if self.protocol_version != AUTHORITY_PROTOCOL_VERSION {
+            return Err(AuthorityError::UnsupportedProtocolVersion {
+                actual: self.protocol_version,
+                expected: AUTHORITY_PROTOCOL_VERSION,
+            });
+        }
+        if self.component != authority.component {
+            return Err(AuthorityError::ComponentMismatch);
+        }
+        if self.authority_epoch < authority.epoch {
+            return Err(AuthorityError::StaleEpoch {
+                provided: self.authority_epoch,
+                current: authority.epoch,
+            });
+        }
+        if self.authority_epoch > authority.epoch {
+            return Err(AuthorityError::FutureEpoch {
+                provided: self.authority_epoch,
+                current: authority.epoch,
+            });
+        }
+        if self.fencing_token != authority.fencing_token {
+            return Err(AuthorityError::FencingTokenMismatch);
+        }
+        if authority.owner != OwnerId::legacy() {
+            return Err(AuthorityError::WrongAuthorityOwner);
+        }
+        if self.component_version != authority.component_version {
+            return Err(AuthorityError::ComponentVersionMismatch);
+        }
+        actor.validate()?;
+        if &self.actor != actor {
+            return Err(AuthorityError::ActorMismatch);
+        }
+        if self.organization_id != organization_id {
+            return Err(AuthorityError::OrganizationMismatch);
+        }
+        if self.action != action {
+            return Err(AuthorityError::ActionMismatch);
+        }
+        if self.request_id != request_id {
+            return Err(AuthorityError::RequestIdMismatch);
+        }
+        if self.expires_at == 0 || now >= self.expires_at {
+            return Err(AuthorityError::Expired);
+        }
+        if self.body_sha256 != body_sha256(body) {
+            return Err(AuthorityError::BodyHashMismatch);
+        }
+        if self.nonce.is_empty() {
+            return Err(AuthorityError::InvalidField { field: "nonce" });
+        }
+        replay.claim(&self.nonce)
+    }
+}
+
+/// Process-local single-use nonce storage for bridge envelopes. A production
+/// bridge must provide an equivalent atomic durable/peer-local store; this
+/// crate intentionally does not open that private transport.
+#[derive(Clone, Debug, Default)]
+pub struct NonceReplayGuard {
+    used: BTreeSet<String>,
+}
+
+impl NonceReplayGuard {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn len(&self) -> usize {
+        self.used.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.used.is_empty()
+    }
+
+    fn claim(&mut self, nonce: &str) -> Result<(), AuthorityError> {
+        if !self.used.insert(nonce.to_owned()) {
+            return Err(AuthorityError::Replay);
+        }
+        Ok(())
+    }
+}
+
+pub fn body_sha256(body: &[u8]) -> String {
+    let mut hash = Sha256::new();
+    hash.update(body);
+    format!("{:x}", hash.finalize())
+}
+
+pub fn hash_body(body: &[u8]) -> String {
+    body_sha256(body)
+}
+
+fn derive_fencing_token(
+    component: &str,
+    component_version: &str,
+    owner: &OwnerId,
+    epoch: u64,
+) -> String {
+    let mut hash = Sha256::new();
+    hash.update(AUTHORITY_SCHEMA.as_bytes());
+    hash.update([0]);
+    hash.update(component.as_bytes());
+    hash.update([0]);
+    hash.update(component_version.as_bytes());
+    hash.update([0]);
+    hash.update(owner.as_str().as_bytes());
+    hash.update([0]);
+    hash.update(epoch.to_be_bytes());
+    format!("{:x}", hash.finalize())
+}
+
+fn validate_owner(owner: &OwnerId) -> Result<(), AuthorityError> {
+    validate_text(owner.as_str(), "owner")
+}
+
+fn validate_text(value: &str, field: &'static str) -> Result<(), AuthorityError> {
+    if value.is_empty()
+        || value.len() > MAX_IDENTIFIER_BYTES
+        || value
+            .bytes()
+            .any(|byte| byte == 0 || byte.is_ascii_control())
+    {
+        return Err(AuthorityError::InvalidField { field });
+    }
+    Ok(())
+}
+
+fn route_rejection(error: AuthorityError) -> RouteRejection {
+    match error {
+        AuthorityError::UnsupportedProtocolVersion { actual, .. } => {
+            RouteRejection::UnsupportedProtocolVersion { actual }
+        }
+        AuthorityError::UnknownOwner { owner } => RouteRejection::UnknownOwner { owner },
+        AuthorityError::UnknownComponent { component } => {
+            RouteRejection::UnknownComponent { component }
+        }
+        AuthorityError::DualOwnership { scope } => RouteRejection::DualOwnership { scope },
+        AuthorityError::RouteOwnerMismatch { route } => RouteRejection::OwnerMismatch { route },
+        AuthorityError::ComponentOwnerMismatch { component } => {
+            RouteRejection::InvalidAuthority { component }
+        }
+        _ => RouteRejection::InvalidAuthority {
+            component: "registry".to_owned(),
+        },
+    }
+}

--- a/native/crates/authority-core/src/lib.rs
+++ b/native/crates/authority-core/src/lib.rs
@@ -19,6 +19,8 @@ pub const LEGACY_OWNER: &str = "legacy";
 
 const MAX_IDENTIFIER_BYTES: usize = 256;
 const FENCING_TOKEN_BYTES: usize = 64;
+pub const DEFAULT_REPLAY_CAPACITY: usize = 16 * 1024;
+pub const MAX_REPLAY_CAPACITY: usize = 64 * 1024;
 
 /// Errors returned by authority construction, handoff, and bridge validation.
 #[derive(Clone, Debug, Error, PartialEq, Eq)]
@@ -69,6 +71,10 @@ pub enum AuthorityError {
     Expired,
     #[error("bridge nonce has already been used")]
     Replay,
+    #[error("bridge replay guard capacity is exhausted")]
+    ReplayCapacityExceeded,
+    #[error("replay guard capacity must be between one and {max} entries")]
+    InvalidReplayCapacity { max: usize },
 }
 
 /// An owner identity is deliberately opaque; only the two migration owners
@@ -635,21 +641,38 @@ impl LegacyBridgeRequestEnvelope {
         if self.nonce.is_empty() {
             return Err(AuthorityError::InvalidField { field: "nonce" });
         }
-        replay.claim(&self.nonce)
+        replay.claim(&self.nonce, self.expires_at, now)
     }
 }
 
 /// Process-local single-use nonce storage for bridge envelopes. A production
 /// bridge must provide an equivalent atomic durable/peer-local store; this
 /// crate intentionally does not open that private transport.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct NonceReplayGuard {
-    used: BTreeSet<String>,
+    used: BTreeMap<String, u64>,
+    capacity: usize,
 }
 
 impl NonceReplayGuard {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    pub fn with_capacity(capacity: usize) -> Result<Self, AuthorityError> {
+        if capacity == 0 || capacity > MAX_REPLAY_CAPACITY {
+            return Err(AuthorityError::InvalidReplayCapacity {
+                max: MAX_REPLAY_CAPACITY,
+            });
+        }
+        Ok(Self {
+            used: BTreeMap::new(),
+            capacity,
+        })
+    }
+
+    pub fn capacity(&self) -> usize {
+        self.capacity
     }
 
     pub fn len(&self) -> usize {
@@ -660,11 +683,28 @@ impl NonceReplayGuard {
         self.used.is_empty()
     }
 
-    fn claim(&mut self, nonce: &str) -> Result<(), AuthorityError> {
-        if !self.used.insert(nonce.to_owned()) {
+    fn claim(&mut self, nonce: &str, expires_at: u64, now: u64) -> Result<(), AuthorityError> {
+        self.used.retain(|_, expiry| *expiry > now);
+        if expires_at <= now {
+            return Err(AuthorityError::Expired);
+        }
+        if self.used.contains_key(nonce) {
             return Err(AuthorityError::Replay);
         }
+        if self.used.len() >= self.capacity {
+            return Err(AuthorityError::ReplayCapacityExceeded);
+        }
+        self.used.insert(nonce.to_owned(), expires_at);
         Ok(())
+    }
+}
+
+impl Default for NonceReplayGuard {
+    fn default() -> Self {
+        Self {
+            used: BTreeMap::new(),
+            capacity: DEFAULT_REPLAY_CAPACITY,
+        }
     }
 }
 

--- a/native/crates/authority-core/src/lib.rs
+++ b/native/crates/authority-core/src/lib.rs
@@ -13,7 +13,8 @@ use thiserror::Error;
 
 pub const AUTHORITY_PROTOCOL_VERSION: u16 = 1;
 pub const AUTHORITY_SCHEMA: &str = "rudder.migration.authority.v1";
-pub const LEGACY_BRIDGE_SCHEMA: &str = "rudder.migration.legacy-bridge.v1";
+pub const LEGACY_BRIDGE_PROTOCOL_VERSION: u16 = 2;
+pub const LEGACY_BRIDGE_SCHEMA: &str = "rudder.migration.legacy-bridge.v2";
 pub const RUST_OWNER: &str = "rust";
 pub const LEGACY_OWNER: &str = "legacy";
 
@@ -533,9 +534,9 @@ pub struct LegacyBridgeRequestEnvelope {
     pub body_sha256: String,
     pub request_id: String,
     pub nonce: String,
-    /// Added without changing the protocol version. Missing legacy-wire values
-    /// default to zero for parsing compatibility, then fail validation rather
-    /// than being accepted without an issuance time.
+    /// Missing values default to zero so pre-v2 payloads can be decoded and
+    /// reported as unsupported; validation never accepts them without an
+    /// issuance time.
     #[serde(default)]
     pub issued_at: u64,
     pub expires_at: u64,
@@ -570,7 +571,7 @@ impl LegacyBridgeRequestEnvelope {
         validate_bridge_lifetime(issued_at, expires_at)?;
         Ok(Self {
             schema: LEGACY_BRIDGE_SCHEMA.to_owned(),
-            protocol_version: AUTHORITY_PROTOCOL_VERSION,
+            protocol_version: LEGACY_BRIDGE_PROTOCOL_VERSION,
             component: authority.component.clone(),
             component_version: authority.component_version.clone(),
             authority_epoch: authority.epoch,
@@ -600,14 +601,14 @@ impl LegacyBridgeRequestEnvelope {
         replay: &mut NonceReplayGuard,
     ) -> Result<(), AuthorityError> {
         authority.validate()?;
-        if self.schema != LEGACY_BRIDGE_SCHEMA {
-            return Err(AuthorityError::InvalidField { field: "schema" });
-        }
-        if self.protocol_version != AUTHORITY_PROTOCOL_VERSION {
+        if self.protocol_version != LEGACY_BRIDGE_PROTOCOL_VERSION {
             return Err(AuthorityError::UnsupportedProtocolVersion {
                 actual: self.protocol_version,
-                expected: AUTHORITY_PROTOCOL_VERSION,
+                expected: LEGACY_BRIDGE_PROTOCOL_VERSION,
             });
+        }
+        if self.schema != LEGACY_BRIDGE_SCHEMA {
+            return Err(AuthorityError::InvalidField { field: "schema" });
         }
         validate_bridge_lifetime(self.issued_at, self.expires_at)?;
         if self.component != authority.component {

--- a/native/crates/authority-core/tests/protocol.rs
+++ b/native/crates/authority-core/tests/protocol.rs
@@ -1,0 +1,318 @@
+use rudder_authority_core::{
+    AUTHORITY_PROTOCOL_VERSION, ActorIdentity, AuthorityError, ComponentAuthority, HandoffRequest,
+    LegacyBridgeRequestEnvelope, MigrationAuthority, NonceReplayGuard, OwnerId, RouteClaim,
+    RouteDecision, RouteRejection,
+};
+
+fn legacy_authority() -> ComponentAuthority {
+    ComponentAuthority::new("issues", "node-0.7.20", OwnerId::legacy()).expect("legacy authority")
+}
+
+fn legacy_registry() -> (MigrationAuthority, ComponentAuthority) {
+    let authority = legacy_authority();
+    let route =
+        RouteClaim::new("/api/issues", "issues", authority.owner.clone()).expect("route claim");
+    (
+        MigrationAuthority::from_parts(vec![authority.clone()], vec![route]),
+        authority,
+    )
+}
+
+fn actor() -> ActorIdentity {
+    ActorIdentity::new("user", "operator-1").expect("actor")
+}
+
+#[test]
+fn authority_and_bridge_envelope_round_trip_with_versioned_fields() {
+    let authority = legacy_authority();
+    let envelope = LegacyBridgeRequestEnvelope::new(
+        &authority,
+        actor(),
+        "org-1",
+        "issue.read",
+        br#"{"issueId":"issue-1"}"#,
+        "request-1",
+        "nonce-1",
+        2_000,
+    )
+    .expect("bridge envelope");
+
+    let encoded = serde_json::to_value(&envelope).expect("serialize envelope");
+    assert_eq!(encoded["protocolVersion"], AUTHORITY_PROTOCOL_VERSION);
+    assert_eq!(encoded["authorityEpoch"], authority.epoch);
+    assert_eq!(encoded["bodySha256"].as_str().map(str::len), Some(64));
+    assert_eq!(encoded["organizationId"], "org-1");
+
+    let decoded: LegacyBridgeRequestEnvelope =
+        serde_json::from_value(encoded).expect("deserialize envelope");
+    assert_eq!(decoded, envelope);
+}
+
+#[test]
+fn route_decision_rejects_unknown_owner_instead_of_falling_back() {
+    let authority = legacy_authority();
+    let unknown_owner = OwnerId::new("mystery-runtime").expect("unknown owner identity");
+    let route =
+        RouteClaim::new("/api/issues", "issues", unknown_owner.clone()).expect("route claim");
+    let registry = MigrationAuthority::from_parts(vec![authority], vec![route]);
+
+    assert!(matches!(
+        registry.route_decision("/api/issues"),
+        RouteDecision::Reject {
+            reason: RouteRejection::UnknownOwner { owner }
+        } if owner == unknown_owner
+    ));
+}
+
+#[test]
+fn route_decision_rejects_dual_component_ownership() {
+    let legacy = legacy_authority();
+    let rust =
+        ComponentAuthority::new("issues", "rust-0.1.0", OwnerId::rust()).expect("rust authority");
+    let route =
+        RouteClaim::new("/api/issues", "issues", legacy.owner.clone()).expect("route claim");
+    let registry = MigrationAuthority::from_parts(vec![legacy, rust], vec![route]);
+
+    assert!(matches!(
+        registry.route_decision("/api/issues"),
+        RouteDecision::Reject {
+            reason: RouteRejection::DualOwnership { .. }
+        }
+    ));
+}
+
+#[test]
+fn bridge_validation_rejects_stale_epoch_before_legacy_owner_fallback() {
+    let (mut registry, old_authority) = legacy_registry();
+    let envelope = LegacyBridgeRequestEnvelope::new(
+        &old_authority,
+        actor(),
+        "org-1",
+        "issue.read",
+        b"body",
+        "request-1",
+        "nonce-1",
+        2_000,
+    )
+    .expect("bridge envelope");
+    let current = registry
+        .handoff(HandoffRequest::new(
+            "issues",
+            old_authority.owner.clone(),
+            old_authority.epoch,
+            old_authority.fencing_token.clone(),
+            OwnerId::rust(),
+            "rust-0.1.0",
+        ))
+        .expect("handoff");
+
+    let mut replay = NonceReplayGuard::new();
+    let error = envelope
+        .validate(
+            &current,
+            &actor(),
+            "org-1",
+            "issue.read",
+            b"body",
+            "request-1",
+            1_000,
+            &mut replay,
+        )
+        .expect_err("stale epoch must fail closed");
+    assert!(matches!(error, AuthorityError::StaleEpoch { .. }));
+}
+
+#[test]
+fn bridge_validation_rejects_a_mismatched_body_hash_without_consuming_nonce() {
+    let (_, authority) = legacy_registry();
+    let envelope = LegacyBridgeRequestEnvelope::new(
+        &authority,
+        actor(),
+        "org-1",
+        "issue.read",
+        b"body",
+        "request-1",
+        "nonce-1",
+        2_000,
+    )
+    .expect("bridge envelope");
+    let mut replay = NonceReplayGuard::new();
+    let error = envelope
+        .validate(
+            &authority,
+            &actor(),
+            "org-1",
+            "issue.read",
+            b"changed-body",
+            "request-1",
+            1_000,
+            &mut replay,
+        )
+        .expect_err("body substitution must fail closed");
+    assert!(matches!(error, AuthorityError::BodyHashMismatch));
+    assert_eq!(replay.len(), 0);
+
+    envelope
+        .validate(
+            &authority,
+            &actor(),
+            "org-1",
+            "issue.read",
+            b"body",
+            "request-1",
+            1_000,
+            &mut replay,
+        )
+        .expect("correct body should still be accepted");
+}
+
+#[test]
+fn bridge_validation_rejects_fencing_token_mismatch() {
+    let (_, authority) = legacy_registry();
+    let mut envelope = LegacyBridgeRequestEnvelope::new(
+        &authority,
+        actor(),
+        "org-1",
+        "issue.read",
+        b"body",
+        "request-1",
+        "nonce-1",
+        2_000,
+    )
+    .expect("bridge envelope");
+    envelope.fencing_token = "not-the-current-fence".into();
+
+    let mut replay = NonceReplayGuard::new();
+    let error = envelope
+        .validate(
+            &authority,
+            &actor(),
+            "org-1",
+            "issue.read",
+            b"body",
+            "request-1",
+            1_000,
+            &mut replay,
+        )
+        .expect_err("fence substitution must fail closed");
+    assert!(matches!(error, AuthorityError::FencingTokenMismatch));
+}
+
+#[test]
+fn bridge_validation_rejects_replay_and_expiry() {
+    let (_, authority) = legacy_registry();
+    let envelope = LegacyBridgeRequestEnvelope::new(
+        &authority,
+        actor(),
+        "org-1",
+        "issue.read",
+        b"body",
+        "request-1",
+        "nonce-1",
+        2_000,
+    )
+    .expect("bridge envelope");
+    let mut replay = NonceReplayGuard::new();
+    envelope
+        .validate(
+            &authority,
+            &actor(),
+            "org-1",
+            "issue.read",
+            b"body",
+            "request-1",
+            1_000,
+            &mut replay,
+        )
+        .expect("first request");
+    let error = envelope
+        .validate(
+            &authority,
+            &actor(),
+            "org-1",
+            "issue.read",
+            b"body",
+            "request-1",
+            1_000,
+            &mut replay,
+        )
+        .expect_err("same nonce must not replay");
+    assert!(matches!(error, AuthorityError::Replay));
+
+    let expired = LegacyBridgeRequestEnvelope::new(
+        &authority,
+        actor(),
+        "org-1",
+        "issue.read",
+        b"body",
+        "request-2",
+        "nonce-2",
+        1_000,
+    )
+    .expect("expired envelope fixture");
+    let error = expired
+        .validate(
+            &authority,
+            &actor(),
+            "org-1",
+            "issue.read",
+            b"body",
+            "request-2",
+            1_000,
+            &mut replay,
+        )
+        .expect_err("expired request must fail closed");
+    assert!(matches!(error, AuthorityError::Expired));
+}
+
+#[test]
+fn valid_handoff_advances_epoch_changes_fence_and_transfers_routes() {
+    let (mut registry, old_authority) = legacy_registry();
+    let new_authority = registry
+        .handoff(HandoffRequest::new(
+            "issues",
+            old_authority.owner.clone(),
+            old_authority.epoch,
+            old_authority.fencing_token.clone(),
+            OwnerId::rust(),
+            "rust-0.1.0",
+        ))
+        .expect("valid handoff");
+
+    assert_eq!(new_authority.epoch, old_authority.epoch + 1);
+    assert_ne!(new_authority.fencing_token, old_authority.fencing_token);
+    assert_eq!(new_authority.owner, OwnerId::rust());
+    assert!(matches!(
+        registry.route_decision("/api/issues"),
+        RouteDecision::Rust { authority } if authority == new_authority
+    ));
+    registry.validate().expect("handoff remains one-writer");
+}
+
+#[test]
+fn stale_handoff_cannot_replace_current_authority() {
+    let (mut registry, authority) = legacy_registry();
+    let first = registry
+        .handoff(HandoffRequest::new(
+            "issues",
+            authority.owner.clone(),
+            authority.epoch,
+            authority.fencing_token.clone(),
+            OwnerId::rust(),
+            "rust-0.1.0",
+        ))
+        .expect("first handoff");
+    let error = registry
+        .handoff(HandoffRequest::new(
+            "issues",
+            authority.owner,
+            authority.epoch,
+            authority.fencing_token,
+            OwnerId::legacy(),
+            "node-0.7.21",
+        ))
+        .expect_err("stale writer must not regain ownership");
+
+    assert!(matches!(error, AuthorityError::StaleEpoch { .. }));
+    assert_eq!(registry.current_authority("issues"), Some(&first));
+}

--- a/native/crates/authority-core/tests/protocol.rs
+++ b/native/crates/authority-core/tests/protocol.rs
@@ -1,7 +1,7 @@
 use rudder_authority_core::{
     AUTHORITY_PROTOCOL_VERSION, ActorIdentity, AuthorityError, ComponentAuthority, HandoffRequest,
-    LegacyBridgeRequestEnvelope, MigrationAuthority, NonceReplayGuard, OwnerId, RouteClaim,
-    RouteDecision, RouteRejection,
+    LegacyBridgeRequestEnvelope, MAX_BRIDGE_LIFETIME, MAX_NONCE_BYTES, MAX_REPLAY_CAPACITY,
+    MigrationAuthority, NonceReplayGuard, OwnerId, RouteClaim, RouteDecision, RouteRejection,
 };
 
 fn legacy_authority() -> ComponentAuthority {
@@ -33,7 +33,8 @@ fn authority_and_bridge_envelope_round_trip_with_versioned_fields() {
         br#"{"issueId":"issue-1"}"#,
         "request-1",
         "nonce-1",
-        2_000,
+        900,
+        1_200,
     )
     .expect("bridge envelope");
 
@@ -46,6 +47,229 @@ fn authority_and_bridge_envelope_round_trip_with_versioned_fields() {
     let decoded: LegacyBridgeRequestEnvelope =
         serde_json::from_value(encoded).expect("deserialize envelope");
     assert_eq!(decoded, envelope);
+}
+
+#[test]
+fn bridge_nonce_is_bounded_on_construction_and_validation_before_replay_claim() {
+    let (_, authority) = legacy_registry();
+    let long_nonce = "n".repeat(MAX_NONCE_BYTES + 1);
+    let error = LegacyBridgeRequestEnvelope::new(
+        &authority,
+        actor(),
+        "org-1",
+        "issue.read",
+        b"body",
+        "request-long",
+        long_nonce.clone(),
+        900,
+        1_200,
+    )
+    .expect_err("construction must reject an overlong nonce");
+    assert!(matches!(
+        error,
+        AuthorityError::InvalidField { field: "nonce" }
+    ));
+
+    let valid = LegacyBridgeRequestEnvelope::new(
+        &authority,
+        actor(),
+        "org-1",
+        "issue.read",
+        b"body",
+        "request-valid",
+        "nonce-valid",
+        900,
+        1_200,
+    )
+    .expect("valid bridge envelope");
+    for (request_id, nonce) in [
+        ("request-long", long_nonce),
+        ("request-control", "nonce\u{0001}".to_owned()),
+    ] {
+        let mut encoded = serde_json::to_value(&valid).expect("serialize envelope");
+        let object = encoded.as_object_mut().expect("object envelope");
+        object.insert(
+            "requestId".to_owned(),
+            serde_json::Value::String(request_id.to_owned()),
+        );
+        object.insert("nonce".to_owned(), serde_json::Value::String(nonce));
+        let envelope: LegacyBridgeRequestEnvelope =
+            serde_json::from_value(encoded).expect("deserialize envelope");
+        let mut replay = NonceReplayGuard::new();
+        let error = envelope
+            .validate(
+                &authority,
+                &actor(),
+                "org-1",
+                "issue.read",
+                b"body",
+                request_id,
+                1_000,
+                &mut replay,
+            )
+            .expect_err("validation must reject an unsafe nonce");
+        assert!(matches!(
+            error,
+            AuthorityError::InvalidField { field: "nonce" }
+        ));
+        assert!(
+            replay.is_empty(),
+            "invalid nonce must not reach replay storage"
+        );
+    }
+}
+
+#[test]
+fn bridge_lifetime_rejects_u64_max_and_far_future_expiry() {
+    let (_, authority) = legacy_registry();
+    for expires_at in [u64::MAX, 1_000 + MAX_BRIDGE_LIFETIME + 1] {
+        let valid = LegacyBridgeRequestEnvelope::new(
+            &authority,
+            actor(),
+            "org-1",
+            "issue.read",
+            b"body",
+            "request-future",
+            "nonce-future",
+            1_000,
+            1_200,
+        )
+        .expect("valid bridge envelope");
+        let mut encoded = serde_json::to_value(&valid).expect("serialize envelope");
+        encoded["expiresAt"] = serde_json::Value::from(expires_at);
+        let envelope: LegacyBridgeRequestEnvelope =
+            serde_json::from_value(encoded).expect("deserialize envelope");
+        let mut replay = NonceReplayGuard::new();
+        let error = envelope
+            .validate(
+                &authority,
+                &actor(),
+                "org-1",
+                "issue.read",
+                b"body",
+                "request-future",
+                1_000,
+                &mut replay,
+            )
+            .expect_err("far-future expiry must fail closed");
+        assert!(matches!(error, AuthorityError::LifetimeTooLong));
+        assert!(replay.is_empty());
+    }
+
+    let error = LegacyBridgeRequestEnvelope::new(
+        &authority,
+        actor(),
+        "org-1",
+        "issue.read",
+        b"body",
+        "request-construction-future",
+        "nonce-construction-future",
+        1_000,
+        1_000 + MAX_BRIDGE_LIFETIME + 1,
+    )
+    .expect_err("construction must reject an overlong bridge lifetime");
+    assert!(matches!(error, AuthorityError::LifetimeTooLong));
+}
+
+#[test]
+fn bridge_validation_rejects_not_yet_valid_and_expired_envelopes() {
+    let (_, authority) = legacy_registry();
+    let not_yet_valid = LegacyBridgeRequestEnvelope::new(
+        &authority,
+        actor(),
+        "org-1",
+        "issue.read",
+        b"body",
+        "request-future",
+        "nonce-future",
+        2_000,
+        2_100,
+    )
+    .expect("future envelope fixture");
+    let mut replay = NonceReplayGuard::new();
+    let error = not_yet_valid
+        .validate(
+            &authority,
+            &actor(),
+            "org-1",
+            "issue.read",
+            b"body",
+            "request-future",
+            1_999,
+            &mut replay,
+        )
+        .expect_err("not-yet-valid envelope must fail closed");
+    assert!(matches!(error, AuthorityError::NotYetValid));
+    assert!(replay.is_empty());
+
+    let expired = LegacyBridgeRequestEnvelope::new(
+        &authority,
+        actor(),
+        "org-1",
+        "issue.read",
+        b"body",
+        "request-expired",
+        "nonce-expired",
+        900,
+        1_000,
+    )
+    .expect("expired envelope fixture");
+    let error = expired
+        .validate(
+            &authority,
+            &actor(),
+            "org-1",
+            "issue.read",
+            b"body",
+            "request-expired",
+            1_000,
+            &mut replay,
+        )
+        .expect_err("expired envelope must fail closed");
+    assert!(matches!(error, AuthorityError::Expired));
+    assert!(replay.is_empty());
+}
+
+#[test]
+fn bridge_wire_without_issued_at_is_parse_compatible_but_rejected() {
+    let (_, authority) = legacy_registry();
+    let envelope = LegacyBridgeRequestEnvelope::new(
+        &authority,
+        actor(),
+        "org-1",
+        "issue.read",
+        b"body",
+        "request-legacy-wire",
+        "nonce-legacy-wire",
+        900,
+        1_200,
+    )
+    .expect("bridge envelope");
+    let mut encoded = serde_json::to_value(&envelope).expect("serialize envelope");
+    encoded
+        .as_object_mut()
+        .expect("object envelope")
+        .remove("issuedAt");
+    let decoded: LegacyBridgeRequestEnvelope =
+        serde_json::from_value(encoded).expect("legacy wire remains parse-compatible");
+    let mut replay = NonceReplayGuard::new();
+    let error = decoded
+        .validate(
+            &authority,
+            &actor(),
+            "org-1",
+            "issue.read",
+            b"body",
+            "request-legacy-wire",
+            1_000,
+            &mut replay,
+        )
+        .expect_err("missing issuedAt must not be accepted");
+    assert!(matches!(
+        error,
+        AuthorityError::InvalidField { field: "issuedAt" }
+    ));
+    assert!(replay.is_empty());
 }
 
 #[test]
@@ -92,7 +316,8 @@ fn bridge_validation_rejects_stale_epoch_before_legacy_owner_fallback() {
         b"body",
         "request-1",
         "nonce-1",
-        2_000,
+        900,
+        1_200,
     )
     .expect("bridge envelope");
     let current = registry
@@ -133,7 +358,8 @@ fn bridge_validation_rejects_a_mismatched_body_hash_without_consuming_nonce() {
         b"body",
         "request-1",
         "nonce-1",
-        2_000,
+        900,
+        1_200,
     )
     .expect("bridge envelope");
     let mut replay = NonceReplayGuard::new();
@@ -177,7 +403,8 @@ fn bridge_validation_rejects_fencing_token_mismatch() {
         b"body",
         "request-1",
         "nonce-1",
-        2_000,
+        900,
+        1_200,
     )
     .expect("bridge envelope");
     envelope.fencing_token = "not-the-current-fence".into();
@@ -209,7 +436,8 @@ fn bridge_validation_rejects_replay_and_expiry() {
         b"body",
         "request-1",
         "nonce-1",
-        2_000,
+        900,
+        1_200,
     )
     .expect("bridge envelope");
     let mut replay = NonceReplayGuard::new();
@@ -247,6 +475,7 @@ fn bridge_validation_rejects_replay_and_expiry() {
         b"body",
         "request-2",
         "nonce-2",
+        900,
         1_000,
     )
     .expect("expired envelope fixture");
@@ -328,6 +557,7 @@ fn bridge_replay_guard_evicts_expired_entries_and_rejects_active_overflow() {
         b"body",
         "request-replay-1",
         "nonce-replay-1",
+        900,
         1_010,
     )
     .expect("first bridge envelope");
@@ -339,6 +569,7 @@ fn bridge_replay_guard_evicts_expired_entries_and_rejects_active_overflow() {
         b"body",
         "request-replay-2",
         "nonce-replay-2",
+        900,
         1_020,
     )
     .expect("second bridge envelope");
@@ -384,4 +615,20 @@ fn bridge_replay_guard_evicts_expired_entries_and_rejects_active_overflow() {
         )
         .expect("expired entries are evicted before a new claim");
     assert_eq!(replay.len(), 1);
+}
+
+#[test]
+fn bridge_replay_guard_rejects_zero_and_oversized_capacity() {
+    assert!(matches!(
+        NonceReplayGuard::with_capacity(0),
+        Err(AuthorityError::InvalidReplayCapacity {
+            max: MAX_REPLAY_CAPACITY
+        })
+    ));
+    assert!(matches!(
+        NonceReplayGuard::with_capacity(MAX_REPLAY_CAPACITY + 1),
+        Err(AuthorityError::InvalidReplayCapacity {
+            max: MAX_REPLAY_CAPACITY
+        })
+    ));
 }

--- a/native/crates/authority-core/tests/protocol.rs
+++ b/native/crates/authority-core/tests/protocol.rs
@@ -1,7 +1,8 @@
 use rudder_authority_core::{
     AUTHORITY_PROTOCOL_VERSION, ActorIdentity, AuthorityError, ComponentAuthority, HandoffRequest,
-    LegacyBridgeRequestEnvelope, MAX_BRIDGE_LIFETIME, MAX_NONCE_BYTES, MAX_REPLAY_CAPACITY,
-    MigrationAuthority, NonceReplayGuard, OwnerId, RouteClaim, RouteDecision, RouteRejection,
+    LEGACY_BRIDGE_PROTOCOL_VERSION, LEGACY_BRIDGE_SCHEMA, LegacyBridgeRequestEnvelope,
+    MAX_BRIDGE_LIFETIME, MAX_NONCE_BYTES, MAX_REPLAY_CAPACITY, MigrationAuthority,
+    NonceReplayGuard, OwnerId, RouteClaim, RouteDecision, RouteRejection,
 };
 
 fn legacy_authority() -> ComponentAuthority {
@@ -39,7 +40,8 @@ fn authority_and_bridge_envelope_round_trip_with_versioned_fields() {
     .expect("bridge envelope");
 
     let encoded = serde_json::to_value(&envelope).expect("serialize envelope");
-    assert_eq!(encoded["protocolVersion"], AUTHORITY_PROTOCOL_VERSION);
+    assert_eq!(encoded["protocolVersion"], LEGACY_BRIDGE_PROTOCOL_VERSION);
+    assert_eq!(encoded["schema"], LEGACY_BRIDGE_SCHEMA);
     assert_eq!(encoded["authorityEpoch"], authority.epoch);
     assert_eq!(encoded["bodySha256"].as_str().map(str::len), Some(64));
     assert_eq!(encoded["organizationId"], "org-1");
@@ -231,7 +233,7 @@ fn bridge_validation_rejects_not_yet_valid_and_expired_envelopes() {
 }
 
 #[test]
-fn bridge_wire_without_issued_at_is_parse_compatible_but_rejected() {
+fn bridge_v2_wire_without_issued_at_is_parse_compatible_but_rejected() {
     let (_, authority) = legacy_registry();
     let envelope = LegacyBridgeRequestEnvelope::new(
         &authority,
@@ -269,6 +271,58 @@ fn bridge_wire_without_issued_at_is_parse_compatible_but_rejected() {
         error,
         AuthorityError::InvalidField { field: "issuedAt" }
     ));
+    assert!(replay.is_empty());
+}
+
+#[test]
+fn legacy_v1_bridge_payload_is_rejected_as_unsupported() {
+    let (_, authority) = legacy_registry();
+    let envelope = LegacyBridgeRequestEnvelope::new(
+        &authority,
+        actor(),
+        "org-1",
+        "issue.read",
+        b"body",
+        "request-legacy-v1",
+        "nonce-legacy-v1",
+        900,
+        1_200,
+    )
+    .expect("bridge envelope");
+    let mut encoded = serde_json::to_value(&envelope).expect("serialize envelope");
+    let object = encoded.as_object_mut().expect("object envelope");
+    object.insert(
+        "schema".to_owned(),
+        serde_json::Value::String("rudder.migration.legacy-bridge.v1".to_owned()),
+    );
+    object.insert(
+        "protocolVersion".to_owned(),
+        serde_json::Value::from(AUTHORITY_PROTOCOL_VERSION),
+    );
+    object.remove("issuedAt");
+
+    let decoded: LegacyBridgeRequestEnvelope =
+        serde_json::from_value(encoded).expect("legacy v1 wire remains parse-compatible");
+    let mut replay = NonceReplayGuard::new();
+    let error = decoded
+        .validate(
+            &authority,
+            &actor(),
+            "org-1",
+            "issue.read",
+            b"body",
+            "request-legacy-v1",
+            1_000,
+            &mut replay,
+        )
+        .expect_err("legacy v1 bridge payload must fail closed as unsupported");
+    assert_eq!(
+        error,
+        AuthorityError::UnsupportedProtocolVersion {
+            actual: AUTHORITY_PROTOCOL_VERSION,
+            expected: LEGACY_BRIDGE_PROTOCOL_VERSION,
+        }
+    );
     assert!(replay.is_empty());
 }
 

--- a/native/crates/authority-core/tests/protocol.rs
+++ b/native/crates/authority-core/tests/protocol.rs
@@ -316,3 +316,72 @@ fn stale_handoff_cannot_replace_current_authority() {
     assert!(matches!(error, AuthorityError::StaleEpoch { .. }));
     assert_eq!(registry.current_authority("issues"), Some(&first));
 }
+
+#[test]
+fn bridge_replay_guard_evicts_expired_entries_and_rejects_active_overflow() {
+    let (_, authority) = legacy_registry();
+    let first = LegacyBridgeRequestEnvelope::new(
+        &authority,
+        actor(),
+        "org-1",
+        "issue.read",
+        b"body",
+        "request-replay-1",
+        "nonce-replay-1",
+        1_010,
+    )
+    .expect("first bridge envelope");
+    let second = LegacyBridgeRequestEnvelope::new(
+        &authority,
+        actor(),
+        "org-1",
+        "issue.read",
+        b"body",
+        "request-replay-2",
+        "nonce-replay-2",
+        1_020,
+    )
+    .expect("second bridge envelope");
+    let mut replay = NonceReplayGuard::with_capacity(1).expect("capacity");
+
+    first
+        .validate(
+            &authority,
+            &actor(),
+            "org-1",
+            "issue.read",
+            b"body",
+            "request-replay-1",
+            1_000,
+            &mut replay,
+        )
+        .expect("first request");
+    let error = second
+        .validate(
+            &authority,
+            &actor(),
+            "org-1",
+            "issue.read",
+            b"body",
+            "request-replay-2",
+            1_000,
+            &mut replay,
+        )
+        .expect_err("active replay entries must remain bounded");
+    assert!(matches!(error, AuthorityError::ReplayCapacityExceeded));
+    assert_eq!(replay.len(), 1);
+
+    second
+        .validate(
+            &authority,
+            &actor(),
+            "org-1",
+            "issue.read",
+            b"body",
+            "request-replay-2",
+            1_010,
+            &mut replay,
+        )
+        .expect("expired entries are evicted before a new claim");
+    assert_eq!(replay.len(), 1);
+}


### PR DESCRIPTION
## Scope
- Add the private, side-effect-free Rust authority-core protocol primitives.
- Add auth-core actor-envelope verification with session/auth-epoch/request binding, bounded replay, constant-time signatures, and redacted zeroizing keys.
- Version the legacy bridge wire shape as v2 after adding issued-at/lifetime/nonce validation.

## Boundaries
- Node/Express/Drizzle remain public production authority.
- No public route registration, database writes, dual writes, cutover, or deployment.
- Later Issue mutation/read-surface and runtime-attempt work remains in separate branches/PRs.

## Validation
- authority-core protocol tests: 16/16
- auth-core protocol/unit tests: 12/12
- Rust workspace tests, strict Clippy, rustfmt, and locked Cargo metadata passed.
- Independent Luna max review accepted the exact pushed candidate.
