### PR TITLE
fix(ui): label App location actions by target

### DIFF
--- a/doc/plans/2026-07-29-app-builder-prd.md
+++ b/doc/plans/2026-07-29-app-builder-prd.md
@@ -81,7 +81,8 @@ V1 delivers:
 - a Desktop-owned fixed runner that installs dependencies, runs typecheck,
   unit tests, production build, and a real loopback readiness check;
 - a reviewed, opaque installation-local App binding;
-- Start, Stop, Open, Copy App link, Continue in Chat, and Open in Finder;
+- Start, Stop, Open, Copy App link, Continue in Chat, and source-location opening
+  through the platform folder opener;
 - development-data Backup, Export, Import, and Restore;
 - clear unavailable and failure states;
 - macOS, Linux, and Windows process-ownership adapters.
@@ -156,13 +157,17 @@ The Apps workspace shows durable build and binding state:
 
 - source work pending: `Continue in Chat`;
 - source exists: `Register & preview`;
-- running: `Open`, `Copy App link`, `Stop`, `Continue in Chat`, `Open in Finder`;
+- running: `Open`, `Copy App link`, `Stop`, `Continue in Chat`, and the platform
+  folder opener (`Open in Finder` on macOS, with the platform equivalent elsewhere);
 - bound App: development-data Backup, Import, and Restore;
 - failed or unavailable: causal error and recovery direction.
 
 `Register & preview` does not create generic source. If Chat/Skill work has not
 produced a valid manifest at the assigned root, the action fails and directs
 the operator back to Chat.
+
+When a managed App has no local Desktop definition yet, its source action opens
+the source in Rudder Library rather than invoking a native folder opener.
 
 ## Build And Runtime Contract
 

