### PR TITLE
fix(ui): keep primary rail inside its column

### DIFF
--- a/tests/e2e/primary-rail-layout.spec.ts
+++ b/tests/e2e/primary-rail-layout.spec.ts
@@ -63,24 +63,34 @@ test.describe("Primary rail layout", () => {
         await expect(nav).toBeVisible();
 
         const navBox = await nav.boundingBox();
+        const railBox = await rail.boundingBox();
         expect(navBox).not.toBeNull();
+        expect(railBox).not.toBeNull();
         expect(navBox!.width).toBeGreaterThanOrEqual(61);
+        const contextCard = page.getByTestId("workspace-context-card");
+        if (await contextCard.count() > 0) {
+          const contextBox = await contextCard.boundingBox();
+          expect(contextBox).not.toBeNull();
+          expect(contextBox!.x).toBeGreaterThanOrEqual(railBox!.x + railBox!.width - 0.5);
+        }
 
         for (const label of ["Messenger", "Organization", "Automations"]) {
           const item = nav.getByRole("link", { name: label, exact: true });
           await expect(item).toBeVisible();
-          const textBox = await item.evaluate((element) => {
+          const itemBox = await item.boundingBox();
+          expect(itemBox).not.toBeNull();
+          expect(itemBox!.x).toBeGreaterThanOrEqual(railBox!.x - 0.5);
+          expect(itemBox!.x + itemBox!.width).toBeLessThanOrEqual(railBox!.x + railBox!.width + 0.5);
+          const labelBox = await item.evaluate((element) => {
             const labelElement = element.lastElementChild;
             if (!labelElement?.textContent?.trim()) {
               throw new Error("Primary rail label element not found");
             }
-            const range = document.createRange();
-            range.selectNodeContents(labelElement);
-            const rect = range.getBoundingClientRect();
+            const rect = labelElement.getBoundingClientRect();
             return { left: rect.left, right: rect.right };
           });
-          expect(textBox.left).toBeGreaterThanOrEqual(navBox!.x - 0.5);
-          expect(textBox.right).toBeLessThanOrEqual(navBox!.x + navBox!.width + 0.5);
+          expect(labelBox.left).toBeGreaterThanOrEqual(itemBox!.x - 0.5);
+          expect(labelBox.right).toBeLessThanOrEqual(itemBox!.x + itemBox!.width + 0.5);
         }
 
         await testInfo.attach(`primary-rail-labels-${platform.expectedPlatform ?? "browser"}`, {

--- a/ui/src/components/PrimaryRail.test.tsx
+++ b/ui/src/components/PrimaryRail.test.tsx
@@ -449,7 +449,10 @@ describe("PrimaryRail active motion indicator", () => {
     const nav = document.querySelector(".motion-rail-nav");
 
     expect(rail?.getAttribute("data-desktop-platform")).toBe("macos");
-    expect(rail?.className).toContain("w-[40px]");
+    expect(rail?.className).toContain("w-[66px]");
+    expect(rail?.className).toContain("[--primary-rail-item-width:66px]");
+    expect(rail?.className).toContain("[--primary-rail-item-shift:0px]");
+    expect(rail?.className).not.toContain("w-[40px]");
     expect(rail?.className).not.toContain("w-[52px]");
     expect(rail?.className).not.toContain("[--primary-rail-item-width:52px]");
     expect(nav?.className).toContain(

--- a/ui/src/components/PrimaryRail.tsx
+++ b/ui/src/components/PrimaryRail.tsx
@@ -521,8 +521,8 @@ export function PrimaryRail({
         desktopRailPlatform === "windows"
           ? "ml-1 mr-1 w-[52px] [--primary-rail-item-shift:0px] [--primary-rail-item-width:52px]"
           : isDesktopShell
-            ? "ml-3 mr-1 w-[40px]"
-            : "ml-2 mr-3 px-5 w-[50px]",
+            ? "ml-3 mr-1 w-[66px] [--primary-rail-item-shift:0px] [--primary-rail-item-width:66px]"
+            : "ml-2 mr-3 w-[66px] [--primary-rail-item-shift:0px] [--primary-rail-item-width:66px]",
       )}
     >
       <div className="flex w-full flex-col items-center gap-4">


### PR DESCRIPTION
## Summary
- prevent the non-Windows primary rail from overflowing into the adjacent workspace panel
- keep the compact Windows rail contract while aligning the macOS/browser rail to its visible item width
- add cross-platform geometry regression coverage for rail and context-panel boundaries

## Validation
- PrimaryRail unit tests: 26 passed
- primary-rail E2E: 3 passed (macOS, Windows, browser)
- Apps registered/multi-tab E2E: passed
- UI typecheck/build and changed-file lint: passed
- exact-candidate verifier: PASS
- final reviewer: accept

The bug was caused by a 40px/50px outer rail containing 66px visible navigation items, which allowed the item backgrounds and labels to overlap the adjacent panel.