--- a/tests/e2e/app-builder.spec.ts
+++ b/tests/e2e/app-builder.spec.ts
@@ -343,8 +343,15 @@ test.describe("Apps workspace", () => {
       Object.defineProperty(window, "desktopShell", {
         configurable: true,
         value: {
+          platform: "darwin",
           copyText: async (text: string) => {
             (window as typeof window & { __copiedText?: string }).__copiedText = text;
+          },
+          openPath: async (targetPath: string) => {
+            (window as typeof window & { __openedPaths?: string[] }).__openedPaths = [
+              ...((window as typeof window & { __openedPaths?: string[] }).__openedPaths ?? []),
+              targetPath,
+            ];
           },
           openExternal: async () => undefined,
           forceOpenExternal: async (target: string) => {
@@ -550,6 +557,14 @@ test.describe("Apps workspace", () => {
     ))).toBe("http://127.0.0.1:41731/");
     await expect(page.getByText("Source", { exact: true })).toHaveCount(0);
     await expect(page.getByRole("button", { name: "Stop App" })).toHaveCount(0);
+
+    await alphaEntry.hover();
+    await page.getByTestId("apps-more-local:definition-alpha").click();
+    await expect(page.getByRole("menuitem", { name: "Open in Finder" })).toBeVisible();
+    await page.getByRole("menuitem", { name: "Open in Finder" }).click();
+    await expect.poll(() => page.evaluate(() => (
+      (window as typeof window & { __openedPaths?: string[] }).__openedPaths ?? []
+    ))).toEqual(["/tmp/alpha"]);
 
     await page.getByTestId("apps-tab-local:definition-beta").getByRole("tab").focus();
     await page.keyboard.press("Delete");
@@ -1094,15 +1109,24 @@ test.describe("Apps workspace", () => {
       `${E2E_BASE_URL}/${organization.issuePrefix}/apps/view/managed%3A${created.id}`,
     );
     await expect(page.getByTestId("apps-retry-managed-app")).toBeVisible();
-    await expect(page.getByRole("button", { name: "Open in Finder" })).toBeVisible();
+    const sourceButton = page.getByRole("button", { name: "Open source" });
+    await expect(sourceButton).toBeVisible();
+    await sourceButton.click();
+    await expect(page).toHaveURL(/\/library\?directory=apps%2Fbroken-preview-app$/i);
+    await page.goto(
+      `${E2E_BASE_URL}/${organization.issuePrefix}/apps/view/managed%3A${created.id}`,
+    );
+    await expect(sourceButton).toBeVisible();
     const managedAppEntry = page.getByTestId(`apps-entry-managed:${created.id}`);
     await managedAppEntry.hover();
     await page.getByTestId(`apps-more-managed:${created.id}`).click();
-    await expect(page.getByRole("menuitem", { name: "Open in Finder" })).toBeVisible();
+    await expect(page.getByRole("menuitem", { name: "Open source" })).toBeVisible();
     await page.screenshot({
-      path: `/tmp/rudder-app-builder-finder-menu-${testInfo.workerIndex}.png`,
+      path: `/tmp/rudder-app-builder-source-menu-${testInfo.workerIndex}.png`,
       fullPage: true,
     });
+    await page.getByRole("menuitem", { name: "Open source" }).click();
+    await expect(page).toHaveURL(/\/library\?directory=apps%2Fbroken-preview-app$/i);
   });
 
   test("keeps App Builder records organization-scoped", async ({ request }) => {

--- a/ui/src/components/AppsContextSidebar.tsx
+++ b/ui/src/components/AppsContextSidebar.tsx
@@ -17,6 +17,8 @@ import { useAppRegistry } from "@/hooks/useAppRegistry";
 import {
   activeKeyFromPath,
   appBuildStatusLabel,
+  appLocationActionErrorTitle,
+  appLocationActionLabel,
   appRoute,
   requestAppDirectOpen,
   type AppEntry,
@@ -107,6 +109,11 @@ function AppRowActions({
   const localApps = desktopShell?.localApps;
   const appBuilder = desktopShell?.appBuilder;
   const definition = entry.definition;
+  const locationActionLabel = appLocationActionLabel(Boolean(definition), desktopShell?.platform);
+  const locationActionErrorTitle = appLocationActionErrorTitle(
+    Boolean(definition),
+    desktopShell?.platform,
+  );
   const [lastSnapshotId, setLastSnapshotId] = useState<string | null>(null);
   const statusQuery = useQuery({
     queryKey: queryKeys.localApps.status(definition?.localBindingId ?? entry.key),
@@ -314,7 +321,7 @@ function AppRowActions({
               if (definition) {
                 void desktopShell?.openPath(definition.cwd).catch((error) => {
                   pushToast({
-                    title: "Could not open App in Finder",
+                    title: locationActionErrorTitle,
                     body: error instanceof Error ? error.message : undefined,
                     tone: "error",
                   });
@@ -327,7 +334,7 @@ function AppRowActions({
             }}
           >
             <FolderSearch aria-hidden />
-            Open in Finder
+            {locationActionLabel}
           </DropdownMenuItem>
         ) : null}
         {entry.kind === "managed" && entry.app.conversationId ? (

--- a/ui/src/lib/apps-workspace.test.ts
+++ b/ui/src/lib/apps-workspace.test.ts
@@ -1,5 +1,11 @@
+// @vitest-environment node
+
 import { describe, expect, it } from "vitest";
-import { shouldPreserveAppDirectOpenDuringOrganizationChange } from "./apps-workspace";
+import {
+  appLocationActionErrorTitle,
+  appLocationActionLabel,
+  shouldPreserveAppDirectOpenDuringOrganizationChange,
+} from "./apps-workspace";
 
 describe("Apps workspace organization changes", () => {
   it("preserves a targeted App route while a fresh direct-open intent is pending", () => {
@@ -15,5 +21,26 @@ describe("Apps workspace organization changes", () => {
       0,
     )).toBe(false);
     expect(shouldPreserveAppDirectOpenDuringOrganizationChange("home", 4)).toBe(false);
+  });
+});
+
+describe("App source location actions", () => {
+  it("keeps unbound managed Apps in Rudder Library", () => {
+    expect(appLocationActionLabel(false, "darwin")).toBe("Open source");
+    expect(appLocationActionErrorTitle(false, "darwin")).toBe("Could not open App source");
+  });
+
+  it.each([
+    ["darwin", "Open in Finder", "Could not open App in Finder"],
+    ["win32", "Open in File Explorer", "Could not open App in File Explorer"],
+    ["linux", "Open in File Manager", "Could not open App in File Manager"],
+  ] as const)("uses the native folder label on %s", (platform, label, errorTitle) => {
+    expect(appLocationActionLabel(true, platform)).toBe(label);
+    expect(appLocationActionErrorTitle(true, platform)).toBe(errorTitle);
+  });
+
+  it("uses a platform-neutral folder label for unsupported platforms", () => {
+    expect(appLocationActionLabel(true, "freebsd")).toBe("Open in File Manager");
+    expect(appLocationActionErrorTitle(true, "freebsd")).toBe("Could not open App in File Manager");
   });
 });

--- a/ui/src/lib/apps-workspace.ts
+++ b/ui/src/lib/apps-workspace.ts
@@ -104,3 +104,23 @@ export function appBuildStatusLabel(status: AppBuilderApp["buildStatus"]) {
   if (status === "launch_failed") return "Could not open";
   return "Needs attention";
 }
+
+export function appLocationActionLabel(
+  hasLocalDefinition: boolean,
+  platform?: NodeJS.Platform,
+) {
+  if (!hasLocalDefinition) return "Open source";
+  if (platform === "darwin") return "Open in Finder";
+  if (platform === "win32") return "Open in File Explorer";
+  return "Open in File Manager";
+}
+
+export function appLocationActionErrorTitle(
+  hasLocalDefinition: boolean,
+  platform?: NodeJS.Platform,
+) {
+  if (!hasLocalDefinition) return "Could not open App source";
+  if (platform === "darwin") return "Could not open App in Finder";
+  if (platform === "win32") return "Could not open App in File Explorer";
+  return "Could not open App in File Manager";
+}

--- a/ui/src/pages/Apps.tsx
+++ b/ui/src/pages/Apps.tsx
@@ -17,6 +17,7 @@ import { launchManagedApp } from "@/lib/app-builder-launch";
 import {
   acknowledgeAppDirectOpen,
   activeKeyFromPath,
+  appLocationActionLabel,
   appRoute,
   localBindingKey,
   readAppDirectOpenIntent,
@@ -413,6 +414,7 @@ function ManagedSetupPane({
   const navigate = useNavigate();
   const desktopShell = readDesktopShell();
   const desktopAppBuilder = desktopShell?.appBuilder;
+  const sourceActionLabel = appLocationActionLabel(false, desktopShell?.platform);
   const retryMutation = useMutation({
     mutationFn: async () => {
       if (!desktopShell || !desktopAppBuilder?.supported) {
@@ -486,7 +488,7 @@ function ManagedSetupPane({
                 `/library?directory=${encodeURIComponent(entry.app.sourceRoot)}`,
               )}
             >
-              Open in Finder
+              {sourceActionLabel}
             </Button>
           </div>
           {retryMutation.error ? (


### PR DESCRIPTION
## Summary
- keep unbound managed Apps labeled `Open source` when the action opens Rudder Library
- use platform-specific native folder labels for bound local Apps
- cover the native opener and Library fallback paths with unit and E2E tests

## Verification
- `pnpm lint:changed`
- `pnpm --filter @rudderhq/ui typecheck`
- `pnpm --filter @rudderhq/ui exec vitest run src/lib/apps-workspace.test.ts`
- targeted App Builder E2E: 2 passed
- `pnpm --filter @rudderhq/ui build`
- final reviewer: accept
- exact-candidate verifier: PASS

Related: #152
