### PR TITLE
feat(native): add heartbeat attempt recovery core

### DIFF
--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -1438,7 +1438,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "rudder-runtime-core"
+name = "rudder-runtime-attempt-core"
+version = "0.7.21"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 version = "0.7.21"
 dependencies = [
  "serde",

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -1446,6 +1446,7 @@ dependencies = [
 ]
 
 [[package]]
+name = "rudder-runtime-core"
 version = "0.7.21"
 dependencies = [
  "serde",

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -12,6 +12,7 @@ members = [
   "crates/runtime-payload-core",
   "crates/runtime-core",
   "crates/migration-core",
+  "crates/runtime-attempt-core",
   "crates/server-foundation",
   "crates/workspace-manifest-core",
   "bins/rudder-native",

--- a/native/crates/runtime-attempt-core/Cargo.toml
+++ b/native/crates/runtime-attempt-core/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "rudder-runtime-attempt-core"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+
+description = "Pure, bounded heartbeat attempt and network-recovery state machine"
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+
+[dev-dependencies]
+serde_json = "1.0"

--- a/native/crates/runtime-attempt-core/src/lib.rs
+++ b/native/crates/runtime-attempt-core/src/lib.rs
@@ -10,9 +10,9 @@ use std::borrow::Borrow;
 use std::fmt;
 
 pub const ATTEMPT_PROTOCOL_VERSION: u16 = 1;
-/// The initial attempt plus one attempt for each bounded network wait.
+/// The maximum number of provider attempts and observed network waits.
 pub const MAX_NETWORK_WAITS: u8 = 6;
-pub const MAX_ATTEMPTS: u8 = MAX_NETWORK_WAITS + 1;
+pub const MAX_ATTEMPTS: u8 = MAX_NETWORK_WAITS;
 pub const MAX_ID_BYTES: usize = 255;
 pub const MAX_REQUEST_FINGERPRINT_BYTES: usize = 4 * 1024;
 pub const MAX_FAILURE_CODE_BYTES: usize = 128;
@@ -894,16 +894,17 @@ impl RecoveryEvidence {
         let model_output_observed = self.model_output_observed || newer.model_output_observed;
         let tool_activity_observed = self.tool_activity_observed || newer.tool_activity_observed;
         let terminal_event_observed = self.terminal_event_observed || newer.terminal_event_observed;
-        let submission_phase = if model_output_observed
+        // An unknown submission outcome is never made safe by a later lower-risk observation.
+        let submission_phase = if self.submission_phase == SubmissionPhase::Indeterminate
+            || newer.submission_phase == SubmissionPhase::Indeterminate
+        {
+            SubmissionPhase::Indeterminate
+        } else if model_output_observed
             || tool_activity_observed
             || self.submission_phase == SubmissionPhase::Accepted
             || newer.submission_phase == SubmissionPhase::Accepted
         {
             SubmissionPhase::Accepted
-        } else if self.submission_phase == SubmissionPhase::Indeterminate
-            || newer.submission_phase == SubmissionPhase::Indeterminate
-        {
-            SubmissionPhase::Indeterminate
         } else {
             SubmissionPhase::PreSubmission
         };
@@ -1361,6 +1362,16 @@ impl Checkpoint {
         evidence
             .validate()
             .map_err(|error| checkpoint_invalid(error.message()))?;
+        if self.terminal_event_observed
+            && !matches!(
+                self.terminal_outcome,
+                Some(TerminalOutcome::NetworkResumeUnsafe { .. })
+            )
+        {
+            return Err(checkpoint_invalid(
+                "terminal event evidence requires a network-unsafe terminal outcome",
+            ));
+        }
         if self.session.pristine && evidence != RecoveryEvidence::pre_submission() {
             return Err(checkpoint_invalid(
                 "a session with submission evidence cannot remain pristine",
@@ -1433,11 +1444,19 @@ impl Checkpoint {
                     return Err(checkpoint_invalid("active phase has inconsistent state"));
                 }
                 if let Some(plan) = &self.recovery {
+                    let evidence_preserves_plan = plan
+                        .evidence()
+                        .merge(evidence)
+                        .map(|merged| merged == evidence)
+                        .map_err(|error| checkpoint_invalid(error.message()))?;
                     if plan.next_attempt != self.attempt
                         || self.last_failure.as_ref() != Some(&plan.failure)
+                        || !evidence_preserves_plan
+                        || (plan.decision == RecoveryDecision::ResumeSameSession
+                            && self.session.pristine)
                     {
                         return Err(checkpoint_invalid(
-                            "active phase recovery plan does not name the active attempt",
+                            "active phase recovery plan is not bound to its state",
                         ));
                     }
                 } else if self.network_wait_count != 0
@@ -1464,7 +1483,6 @@ impl Checkpoint {
                     || (plan.decision == RecoveryDecision::FreshIfPristine
                         && !self.session.pristine)
                     || (plan.decision == RecoveryDecision::ResumeSameSession
-                        && plan.evidence().submission_phase == SubmissionPhase::PreSubmission
                         && self.session.pristine)
                 {
                     return Err(checkpoint_invalid("retry phase has inconsistent state"));
@@ -2176,11 +2194,14 @@ impl AttemptMachine {
         self.revision
     }
 
-    fn bump_revision(&mut self) -> Result<(), AttemptError> {
-        self.revision = self
-            .revision
+    fn next_revision(&self) -> Result<u64, AttemptError> {
+        self.revision
             .checked_add(1)
-            .ok_or_else(|| AttemptError::invalid("checkpoint revision overflow"))?;
+            .ok_or_else(|| AttemptError::invalid("checkpoint revision overflow"))
+    }
+
+    fn bump_revision(&mut self) -> Result<(), AttemptError> {
+        self.revision = self.next_revision()?;
         Ok(())
     }
 
@@ -2198,6 +2219,13 @@ impl AttemptMachine {
                 "stale_lease_fence",
                 ErrorKind::StaleLeaseFence,
                 "presented lease fence does not own this attempt",
+            ));
+        }
+        if matches!(self.phase, Phase::Succeeded | Phase::Terminal) {
+            return Err(AttemptError::new(
+                "already_terminal",
+                ErrorKind::AlreadyTerminal,
+                "terminal attempt leases are immutable",
             ));
         }
         new_lease.validate()?;
@@ -2246,6 +2274,7 @@ impl AttemptMachine {
         if merged == current {
             return Ok(());
         }
+        let next_revision = self.next_revision()?;
         self.submission_phase = merged.submission_phase;
         self.side_effect_risk = merged.side_effect_risk;
         self.model_output_observed = merged.model_output_observed;
@@ -2254,7 +2283,8 @@ impl AttemptMachine {
         if merged != RecoveryEvidence::pre_submission() {
             self.session.pristine = false;
         }
-        self.bump_revision()
+        self.revision = next_revision;
+        Ok(())
     }
 
     pub fn record_evidence(
@@ -2277,6 +2307,13 @@ impl AttemptMachine {
                 Ok(self.checkpoint())
             }
             Phase::Executing | Phase::WaitingForNetwork => {
+                if evidence.terminal_event_observed {
+                    return Err(AttemptError::new(
+                        "network_resume_unsafe",
+                        ErrorKind::NetworkResumeUnsafe,
+                        "a terminal event requires a network-unsafe terminal outcome",
+                    ));
+                }
                 self.install_evidence(evidence)?;
                 Ok(self.checkpoint())
             }
@@ -2473,11 +2510,34 @@ impl AttemptMachine {
         now_millis: u64,
         jitter_seed: Option<u64>,
     ) -> Result<RecoveryResult, AttemptError> {
+        // Evaluate the fallible transition on a candidate so evidence and session writes cannot
+        // survive a later revision, attempt, or retry-timestamp overflow.
+        let mut candidate = self.clone();
+        let result =
+            candidate.record_failure_unchecked(failure, evidence, fence, now_millis, jitter_seed);
+        if result.is_ok() {
+            *self = candidate;
+        }
+        result
+    }
+
+    fn record_failure_unchecked(
+        &mut self,
+        failure: Failure,
+        evidence: Option<RecoveryEvidence>,
+        fence: &LeaseFence,
+        now_millis: u64,
+        jitter_seed: Option<u64>,
+    ) -> Result<RecoveryResult, AttemptError> {
         self.lease.assert_presented(fence, now_millis)?;
         self.ensure_not_cancelled()?;
         failure.validate()?;
 
         let current_evidence = self.recovery_evidence();
+        let incoming_unsafe = evidence.is_some_and(|evidence| {
+            evidence.submission_phase == SubmissionPhase::Indeterminate
+                || evidence.terminal_event_observed
+        });
         let effective_evidence = match evidence {
             Some(evidence) if matches!(self.phase, Phase::WaitingForRetry | Phase::Terminal) => {
                 if evidence != current_evidence {
@@ -2489,7 +2549,14 @@ impl AttemptMachine {
                 }
                 current_evidence
             }
-            Some(evidence) => current_evidence.merge(evidence)?,
+            Some(evidence) => {
+                evidence.validate()?;
+                match current_evidence.merge(evidence) {
+                    Ok(merged) => merged,
+                    Err(_error) if incoming_unsafe => current_evidence,
+                    Err(error) => return Err(error),
+                }
+            }
             None => current_evidence,
         };
 
@@ -2550,6 +2617,32 @@ impl AttemptMachine {
         if effective_evidence != current_evidence {
             self.install_evidence(effective_evidence)?;
         }
+        let unsafe_evidence = incoming_unsafe
+            || effective_evidence.submission_phase == SubmissionPhase::Indeterminate
+            || effective_evidence.terminal_event_observed;
+        if unsafe_evidence {
+            let retry_number = if failure.retryable() {
+                Some(
+                    self.network_wait_count
+                        .checked_add(1)
+                        .ok_or_else(|| AttemptError::invalid("network wait count overflow"))?,
+                )
+            } else {
+                None
+            };
+            let outcome = TerminalOutcome::NetworkResumeUnsafe {
+                attempt: current_attempt,
+                failure: failure.clone(),
+            };
+            let result = self.install_terminal(outcome, Some(failure));
+            match retry_number {
+                Some(number) if number >= MAX_ATTEMPTS && result.is_ok() => {
+                    self.network_wait_count = number;
+                }
+                _ => {}
+            }
+            return result;
+        }
         if failure.classification() == FailureClassification::Ambiguous {
             let outcome = TerminalOutcome::NetworkResumeUnsafe {
                 attempt: current_attempt,
@@ -2569,20 +2662,29 @@ impl AttemptMachine {
             .network_wait_count
             .checked_add(1)
             .ok_or_else(|| AttemptError::invalid("network wait count overflow"))?;
-        if retry_number > MAX_NETWORK_WAITS {
-            let outcome = TerminalOutcome::NetworkRetryExhausted {
-                attempt: current_attempt,
-                failure: failure.clone(),
-            };
-            return self.install_terminal(outcome, Some(failure));
-        }
         let decision = effective_evidence.decision(self.session.pristine, true);
+        let exhausted = retry_number >= MAX_ATTEMPTS;
         if decision == RecoveryDecision::FailClosed {
             let outcome = TerminalOutcome::NetworkResumeUnsafe {
                 attempt: current_attempt,
                 failure: failure.clone(),
             };
-            return self.install_terminal(outcome, Some(failure));
+            let result = self.install_terminal(outcome, Some(failure));
+            if exhausted && result.is_ok() {
+                self.network_wait_count = retry_number;
+            }
+            return result;
+        }
+        if exhausted {
+            let outcome = TerminalOutcome::NetworkRetryExhausted {
+                attempt: current_attempt,
+                failure: failure.clone(),
+            };
+            let result = self.install_terminal(outcome, Some(failure));
+            if result.is_ok() {
+                self.network_wait_count = retry_number;
+            }
+            return result;
         }
         let backoff = BackoffDelay::for_retry(retry_number, jitter_seed)?;
         let next_attempt_number = self
@@ -2631,6 +2733,25 @@ impl AttemptMachine {
                 .as_ref()
                 .is_some_and(|plan| plan.decision == decision)
         {
+            if decision == RecoveryDecision::FreshIfPristine {
+                let session_id = fresh_session_id.ok_or_else(|| {
+                    AttemptError::invalid("fresh_if_pristine requires a new session id")
+                })?;
+                let session_id = bounded_string(session_id, "session_id", MAX_ID_BYTES)?;
+                if session_id != self.session.session_id {
+                    return Err(AttemptError::new(
+                        "recovery_choice_mismatch",
+                        ErrorKind::RecoveryChoiceMismatch,
+                        "fresh recovery replay must use its persisted replacement session",
+                    ));
+                }
+            } else if fresh_session_id.is_some() {
+                return Err(AttemptError::new(
+                    "recovery_choice_mismatch",
+                    ErrorKind::RecoveryChoiceMismatch,
+                    "resume_same_session cannot accept a replacement session",
+                ));
+            }
             return Ok(self.attempt_identity());
         }
         if self.phase != Phase::WaitingForRetry {
@@ -2668,7 +2789,7 @@ impl AttemptMachine {
                 "an unsafe recovery plan must be failed closed",
             ));
         }
-        if decision == RecoveryDecision::FreshIfPristine {
+        let replacement_session_id = if decision == RecoveryDecision::FreshIfPristine {
             if !self.session.pristine {
                 return Err(AttemptError::new(
                     "recovery_choice_mismatch",
@@ -2687,15 +2808,22 @@ impl AttemptMachine {
                     "fresh_if_pristine requires a different session id",
                 ));
             }
+            Some(session_id)
+        } else {
+            if fresh_session_id.is_some() {
+                return Err(AttemptError::new(
+                    "recovery_choice_mismatch",
+                    ErrorKind::RecoveryChoiceMismatch,
+                    "resume_same_session cannot accept a replacement session",
+                ));
+            }
+            None
+        };
+        let next_revision = self.next_revision()?;
+        if let Some(session_id) = replacement_session_id {
             self.session.session_id = session_id;
-        } else if fresh_session_id.is_some() {
-            return Err(AttemptError::new(
-                "recovery_choice_mismatch",
-                ErrorKind::RecoveryChoiceMismatch,
-                "resume_same_session cannot accept a replacement session",
-            ));
         }
-        self.bump_revision()?;
+        self.revision = next_revision;
         self.attempt = plan.next_attempt.attempt;
         self.phase = Phase::Executing;
         Ok(self.attempt_identity())

--- a/native/crates/runtime-attempt-core/src/lib.rs
+++ b/native/crates/runtime-attempt-core/src/lib.rs
@@ -1,0 +1,1294 @@
+//! Pure, bounded heartbeat attempt and network-recovery state.
+//!
+//! The crate contains only data validation and deterministic state transitions. It deliberately
+//! does not perform network, database, process, clock, or sleep operations; an adapter can carry
+//! the returned checkpoint and recovery plan to the current runtime authority.
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::fmt;
+
+pub const ATTEMPT_PROTOCOL_VERSION: u16 = 1;
+pub const MAX_ATTEMPTS: u8 = 6;
+pub const MAX_ID_BYTES: usize = 255;
+pub const NETWORK_BACKOFF_SECONDS: [u64; 6] = [2, 5, 10, 20, 30, 60];
+pub const MAX_JITTER_PERCENT: u64 = 25;
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ErrorKind {
+    InvalidInput,
+    InvalidTransition,
+    StaleLeaseFence,
+    LeaseExpired,
+    CancellationRequested,
+    AlreadyTerminal,
+    IdempotencyConflict,
+    RetryNotDue,
+    RecoveryChoiceMismatch,
+    AttemptLimitReached,
+    CheckpointInvalid,
+    NetworkResumeUnsafe,
+    NetworkRetryExhausted,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AttemptError {
+    code: &'static str,
+    kind: ErrorKind,
+    message: String,
+}
+
+impl AttemptError {
+    fn new(code: &'static str, kind: ErrorKind, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            kind,
+            message: message.into(),
+        }
+    }
+
+    fn invalid(message: impl Into<String>) -> Self {
+        Self::new("invalid_input", ErrorKind::InvalidInput, message)
+    }
+
+    pub fn code(&self) -> &'static str {
+        self.code
+    }
+
+    pub fn kind(&self) -> ErrorKind {
+        self.kind
+    }
+
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+}
+
+impl fmt::Display for AttemptError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "{}: {}", self.code, self.message)
+    }
+}
+
+impl std::error::Error for AttemptError {}
+
+fn bounded_string(
+    value: impl Into<String>,
+    field: &'static str,
+    max_bytes: usize,
+) -> Result<String, AttemptError> {
+    let value = value.into();
+    if value.trim().is_empty() {
+        return Err(AttemptError::invalid(format!("{field} must not be empty")));
+    }
+    if value.len() > max_bytes {
+        return Err(AttemptError::invalid(format!(
+            "{field} exceeds {max_bytes} bytes"
+        )));
+    }
+    Ok(value)
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HeartbeatIdentity {
+    pub organization_id: String,
+    pub run_id: String,
+    pub agent_id: String,
+}
+
+impl HeartbeatIdentity {
+    pub fn new(
+        organization_id: impl Into<String>,
+        run_id: impl Into<String>,
+        agent_id: impl Into<String>,
+    ) -> Result<Self, AttemptError> {
+        Ok(Self {
+            organization_id: bounded_string(organization_id, "organization_id", MAX_ID_BYTES)?,
+            run_id: bounded_string(run_id, "run_id", MAX_ID_BYTES)?,
+            agent_id: bounded_string(agent_id, "agent_id", MAX_ID_BYTES)?,
+        })
+    }
+
+    pub fn attempt(&self, attempt: u8) -> Result<AttemptIdentity, AttemptError> {
+        AttemptIdentity::new(
+            self.organization_id.clone(),
+            self.run_id.clone(),
+            self.agent_id.clone(),
+            attempt,
+        )
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AttemptIdentity {
+    pub organization_id: String,
+    pub run_id: String,
+    pub agent_id: String,
+    pub attempt: u8,
+}
+
+impl AttemptIdentity {
+    pub fn new(
+        organization_id: impl Into<String>,
+        run_id: impl Into<String>,
+        agent_id: impl Into<String>,
+        attempt: u8,
+    ) -> Result<Self, AttemptError> {
+        if !(1..=MAX_ATTEMPTS).contains(&attempt) {
+            return Err(AttemptError::invalid(format!(
+                "attempt must be between 1 and {MAX_ATTEMPTS}"
+            )));
+        }
+        Ok(Self {
+            organization_id: bounded_string(organization_id, "organization_id", MAX_ID_BYTES)?,
+            run_id: bounded_string(run_id, "run_id", MAX_ID_BYTES)?,
+            agent_id: bounded_string(agent_id, "agent_id", MAX_ID_BYTES)?,
+            attempt,
+        })
+    }
+
+    pub fn heartbeat_identity(&self) -> HeartbeatIdentity {
+        HeartbeatIdentity {
+            organization_id: self.organization_id.clone(),
+            run_id: self.run_id.clone(),
+            agent_id: self.agent_id.clone(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LeaseFence {
+    pub owner_id: String,
+    pub epoch: u64,
+    pub issued_at_millis: u64,
+    pub expires_at_millis: u64,
+}
+
+impl LeaseFence {
+    pub fn new(
+        owner_id: impl Into<String>,
+        epoch: u64,
+        issued_at_millis: u64,
+        expires_at_millis: u64,
+    ) -> Result<Self, AttemptError> {
+        if epoch == 0 {
+            return Err(AttemptError::invalid(
+                "lease epoch must be greater than zero",
+            ));
+        }
+        if expires_at_millis <= issued_at_millis {
+            return Err(AttemptError::invalid(
+                "lease expiry must be after its issue time",
+            ));
+        }
+        Ok(Self {
+            owner_id: bounded_string(owner_id, "lease owner", MAX_ID_BYTES)?,
+            epoch,
+            issued_at_millis,
+            expires_at_millis,
+        })
+    }
+
+    pub fn valid_at(&self, now_millis: u64) -> bool {
+        now_millis >= self.issued_at_millis && now_millis < self.expires_at_millis
+    }
+
+    fn assert_presented(&self, presented: &Self, now_millis: u64) -> Result<(), AttemptError> {
+        if self != presented {
+            return Err(AttemptError::new(
+                "stale_lease_fence",
+                ErrorKind::StaleLeaseFence,
+                "presented lease fence does not own this attempt",
+            ));
+        }
+        if !self.valid_at(now_millis) {
+            return Err(AttemptError::new(
+                "lease_expired",
+                ErrorKind::LeaseExpired,
+                "attempt lease is not valid at the supplied time",
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Phase {
+    Pristine,
+    Executing,
+    WaitingForNetwork,
+    WaitingForRetry,
+    Succeeded,
+    Terminal,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BackoffDelay {
+    pub retry_number: u8,
+    pub base_seconds: u64,
+    pub jitter_millis: u64,
+    pub delay_millis: u64,
+}
+
+pub fn network_backoff_seconds(retry_number: u8) -> Option<u64> {
+    retry_number
+        .checked_sub(1)
+        .and_then(|index| NETWORK_BACKOFF_SECONDS.get(index as usize).copied())
+}
+
+/// Produce stable positive jitter without depending on a clock or random source.
+///
+/// The input seed belongs to the caller's durable request context. Jitter is capped at 25% of
+/// the frozen delay, so retry timing stays bounded and a replay receives the same schedule.
+pub fn deterministic_jitter_millis(retry_number: u8, seed: u64) -> Result<u64, AttemptError> {
+    let base_seconds = network_backoff_seconds(retry_number)
+        .ok_or_else(|| AttemptError::invalid("retry number is outside the backoff schedule"))?;
+    let bound = base_seconds * 1_000 * MAX_JITTER_PERCENT / 100;
+    Ok(splitmix64(seed ^ u64::from(retry_number)) % (bound + 1))
+}
+
+impl BackoffDelay {
+    pub fn for_retry(retry_number: u8, jitter_seed: Option<u64>) -> Result<Self, AttemptError> {
+        let base_seconds = network_backoff_seconds(retry_number)
+            .ok_or_else(|| AttemptError::invalid("retry number is outside the backoff schedule"))?;
+        let jitter_millis = match jitter_seed {
+            Some(seed) => deterministic_jitter_millis(retry_number, seed)?,
+            None => 0,
+        };
+        let delay_millis = base_seconds
+            .checked_mul(1_000)
+            .and_then(|base| base.checked_add(jitter_millis))
+            .ok_or_else(|| AttemptError::invalid("retry delay overflow"))?;
+        Ok(Self {
+            retry_number,
+            base_seconds,
+            jitter_millis,
+            delay_millis,
+        })
+    }
+}
+
+fn splitmix64(mut value: u64) -> u64 {
+    value = value.wrapping_add(0x9e37_79b9_7f4a_7c15);
+    value = (value ^ (value >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+    value = (value ^ (value >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+    value ^ (value >> 31)
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TransportFailure {
+    Dns,
+    ConnectionRefused,
+    ConnectionReset,
+    Timeout,
+    Tls,
+    BodyInterrupted,
+}
+
+impl TransportFailure {
+    fn code(self) -> &'static str {
+        match self {
+            Self::Dns => "transport_dns",
+            Self::ConnectionRefused => "transport_connection_refused",
+            Self::ConnectionReset => "transport_connection_reset",
+            Self::Timeout => "transport_timeout",
+            Self::Tls => "transport_tls",
+            Self::BodyInterrupted => "transport_body_interrupted",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FailureClassification {
+    Transport,
+    Server5xx,
+    Credential,
+    Quota,
+    Ambiguous,
+    NonRetryable,
+}
+
+impl FailureClassification {
+    pub fn retryable(self) -> bool {
+        matches!(self, Self::Transport | Self::Server5xx)
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(tag = "kind", rename_all = "camelCase")]
+pub enum Failure {
+    Transport {
+        reason: TransportFailure,
+        code: String,
+        summary: String,
+    },
+    Credential {
+        code: String,
+        summary: String,
+    },
+    Quota {
+        code: String,
+        summary: String,
+    },
+    Server5xx {
+        status: u16,
+        code: String,
+        summary: String,
+    },
+    Ambiguous {
+        code: String,
+        summary: String,
+    },
+    NonRetryable {
+        code: String,
+        summary: String,
+    },
+}
+
+impl Failure {
+    pub fn transport(
+        reason: TransportFailure,
+        summary: impl Into<String>,
+    ) -> Result<Self, AttemptError> {
+        Ok(Self::Transport {
+            reason,
+            code: reason.code().to_owned(),
+            summary: bounded_string(summary, "failure_summary", 4 * 1024)?,
+        })
+    }
+
+    pub fn credential(
+        code: impl Into<String>,
+        summary: impl Into<String>,
+    ) -> Result<Self, AttemptError> {
+        Ok(Self::Credential {
+            code: bounded_string(code, "failure_code", 128)?,
+            summary: bounded_string(summary, "failure_summary", 4 * 1024)?,
+        })
+    }
+
+    pub fn quota(
+        code: impl Into<String>,
+        summary: impl Into<String>,
+    ) -> Result<Self, AttemptError> {
+        Ok(Self::Quota {
+            code: bounded_string(code, "failure_code", 128)?,
+            summary: bounded_string(summary, "failure_summary", 4 * 1024)?,
+        })
+    }
+
+    pub fn server_5xx(status: u16, summary: impl Into<String>) -> Result<Self, AttemptError> {
+        if !(500..=599).contains(&status) {
+            return Err(AttemptError::invalid(
+                "server failure status must be 500..=599",
+            ));
+        }
+        Ok(Self::Server5xx {
+            status,
+            code: "http_5xx".to_owned(),
+            summary: bounded_string(summary, "failure_summary", 4 * 1024)?,
+        })
+    }
+
+    pub fn ambiguous(
+        code: impl Into<String>,
+        summary: impl Into<String>,
+    ) -> Result<Self, AttemptError> {
+        Ok(Self::Ambiguous {
+            code: bounded_string(code, "failure_code", 128)?,
+            summary: bounded_string(summary, "failure_summary", 4 * 1024)?,
+        })
+    }
+
+    pub fn non_retryable(
+        code: impl Into<String>,
+        summary: impl Into<String>,
+    ) -> Result<Self, AttemptError> {
+        Ok(Self::NonRetryable {
+            code: bounded_string(code, "failure_code", 128)?,
+            summary: bounded_string(summary, "failure_summary", 4 * 1024)?,
+        })
+    }
+
+    pub fn classification(&self) -> FailureClassification {
+        match self {
+            Self::Transport { .. } => FailureClassification::Transport,
+            Self::Credential { .. } => FailureClassification::Credential,
+            Self::Quota { .. } => FailureClassification::Quota,
+            Self::Server5xx { .. } => FailureClassification::Server5xx,
+            Self::Ambiguous { .. } => FailureClassification::Ambiguous,
+            Self::NonRetryable { .. } => FailureClassification::NonRetryable,
+        }
+    }
+
+    pub fn code(&self) -> &str {
+        match self {
+            Self::Transport { code, .. }
+            | Self::Credential { code, .. }
+            | Self::Quota { code, .. }
+            | Self::Server5xx { code, .. }
+            | Self::Ambiguous { code, .. }
+            | Self::NonRetryable { code, .. } => code,
+        }
+    }
+
+    pub fn summary(&self) -> &str {
+        match self {
+            Self::Transport { summary, .. }
+            | Self::Credential { summary, .. }
+            | Self::Quota { summary, .. }
+            | Self::Server5xx { summary, .. }
+            | Self::Ambiguous { summary, .. }
+            | Self::NonRetryable { summary, .. } => summary,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RecoveryDecision {
+    ResumeSameSession,
+    FreshIfPristine,
+    FailClosed,
+}
+
+impl RecoveryDecision {
+    pub fn code(self) -> &'static str {
+        match self {
+            Self::ResumeSameSession => "resume_same_session",
+            Self::FreshIfPristine => "fresh_if_pristine",
+            Self::FailClosed => "fail_closed",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CancellationReason {
+    Operator,
+    Shutdown,
+    Timeout,
+    LeaseLost,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CancellationState {
+    NotRequested,
+    Requested(CancellationReason),
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum TerminalOutcome {
+    Succeeded {
+        attempt: AttemptIdentity,
+    },
+    Cancelled {
+        attempt: AttemptIdentity,
+        reason: CancellationReason,
+    },
+    Failed {
+        attempt: AttemptIdentity,
+        failure: Failure,
+    },
+    NetworkRetryExhausted {
+        attempt: AttemptIdentity,
+        failure: Failure,
+    },
+    NetworkResumeUnsafe {
+        attempt: AttemptIdentity,
+        failure: Failure,
+    },
+}
+
+impl TerminalOutcome {
+    pub fn code(&self) -> &'static str {
+        match self {
+            Self::Succeeded { .. } => "succeeded",
+            Self::Cancelled { .. } => "cancelled",
+            Self::Failed { .. } => "failed",
+            Self::NetworkRetryExhausted { .. } => "network_retry_exhausted",
+            Self::NetworkResumeUnsafe { .. } => "network_resume_unsafe",
+        }
+    }
+
+    pub fn failure(&self) -> Option<&Failure> {
+        match self {
+            Self::Failed { failure, .. }
+            | Self::NetworkRetryExhausted { failure, .. }
+            | Self::NetworkResumeUnsafe { failure, .. } => Some(failure),
+            Self::Succeeded { .. } | Self::Cancelled { .. } => None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RecoveryPlan {
+    pub failed_attempt: AttemptIdentity,
+    pub next_attempt: AttemptIdentity,
+    pub classification: FailureClassification,
+    pub decision: RecoveryDecision,
+    pub backoff: BackoffDelay,
+    pub next_attempt_at_millis: u64,
+    pub failure: Failure,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum RecoveryResult {
+    RetryScheduled(RecoveryPlan),
+    Terminal(TerminalOutcome),
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionCheckpoint {
+    pub session_id: String,
+    pub pristine: bool,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Checkpoint {
+    pub protocol_version: u16,
+    pub identity: HeartbeatIdentity,
+    pub attempt: AttemptIdentity,
+    pub phase: Phase,
+    pub session: SessionCheckpoint,
+    pub lease: LeaseFence,
+    pub idempotency_key: IdempotencyKey,
+    pub request_fingerprint: String,
+    pub revision: u64,
+    pub cancellation: CancellationState,
+    pub last_failure: Option<Failure>,
+    pub recovery: Option<RecoveryPlan>,
+    pub terminal_outcome: Option<TerminalOutcome>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IdempotencyKey(String);
+
+impl IdempotencyKey {
+    pub fn new(value: impl Into<String>) -> Result<Self, AttemptError> {
+        Ok(Self(bounded_string(
+            value,
+            "idempotency_key",
+            MAX_ID_BYTES,
+        )?))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<IdempotencyKey> for String {
+    fn from(value: IdempotencyKey) -> Self {
+        value.0
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IdempotencyRecord {
+    pub organization_id: String,
+    pub key: IdempotencyKey,
+    pub fingerprint: String,
+    pub run_id: String,
+    pub outcome: Option<TerminalOutcome>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum IdempotencyDecision {
+    New,
+    Replay { run_id: String },
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct IdempotencyLedger {
+    records: BTreeMap<(String, IdempotencyKey), IdempotencyRecord>,
+}
+
+impl IdempotencyLedger {
+    pub fn reserve(
+        &mut self,
+        organization_id: impl Into<String>,
+        key: IdempotencyKey,
+        fingerprint: impl Into<String>,
+        run_id: impl Into<String>,
+    ) -> Result<IdempotencyDecision, AttemptError> {
+        let organization_id = bounded_string(organization_id, "organization_id", MAX_ID_BYTES)?;
+        let fingerprint = bounded_string(fingerprint, "request_fingerprint", 4 * 1024)?;
+        let run_id = bounded_string(run_id, "run_id", MAX_ID_BYTES)?;
+        let index = (organization_id.clone(), key.clone());
+        if let Some(existing) = self.records.get(&index) {
+            if existing.fingerprint == fingerprint {
+                return Ok(IdempotencyDecision::Replay {
+                    run_id: existing.run_id.clone(),
+                });
+            }
+            return Err(AttemptError::new(
+                "idempotency_conflict",
+                ErrorKind::IdempotencyConflict,
+                "idempotency key was reused with a different fingerprint",
+            ));
+        }
+        self.records.insert(
+            index,
+            IdempotencyRecord {
+                organization_id,
+                key,
+                fingerprint,
+                run_id,
+                outcome: None,
+            },
+        );
+        Ok(IdempotencyDecision::New)
+    }
+
+    pub fn record_outcome(
+        &mut self,
+        organization_id: impl Into<String>,
+        key: IdempotencyKey,
+        outcome: TerminalOutcome,
+    ) -> Result<(), AttemptError> {
+        let organization_id = bounded_string(organization_id, "organization_id", MAX_ID_BYTES)?;
+        let record = self
+            .records
+            .get_mut(&(organization_id, key))
+            .ok_or_else(|| {
+                AttemptError::new(
+                    "idempotency_missing",
+                    ErrorKind::InvalidInput,
+                    "idempotency key has not been reserved",
+                )
+            })?;
+        if let Some(existing) = &record.outcome {
+            if existing != &outcome {
+                return Err(AttemptError::new(
+                    "idempotency_conflict",
+                    ErrorKind::IdempotencyConflict,
+                    "idempotency key already has a different terminal outcome",
+                ));
+            }
+            return Ok(());
+        }
+        record.outcome = Some(outcome);
+        Ok(())
+    }
+
+    pub fn outcome(
+        &self,
+        organization_id: impl AsRef<str>,
+        key: &IdempotencyKey,
+    ) -> Option<&TerminalOutcome> {
+        self.records
+            .get(&(organization_id.as_ref().to_owned(), key.clone()))
+            .and_then(|record| record.outcome.as_ref())
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AttemptMachine {
+    identity: HeartbeatIdentity,
+    attempt: u8,
+    phase: Phase,
+    session: SessionCheckpoint,
+    lease: LeaseFence,
+    idempotency_key: IdempotencyKey,
+    request_fingerprint: String,
+    revision: u64,
+    cancellation: CancellationState,
+    last_failure: Option<Failure>,
+    recovery: Option<RecoveryPlan>,
+    terminal_outcome: Option<TerminalOutcome>,
+}
+
+impl AttemptMachine {
+    pub fn new(
+        identity: HeartbeatIdentity,
+        session_id: impl Into<String>,
+        lease: LeaseFence,
+        idempotency_key: impl Into<String>,
+        request_fingerprint: impl Into<String>,
+    ) -> Result<Self, AttemptError> {
+        Ok(Self {
+            identity,
+            attempt: 1,
+            phase: Phase::Pristine,
+            session: SessionCheckpoint {
+                session_id: bounded_string(session_id, "session_id", MAX_ID_BYTES)?,
+                pristine: true,
+            },
+            lease,
+            idempotency_key: IdempotencyKey::new(idempotency_key)?,
+            request_fingerprint: bounded_string(
+                request_fingerprint,
+                "request_fingerprint",
+                4 * 1024,
+            )?,
+            revision: 0,
+            cancellation: CancellationState::NotRequested,
+            last_failure: None,
+            recovery: None,
+            terminal_outcome: None,
+        })
+    }
+
+    pub fn from_checkpoint(checkpoint: Checkpoint) -> Result<Self, AttemptError> {
+        if checkpoint.protocol_version != ATTEMPT_PROTOCOL_VERSION {
+            return Err(AttemptError::invalid(
+                "unsupported checkpoint protocol version",
+            ));
+        }
+        if checkpoint.identity != checkpoint.attempt.heartbeat_identity()
+            || checkpoint.attempt.attempt == 0
+            || checkpoint.attempt.attempt > MAX_ATTEMPTS
+        {
+            return Err(AttemptError::invalid(
+                "checkpoint identity and attempt do not agree",
+            ));
+        }
+        let request_fingerprint = bounded_string(
+            checkpoint.request_fingerprint.clone(),
+            "request_fingerprint",
+            4 * 1024,
+        )?;
+        let session_id = bounded_string(
+            checkpoint.session.session_id.clone(),
+            "session_id",
+            MAX_ID_BYTES,
+        )?;
+        Ok(Self {
+            identity: checkpoint.identity,
+            attempt: checkpoint.attempt.attempt,
+            phase: checkpoint.phase,
+            session: SessionCheckpoint {
+                session_id,
+                pristine: checkpoint.session.pristine,
+            },
+            lease: checkpoint.lease,
+            idempotency_key: checkpoint.idempotency_key,
+            request_fingerprint,
+            revision: checkpoint.revision,
+            cancellation: checkpoint.cancellation,
+            last_failure: checkpoint.last_failure,
+            recovery: checkpoint.recovery,
+            terminal_outcome: checkpoint.terminal_outcome,
+        })
+    }
+
+    pub fn checkpoint(&self) -> Checkpoint {
+        Checkpoint {
+            protocol_version: ATTEMPT_PROTOCOL_VERSION,
+            identity: self.identity.clone(),
+            attempt: self.attempt_identity(),
+            phase: self.phase,
+            session: self.session.clone(),
+            lease: self.lease.clone(),
+            idempotency_key: self.idempotency_key.clone(),
+            request_fingerprint: self.request_fingerprint.clone(),
+            revision: self.revision,
+            cancellation: self.cancellation,
+            last_failure: self.last_failure.clone(),
+            recovery: self.recovery.clone(),
+            terminal_outcome: self.terminal_outcome.clone(),
+        }
+    }
+
+    pub fn identity(&self) -> &HeartbeatIdentity {
+        &self.identity
+    }
+
+    pub fn attempt_identity(&self) -> AttemptIdentity {
+        self.identity
+            .attempt(self.attempt)
+            .expect("machine invariants keep attempt within the hard bound")
+    }
+
+    pub fn phase(&self) -> Phase {
+        self.phase
+    }
+
+    pub fn session_id(&self) -> &str {
+        &self.session.session_id
+    }
+
+    pub fn session_pristine(&self) -> bool {
+        self.session.pristine
+    }
+
+    pub fn cancellation(&self) -> CancellationState {
+        self.cancellation
+    }
+
+    pub fn terminal_outcome(&self) -> Option<&TerminalOutcome> {
+        self.terminal_outcome.as_ref()
+    }
+
+    pub fn recovery_plan(&self) -> Option<&RecoveryPlan> {
+        self.recovery.as_ref()
+    }
+
+    pub fn revision(&self) -> u64 {
+        self.revision
+    }
+
+    fn bump_revision(&mut self) -> Result<(), AttemptError> {
+        self.revision = self
+            .revision
+            .checked_add(1)
+            .ok_or_else(|| AttemptError::invalid("checkpoint revision overflow"))?;
+        Ok(())
+    }
+
+    fn ensure_not_cancelled(&self) -> Result<(), AttemptError> {
+        if let CancellationState::Requested(reason) = self.cancellation {
+            return Err(AttemptError::new(
+                "cancellation_requested",
+                ErrorKind::CancellationRequested,
+                format!("attempt cancellation was requested: {reason:?}"),
+            ));
+        }
+        Ok(())
+    }
+
+    pub fn start(
+        &mut self,
+        fence: &LeaseFence,
+        now_millis: u64,
+    ) -> Result<AttemptIdentity, AttemptError> {
+        self.lease.assert_presented(fence, now_millis)?;
+        self.ensure_not_cancelled()?;
+        match self.phase {
+            Phase::Pristine => {
+                self.bump_revision()?;
+                self.phase = Phase::Executing;
+                Ok(self.attempt_identity())
+            }
+            Phase::Executing => Ok(self.attempt_identity()),
+            Phase::Terminal | Phase::Succeeded => Err(AttemptError::new(
+                "already_terminal",
+                ErrorKind::AlreadyTerminal,
+                "attempt machine is already terminal",
+            )),
+            _ => Err(AttemptError::new(
+                "invalid_transition",
+                ErrorKind::InvalidTransition,
+                "attempt cannot start from its current phase",
+            )),
+        }
+    }
+
+    /// Persist the boundary at which an in-flight network operation is being observed.
+    pub fn mark_waiting_for_network(
+        &mut self,
+        fence: &LeaseFence,
+        now_millis: u64,
+    ) -> Result<Checkpoint, AttemptError> {
+        self.lease.assert_presented(fence, now_millis)?;
+        self.ensure_not_cancelled()?;
+        match self.phase {
+            Phase::Executing => {
+                self.bump_revision()?;
+                self.phase = Phase::WaitingForNetwork;
+                Ok(self.checkpoint())
+            }
+            Phase::WaitingForNetwork => Ok(self.checkpoint()),
+            _ => Err(AttemptError::new(
+                "invalid_transition",
+                ErrorKind::InvalidTransition,
+                "network wait can only begin while executing",
+            )),
+        }
+    }
+
+    /// Record a durable progress marker. A non-pristine session may be resumed, but it must not
+    /// be replaced with a fresh session after a network failure.
+    pub fn checkpoint_progress(
+        &mut self,
+        fence: &LeaseFence,
+        now_millis: u64,
+    ) -> Result<Checkpoint, AttemptError> {
+        self.lease.assert_presented(fence, now_millis)?;
+        self.ensure_not_cancelled()?;
+        match self.phase {
+            Phase::Executing | Phase::WaitingForNetwork if self.session.pristine => {
+                self.bump_revision()?;
+                self.session.pristine = false;
+                Ok(self.checkpoint())
+            }
+            Phase::Executing | Phase::WaitingForNetwork => Ok(self.checkpoint()),
+            _ => Err(AttemptError::new(
+                "invalid_transition",
+                ErrorKind::InvalidTransition,
+                "progress can only be checkpointed while executing",
+            )),
+        }
+    }
+
+    fn install_terminal(
+        &mut self,
+        outcome: TerminalOutcome,
+        failure: Option<Failure>,
+    ) -> Result<RecoveryResult, AttemptError> {
+        self.bump_revision()?;
+        self.phase = Phase::Terminal;
+        self.last_failure = failure;
+        self.recovery = None;
+        self.terminal_outcome = Some(outcome.clone());
+        Ok(RecoveryResult::Terminal(outcome))
+    }
+
+    fn install_success(&mut self) -> Result<TerminalOutcome, AttemptError> {
+        self.bump_revision()?;
+        self.phase = Phase::Succeeded;
+        self.last_failure = None;
+        self.recovery = None;
+        let outcome = TerminalOutcome::Succeeded {
+            attempt: self.attempt_identity(),
+        };
+        self.terminal_outcome = Some(outcome.clone());
+        Ok(outcome)
+    }
+
+    pub fn succeed(
+        &mut self,
+        fence: &LeaseFence,
+        now_millis: u64,
+    ) -> Result<TerminalOutcome, AttemptError> {
+        self.lease.assert_presented(fence, now_millis)?;
+        if let Some(TerminalOutcome::Succeeded { .. }) = &self.terminal_outcome {
+            return self.terminal_outcome.clone().ok_or_else(|| {
+                AttemptError::new(
+                    "checkpoint_invalid",
+                    ErrorKind::CheckpointInvalid,
+                    "successful phase has no outcome",
+                )
+            });
+        }
+        self.ensure_not_cancelled()?;
+        if self.phase == Phase::Terminal || self.phase == Phase::Succeeded {
+            return Err(AttemptError::new(
+                "already_terminal",
+                ErrorKind::AlreadyTerminal,
+                "attempt machine is already terminal",
+            ));
+        }
+        if !matches!(self.phase, Phase::Executing | Phase::WaitingForNetwork) {
+            return Err(AttemptError::new(
+                "invalid_transition",
+                ErrorKind::InvalidTransition,
+                "success can only be recorded for an executing attempt",
+            ));
+        }
+        self.install_success()
+    }
+
+    /// Classify a transport/provider result and return a side-effect-free recovery plan.
+    pub fn record_failure(
+        &mut self,
+        failure: Failure,
+        fence: &LeaseFence,
+        now_millis: u64,
+        jitter_seed: Option<u64>,
+    ) -> Result<RecoveryResult, AttemptError> {
+        self.lease.assert_presented(fence, now_millis)?;
+        self.ensure_not_cancelled()?;
+
+        if self.phase == Phase::WaitingForRetry {
+            if self.last_failure.as_ref() == Some(&failure) {
+                return self
+                    .recovery
+                    .clone()
+                    .map(RecoveryResult::RetryScheduled)
+                    .ok_or_else(|| {
+                        AttemptError::new(
+                            "checkpoint_invalid",
+                            ErrorKind::CheckpointInvalid,
+                            "retry phase has no recovery plan",
+                        )
+                    });
+            }
+            return Err(AttemptError::new(
+                "idempotency_conflict",
+                ErrorKind::IdempotencyConflict,
+                "a different failure was replayed for the same attempt",
+            ));
+        }
+        if self.phase == Phase::Terminal {
+            if self
+                .terminal_outcome
+                .as_ref()
+                .and_then(TerminalOutcome::failure)
+                == Some(&failure)
+            {
+                return self
+                    .terminal_outcome
+                    .clone()
+                    .map(RecoveryResult::Terminal)
+                    .ok_or_else(|| {
+                        AttemptError::new(
+                            "checkpoint_invalid",
+                            ErrorKind::CheckpointInvalid,
+                            "terminal phase has no outcome",
+                        )
+                    });
+            }
+            return Err(AttemptError::new(
+                "already_terminal",
+                ErrorKind::AlreadyTerminal,
+                "attempt machine is already terminal",
+            ));
+        }
+        if !matches!(self.phase, Phase::Executing | Phase::WaitingForNetwork) {
+            return Err(AttemptError::new(
+                "invalid_transition",
+                ErrorKind::InvalidTransition,
+                "failure can only be recorded for an executing attempt",
+            ));
+        }
+
+        let classification = failure.classification();
+        let current_attempt = self.attempt_identity();
+        if classification == FailureClassification::Ambiguous {
+            let outcome = TerminalOutcome::NetworkResumeUnsafe {
+                attempt: current_attempt,
+                failure: failure.clone(),
+            };
+            return self.install_terminal(outcome, Some(failure));
+        }
+        if !classification.retryable() {
+            let outcome = TerminalOutcome::Failed {
+                attempt: current_attempt,
+                failure: failure.clone(),
+            };
+            return self.install_terminal(outcome, Some(failure));
+        }
+        if self.attempt >= MAX_ATTEMPTS {
+            let outcome = TerminalOutcome::NetworkRetryExhausted {
+                attempt: current_attempt,
+                failure: failure.clone(),
+            };
+            return self.install_terminal(outcome, Some(failure));
+        }
+
+        let retry_number = self.attempt;
+        let backoff = BackoffDelay::for_retry(retry_number, jitter_seed)?;
+        let next_attempt_at_millis = now_millis
+            .checked_add(backoff.delay_millis)
+            .ok_or_else(|| AttemptError::invalid("retry timestamp overflow"))?;
+        let next_attempt = self.identity.attempt(self.attempt + 1)?;
+        let decision = if self.session.pristine {
+            RecoveryDecision::FreshIfPristine
+        } else {
+            RecoveryDecision::ResumeSameSession
+        };
+        let plan = RecoveryPlan {
+            failed_attempt: current_attempt,
+            next_attempt,
+            classification,
+            decision,
+            backoff,
+            next_attempt_at_millis,
+            failure: failure.clone(),
+        };
+        self.bump_revision()?;
+        self.phase = Phase::WaitingForRetry;
+        self.last_failure = Some(failure);
+        self.recovery = Some(plan.clone());
+        Ok(RecoveryResult::RetryScheduled(plan))
+    }
+
+    fn recover(
+        &mut self,
+        decision: RecoveryDecision,
+        fence: &LeaseFence,
+        now_millis: u64,
+        fresh_session_id: Option<String>,
+    ) -> Result<AttemptIdentity, AttemptError> {
+        self.lease.assert_presented(fence, now_millis)?;
+        self.ensure_not_cancelled()?;
+        if self.phase == Phase::Executing
+            && self
+                .recovery
+                .as_ref()
+                .is_some_and(|plan| plan.decision == decision)
+        {
+            return Ok(self.attempt_identity());
+        }
+        if self.phase != Phase::WaitingForRetry {
+            return Err(AttemptError::new(
+                "invalid_transition",
+                ErrorKind::InvalidTransition,
+                "recovery requires a scheduled retry",
+            ));
+        }
+        let plan = self.recovery.clone().ok_or_else(|| {
+            AttemptError::new(
+                "checkpoint_invalid",
+                ErrorKind::CheckpointInvalid,
+                "retry phase has no recovery plan",
+            )
+        })?;
+        if now_millis < plan.next_attempt_at_millis {
+            return Err(AttemptError::new(
+                "retry_not_due",
+                ErrorKind::RetryNotDue,
+                "retry cannot resume before its scheduled time",
+            ));
+        }
+        if plan.decision != decision {
+            return Err(AttemptError::new(
+                "recovery_choice_mismatch",
+                ErrorKind::RecoveryChoiceMismatch,
+                format!("recovery requires {}", plan.decision.code()),
+            ));
+        }
+        if decision == RecoveryDecision::FreshIfPristine {
+            if !self.session.pristine {
+                return Err(AttemptError::new(
+                    "recovery_choice_mismatch",
+                    ErrorKind::RecoveryChoiceMismatch,
+                    "a non-pristine session cannot be replaced",
+                ));
+            }
+            let session_id = fresh_session_id.ok_or_else(|| {
+                AttemptError::invalid("fresh_if_pristine requires a new session id")
+            })?;
+            self.session.session_id = bounded_string(session_id, "session_id", MAX_ID_BYTES)?;
+        } else if fresh_session_id.is_some() {
+            return Err(AttemptError::new(
+                "recovery_choice_mismatch",
+                ErrorKind::RecoveryChoiceMismatch,
+                "resume_same_session cannot accept a replacement session",
+            ));
+        }
+        self.bump_revision()?;
+        self.attempt = plan.next_attempt.attempt;
+        self.phase = Phase::Executing;
+        Ok(self.attempt_identity())
+    }
+
+    pub fn resume_same_session(
+        &mut self,
+        fence: &LeaseFence,
+        now_millis: u64,
+    ) -> Result<AttemptIdentity, AttemptError> {
+        self.recover(RecoveryDecision::ResumeSameSession, fence, now_millis, None)
+    }
+
+    pub fn fail_closed(
+        &mut self,
+        fence: &LeaseFence,
+        now_millis: u64,
+    ) -> Result<TerminalOutcome, AttemptError> {
+        self.lease.assert_presented(fence, now_millis)?;
+        if let Some(TerminalOutcome::NetworkResumeUnsafe { .. }) = &self.terminal_outcome {
+            return self.terminal_outcome.clone().ok_or_else(|| {
+                AttemptError::new(
+                    "checkpoint_invalid",
+                    ErrorKind::CheckpointInvalid,
+                    "unsafe terminal phase has no outcome",
+                )
+            });
+        }
+        self.ensure_not_cancelled()?;
+        let failure = match self.phase {
+            Phase::WaitingForRetry => self
+                .recovery
+                .as_ref()
+                .map(|plan| plan.failure.clone())
+                .or_else(|| self.last_failure.clone()),
+            Phase::Executing | Phase::WaitingForNetwork => self.last_failure.clone(),
+            Phase::Terminal | Phase::Succeeded => None,
+            Phase::Pristine => None,
+        }
+        .ok_or_else(|| {
+            AttemptError::new(
+                "invalid_transition",
+                ErrorKind::InvalidTransition,
+                "fail_closed requires a recorded network failure",
+            )
+        })?;
+        let outcome = TerminalOutcome::NetworkResumeUnsafe {
+            attempt: self.attempt_identity(),
+            failure: failure.clone(),
+        };
+        match self.install_terminal(outcome, Some(failure))? {
+            RecoveryResult::Terminal(outcome) => Ok(outcome),
+            RecoveryResult::RetryScheduled(_) => Err(AttemptError::invalid(
+                "fail_closed unexpectedly scheduled a retry",
+            )),
+        }
+    }
+
+    pub fn cancel(
+        &mut self,
+        fence: &LeaseFence,
+        reason: CancellationReason,
+        now_millis: u64,
+    ) -> Result<TerminalOutcome, AttemptError> {
+        self.lease.assert_presented(fence, now_millis)?;
+        let already_cancelled = matches!(
+            &self.terminal_outcome,
+            Some(TerminalOutcome::Cancelled {
+                reason: existing_reason,
+                ..
+            }) if *existing_reason == reason
+        );
+        if already_cancelled {
+            return self.terminal_outcome.clone().ok_or_else(|| {
+                AttemptError::new(
+                    "checkpoint_invalid",
+                    ErrorKind::CheckpointInvalid,
+                    "cancelled phase has no outcome",
+                )
+            });
+        }
+        if self.phase == Phase::Terminal || self.phase == Phase::Succeeded {
+            return Err(AttemptError::new(
+                "already_terminal",
+                ErrorKind::AlreadyTerminal,
+                "attempt machine is already terminal",
+            ));
+        }
+        self.bump_revision()?;
+        self.cancellation = CancellationState::Requested(reason);
+        let outcome = TerminalOutcome::Cancelled {
+            attempt: self.attempt_identity(),
+            reason,
+        };
+        self.phase = Phase::Terminal;
+        self.recovery = None;
+        self.terminal_outcome = Some(outcome.clone());
+        Ok(outcome)
+    }
+
+    pub fn fresh_if_pristine(
+        &mut self,
+        fence: &LeaseFence,
+        now_millis: u64,
+        fresh_session_id: impl Into<String>,
+    ) -> Result<AttemptIdentity, AttemptError> {
+        self.recover(
+            RecoveryDecision::FreshIfPristine,
+            fence,
+            now_millis,
+            Some(fresh_session_id.into()),
+        )
+    }
+}

--- a/native/crates/runtime-attempt-core/src/lib.rs
+++ b/native/crates/runtime-attempt-core/src/lib.rs
@@ -4,13 +4,20 @@
 //! does not perform network, database, process, clock, or sleep operations; an adapter can carry
 //! the returned checkpoint and recovery plan to the current runtime authority.
 
+use serde::de::{self, Deserializer};
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
+use std::borrow::Borrow;
 use std::fmt;
 
 pub const ATTEMPT_PROTOCOL_VERSION: u16 = 1;
-pub const MAX_ATTEMPTS: u8 = 6;
+/// The initial attempt plus one attempt for each bounded network wait.
+pub const MAX_NETWORK_WAITS: u8 = 6;
+pub const MAX_ATTEMPTS: u8 = MAX_NETWORK_WAITS + 1;
 pub const MAX_ID_BYTES: usize = 255;
+pub const MAX_REQUEST_FINGERPRINT_BYTES: usize = 4 * 1024;
+pub const MAX_FAILURE_CODE_BYTES: usize = 128;
+pub const MAX_FAILURE_SUMMARY_BYTES: usize = 4 * 1024;
+pub const MAX_IDEMPOTENCY_RECORDS: usize = 1_024;
 pub const NETWORK_BACKOFF_SECONDS: [u64; 6] = [2, 5, 10, 20, 30, 60];
 pub const MAX_JITTER_PERCENT: u64 = 25;
 
@@ -90,7 +97,7 @@ fn bounded_string(
     Ok(value)
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct HeartbeatIdentity {
     pub organization_id: String,
@@ -119,9 +126,20 @@ impl HeartbeatIdentity {
             attempt,
         )
     }
+
+    fn validate(&self) -> Result<(), AttemptError> {
+        bounded_string(
+            self.organization_id.clone(),
+            "organization_id",
+            MAX_ID_BYTES,
+        )?;
+        bounded_string(self.run_id.clone(), "run_id", MAX_ID_BYTES)?;
+        bounded_string(self.agent_id.clone(), "agent_id", MAX_ID_BYTES)?;
+        Ok(())
+    }
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AttemptIdentity {
     pub organization_id: String,
@@ -157,9 +175,19 @@ impl AttemptIdentity {
             agent_id: self.agent_id.clone(),
         }
     }
+
+    fn validate(&self) -> Result<(), AttemptError> {
+        self.heartbeat_identity().validate()?;
+        if !(1..=MAX_ATTEMPTS).contains(&self.attempt) {
+            return Err(AttemptError::invalid(format!(
+                "attempt must be between 1 and {MAX_ATTEMPTS}"
+            )));
+        }
+        Ok(())
+    }
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct LeaseFence {
     pub owner_id: String,
@@ -194,7 +222,22 @@ impl LeaseFence {
     }
 
     pub fn valid_at(&self, now_millis: u64) -> bool {
-        now_millis >= self.issued_at_millis && now_millis < self.expires_at_millis
+        self.epoch > 0
+            && !self.owner_id.trim().is_empty()
+            && self.owner_id.len() <= MAX_ID_BYTES
+            && self.expires_at_millis > self.issued_at_millis
+            && now_millis >= self.issued_at_millis
+            && now_millis < self.expires_at_millis
+    }
+
+    fn validate(&self) -> Result<(), AttemptError> {
+        Self::new(
+            self.owner_id.clone(),
+            self.epoch,
+            self.issued_at_millis,
+            self.expires_at_millis,
+        )
+        .map(|_| ())
     }
 
     fn assert_presented(&self, presented: &Self, now_millis: u64) -> Result<(), AttemptError> {
@@ -216,6 +259,74 @@ impl LeaseFence {
     }
 }
 
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct HeartbeatIdentityWire {
+    organization_id: String,
+    run_id: String,
+    agent_id: String,
+}
+
+impl<'de> Deserialize<'de> for HeartbeatIdentity {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let wire = HeartbeatIdentityWire::deserialize(deserializer)?;
+        Self::new(wire.organization_id, wire.run_id, wire.agent_id).map_err(de::Error::custom)
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct AttemptIdentityWire {
+    organization_id: String,
+    run_id: String,
+    agent_id: String,
+    attempt: u8,
+}
+
+impl<'de> Deserialize<'de> for AttemptIdentity {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let wire = AttemptIdentityWire::deserialize(deserializer)?;
+        Self::new(
+            wire.organization_id,
+            wire.run_id,
+            wire.agent_id,
+            wire.attempt,
+        )
+        .map_err(de::Error::custom)
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct LeaseFenceWire {
+    owner_id: String,
+    epoch: u64,
+    issued_at_millis: u64,
+    expires_at_millis: u64,
+}
+
+impl<'de> Deserialize<'de> for LeaseFence {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let wire = LeaseFenceWire::deserialize(deserializer)?;
+        Self::new(
+            wire.owner_id,
+            wire.epoch,
+            wire.issued_at_millis,
+            wire.expires_at_millis,
+        )
+        .map_err(de::Error::custom)
+    }
+}
+
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Phase {
@@ -227,7 +338,7 @@ pub enum Phase {
     Terminal,
 }
 
-#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BackoffDelay {
     pub retry_number: u8,
@@ -271,6 +382,59 @@ impl BackoffDelay {
             jitter_millis,
             delay_millis,
         })
+    }
+
+    fn validate(&self) -> Result<(), AttemptError> {
+        let expected_base = network_backoff_seconds(self.retry_number)
+            .ok_or_else(|| AttemptError::invalid("retry number is outside the backoff schedule"))?;
+        let jitter_bound = expected_base
+            .checked_mul(1_000)
+            .and_then(|millis| millis.checked_mul(MAX_JITTER_PERCENT))
+            .map(|millis| millis / 100)
+            .ok_or_else(|| AttemptError::invalid("retry jitter overflow"))?;
+        if self.base_seconds != expected_base {
+            return Err(AttemptError::invalid(
+                "backoff base does not match its retry number",
+            ));
+        }
+        if self.jitter_millis > jitter_bound {
+            return Err(AttemptError::invalid("backoff jitter exceeds its bound"));
+        }
+        let expected_delay = expected_base
+            .checked_mul(1_000)
+            .and_then(|millis| millis.checked_add(self.jitter_millis))
+            .ok_or_else(|| AttemptError::invalid("retry delay overflow"))?;
+        if self.delay_millis != expected_delay {
+            return Err(AttemptError::invalid(
+                "backoff delay does not match its components",
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct BackoffDelayWire {
+    retry_number: u8,
+    base_seconds: u64,
+    jitter_millis: u64,
+    delay_millis: u64,
+}
+
+impl<'de> Deserialize<'de> for BackoffDelay {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let wire = BackoffDelayWire::deserialize(deserializer)?;
+        let delay = Self {
+            retry_number: wire.retry_number,
+            base_seconds: wire.base_seconds,
+            jitter_millis: wire.jitter_millis,
+            delay_millis: wire.delay_millis,
+        };
+        delay.validate().map(|_| delay).map_err(de::Error::custom)
     }
 }
 
@@ -317,12 +481,16 @@ pub enum FailureClassification {
 }
 
 impl FailureClassification {
+    /// Returns the retryable class, not the final decision for a concrete failure.
+    ///
+    /// Transport failures still require [`Failure::retryable`] because TLS transport failures are
+    /// terminal under the conservative recovery contract.
     pub fn retryable(self) -> bool {
-        matches!(self, Self::Transport | Self::Server5xx)
+        matches!(self, Self::Transport)
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 #[serde(tag = "kind", rename_all = "camelCase")]
 pub enum Failure {
     Transport {
@@ -361,7 +529,7 @@ impl Failure {
         Ok(Self::Transport {
             reason,
             code: reason.code().to_owned(),
-            summary: bounded_string(summary, "failure_summary", 4 * 1024)?,
+            summary: bounded_string(summary, "failure_summary", MAX_FAILURE_SUMMARY_BYTES)?,
         })
     }
 
@@ -370,8 +538,8 @@ impl Failure {
         summary: impl Into<String>,
     ) -> Result<Self, AttemptError> {
         Ok(Self::Credential {
-            code: bounded_string(code, "failure_code", 128)?,
-            summary: bounded_string(summary, "failure_summary", 4 * 1024)?,
+            code: bounded_string(code, "failure_code", MAX_FAILURE_CODE_BYTES)?,
+            summary: bounded_string(summary, "failure_summary", MAX_FAILURE_SUMMARY_BYTES)?,
         })
     }
 
@@ -380,8 +548,8 @@ impl Failure {
         summary: impl Into<String>,
     ) -> Result<Self, AttemptError> {
         Ok(Self::Quota {
-            code: bounded_string(code, "failure_code", 128)?,
-            summary: bounded_string(summary, "failure_summary", 4 * 1024)?,
+            code: bounded_string(code, "failure_code", MAX_FAILURE_CODE_BYTES)?,
+            summary: bounded_string(summary, "failure_summary", MAX_FAILURE_SUMMARY_BYTES)?,
         })
     }
 
@@ -394,7 +562,7 @@ impl Failure {
         Ok(Self::Server5xx {
             status,
             code: "http_5xx".to_owned(),
-            summary: bounded_string(summary, "failure_summary", 4 * 1024)?,
+            summary: bounded_string(summary, "failure_summary", MAX_FAILURE_SUMMARY_BYTES)?,
         })
     }
 
@@ -403,8 +571,8 @@ impl Failure {
         summary: impl Into<String>,
     ) -> Result<Self, AttemptError> {
         Ok(Self::Ambiguous {
-            code: bounded_string(code, "failure_code", 128)?,
-            summary: bounded_string(summary, "failure_summary", 4 * 1024)?,
+            code: bounded_string(code, "failure_code", MAX_FAILURE_CODE_BYTES)?,
+            summary: bounded_string(summary, "failure_summary", MAX_FAILURE_SUMMARY_BYTES)?,
         })
     }
 
@@ -413,8 +581,8 @@ impl Failure {
         summary: impl Into<String>,
     ) -> Result<Self, AttemptError> {
         Ok(Self::NonRetryable {
-            code: bounded_string(code, "failure_code", 128)?,
-            summary: bounded_string(summary, "failure_summary", 4 * 1024)?,
+            code: bounded_string(code, "failure_code", MAX_FAILURE_CODE_BYTES)?,
+            summary: bounded_string(summary, "failure_summary", MAX_FAILURE_SUMMARY_BYTES)?,
         })
     }
 
@@ -427,6 +595,70 @@ impl Failure {
             Self::Ambiguous { .. } => FailureClassification::Ambiguous,
             Self::NonRetryable { .. } => FailureClassification::NonRetryable,
         }
+    }
+
+    /// Only failures whose outcome is safe to retry may create a network wait.
+    pub fn retryable(&self) -> bool {
+        matches!(
+            self,
+            Self::Transport {
+                reason: TransportFailure::Dns
+                    | TransportFailure::ConnectionRefused
+                    | TransportFailure::ConnectionReset
+                    | TransportFailure::Timeout
+                    | TransportFailure::BodyInterrupted,
+                ..
+            }
+        )
+    }
+
+    fn validate(&self) -> Result<(), AttemptError> {
+        match self {
+            Self::Transport {
+                reason,
+                code,
+                summary,
+            } => {
+                if code != reason.code() {
+                    return Err(AttemptError::invalid(
+                        "transport failure code does not match its reason",
+                    ));
+                }
+                bounded_string(
+                    summary.clone(),
+                    "failure_summary",
+                    MAX_FAILURE_SUMMARY_BYTES,
+                )?;
+            }
+            Self::Credential { code, summary }
+            | Self::Quota { code, summary }
+            | Self::Ambiguous { code, summary }
+            | Self::NonRetryable { code, summary } => {
+                bounded_string(code.clone(), "failure_code", MAX_FAILURE_CODE_BYTES)?;
+                bounded_string(
+                    summary.clone(),
+                    "failure_summary",
+                    MAX_FAILURE_SUMMARY_BYTES,
+                )?;
+            }
+            Self::Server5xx {
+                status,
+                code,
+                summary,
+            } => {
+                if !(500..=599).contains(status) || code != "http_5xx" {
+                    return Err(AttemptError::invalid(
+                        "server failure has an invalid status or code",
+                    ));
+                }
+                bounded_string(
+                    summary.clone(),
+                    "failure_summary",
+                    MAX_FAILURE_SUMMARY_BYTES,
+                )?;
+            }
+        }
+        Ok(())
     }
 
     pub fn code(&self) -> &str {
@@ -452,6 +684,73 @@ impl Failure {
     }
 }
 
+#[derive(Deserialize)]
+#[serde(tag = "kind", rename_all = "camelCase", deny_unknown_fields)]
+enum FailureWire {
+    Transport {
+        reason: TransportFailure,
+        code: String,
+        summary: String,
+    },
+    Credential {
+        code: String,
+        summary: String,
+    },
+    Quota {
+        code: String,
+        summary: String,
+    },
+    Server5xx {
+        status: u16,
+        code: String,
+        summary: String,
+    },
+    Ambiguous {
+        code: String,
+        summary: String,
+    },
+    NonRetryable {
+        code: String,
+        summary: String,
+    },
+}
+
+impl<'de> Deserialize<'de> for Failure {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let failure = match FailureWire::deserialize(deserializer)? {
+            FailureWire::Transport {
+                reason,
+                code,
+                summary,
+            } => Self::Transport {
+                reason,
+                code,
+                summary,
+            },
+            FailureWire::Credential { code, summary } => Self::Credential { code, summary },
+            FailureWire::Quota { code, summary } => Self::Quota { code, summary },
+            FailureWire::Server5xx {
+                status,
+                code,
+                summary,
+            } => Self::Server5xx {
+                status,
+                code,
+                summary,
+            },
+            FailureWire::Ambiguous { code, summary } => Self::Ambiguous { code, summary },
+            FailureWire::NonRetryable { code, summary } => Self::NonRetryable { code, summary },
+        };
+        failure
+            .validate()
+            .map(|_| failure)
+            .map_err(de::Error::custom)
+    }
+}
+
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum RecoveryDecision {
@@ -472,6 +771,192 @@ impl RecoveryDecision {
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
+pub enum SubmissionPhase {
+    PreSubmission,
+    Accepted,
+    Indeterminate,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SideEffectRisk {
+    None,
+    Possible,
+    Confirmed,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RecoveryEvidence {
+    pub submission_phase: SubmissionPhase,
+    pub side_effect_risk: SideEffectRisk,
+    pub model_output_observed: bool,
+    pub tool_activity_observed: bool,
+    pub terminal_event_observed: bool,
+}
+
+impl RecoveryEvidence {
+    pub const fn pre_submission() -> Self {
+        Self {
+            submission_phase: SubmissionPhase::PreSubmission,
+            side_effect_risk: SideEffectRisk::None,
+            model_output_observed: false,
+            tool_activity_observed: false,
+            terminal_event_observed: false,
+        }
+    }
+
+    pub fn new(
+        submission_phase: SubmissionPhase,
+        side_effect_risk: SideEffectRisk,
+        model_output_observed: bool,
+        tool_activity_observed: bool,
+        terminal_event_observed: bool,
+    ) -> Result<Self, AttemptError> {
+        let evidence = Self {
+            submission_phase,
+            side_effect_risk,
+            model_output_observed,
+            tool_activity_observed,
+            terminal_event_observed,
+        };
+        evidence.validate().map(|_| evidence)
+    }
+
+    fn validate(&self) -> Result<(), AttemptError> {
+        if self.tool_activity_observed && self.submission_phase != SubmissionPhase::Accepted {
+            return Err(AttemptError::invalid(
+                "tool activity requires an accepted submission phase",
+            ));
+        }
+        if self.model_output_observed && self.submission_phase != SubmissionPhase::Accepted {
+            return Err(AttemptError::invalid(
+                "model output requires an accepted submission phase",
+            ));
+        }
+        if self.terminal_event_observed && self.submission_phase == SubmissionPhase::PreSubmission {
+            return Err(AttemptError::invalid(
+                "terminal event evidence requires a submitted or indeterminate phase",
+            ));
+        }
+        match self.side_effect_risk {
+            SideEffectRisk::None => {
+                if self.submission_phase != SubmissionPhase::PreSubmission
+                    || self.model_output_observed
+                    || self.tool_activity_observed
+                    || self.terminal_event_observed
+                {
+                    return Err(AttemptError::invalid(
+                        "none side-effect risk requires an untouched submission",
+                    ));
+                }
+            }
+            SideEffectRisk::Possible => {
+                if self.submission_phase == SubmissionPhase::PreSubmission {
+                    return Err(AttemptError::invalid(
+                        "pre-submission evidence cannot have possible side effects",
+                    ));
+                }
+            }
+            SideEffectRisk::Confirmed => {
+                if !self.tool_activity_observed {
+                    return Err(AttemptError::invalid(
+                        "confirmed side effects require tool activity evidence",
+                    ));
+                }
+            }
+        }
+        if self.submission_phase == SubmissionPhase::Accepted
+            && self.side_effect_risk == SideEffectRisk::None
+        {
+            return Err(AttemptError::invalid(
+                "accepted submission requires side-effect risk evidence",
+            ));
+        }
+        Ok(())
+    }
+
+    fn decision(self, session_pristine: bool, has_session: bool) -> RecoveryDecision {
+        if !has_session || self.terminal_event_observed {
+            return RecoveryDecision::FailClosed;
+        }
+        match self.submission_phase {
+            SubmissionPhase::PreSubmission if session_pristine => RecoveryDecision::FreshIfPristine,
+            SubmissionPhase::PreSubmission | SubmissionPhase::Accepted => {
+                RecoveryDecision::ResumeSameSession
+            }
+            SubmissionPhase::Indeterminate => RecoveryDecision::FailClosed,
+        }
+    }
+
+    fn merge(self, newer: Self) -> Result<Self, AttemptError> {
+        newer.validate()?;
+        let model_output_observed = self.model_output_observed || newer.model_output_observed;
+        let tool_activity_observed = self.tool_activity_observed || newer.tool_activity_observed;
+        let terminal_event_observed = self.terminal_event_observed || newer.terminal_event_observed;
+        let submission_phase = if model_output_observed
+            || tool_activity_observed
+            || self.submission_phase == SubmissionPhase::Accepted
+            || newer.submission_phase == SubmissionPhase::Accepted
+        {
+            SubmissionPhase::Accepted
+        } else if self.submission_phase == SubmissionPhase::Indeterminate
+            || newer.submission_phase == SubmissionPhase::Indeterminate
+        {
+            SubmissionPhase::Indeterminate
+        } else {
+            SubmissionPhase::PreSubmission
+        };
+        let side_effect_risk = if tool_activity_observed {
+            SideEffectRisk::Confirmed
+        } else if model_output_observed
+            || submission_phase != SubmissionPhase::PreSubmission
+            || self.side_effect_risk != SideEffectRisk::None
+            || newer.side_effect_risk != SideEffectRisk::None
+        {
+            SideEffectRisk::Possible
+        } else {
+            SideEffectRisk::None
+        };
+        Self::new(
+            submission_phase,
+            side_effect_risk,
+            model_output_observed,
+            tool_activity_observed,
+            terminal_event_observed,
+        )
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct RecoveryEvidenceWire {
+    submission_phase: SubmissionPhase,
+    side_effect_risk: SideEffectRisk,
+    model_output_observed: bool,
+    tool_activity_observed: bool,
+    terminal_event_observed: bool,
+}
+
+impl<'de> Deserialize<'de> for RecoveryEvidence {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let wire = RecoveryEvidenceWire::deserialize(deserializer)?;
+        Self::new(
+            wire.submission_phase,
+            wire.side_effect_risk,
+            wire.model_output_observed,
+            wire.tool_activity_observed,
+            wire.terminal_event_observed,
+        )
+        .map_err(de::Error::custom)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum CancellationReason {
     Operator,
     Shutdown,
@@ -486,7 +971,7 @@ pub enum CancellationState {
     Requested(CancellationReason),
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub enum TerminalOutcome {
     Succeeded {
@@ -529,9 +1014,106 @@ impl TerminalOutcome {
             Self::Succeeded { .. } | Self::Cancelled { .. } => None,
         }
     }
+
+    pub fn attempt_identity(&self) -> &AttemptIdentity {
+        match self {
+            Self::Succeeded { attempt }
+            | Self::Cancelled { attempt, .. }
+            | Self::Failed { attempt, .. }
+            | Self::NetworkRetryExhausted { attempt, .. }
+            | Self::NetworkResumeUnsafe { attempt, .. } => attempt,
+        }
+    }
+
+    fn validate(&self) -> Result<(), AttemptError> {
+        match self {
+            Self::Succeeded { attempt } | Self::Cancelled { attempt, .. } => attempt.validate()?,
+            Self::Failed { attempt, failure } => {
+                attempt.validate()?;
+                failure.validate()?;
+                if failure.retryable()
+                    || failure.classification() == FailureClassification::Ambiguous
+                {
+                    return Err(AttemptError::invalid(
+                        "retryable or ambiguous failures require a network-safe terminal outcome",
+                    ));
+                }
+            }
+            Self::NetworkRetryExhausted { attempt, failure } => {
+                attempt.validate()?;
+                failure.validate()?;
+                if attempt.attempt != MAX_ATTEMPTS || !failure.retryable() {
+                    return Err(AttemptError::invalid(
+                        "network exhaustion must be the final retryable attempt",
+                    ));
+                }
+            }
+            Self::NetworkResumeUnsafe { attempt, failure } => {
+                attempt.validate()?;
+                failure.validate()?;
+                if !failure.retryable()
+                    && failure.classification() != FailureClassification::Ambiguous
+                {
+                    return Err(AttemptError::invalid(
+                        "unsafe network recovery requires a retryable or ambiguous failure",
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+enum TerminalOutcomeWire {
+    Succeeded {
+        attempt: AttemptIdentity,
+    },
+    Cancelled {
+        attempt: AttemptIdentity,
+        reason: CancellationReason,
+    },
+    Failed {
+        attempt: AttemptIdentity,
+        failure: Failure,
+    },
+    NetworkRetryExhausted {
+        attempt: AttemptIdentity,
+        failure: Failure,
+    },
+    NetworkResumeUnsafe {
+        attempt: AttemptIdentity,
+        failure: Failure,
+    },
+}
+
+impl<'de> Deserialize<'de> for TerminalOutcome {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let outcome = match TerminalOutcomeWire::deserialize(deserializer)? {
+            TerminalOutcomeWire::Succeeded { attempt } => Self::Succeeded { attempt },
+            TerminalOutcomeWire::Cancelled { attempt, reason } => {
+                Self::Cancelled { attempt, reason }
+            }
+            TerminalOutcomeWire::Failed { attempt, failure } => Self::Failed { attempt, failure },
+            TerminalOutcomeWire::NetworkRetryExhausted { attempt, failure } => {
+                Self::NetworkRetryExhausted { attempt, failure }
+            }
+            TerminalOutcomeWire::NetworkResumeUnsafe { attempt, failure } => {
+                Self::NetworkResumeUnsafe { attempt, failure }
+            }
+        };
+        outcome
+            .validate()
+            .map(|_| outcome)
+            .map_err(de::Error::custom)
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RecoveryPlan {
     pub failed_attempt: AttemptIdentity,
@@ -539,8 +1121,120 @@ pub struct RecoveryPlan {
     pub classification: FailureClassification,
     pub decision: RecoveryDecision,
     pub backoff: BackoffDelay,
+    pub network_wait_number: u8,
     pub next_attempt_at_millis: u64,
     pub failure: Failure,
+    pub submission_phase: SubmissionPhase,
+    pub side_effect_risk: SideEffectRisk,
+    pub model_output_observed: bool,
+    pub tool_activity_observed: bool,
+    pub terminal_event_observed: bool,
+}
+
+impl RecoveryPlan {
+    fn evidence(&self) -> RecoveryEvidence {
+        RecoveryEvidence {
+            submission_phase: self.submission_phase,
+            side_effect_risk: self.side_effect_risk,
+            model_output_observed: self.model_output_observed,
+            tool_activity_observed: self.tool_activity_observed,
+            terminal_event_observed: self.terminal_event_observed,
+        }
+    }
+
+    fn validate(&self) -> Result<(), AttemptError> {
+        self.failed_attempt.validate()?;
+        self.next_attempt.validate()?;
+        if self.failed_attempt.heartbeat_identity() != self.next_attempt.heartbeat_identity()
+            || self.next_attempt.attempt != self.failed_attempt.attempt.saturating_add(1)
+        {
+            return Err(AttemptError::invalid(
+                "recovery plan attempt identities do not progress by one",
+            ));
+        }
+        if !(1..=MAX_NETWORK_WAITS).contains(&self.network_wait_number)
+            || self.backoff.retry_number != self.network_wait_number
+            || self.failed_attempt.attempt != self.network_wait_number
+        {
+            return Err(AttemptError::invalid(
+                "recovery plan has an invalid network wait number",
+            ));
+        }
+        self.backoff.validate()?;
+        if self.classification != self.failure.classification() {
+            return Err(AttemptError::invalid(
+                "recovery plan classification does not match its failure",
+            ));
+        }
+        if !self.failure.retryable() {
+            return Err(AttemptError::invalid(
+                "non-retryable failures cannot have a recovery plan",
+            ));
+        }
+        let evidence = self.evidence();
+        evidence.validate()?;
+        if self.decision == RecoveryDecision::FailClosed {
+            return Err(AttemptError::invalid(
+                "fail-closed recovery must be represented by a terminal outcome",
+            ));
+        }
+        if evidence.terminal_event_observed {
+            return Err(AttemptError::invalid(
+                "terminal event evidence must fail closed",
+            ));
+        }
+        if self.decision == RecoveryDecision::FreshIfPristine
+            && evidence.submission_phase != SubmissionPhase::PreSubmission
+        {
+            return Err(AttemptError::invalid(
+                "fresh recovery requires pre-submission evidence",
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct RecoveryPlanWire {
+    failed_attempt: AttemptIdentity,
+    next_attempt: AttemptIdentity,
+    classification: FailureClassification,
+    decision: RecoveryDecision,
+    backoff: BackoffDelay,
+    network_wait_number: u8,
+    next_attempt_at_millis: u64,
+    failure: Failure,
+    submission_phase: SubmissionPhase,
+    side_effect_risk: SideEffectRisk,
+    model_output_observed: bool,
+    tool_activity_observed: bool,
+    terminal_event_observed: bool,
+}
+
+impl<'de> Deserialize<'de> for RecoveryPlan {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let wire = RecoveryPlanWire::deserialize(deserializer)?;
+        let plan = Self {
+            failed_attempt: wire.failed_attempt,
+            next_attempt: wire.next_attempt,
+            classification: wire.classification,
+            decision: wire.decision,
+            backoff: wire.backoff,
+            network_wait_number: wire.network_wait_number,
+            next_attempt_at_millis: wire.next_attempt_at_millis,
+            failure: wire.failure,
+            submission_phase: wire.submission_phase,
+            side_effect_risk: wire.side_effect_risk,
+            model_output_observed: wire.model_output_observed,
+            tool_activity_observed: wire.tool_activity_observed,
+            terminal_event_observed: wire.terminal_event_observed,
+        };
+        plan.validate().map(|_| plan).map_err(de::Error::custom)
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -550,24 +1244,64 @@ pub enum RecoveryResult {
     Terminal(TerminalOutcome),
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SessionCheckpoint {
     pub session_id: String,
     pub pristine: bool,
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+impl SessionCheckpoint {
+    fn validate(&self) -> Result<(), AttemptError> {
+        bounded_string(self.session_id.clone(), "session_id", MAX_ID_BYTES).map(|_| ())
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct SessionCheckpointWire {
+    session_id: String,
+    pristine: bool,
+}
+
+impl<'de> Deserialize<'de> for SessionCheckpoint {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let wire = SessionCheckpointWire::deserialize(deserializer)?;
+        let session = Self {
+            session_id: wire.session_id,
+            pristine: wire.pristine,
+        };
+        session
+            .validate()
+            .map(|_| session)
+            .map_err(de::Error::custom)
+    }
+}
+
+fn checkpoint_invalid(message: impl Into<String>) -> AttemptError {
+    AttemptError::new("checkpoint_invalid", ErrorKind::CheckpointInvalid, message)
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Checkpoint {
     pub protocol_version: u16,
     pub identity: HeartbeatIdentity,
     pub attempt: AttemptIdentity,
     pub phase: Phase,
+    pub network_wait_count: u8,
     pub session: SessionCheckpoint,
     pub lease: LeaseFence,
     pub idempotency_key: IdempotencyKey,
     pub request_fingerprint: String,
+    pub submission_phase: SubmissionPhase,
+    pub side_effect_risk: SideEffectRisk,
+    pub model_output_observed: bool,
+    pub tool_activity_observed: bool,
+    pub terminal_event_observed: bool,
     pub revision: u64,
     pub cancellation: CancellationState,
     pub last_failure: Option<Failure>,
@@ -575,7 +1309,300 @@ pub struct Checkpoint {
     pub terminal_outcome: Option<TerminalOutcome>,
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+impl Checkpoint {
+    fn evidence(&self) -> RecoveryEvidence {
+        RecoveryEvidence {
+            submission_phase: self.submission_phase,
+            side_effect_risk: self.side_effect_risk,
+            model_output_observed: self.model_output_observed,
+            tool_activity_observed: self.tool_activity_observed,
+            terminal_event_observed: self.terminal_event_observed,
+        }
+    }
+
+    fn validate(&self) -> Result<(), AttemptError> {
+        if self.protocol_version != ATTEMPT_PROTOCOL_VERSION {
+            return Err(checkpoint_invalid(
+                "unsupported checkpoint protocol version",
+            ));
+        }
+        self.identity
+            .validate()
+            .map_err(|error| checkpoint_invalid(error.message()))?;
+        self.attempt
+            .validate()
+            .map_err(|error| checkpoint_invalid(error.message()))?;
+        if self.identity != self.attempt.heartbeat_identity() {
+            return Err(checkpoint_invalid(
+                "checkpoint identity and attempt do not agree",
+            ));
+        }
+        if self.network_wait_count > MAX_NETWORK_WAITS {
+            return Err(checkpoint_invalid(
+                "checkpoint network wait count exceeds its bound",
+            ));
+        }
+        self.session
+            .validate()
+            .map_err(|error| checkpoint_invalid(error.message()))?;
+        self.lease
+            .validate()
+            .map_err(|error| checkpoint_invalid(error.message()))?;
+        self.idempotency_key
+            .validate()
+            .map_err(|error| checkpoint_invalid(error.message()))?;
+        bounded_string(
+            self.request_fingerprint.clone(),
+            "request_fingerprint",
+            MAX_REQUEST_FINGERPRINT_BYTES,
+        )
+        .map_err(|error| checkpoint_invalid(error.message()))?;
+        let evidence = self.evidence();
+        evidence
+            .validate()
+            .map_err(|error| checkpoint_invalid(error.message()))?;
+        if self.session.pristine && evidence != RecoveryEvidence::pre_submission() {
+            return Err(checkpoint_invalid(
+                "a session with submission evidence cannot remain pristine",
+            ));
+        }
+        if let Some(failure) = &self.last_failure {
+            failure
+                .validate()
+                .map_err(|error| checkpoint_invalid(error.message()))?;
+        }
+        if let Some(plan) = &self.recovery {
+            plan.validate()
+                .map_err(|error| checkpoint_invalid(error.message()))?;
+            if plan.failed_attempt.heartbeat_identity() != self.identity
+                || plan.next_attempt.heartbeat_identity() != self.identity
+            {
+                return Err(checkpoint_invalid(
+                    "recovery plan identity is not bound to the checkpoint",
+                ));
+            }
+            if plan.network_wait_number != self.network_wait_count {
+                return Err(checkpoint_invalid(
+                    "recovery plan wait count does not match the checkpoint",
+                ));
+            }
+        }
+        if let Some(outcome) = &self.terminal_outcome {
+            outcome
+                .validate()
+                .map_err(|error| checkpoint_invalid(error.message()))?;
+            let outcome_attempt = match outcome {
+                TerminalOutcome::Succeeded { attempt }
+                | TerminalOutcome::Cancelled { attempt, .. }
+                | TerminalOutcome::Failed { attempt, .. }
+                | TerminalOutcome::NetworkRetryExhausted { attempt, .. }
+                | TerminalOutcome::NetworkResumeUnsafe { attempt, .. } => attempt,
+            };
+            if outcome_attempt != &self.attempt {
+                return Err(checkpoint_invalid(
+                    "terminal outcome attempt is not bound to the checkpoint",
+                ));
+            }
+        }
+
+        let expected_active_attempt = self
+            .network_wait_count
+            .checked_add(1)
+            .ok_or_else(|| checkpoint_invalid("checkpoint attempt progression overflow"))?;
+        match self.phase {
+            Phase::Pristine => {
+                if self.attempt.attempt != 1
+                    || self.network_wait_count != 0
+                    || !self.session.pristine
+                    || self.revision != 0
+                    || self.cancellation != CancellationState::NotRequested
+                    || self.last_failure.is_some()
+                    || self.recovery.is_some()
+                    || self.terminal_outcome.is_some()
+                    || evidence != RecoveryEvidence::pre_submission()
+                {
+                    return Err(checkpoint_invalid("pristine phase has inconsistent state"));
+                }
+            }
+            Phase::Executing | Phase::WaitingForNetwork => {
+                if self.attempt.attempt != expected_active_attempt
+                    || self.cancellation != CancellationState::NotRequested
+                    || self.terminal_outcome.is_some()
+                    || self.revision == 0
+                {
+                    return Err(checkpoint_invalid("active phase has inconsistent state"));
+                }
+                if let Some(plan) = &self.recovery {
+                    if plan.next_attempt != self.attempt
+                        || self.last_failure.as_ref() != Some(&plan.failure)
+                    {
+                        return Err(checkpoint_invalid(
+                            "active phase recovery plan does not name the active attempt",
+                        ));
+                    }
+                } else if self.network_wait_count != 0
+                    || self.attempt.attempt != 1
+                    || self.last_failure.is_some()
+                {
+                    return Err(checkpoint_invalid(
+                        "active phase is missing its recovery history",
+                    ));
+                }
+            }
+            Phase::WaitingForRetry => {
+                let plan = self
+                    .recovery
+                    .as_ref()
+                    .ok_or_else(|| checkpoint_invalid("retry phase has no recovery plan"))?;
+                if self.network_wait_count == 0
+                    || self.attempt.attempt != self.network_wait_count
+                    || plan.failed_attempt != self.attempt
+                    || self.last_failure.as_ref() != Some(&plan.failure)
+                    || self.cancellation != CancellationState::NotRequested
+                    || self.terminal_outcome.is_some()
+                    || plan.evidence() != evidence
+                    || (plan.decision == RecoveryDecision::FreshIfPristine
+                        && !self.session.pristine)
+                    || (plan.decision == RecoveryDecision::ResumeSameSession
+                        && plan.evidence().submission_phase == SubmissionPhase::PreSubmission
+                        && self.session.pristine)
+                {
+                    return Err(checkpoint_invalid("retry phase has inconsistent state"));
+                }
+            }
+            Phase::Succeeded => {
+                if self.cancellation != CancellationState::NotRequested
+                    || self.last_failure.is_some()
+                    || self.recovery.is_some()
+                    || self.revision == 0
+                    || self.attempt.attempt != expected_active_attempt
+                    || !matches!(
+                        self.terminal_outcome,
+                        Some(TerminalOutcome::Succeeded { .. })
+                    )
+                    || evidence.submission_phase == SubmissionPhase::Indeterminate
+                {
+                    return Err(checkpoint_invalid("succeeded phase has inconsistent state"));
+                }
+            }
+            Phase::Terminal => {
+                if self.recovery.is_some()
+                    || self.terminal_outcome.is_none()
+                    || self.revision == 0
+                    || (self.attempt.attempt != expected_active_attempt
+                        && self.attempt.attempt != self.network_wait_count)
+                {
+                    return Err(checkpoint_invalid("terminal phase has inconsistent state"));
+                }
+                if matches!(
+                    self.terminal_outcome,
+                    Some(TerminalOutcome::NetworkRetryExhausted { .. })
+                ) && (evidence.submission_phase == SubmissionPhase::Indeterminate
+                    || evidence.terminal_event_observed)
+                {
+                    return Err(checkpoint_invalid(
+                        "network exhaustion cannot contain unsafe submission evidence",
+                    ));
+                }
+                match (&self.cancellation, self.terminal_outcome.as_ref()) {
+                    (
+                        CancellationState::Requested(reason),
+                        Some(TerminalOutcome::Cancelled {
+                            reason: outcome_reason,
+                            ..
+                        }),
+                    ) if reason == outcome_reason => {}
+                    (CancellationState::Requested(_), _) => {
+                        return Err(checkpoint_invalid(
+                            "cancellation state does not match terminal outcome",
+                        ));
+                    }
+                    (CancellationState::NotRequested, Some(TerminalOutcome::Cancelled { .. })) => {
+                        return Err(checkpoint_invalid(
+                            "cancelled outcome is missing its cancellation state",
+                        ));
+                    }
+                    (CancellationState::NotRequested, Some(TerminalOutcome::Succeeded { .. })) => {
+                        return Err(checkpoint_invalid(
+                            "successful outcome belongs to the succeeded phase",
+                        ));
+                    }
+                    (CancellationState::NotRequested, Some(outcome)) => {
+                        if self.last_failure.as_ref() != outcome.failure() {
+                            return Err(checkpoint_invalid(
+                                "terminal failure does not match the last failure",
+                            ));
+                        }
+                    }
+                    (CancellationState::NotRequested, None) => {
+                        return Err(checkpoint_invalid("terminal phase has no outcome"));
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct CheckpointWire {
+    protocol_version: u16,
+    identity: HeartbeatIdentity,
+    attempt: AttemptIdentity,
+    phase: Phase,
+    network_wait_count: u8,
+    session: SessionCheckpoint,
+    lease: LeaseFence,
+    idempotency_key: IdempotencyKey,
+    request_fingerprint: String,
+    submission_phase: SubmissionPhase,
+    side_effect_risk: SideEffectRisk,
+    model_output_observed: bool,
+    tool_activity_observed: bool,
+    terminal_event_observed: bool,
+    revision: u64,
+    cancellation: CancellationState,
+    last_failure: Option<Failure>,
+    recovery: Option<RecoveryPlan>,
+    terminal_outcome: Option<TerminalOutcome>,
+}
+
+impl<'de> Deserialize<'de> for Checkpoint {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let wire = CheckpointWire::deserialize(deserializer)?;
+        let checkpoint = Self {
+            protocol_version: wire.protocol_version,
+            identity: wire.identity,
+            attempt: wire.attempt,
+            phase: wire.phase,
+            network_wait_count: wire.network_wait_count,
+            session: wire.session,
+            lease: wire.lease,
+            idempotency_key: wire.idempotency_key,
+            request_fingerprint: wire.request_fingerprint,
+            submission_phase: wire.submission_phase,
+            side_effect_risk: wire.side_effect_risk,
+            model_output_observed: wire.model_output_observed,
+            tool_activity_observed: wire.tool_activity_observed,
+            terminal_event_observed: wire.terminal_event_observed,
+            revision: wire.revision,
+            cancellation: wire.cancellation,
+            last_failure: wire.last_failure,
+            recovery: wire.recovery,
+            terminal_outcome: wire.terminal_outcome,
+        };
+        checkpoint
+            .validate()
+            .map(|_| checkpoint)
+            .map_err(de::Error::custom)
+    }
+}
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct IdempotencyKey(String);
 
@@ -593,20 +1620,91 @@ impl IdempotencyKey {
     }
 }
 
+impl<'de> Deserialize<'de> for IdempotencyKey {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Self::new(String::deserialize(deserializer)?).map_err(de::Error::custom)
+    }
+}
+
+impl IdempotencyKey {
+    fn validate(&self) -> Result<(), AttemptError> {
+        bounded_string(self.0.clone(), "idempotency_key", MAX_ID_BYTES).map(|_| ())
+    }
+}
+
 impl From<IdempotencyKey> for String {
     fn from(value: IdempotencyKey) -> Self {
         value.0
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct IdempotencyRecord {
-    pub organization_id: String,
+    pub identity: HeartbeatIdentity,
     pub key: IdempotencyKey,
     pub fingerprint: String,
-    pub run_id: String,
     pub outcome: Option<TerminalOutcome>,
+}
+
+impl IdempotencyRecord {
+    fn validate(&self) -> Result<(), AttemptError> {
+        self.identity.validate()?;
+        self.key.validate()?;
+        bounded_string(
+            self.fingerprint.clone(),
+            "request_fingerprint",
+            MAX_REQUEST_FINGERPRINT_BYTES,
+        )?;
+        if let Some(outcome) = &self.outcome {
+            outcome.validate()?;
+            let outcome_identity = match outcome {
+                TerminalOutcome::Succeeded { attempt }
+                | TerminalOutcome::Cancelled { attempt, .. }
+                | TerminalOutcome::Failed { attempt, .. }
+                | TerminalOutcome::NetworkRetryExhausted { attempt, .. }
+                | TerminalOutcome::NetworkResumeUnsafe { attempt, .. } => {
+                    attempt.heartbeat_identity()
+                }
+            };
+            if outcome_identity != self.identity {
+                return Err(AttemptError::new(
+                    "idempotency_conflict",
+                    ErrorKind::IdempotencyConflict,
+                    "terminal outcome identity does not match its idempotency record",
+                ));
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct IdempotencyRecordWire {
+    identity: HeartbeatIdentity,
+    key: IdempotencyKey,
+    fingerprint: String,
+    outcome: Option<TerminalOutcome>,
+}
+
+impl<'de> Deserialize<'de> for IdempotencyRecord {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let wire = IdempotencyRecordWire::deserialize(deserializer)?;
+        let record = Self {
+            identity: wire.identity,
+            key: wire.key,
+            fingerprint: wire.fingerprint,
+            outcome: wire.outcome,
+        };
+        record.validate().map(|_| record).map_err(de::Error::custom)
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -616,27 +1714,111 @@ pub enum IdempotencyDecision {
     Replay { run_id: String },
 }
 
-#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+fn deserialize_bounded_records<'de, D>(deserializer: D) -> Result<Vec<IdempotencyRecord>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct RecordsVisitor;
+
+    impl<'de> de::Visitor<'de> for RecordsVisitor {
+        type Value = Vec<IdempotencyRecord>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            formatter.write_str("a bounded sequence of idempotency records")
+        }
+
+        fn visit_seq<A>(self, mut sequence: A) -> Result<Self::Value, A::Error>
+        where
+            A: de::SeqAccess<'de>,
+        {
+            let mut records = Vec::new();
+            while let Some(record) = sequence.next_element()? {
+                if records.len() >= MAX_IDEMPOTENCY_RECORDS {
+                    return Err(de::Error::custom(
+                        "idempotency ledger exceeds its record bound",
+                    ));
+                }
+                records.push(record);
+            }
+            Ok(records)
+        }
+    }
+
+    deserializer.deserialize_seq(RecordsVisitor)
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct IdempotencyLedger {
-    records: BTreeMap<(String, IdempotencyKey), IdempotencyRecord>,
+    records: Vec<IdempotencyRecord>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct IdempotencyLedgerWire {
+    #[serde(deserialize_with = "deserialize_bounded_records")]
+    records: Vec<IdempotencyRecord>,
+}
+
+impl<'de> Deserialize<'de> for IdempotencyLedger {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let wire = IdempotencyLedgerWire::deserialize(deserializer)?;
+        let ledger = Self {
+            records: wire.records,
+        };
+        ledger.validate().map(|_| ledger).map_err(de::Error::custom)
+    }
 }
 
 impl IdempotencyLedger {
-    pub fn reserve(
+    fn validate(&self) -> Result<(), AttemptError> {
+        if self.records.len() > MAX_IDEMPOTENCY_RECORDS {
+            return Err(AttemptError::invalid(
+                "idempotency ledger exceeds its record bound",
+            ));
+        }
+        for (index, record) in self.records.iter().enumerate() {
+            record.validate()?;
+            if self.records[..index]
+                .iter()
+                .any(|existing| existing.identity == record.identity && existing.key == record.key)
+            {
+                return Err(AttemptError::new(
+                    "idempotency_conflict",
+                    ErrorKind::IdempotencyConflict,
+                    "idempotency ledger contains a duplicate identity and key",
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    pub fn reserve_for_identity(
         &mut self,
-        organization_id: impl Into<String>,
-        key: IdempotencyKey,
+        identity: impl Borrow<HeartbeatIdentity>,
+        key: impl Borrow<IdempotencyKey>,
         fingerprint: impl Into<String>,
-        run_id: impl Into<String>,
     ) -> Result<IdempotencyDecision, AttemptError> {
-        let organization_id = bounded_string(organization_id, "organization_id", MAX_ID_BYTES)?;
-        let fingerprint = bounded_string(fingerprint, "request_fingerprint", 4 * 1024)?;
-        let run_id = bounded_string(run_id, "run_id", MAX_ID_BYTES)?;
-        let index = (organization_id.clone(), key.clone());
-        if let Some(existing) = self.records.get(&index) {
+        let identity = identity.borrow().clone();
+        let key = key.borrow().clone();
+        identity.validate()?;
+        key.validate()?;
+        let fingerprint = bounded_string(
+            fingerprint,
+            "request_fingerprint",
+            MAX_REQUEST_FINGERPRINT_BYTES,
+        )?;
+        if let Some(existing) = self
+            .records
+            .iter()
+            .find(|record| record.identity == identity && record.key == key)
+        {
             if existing.fingerprint == fingerprint {
                 return Ok(IdempotencyDecision::Replay {
-                    run_id: existing.run_id.clone(),
+                    run_id: existing.identity.run_id.clone(),
                 });
             }
             return Err(AttemptError::new(
@@ -645,36 +1827,74 @@ impl IdempotencyLedger {
                 "idempotency key was reused with a different fingerprint",
             ));
         }
-        self.records.insert(
-            index,
-            IdempotencyRecord {
-                organization_id,
-                key,
-                fingerprint,
-                run_id,
-                outcome: None,
-            },
-        );
+        if self.records.len() >= MAX_IDEMPOTENCY_RECORDS {
+            return Err(AttemptError::invalid(
+                "idempotency ledger exceeds its record bound",
+            ));
+        }
+        self.records.push(IdempotencyRecord {
+            identity,
+            key,
+            fingerprint,
+            outcome: None,
+        });
         Ok(IdempotencyDecision::New)
     }
 
-    pub fn record_outcome(
+    pub fn record_outcome_for_identity(
         &mut self,
-        organization_id: impl Into<String>,
-        key: IdempotencyKey,
+        identity: &HeartbeatIdentity,
+        key: &IdempotencyKey,
+        fingerprint: impl AsRef<str>,
         outcome: TerminalOutcome,
     ) -> Result<(), AttemptError> {
-        let organization_id = bounded_string(organization_id, "organization_id", MAX_ID_BYTES)?;
+        identity.validate()?;
+        key.validate()?;
+        let fingerprint = bounded_string(
+            fingerprint.as_ref().to_owned(),
+            "request_fingerprint",
+            MAX_REQUEST_FINGERPRINT_BYTES,
+        )?;
+        outcome.validate()?;
+        let outcome_identity = match &outcome {
+            TerminalOutcome::Succeeded { attempt }
+            | TerminalOutcome::Cancelled { attempt, .. }
+            | TerminalOutcome::Failed { attempt, .. }
+            | TerminalOutcome::NetworkRetryExhausted { attempt, .. }
+            | TerminalOutcome::NetworkResumeUnsafe { attempt, .. } => attempt.heartbeat_identity(),
+        };
+        if outcome_identity != *identity {
+            return Err(AttemptError::new(
+                "idempotency_conflict",
+                ErrorKind::IdempotencyConflict,
+                "terminal outcome identity does not match the trusted identity",
+            ));
+        }
         let record = self
             .records
-            .get_mut(&(organization_id, key))
-            .ok_or_else(|| {
-                AttemptError::new(
-                    "idempotency_missing",
-                    ErrorKind::InvalidInput,
-                    "idempotency key has not been reserved",
-                )
-            })?;
+            .iter_mut()
+            .find(|record| record.identity == *identity && record.key == *key);
+        let Some(record) = record else {
+            if self.records.iter().any(|record| record.key == *key) {
+                return Err(AttemptError::new(
+                    "idempotency_conflict",
+                    ErrorKind::IdempotencyConflict,
+                    "idempotency key belongs to a different trusted identity",
+                ));
+            }
+            return Err(AttemptError::new(
+                "idempotency_missing",
+                ErrorKind::InvalidInput,
+                "idempotency key has not been reserved",
+            ));
+        };
+        if record.fingerprint != fingerprint {
+            return Err(AttemptError::new(
+                "idempotency_conflict",
+                ErrorKind::IdempotencyConflict,
+                "terminal outcome fingerprint does not match its reservation",
+            ));
+        }
         if let Some(existing) = &record.outcome {
             if existing != &outcome {
                 return Err(AttemptError::new(
@@ -689,32 +1909,102 @@ impl IdempotencyLedger {
         Ok(())
     }
 
-    pub fn outcome(
+    pub fn outcome_for_identity(
         &self,
-        organization_id: impl AsRef<str>,
+        identity: &HeartbeatIdentity,
         key: &IdempotencyKey,
+        fingerprint: impl AsRef<str>,
     ) -> Option<&TerminalOutcome> {
         self.records
-            .get(&(organization_id.as_ref().to_owned(), key.clone()))
+            .iter()
+            .find(|record| {
+                record.identity == *identity
+                    && record.key == *key
+                    && record.fingerprint == fingerprint.as_ref()
+            })
             .and_then(|record| record.outcome.as_ref())
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AttemptMachine {
     identity: HeartbeatIdentity,
     attempt: u8,
     phase: Phase,
+    network_wait_count: u8,
     session: SessionCheckpoint,
     lease: LeaseFence,
     idempotency_key: IdempotencyKey,
     request_fingerprint: String,
+    submission_phase: SubmissionPhase,
+    side_effect_risk: SideEffectRisk,
+    model_output_observed: bool,
+    tool_activity_observed: bool,
+    terminal_event_observed: bool,
     revision: u64,
     cancellation: CancellationState,
     last_failure: Option<Failure>,
     recovery: Option<RecoveryPlan>,
     terminal_outcome: Option<TerminalOutcome>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct AttemptMachineWire {
+    identity: HeartbeatIdentity,
+    attempt: u8,
+    phase: Phase,
+    network_wait_count: u8,
+    session: SessionCheckpoint,
+    lease: LeaseFence,
+    idempotency_key: IdempotencyKey,
+    request_fingerprint: String,
+    submission_phase: SubmissionPhase,
+    side_effect_risk: SideEffectRisk,
+    model_output_observed: bool,
+    tool_activity_observed: bool,
+    terminal_event_observed: bool,
+    revision: u64,
+    cancellation: CancellationState,
+    last_failure: Option<Failure>,
+    recovery: Option<RecoveryPlan>,
+    terminal_outcome: Option<TerminalOutcome>,
+}
+
+impl<'de> Deserialize<'de> for AttemptMachine {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let wire = AttemptMachineWire::deserialize(deserializer)?;
+        let attempt = wire
+            .identity
+            .attempt(wire.attempt)
+            .map_err(de::Error::custom)?;
+        let checkpoint = Checkpoint {
+            protocol_version: ATTEMPT_PROTOCOL_VERSION,
+            identity: wire.identity,
+            attempt,
+            phase: wire.phase,
+            network_wait_count: wire.network_wait_count,
+            session: wire.session,
+            lease: wire.lease,
+            idempotency_key: wire.idempotency_key,
+            request_fingerprint: wire.request_fingerprint,
+            submission_phase: wire.submission_phase,
+            side_effect_risk: wire.side_effect_risk,
+            model_output_observed: wire.model_output_observed,
+            tool_activity_observed: wire.tool_activity_observed,
+            terminal_event_observed: wire.terminal_event_observed,
+            revision: wire.revision,
+            cancellation: wire.cancellation,
+            last_failure: wire.last_failure,
+            recovery: wire.recovery,
+            terminal_outcome: wire.terminal_outcome,
+        };
+        Self::from_checkpoint(checkpoint).map_err(de::Error::custom)
+    }
 }
 
 impl AttemptMachine {
@@ -725,10 +2015,13 @@ impl AttemptMachine {
         idempotency_key: impl Into<String>,
         request_fingerprint: impl Into<String>,
     ) -> Result<Self, AttemptError> {
+        identity.validate()?;
+        lease.validate()?;
         Ok(Self {
             identity,
             attempt: 1,
             phase: Phase::Pristine,
+            network_wait_count: 0,
             session: SessionCheckpoint {
                 session_id: bounded_string(session_id, "session_id", MAX_ID_BYTES)?,
                 pristine: true,
@@ -738,8 +2031,13 @@ impl AttemptMachine {
             request_fingerprint: bounded_string(
                 request_fingerprint,
                 "request_fingerprint",
-                4 * 1024,
+                MAX_REQUEST_FINGERPRINT_BYTES,
             )?,
+            submission_phase: SubmissionPhase::PreSubmission,
+            side_effect_risk: SideEffectRisk::None,
+            model_output_observed: false,
+            tool_activity_observed: false,
+            terminal_event_observed: false,
             revision: 0,
             cancellation: CancellationState::NotRequested,
             last_failure: None,
@@ -749,40 +2047,23 @@ impl AttemptMachine {
     }
 
     pub fn from_checkpoint(checkpoint: Checkpoint) -> Result<Self, AttemptError> {
-        if checkpoint.protocol_version != ATTEMPT_PROTOCOL_VERSION {
-            return Err(AttemptError::invalid(
-                "unsupported checkpoint protocol version",
-            ));
-        }
-        if checkpoint.identity != checkpoint.attempt.heartbeat_identity()
-            || checkpoint.attempt.attempt == 0
-            || checkpoint.attempt.attempt > MAX_ATTEMPTS
-        {
-            return Err(AttemptError::invalid(
-                "checkpoint identity and attempt do not agree",
-            ));
-        }
-        let request_fingerprint = bounded_string(
-            checkpoint.request_fingerprint.clone(),
-            "request_fingerprint",
-            4 * 1024,
-        )?;
-        let session_id = bounded_string(
-            checkpoint.session.session_id.clone(),
-            "session_id",
-            MAX_ID_BYTES,
-        )?;
+        checkpoint
+            .validate()
+            .map_err(|error| checkpoint_invalid(error.message()))?;
         Ok(Self {
             identity: checkpoint.identity,
             attempt: checkpoint.attempt.attempt,
             phase: checkpoint.phase,
-            session: SessionCheckpoint {
-                session_id,
-                pristine: checkpoint.session.pristine,
-            },
+            network_wait_count: checkpoint.network_wait_count,
+            session: checkpoint.session,
             lease: checkpoint.lease,
             idempotency_key: checkpoint.idempotency_key,
-            request_fingerprint,
+            request_fingerprint: checkpoint.request_fingerprint,
+            submission_phase: checkpoint.submission_phase,
+            side_effect_risk: checkpoint.side_effect_risk,
+            model_output_observed: checkpoint.model_output_observed,
+            tool_activity_observed: checkpoint.tool_activity_observed,
+            terminal_event_observed: checkpoint.terminal_event_observed,
             revision: checkpoint.revision,
             cancellation: checkpoint.cancellation,
             last_failure: checkpoint.last_failure,
@@ -797,10 +2078,16 @@ impl AttemptMachine {
             identity: self.identity.clone(),
             attempt: self.attempt_identity(),
             phase: self.phase,
+            network_wait_count: self.network_wait_count,
             session: self.session.clone(),
             lease: self.lease.clone(),
             idempotency_key: self.idempotency_key.clone(),
             request_fingerprint: self.request_fingerprint.clone(),
+            submission_phase: self.submission_phase,
+            side_effect_risk: self.side_effect_risk,
+            model_output_observed: self.model_output_observed,
+            tool_activity_observed: self.tool_activity_observed,
+            terminal_event_observed: self.terminal_event_observed,
             revision: self.revision,
             cancellation: self.cancellation,
             last_failure: self.last_failure.clone(),
@@ -813,10 +2100,18 @@ impl AttemptMachine {
         &self.identity
     }
 
+    pub fn lease(&self) -> &LeaseFence {
+        &self.lease
+    }
+
     pub fn attempt_identity(&self) -> AttemptIdentity {
-        self.identity
-            .attempt(self.attempt)
-            .expect("machine invariants keep attempt within the hard bound")
+        debug_assert!((1..=MAX_ATTEMPTS).contains(&self.attempt));
+        AttemptIdentity {
+            organization_id: self.identity.organization_id.clone(),
+            run_id: self.identity.run_id.clone(),
+            agent_id: self.identity.agent_id.clone(),
+            attempt: self.attempt,
+        }
     }
 
     pub fn phase(&self) -> Phase {
@@ -829,6 +2124,40 @@ impl AttemptMachine {
 
     pub fn session_pristine(&self) -> bool {
         self.session.pristine
+    }
+
+    pub fn network_wait_count(&self) -> u8 {
+        self.network_wait_count
+    }
+
+    pub fn recovery_evidence(&self) -> RecoveryEvidence {
+        RecoveryEvidence {
+            submission_phase: self.submission_phase,
+            side_effect_risk: self.side_effect_risk,
+            model_output_observed: self.model_output_observed,
+            tool_activity_observed: self.tool_activity_observed,
+            terminal_event_observed: self.terminal_event_observed,
+        }
+    }
+
+    pub fn submission_phase(&self) -> SubmissionPhase {
+        self.submission_phase
+    }
+
+    pub fn side_effect_risk(&self) -> SideEffectRisk {
+        self.side_effect_risk
+    }
+
+    pub fn model_output_observed(&self) -> bool {
+        self.model_output_observed
+    }
+
+    pub fn tool_activity_observed(&self) -> bool {
+        self.tool_activity_observed
+    }
+
+    pub fn terminal_event_observed(&self) -> bool {
+        self.terminal_event_observed
     }
 
     pub fn cancellation(&self) -> CancellationState {
@@ -855,6 +2184,51 @@ impl AttemptMachine {
         Ok(())
     }
 
+    /// Replace an expired or superseded lease only when the exact current fence is presented.
+    /// The replacement must be a newer, currently valid fence; no lease authority is performed
+    /// by this crate.
+    pub fn rebind_lease(
+        &mut self,
+        current_fence: &LeaseFence,
+        new_lease: LeaseFence,
+        now_millis: u64,
+    ) -> Result<Checkpoint, AttemptError> {
+        if &self.lease != current_fence {
+            return Err(AttemptError::new(
+                "stale_lease_fence",
+                ErrorKind::StaleLeaseFence,
+                "presented lease fence does not own this attempt",
+            ));
+        }
+        new_lease.validate()?;
+        if new_lease.epoch <= self.lease.epoch {
+            return Err(AttemptError::new(
+                "stale_lease_fence",
+                ErrorKind::StaleLeaseFence,
+                "replacement lease epoch must advance the current fence",
+            ));
+        }
+        if !new_lease.valid_at(now_millis) {
+            return Err(AttemptError::new(
+                "lease_expired",
+                ErrorKind::LeaseExpired,
+                "replacement lease is not valid at the supplied time",
+            ));
+        }
+        self.bump_revision()?;
+        self.lease = new_lease;
+        Ok(self.checkpoint())
+    }
+
+    pub fn renew_lease(
+        &mut self,
+        current_fence: &LeaseFence,
+        new_lease: LeaseFence,
+        now_millis: u64,
+    ) -> Result<Checkpoint, AttemptError> {
+        self.rebind_lease(current_fence, new_lease, now_millis)
+    }
+
     fn ensure_not_cancelled(&self) -> Result<(), AttemptError> {
         if let CancellationState::Requested(reason) = self.cancellation {
             return Err(AttemptError::new(
@@ -864,6 +2238,64 @@ impl AttemptMachine {
             ));
         }
         Ok(())
+    }
+
+    fn install_evidence(&mut self, evidence: RecoveryEvidence) -> Result<(), AttemptError> {
+        let current = self.recovery_evidence();
+        let merged = current.merge(evidence)?;
+        if merged == current {
+            return Ok(());
+        }
+        self.submission_phase = merged.submission_phase;
+        self.side_effect_risk = merged.side_effect_risk;
+        self.model_output_observed = merged.model_output_observed;
+        self.tool_activity_observed = merged.tool_activity_observed;
+        self.terminal_event_observed = merged.terminal_event_observed;
+        if merged != RecoveryEvidence::pre_submission() {
+            self.session.pristine = false;
+        }
+        self.bump_revision()
+    }
+
+    pub fn record_evidence(
+        &mut self,
+        evidence: RecoveryEvidence,
+        fence: &LeaseFence,
+        now_millis: u64,
+    ) -> Result<Checkpoint, AttemptError> {
+        self.lease.assert_presented(fence, now_millis)?;
+        self.ensure_not_cancelled()?;
+        match self.phase {
+            Phase::Pristine => {
+                if evidence != RecoveryEvidence::pre_submission() {
+                    return Err(AttemptError::new(
+                        "invalid_transition",
+                        ErrorKind::InvalidTransition,
+                        "submission evidence requires an executing attempt",
+                    ));
+                }
+                Ok(self.checkpoint())
+            }
+            Phase::Executing | Phase::WaitingForNetwork => {
+                self.install_evidence(evidence)?;
+                Ok(self.checkpoint())
+            }
+            Phase::WaitingForRetry => {
+                if self.recovery_evidence() != evidence {
+                    return Err(AttemptError::new(
+                        "idempotency_conflict",
+                        ErrorKind::IdempotencyConflict,
+                        "retry evidence cannot change after it is scheduled",
+                    ));
+                }
+                Ok(self.checkpoint())
+            }
+            Phase::Succeeded | Phase::Terminal => Err(AttemptError::new(
+                "already_terminal",
+                ErrorKind::AlreadyTerminal,
+                "attempt evidence cannot change after completion",
+            )),
+        }
     }
 
     pub fn start(
@@ -945,6 +2377,12 @@ impl AttemptMachine {
         outcome: TerminalOutcome,
         failure: Option<Failure>,
     ) -> Result<RecoveryResult, AttemptError> {
+        outcome.validate()?;
+        if outcome.failure() != failure.as_ref() {
+            return Err(AttemptError::invalid(
+                "terminal outcome and last failure do not match",
+            ));
+        }
         self.bump_revision()?;
         self.phase = Phase::Terminal;
         self.last_failure = failure;
@@ -995,6 +2433,13 @@ impl AttemptMachine {
                 "success can only be recorded for an executing attempt",
             ));
         }
+        if self.submission_phase == SubmissionPhase::Indeterminate || self.terminal_event_observed {
+            return Err(AttemptError::new(
+                "network_resume_unsafe",
+                ErrorKind::NetworkResumeUnsafe,
+                "an indeterminate or terminal event cannot be recorded as success",
+            ));
+        }
         self.install_success()
     }
 
@@ -1006,8 +2451,47 @@ impl AttemptMachine {
         now_millis: u64,
         jitter_seed: Option<u64>,
     ) -> Result<RecoveryResult, AttemptError> {
+        self.record_failure_internal(failure, None, fence, now_millis, jitter_seed)
+    }
+
+    pub fn record_failure_with_evidence(
+        &mut self,
+        failure: Failure,
+        evidence: RecoveryEvidence,
+        fence: &LeaseFence,
+        now_millis: u64,
+        jitter_seed: Option<u64>,
+    ) -> Result<RecoveryResult, AttemptError> {
+        self.record_failure_internal(failure, Some(evidence), fence, now_millis, jitter_seed)
+    }
+
+    fn record_failure_internal(
+        &mut self,
+        failure: Failure,
+        evidence: Option<RecoveryEvidence>,
+        fence: &LeaseFence,
+        now_millis: u64,
+        jitter_seed: Option<u64>,
+    ) -> Result<RecoveryResult, AttemptError> {
         self.lease.assert_presented(fence, now_millis)?;
         self.ensure_not_cancelled()?;
+        failure.validate()?;
+
+        let current_evidence = self.recovery_evidence();
+        let effective_evidence = match evidence {
+            Some(evidence) if matches!(self.phase, Phase::WaitingForRetry | Phase::Terminal) => {
+                if evidence != current_evidence {
+                    return Err(AttemptError::new(
+                        "idempotency_conflict",
+                        ErrorKind::IdempotencyConflict,
+                        "recovery evidence cannot change after the result is recorded",
+                    ));
+                }
+                current_evidence
+            }
+            Some(evidence) => current_evidence.merge(evidence)?,
+            None => current_evidence,
+        };
 
         if self.phase == Phase::WaitingForRetry {
             if self.last_failure.as_ref() == Some(&failure) {
@@ -1062,51 +2546,70 @@ impl AttemptMachine {
             ));
         }
 
-        let classification = failure.classification();
         let current_attempt = self.attempt_identity();
-        if classification == FailureClassification::Ambiguous {
+        if effective_evidence != current_evidence {
+            self.install_evidence(effective_evidence)?;
+        }
+        if failure.classification() == FailureClassification::Ambiguous {
             let outcome = TerminalOutcome::NetworkResumeUnsafe {
                 attempt: current_attempt,
                 failure: failure.clone(),
             };
             return self.install_terminal(outcome, Some(failure));
         }
-        if !classification.retryable() {
+        if !failure.retryable() {
             let outcome = TerminalOutcome::Failed {
                 attempt: current_attempt,
                 failure: failure.clone(),
             };
             return self.install_terminal(outcome, Some(failure));
         }
-        if self.attempt >= MAX_ATTEMPTS {
+
+        let retry_number = self
+            .network_wait_count
+            .checked_add(1)
+            .ok_or_else(|| AttemptError::invalid("network wait count overflow"))?;
+        if retry_number > MAX_NETWORK_WAITS {
             let outcome = TerminalOutcome::NetworkRetryExhausted {
                 attempt: current_attempt,
                 failure: failure.clone(),
             };
             return self.install_terminal(outcome, Some(failure));
         }
-
-        let retry_number = self.attempt;
+        let decision = effective_evidence.decision(self.session.pristine, true);
+        if decision == RecoveryDecision::FailClosed {
+            let outcome = TerminalOutcome::NetworkResumeUnsafe {
+                attempt: current_attempt,
+                failure: failure.clone(),
+            };
+            return self.install_terminal(outcome, Some(failure));
+        }
         let backoff = BackoffDelay::for_retry(retry_number, jitter_seed)?;
+        let next_attempt_number = self
+            .attempt
+            .checked_add(1)
+            .ok_or_else(|| AttemptError::invalid("attempt progression overflow"))?;
+        let next_attempt = self.identity.attempt(next_attempt_number)?;
         let next_attempt_at_millis = now_millis
             .checked_add(backoff.delay_millis)
             .ok_or_else(|| AttemptError::invalid("retry timestamp overflow"))?;
-        let next_attempt = self.identity.attempt(self.attempt + 1)?;
-        let decision = if self.session.pristine {
-            RecoveryDecision::FreshIfPristine
-        } else {
-            RecoveryDecision::ResumeSameSession
-        };
         let plan = RecoveryPlan {
             failed_attempt: current_attempt,
             next_attempt,
-            classification,
+            classification: failure.classification(),
             decision,
             backoff,
+            network_wait_number: retry_number,
             next_attempt_at_millis,
             failure: failure.clone(),
+            submission_phase: effective_evidence.submission_phase,
+            side_effect_risk: effective_evidence.side_effect_risk,
+            model_output_observed: effective_evidence.model_output_observed,
+            tool_activity_observed: effective_evidence.tool_activity_observed,
+            terminal_event_observed: effective_evidence.terminal_event_observed,
         };
         self.bump_revision()?;
+        self.network_wait_count = retry_number;
         self.phase = Phase::WaitingForRetry;
         self.last_failure = Some(failure);
         self.recovery = Some(plan.clone());
@@ -1158,6 +2661,13 @@ impl AttemptMachine {
                 format!("recovery requires {}", plan.decision.code()),
             ));
         }
+        if decision == RecoveryDecision::FailClosed {
+            return Err(AttemptError::new(
+                "network_resume_unsafe",
+                ErrorKind::NetworkResumeUnsafe,
+                "an unsafe recovery plan must be failed closed",
+            ));
+        }
         if decision == RecoveryDecision::FreshIfPristine {
             if !self.session.pristine {
                 return Err(AttemptError::new(
@@ -1169,7 +2679,15 @@ impl AttemptMachine {
             let session_id = fresh_session_id.ok_or_else(|| {
                 AttemptError::invalid("fresh_if_pristine requires a new session id")
             })?;
-            self.session.session_id = bounded_string(session_id, "session_id", MAX_ID_BYTES)?;
+            let session_id = bounded_string(session_id, "session_id", MAX_ID_BYTES)?;
+            if session_id == self.session.session_id {
+                return Err(AttemptError::new(
+                    "recovery_choice_mismatch",
+                    ErrorKind::RecoveryChoiceMismatch,
+                    "fresh_if_pristine requires a different session id",
+                ));
+            }
+            self.session.session_id = session_id;
         } else if fresh_session_id.is_some() {
             return Err(AttemptError::new(
                 "recovery_choice_mismatch",

--- a/native/crates/runtime-attempt-core/src/lib.rs
+++ b/native/crates/runtime-attempt-core/src/lib.rs
@@ -1241,7 +1241,9 @@ struct RecoveryPlanWire {
     backoff: BackoffDelay,
     network_wait_number: u8,
     next_attempt_at_millis: u64,
-    source_session_id: String,
+    #[serde(default)]
+    source_session_id: Option<String>,
+    #[serde(default)]
     replacement_session_id: Option<String>,
     failure: Failure,
     submission_phase: SubmissionPhase,
@@ -1251,30 +1253,52 @@ struct RecoveryPlanWire {
     terminal_event_observed: bool,
 }
 
+impl RecoveryPlanWire {
+    fn into_plan(
+        self,
+        fallback_source_session_id: Option<&str>,
+    ) -> Result<RecoveryPlan, AttemptError> {
+        let source_session_id = match (self.source_session_id, fallback_source_session_id) {
+            (Some(source_session_id), _) => source_session_id,
+            (None, Some(source_session_id))
+                if self.decision == RecoveryDecision::ResumeSameSession =>
+            {
+                source_session_id.to_owned()
+            }
+            (None, _) => {
+                return Err(AttemptError::invalid(
+                    "recovery plan is missing its source session binding",
+                ));
+            }
+        };
+        let plan = RecoveryPlan {
+            failed_attempt: self.failed_attempt,
+            next_attempt: self.next_attempt,
+            classification: self.classification,
+            decision: self.decision,
+            backoff: self.backoff,
+            network_wait_number: self.network_wait_number,
+            next_attempt_at_millis: self.next_attempt_at_millis,
+            source_session_id,
+            replacement_session_id: self.replacement_session_id,
+            failure: self.failure,
+            submission_phase: self.submission_phase,
+            side_effect_risk: self.side_effect_risk,
+            model_output_observed: self.model_output_observed,
+            tool_activity_observed: self.tool_activity_observed,
+            terminal_event_observed: self.terminal_event_observed,
+        };
+        plan.validate().map(|_| plan)
+    }
+}
+
 impl<'de> Deserialize<'de> for RecoveryPlan {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
         let wire = RecoveryPlanWire::deserialize(deserializer)?;
-        let plan = Self {
-            failed_attempt: wire.failed_attempt,
-            next_attempt: wire.next_attempt,
-            classification: wire.classification,
-            decision: wire.decision,
-            backoff: wire.backoff,
-            network_wait_number: wire.network_wait_number,
-            next_attempt_at_millis: wire.next_attempt_at_millis,
-            source_session_id: wire.source_session_id,
-            replacement_session_id: wire.replacement_session_id,
-            failure: wire.failure,
-            submission_phase: wire.submission_phase,
-            side_effect_risk: wire.side_effect_risk,
-            model_output_observed: wire.model_output_observed,
-            tool_activity_observed: wire.tool_activity_observed,
-            terminal_event_observed: wire.terminal_event_observed,
-        };
-        plan.validate().map(|_| plan).map_err(de::Error::custom)
+        wire.into_plan(None).map_err(de::Error::custom)
     }
 }
 
@@ -1685,7 +1709,7 @@ struct CheckpointWire {
     revision: u64,
     cancellation: CancellationState,
     last_failure: Option<Failure>,
-    recovery: Option<RecoveryPlan>,
+    recovery: Option<RecoveryPlanWire>,
     terminal_outcome: Option<TerminalOutcome>,
 }
 
@@ -1695,6 +1719,20 @@ impl<'de> Deserialize<'de> for Checkpoint {
         D: Deserializer<'de>,
     {
         let wire = CheckpointWire::deserialize(deserializer)?;
+        let session_id = wire.session.session_id.clone();
+        // v1 did not persist recovery session bindings. A missing binding is
+        // safe to derive only for same-session recovery; fresh recovery must
+        // retain its source binding and therefore fails closed.
+        let recovery = wire
+            .recovery
+            .map(|recovery| {
+                recovery.into_plan(
+                    (wire.protocol_version == ATTEMPT_PROTOCOL_VERSION)
+                        .then_some(session_id.as_str()),
+                )
+            })
+            .transpose()
+            .map_err(de::Error::custom)?;
         let checkpoint = Self {
             protocol_version: wire.protocol_version,
             identity: wire.identity,
@@ -1713,7 +1751,7 @@ impl<'de> Deserialize<'de> for Checkpoint {
             revision: wire.revision,
             cancellation: wire.cancellation,
             last_failure: wire.last_failure,
-            recovery: wire.recovery,
+            recovery,
             terminal_outcome: wire.terminal_outcome,
         };
         checkpoint

--- a/native/crates/runtime-attempt-core/src/lib.rs
+++ b/native/crates/runtime-attempt-core/src/lib.rs
@@ -1124,6 +1124,8 @@ pub struct RecoveryPlan {
     pub backoff: BackoffDelay,
     pub network_wait_number: u8,
     pub next_attempt_at_millis: u64,
+    pub source_session_id: String,
+    pub replacement_session_id: Option<String>,
     pub failure: Failure,
     pub submission_phase: SubmissionPhase,
     pub side_effect_risk: SideEffectRisk,
@@ -1162,6 +1164,33 @@ impl RecoveryPlan {
             ));
         }
         self.backoff.validate()?;
+        if self.next_attempt_at_millis < self.backoff.delay_millis {
+            return Err(AttemptError::invalid(
+                "recovery plan retry timestamp is earlier than its backoff delay",
+            ));
+        }
+        bounded_string(
+            self.source_session_id.clone(),
+            "source_session_id",
+            MAX_ID_BYTES,
+        )?;
+        if let Some(replacement_session_id) = &self.replacement_session_id {
+            bounded_string(
+                replacement_session_id.clone(),
+                "replacement_session_id",
+                MAX_ID_BYTES,
+            )?;
+            if replacement_session_id == &self.source_session_id {
+                return Err(AttemptError::invalid(
+                    "fresh recovery replacement must differ from its source session",
+                ));
+            }
+            if self.decision != RecoveryDecision::FreshIfPristine {
+                return Err(AttemptError::invalid(
+                    "only fresh recovery can bind a replacement session",
+                ));
+            }
+        }
         if self.classification != self.failure.classification() {
             return Err(AttemptError::invalid(
                 "recovery plan classification does not match its failure",
@@ -1191,6 +1220,13 @@ impl RecoveryPlan {
                 "fresh recovery requires pre-submission evidence",
             ));
         }
+        if self.decision == RecoveryDecision::ResumeSameSession
+            && evidence.submission_phase == SubmissionPhase::Indeterminate
+        {
+            return Err(AttemptError::invalid(
+                "indeterminate evidence requires fail-closed recovery",
+            ));
+        }
         Ok(())
     }
 }
@@ -1205,6 +1241,8 @@ struct RecoveryPlanWire {
     backoff: BackoffDelay,
     network_wait_number: u8,
     next_attempt_at_millis: u64,
+    source_session_id: String,
+    replacement_session_id: Option<String>,
     failure: Failure,
     submission_phase: SubmissionPhase,
     side_effect_risk: SideEffectRisk,
@@ -1227,6 +1265,8 @@ impl<'de> Deserialize<'de> for RecoveryPlan {
             backoff: wire.backoff,
             network_wait_number: wire.network_wait_number,
             next_attempt_at_millis: wire.next_attempt_at_millis,
+            source_session_id: wire.source_session_id,
+            replacement_session_id: wire.replacement_session_id,
             failure: wire.failure,
             submission_phase: wire.submission_phase,
             side_effect_risk: wire.side_effect_risk,
@@ -1397,6 +1437,48 @@ impl Checkpoint {
                     "recovery plan wait count does not match the checkpoint",
                 ));
             }
+            match self.phase {
+                Phase::Executing | Phase::WaitingForNetwork => match plan.decision {
+                    RecoveryDecision::FreshIfPristine => {
+                        if plan.replacement_session_id.as_deref()
+                            != Some(self.session.session_id.as_str())
+                            || plan.source_session_id == self.session.session_id
+                        {
+                            return Err(checkpoint_invalid(
+                                "active fresh recovery is not bound to its replacement session",
+                            ));
+                        }
+                    }
+                    RecoveryDecision::ResumeSameSession => {
+                        if plan.replacement_session_id.is_some()
+                            || plan.source_session_id != self.session.session_id
+                        {
+                            return Err(checkpoint_invalid(
+                                "active same-session recovery is not bound to its session",
+                            ));
+                        }
+                    }
+                    RecoveryDecision::FailClosed => {
+                        return Err(checkpoint_invalid(
+                            "active recovery cannot use a fail-closed decision",
+                        ));
+                    }
+                },
+                Phase::WaitingForRetry => {
+                    if plan.source_session_id != self.session.session_id
+                        || plan.replacement_session_id.is_some()
+                    {
+                        return Err(checkpoint_invalid(
+                            "scheduled recovery is not bound to its source session",
+                        ));
+                    }
+                }
+                Phase::Pristine | Phase::Succeeded | Phase::Terminal => {
+                    return Err(checkpoint_invalid(
+                        "recovery plan is not valid in this checkpoint phase",
+                    ));
+                }
+            }
         }
         if let Some(outcome) = &self.terminal_outcome {
             outcome
@@ -1504,11 +1586,32 @@ impl Checkpoint {
                 }
             }
             Phase::Terminal => {
+                let terminal_attempt_is_valid = match self.terminal_outcome.as_ref() {
+                    Some(TerminalOutcome::Succeeded { attempt })
+                    | Some(TerminalOutcome::Failed { attempt, .. }) => {
+                        attempt.attempt == expected_active_attempt
+                    }
+                    Some(TerminalOutcome::Cancelled { attempt, .. }) => {
+                        attempt.attempt == expected_active_attempt
+                            || (self.network_wait_count > 0
+                                && attempt.attempt == self.network_wait_count)
+                    }
+                    Some(TerminalOutcome::NetworkResumeUnsafe { attempt, failure }) => {
+                        attempt.attempt == expected_active_attempt
+                            || (self.network_wait_count > 0
+                                && attempt.attempt == self.network_wait_count
+                                && failure.retryable())
+                    }
+                    Some(TerminalOutcome::NetworkRetryExhausted { attempt, .. }) => {
+                        self.network_wait_count == MAX_NETWORK_WAITS
+                            && attempt.attempt == MAX_ATTEMPTS
+                    }
+                    None => false,
+                };
                 if self.recovery.is_some()
                     || self.terminal_outcome.is_none()
                     || self.revision == 0
-                    || (self.attempt.attempt != expected_active_attempt
-                        && self.attempt.attempt != self.network_wait_count)
+                    || !terminal_attempt_is_valid
                 {
                     return Err(checkpoint_invalid("terminal phase has inconsistent state"));
                 }
@@ -2538,6 +2641,8 @@ impl AttemptMachine {
             evidence.submission_phase == SubmissionPhase::Indeterminate
                 || evidence.terminal_event_observed
         });
+        let incoming_terminal_event =
+            evidence.is_some_and(|evidence| evidence.terminal_event_observed);
         let effective_evidence = match evidence {
             Some(evidence) if matches!(self.phase, Phase::WaitingForRetry | Phase::Terminal) => {
                 if evidence != current_evidence {
@@ -2553,7 +2658,18 @@ impl AttemptMachine {
                 evidence.validate()?;
                 match current_evidence.merge(evidence) {
                     Ok(merged) => merged,
-                    Err(_error) if incoming_unsafe => current_evidence,
+                    Err(_error) if incoming_unsafe => {
+                        let mut fallback = current_evidence;
+                        if incoming_terminal_event {
+                            if fallback.submission_phase == SubmissionPhase::PreSubmission {
+                                fallback.submission_phase = SubmissionPhase::Indeterminate;
+                                fallback.side_effect_risk = SideEffectRisk::Possible;
+                            }
+                            fallback.terminal_event_observed = true;
+                            fallback.validate()?;
+                        }
+                        fallback
+                    }
                     Err(error) => return Err(error),
                 }
             }
@@ -2703,6 +2819,8 @@ impl AttemptMachine {
             backoff,
             network_wait_number: retry_number,
             next_attempt_at_millis,
+            source_session_id: self.session.session_id.clone(),
+            replacement_session_id: None,
             failure: failure.clone(),
             submission_phase: effective_evidence.submission_phase,
             side_effect_risk: effective_evidence.side_effect_risk,
@@ -2733,24 +2851,45 @@ impl AttemptMachine {
                 .as_ref()
                 .is_some_and(|plan| plan.decision == decision)
         {
-            if decision == RecoveryDecision::FreshIfPristine {
-                let session_id = fresh_session_id.ok_or_else(|| {
-                    AttemptError::invalid("fresh_if_pristine requires a new session id")
-                })?;
-                let session_id = bounded_string(session_id, "session_id", MAX_ID_BYTES)?;
-                if session_id != self.session.session_id {
+            let plan = self
+                .recovery
+                .as_ref()
+                .ok_or_else(|| checkpoint_invalid("active recovery choice has no recovery plan"))?;
+            match decision {
+                RecoveryDecision::FreshIfPristine => {
+                    let session_id = fresh_session_id.ok_or_else(|| {
+                        AttemptError::invalid("fresh_if_pristine requires a new session id")
+                    })?;
+                    let session_id = bounded_string(session_id, "session_id", MAX_ID_BYTES)?;
+                    if plan.replacement_session_id.as_deref() != Some(session_id.as_str())
+                        || plan.source_session_id == self.session.session_id
+                    {
+                        return Err(AttemptError::new(
+                            "recovery_choice_mismatch",
+                            ErrorKind::RecoveryChoiceMismatch,
+                            "fresh recovery replay must use its persisted replacement session",
+                        ));
+                    }
+                }
+                RecoveryDecision::ResumeSameSession => {
+                    if fresh_session_id.is_some()
+                        || plan.replacement_session_id.is_some()
+                        || plan.source_session_id != self.session.session_id
+                    {
+                        return Err(AttemptError::new(
+                            "recovery_choice_mismatch",
+                            ErrorKind::RecoveryChoiceMismatch,
+                            "resume_same_session cannot accept a replacement session",
+                        ));
+                    }
+                }
+                RecoveryDecision::FailClosed => {
                     return Err(AttemptError::new(
-                        "recovery_choice_mismatch",
-                        ErrorKind::RecoveryChoiceMismatch,
-                        "fresh recovery replay must use its persisted replacement session",
+                        "network_resume_unsafe",
+                        ErrorKind::NetworkResumeUnsafe,
+                        "an unsafe recovery plan must be failed closed",
                     ));
                 }
-            } else if fresh_session_id.is_some() {
-                return Err(AttemptError::new(
-                    "recovery_choice_mismatch",
-                    ErrorKind::RecoveryChoiceMismatch,
-                    "resume_same_session cannot accept a replacement session",
-                ));
             }
             return Ok(self.attempt_identity());
         }
@@ -2761,13 +2900,18 @@ impl AttemptMachine {
                 "recovery requires a scheduled retry",
             ));
         }
-        let plan = self.recovery.clone().ok_or_else(|| {
+        let mut plan = self.recovery.clone().ok_or_else(|| {
             AttemptError::new(
                 "checkpoint_invalid",
                 ErrorKind::CheckpointInvalid,
                 "retry phase has no recovery plan",
             )
         })?;
+        if plan.source_session_id != self.session.session_id {
+            return Err(checkpoint_invalid(
+                "recovery plan is not bound to its source session",
+            ));
+        }
         if now_millis < plan.next_attempt_at_millis {
             return Err(AttemptError::new(
                 "retry_not_due",
@@ -2797,6 +2941,13 @@ impl AttemptMachine {
                     "a non-pristine session cannot be replaced",
                 ));
             }
+            if plan.replacement_session_id.is_some() {
+                return Err(AttemptError::new(
+                    "recovery_choice_mismatch",
+                    ErrorKind::RecoveryChoiceMismatch,
+                    "fresh recovery already has a replacement session",
+                ));
+            }
             let session_id = fresh_session_id.ok_or_else(|| {
                 AttemptError::invalid("fresh_if_pristine requires a new session id")
             })?;
@@ -2810,7 +2961,7 @@ impl AttemptMachine {
             }
             Some(session_id)
         } else {
-            if fresh_session_id.is_some() {
+            if plan.replacement_session_id.is_some() || fresh_session_id.is_some() {
                 return Err(AttemptError::new(
                     "recovery_choice_mismatch",
                     ErrorKind::RecoveryChoiceMismatch,
@@ -2821,7 +2972,9 @@ impl AttemptMachine {
         };
         let next_revision = self.next_revision()?;
         if let Some(session_id) = replacement_session_id {
-            self.session.session_id = session_id;
+            self.session.session_id = session_id.clone();
+            plan.replacement_session_id = Some(session_id);
+            self.recovery = Some(plan.clone());
         }
         self.revision = next_revision;
         self.attempt = plan.next_attempt.attempt;

--- a/native/crates/runtime-attempt-core/tests/recovery_core.rs
+++ b/native/crates/runtime-attempt-core/tests/recovery_core.rs
@@ -103,6 +103,8 @@ fn pristine_transport_failure_chooses_fresh_session_and_persists_retry_plan() {
         RecoveryResult::Terminal(outcome) => panic!("unexpected terminal outcome: {outcome:?}"),
     };
     assert_eq!(plan.failed_attempt.attempt, 1);
+    assert_eq!(plan.source_session_id, "session-1");
+    assert_eq!(plan.replacement_session_id, None);
     assert_eq!(plan.classification, FailureClassification::Transport);
     assert_eq!(plan.decision, RecoveryDecision::FreshIfPristine);
     assert_eq!(plan.backoff.base_seconds, 2);
@@ -1350,4 +1352,293 @@ fn indeterminate_evidence_is_monotonic_against_later_accepted_observations() {
         rudder_runtime_attempt_core::SideEffectRisk::Possible
     );
     assert!(!machine.model_output_observed());
+}
+
+#[test]
+fn terminal_checkpoint_ordinals_are_specific_to_each_outcome() {
+    let identity = HeartbeatIdentity::new("org-1", "run-1", "agent-1").unwrap();
+    let fence = lease();
+    let mut waiting = AttemptMachine::new(
+        identity.clone(),
+        "session-1",
+        fence.clone(),
+        "heartbeat-1",
+        "fingerprint-1",
+    )
+    .unwrap();
+    waiting.start(&fence, 0).unwrap();
+    waiting.mark_waiting_for_network(&fence, 0).unwrap();
+    let retry_failure = Failure::transport(TransportFailure::Timeout, "timeout").unwrap();
+    waiting
+        .record_failure(retry_failure, &fence, 0, None)
+        .unwrap();
+
+    let failed = Failure::non_retryable("provider_rejected", "provider rejected").unwrap();
+    let mut forged_failed = waiting.checkpoint();
+    forged_failed.phase = Phase::Terminal;
+    forged_failed.last_failure = Some(failed.clone());
+    forged_failed.recovery = None;
+    forged_failed.terminal_outcome = Some(rudder_runtime_attempt_core::TerminalOutcome::Failed {
+        attempt: identity.attempt(1).unwrap(),
+        failure: failed,
+    });
+    let encoded = serde_json::to_value(&forged_failed).unwrap();
+    assert!(serde_json::from_value::<rudder_runtime_attempt_core::Checkpoint>(encoded).is_err());
+    assert!(AttemptMachine::from_checkpoint(forged_failed).is_err());
+
+    let mut exhausted = AttemptMachine::new(
+        identity.clone(),
+        "session-2",
+        fence.clone(),
+        "heartbeat-2",
+        "fingerprint-2",
+    )
+    .unwrap();
+    exhausted.start(&fence, 0).unwrap();
+    exhausted.checkpoint_progress(&fence, 0).unwrap();
+    for _ in 0..MAX_ATTEMPTS {
+        exhausted.mark_waiting_for_network(&fence, 0).unwrap();
+        let result = exhausted
+            .record_failure(
+                Failure::transport(TransportFailure::Timeout, "timeout").unwrap(),
+                &fence,
+                0,
+                None,
+            )
+            .unwrap();
+        if let RecoveryResult::RetryScheduled(plan) = result {
+            exhausted
+                .resume_same_session(&fence, plan.next_attempt_at_millis)
+                .unwrap();
+        } else {
+            break;
+        }
+    }
+    let mut forged_exhaustion = exhausted.checkpoint();
+    assert!(matches!(
+        forged_exhaustion.terminal_outcome,
+        Some(rudder_runtime_attempt_core::TerminalOutcome::NetworkRetryExhausted { .. })
+    ));
+    forged_exhaustion.network_wait_count = MAX_NETWORK_WAITS - 1;
+    let encoded = serde_json::to_value(&forged_exhaustion).unwrap();
+    assert!(serde_json::from_value::<rudder_runtime_attempt_core::Checkpoint>(encoded).is_err());
+    assert!(AttemptMachine::from_checkpoint(forged_exhaustion).is_err());
+
+    let mut cancelled = waiting;
+    cancelled
+        .cancel(&fence, CancellationReason::Operator, 0)
+        .unwrap();
+    assert!(AttemptMachine::from_checkpoint(cancelled.checkpoint()).is_ok());
+
+    let mut fail_closed = AttemptMachine::new(
+        identity,
+        "session-3",
+        fence.clone(),
+        "heartbeat-3",
+        "fingerprint-3",
+    )
+    .unwrap();
+    fail_closed.start(&fence, 0).unwrap();
+    fail_closed.mark_waiting_for_network(&fence, 0).unwrap();
+    fail_closed
+        .record_failure(
+            Failure::transport(TransportFailure::Timeout, "timeout").unwrap(),
+            &fence,
+            0,
+            None,
+        )
+        .unwrap();
+    fail_closed.fail_closed(&fence, 0).unwrap();
+    assert!(AttemptMachine::from_checkpoint(fail_closed.checkpoint()).is_ok());
+
+    let mut unsupported_unsafe = fail_closed.checkpoint();
+    let ambiguous = Failure::ambiguous("ambiguous", "ambiguous outcome").unwrap();
+    unsupported_unsafe.last_failure = Some(ambiguous.clone());
+    unsupported_unsafe.terminal_outcome = Some(
+        rudder_runtime_attempt_core::TerminalOutcome::NetworkResumeUnsafe {
+            attempt: unsupported_unsafe.attempt.clone(),
+            failure: ambiguous,
+        },
+    );
+    let encoded = serde_json::to_value(&unsupported_unsafe).unwrap();
+    assert!(serde_json::from_value::<rudder_runtime_attempt_core::Checkpoint>(encoded).is_err());
+    assert!(AttemptMachine::from_checkpoint(unsupported_unsafe).is_err());
+}
+
+#[test]
+fn deserialized_resume_plan_rejects_indeterminate_evidence() {
+    let identity = HeartbeatIdentity::new("org-1", "run-1", "agent-1").unwrap();
+    let fence = lease();
+    let mut machine = AttemptMachine::new(
+        identity,
+        "session-1",
+        fence.clone(),
+        "heartbeat-1",
+        "fingerprint-1",
+    )
+    .unwrap();
+    machine.start(&fence, 0).unwrap();
+    machine.checkpoint_progress(&fence, 0).unwrap();
+    machine.mark_waiting_for_network(&fence, 0).unwrap();
+    machine
+        .record_failure(
+            Failure::transport(TransportFailure::Timeout, "timeout").unwrap(),
+            &fence,
+            0,
+            None,
+        )
+        .unwrap();
+
+    let mut forged = machine.checkpoint();
+    forged.submission_phase = rudder_runtime_attempt_core::SubmissionPhase::Indeterminate;
+    forged.side_effect_risk = rudder_runtime_attempt_core::SideEffectRisk::Possible;
+    forged.recovery.as_mut().unwrap().submission_phase =
+        rudder_runtime_attempt_core::SubmissionPhase::Indeterminate;
+    forged.recovery.as_mut().unwrap().side_effect_risk =
+        rudder_runtime_attempt_core::SideEffectRisk::Possible;
+    let raw_plan = serde_json::to_value(forged.recovery.as_ref().unwrap()).unwrap();
+    assert!(serde_json::from_value::<rudder_runtime_attempt_core::RecoveryPlan>(raw_plan).is_err());
+    let raw_checkpoint = serde_json::to_value(forged).unwrap();
+    assert!(
+        serde_json::from_value::<rudder_runtime_attempt_core::Checkpoint>(raw_checkpoint).is_err()
+    );
+}
+
+#[test]
+fn fresh_recovery_persists_source_and_replacement_binding() {
+    let identity = HeartbeatIdentity::new("org-1", "run-1", "agent-1").unwrap();
+    let fence = lease();
+    let mut machine = AttemptMachine::new(
+        identity.clone(),
+        "session-1",
+        fence.clone(),
+        "heartbeat-1",
+        "fingerprint-1",
+    )
+    .unwrap();
+    machine.start(&fence, 0).unwrap();
+    machine.mark_waiting_for_network(&fence, 0).unwrap();
+    let plan = match machine
+        .record_failure(
+            Failure::transport(TransportFailure::Timeout, "timeout").unwrap(),
+            &fence,
+            0,
+            None,
+        )
+        .unwrap()
+    {
+        RecoveryResult::RetryScheduled(plan) => plan,
+        RecoveryResult::Terminal(outcome) => panic!("unexpected terminal outcome: {outcome:?}"),
+    };
+
+    let mut forged_active = machine.checkpoint();
+    forged_active.phase = Phase::Executing;
+    forged_active.attempt = plan.next_attempt.clone();
+    forged_active.recovery = Some(plan.clone());
+    assert!(AttemptMachine::from_checkpoint(forged_active).is_err());
+
+    machine
+        .fresh_if_pristine(&fence, plan.next_attempt_at_millis, "session-2")
+        .unwrap();
+    let checkpoint = machine.checkpoint();
+    let encoded = serde_json::to_string(&checkpoint).unwrap();
+    let decoded: rudder_runtime_attempt_core::Checkpoint = serde_json::from_str(&encoded).unwrap();
+    let mut restored = AttemptMachine::from_checkpoint(decoded).unwrap();
+    assert_eq!(
+        restored
+            .fresh_if_pristine(&fence, plan.next_attempt_at_millis, "session-2")
+            .unwrap()
+            .attempt,
+        2
+    );
+    assert_eq!(
+        restored
+            .fresh_if_pristine(&fence, plan.next_attempt_at_millis, "session-3")
+            .unwrap_err()
+            .code(),
+        "recovery_choice_mismatch"
+    );
+}
+
+#[test]
+fn deserialized_recovery_plan_rejects_timestamp_before_its_backoff() {
+    let identity = HeartbeatIdentity::new("org-1", "run-1", "agent-1").unwrap();
+    let fence = lease();
+    let mut machine = AttemptMachine::new(
+        identity,
+        "session-1",
+        fence.clone(),
+        "heartbeat-1",
+        "fingerprint-1",
+    )
+    .unwrap();
+    machine.start(&fence, 100).unwrap();
+    machine.mark_waiting_for_network(&fence, 100).unwrap();
+    machine
+        .record_failure(
+            Failure::transport(TransportFailure::Timeout, "timeout").unwrap(),
+            &fence,
+            100,
+            None,
+        )
+        .unwrap();
+
+    let mut forged = machine.checkpoint();
+    let plan = forged.recovery.as_mut().unwrap();
+    plan.next_attempt_at_millis = plan.backoff.delay_millis - 1;
+    let raw_plan = serde_json::to_value(plan).unwrap();
+    assert!(serde_json::from_value::<rudder_runtime_attempt_core::RecoveryPlan>(raw_plan).is_err());
+    assert!(AttemptMachine::from_checkpoint(forged).is_err());
+}
+
+#[test]
+fn conflicting_unsafe_evidence_preserves_the_terminal_event_bit() {
+    let identity = HeartbeatIdentity::new("org-1", "run-1", "agent-1").unwrap();
+    let fence = lease();
+    let mut machine = AttemptMachine::new(
+        identity,
+        "session-1",
+        fence.clone(),
+        "heartbeat-1",
+        "fingerprint-1",
+    )
+    .unwrap();
+    machine.start(&fence, 0).unwrap();
+    machine
+        .record_evidence(
+            rudder_runtime_attempt_core::RecoveryEvidence::new(
+                rudder_runtime_attempt_core::SubmissionPhase::Accepted,
+                rudder_runtime_attempt_core::SideEffectRisk::Confirmed,
+                false,
+                true,
+                false,
+            )
+            .unwrap(),
+            &fence,
+            0,
+        )
+        .unwrap();
+    machine.mark_waiting_for_network(&fence, 0).unwrap();
+    let result = machine
+        .record_failure_with_evidence(
+            Failure::transport(TransportFailure::Timeout, "timeout").unwrap(),
+            rudder_runtime_attempt_core::RecoveryEvidence::new(
+                rudder_runtime_attempt_core::SubmissionPhase::Indeterminate,
+                rudder_runtime_attempt_core::SideEffectRisk::Possible,
+                false,
+                false,
+                true,
+            )
+            .unwrap(),
+            &fence,
+            0,
+            None,
+        )
+        .unwrap();
+    assert!(matches!(
+        result,
+        RecoveryResult::Terminal(ref outcome) if outcome.code() == "network_resume_unsafe"
+    ));
+    assert!(machine.terminal_event_observed());
+    assert!(AttemptMachine::from_checkpoint(machine.checkpoint()).is_ok());
 }

--- a/native/crates/runtime-attempt-core/tests/recovery_core.rs
+++ b/native/crates/runtime-attempt-core/tests/recovery_core.rs
@@ -1,0 +1,432 @@
+use rudder_runtime_attempt_core::{
+    ATTEMPT_PROTOCOL_VERSION, AttemptMachine, BackoffDelay, CancellationReason, CancellationState,
+    Failure, FailureClassification, HeartbeatIdentity, IdempotencyDecision, IdempotencyKey,
+    IdempotencyLedger, LeaseFence, MAX_ATTEMPTS, NETWORK_BACKOFF_SECONDS, Phase, RecoveryDecision,
+    RecoveryResult, TransportFailure,
+};
+
+fn lease() -> LeaseFence {
+    LeaseFence::new("worker-1", 1, 0, 100_000).unwrap()
+}
+
+#[test]
+fn starts_the_first_attempt_and_replays_duplicate_start() {
+    let identity = HeartbeatIdentity::new("org-1", "run-1", "agent-1").unwrap();
+    let fence = lease();
+    let mut machine = AttemptMachine::new(
+        identity,
+        "session-1",
+        fence.clone(),
+        "heartbeat-1",
+        "fingerprint-1",
+    )
+    .unwrap();
+
+    assert_eq!(machine.phase(), Phase::Pristine);
+    let attempt = machine.start(&fence, 10).unwrap();
+    assert_eq!(attempt.attempt, 1);
+    assert_eq!(machine.phase(), Phase::Executing);
+    assert_eq!(machine.start(&fence, 10).unwrap(), attempt);
+}
+
+#[test]
+fn checkpoint_round_trip_preserves_identity_phase_and_session_metadata() {
+    let identity = HeartbeatIdentity::new("org-1", "run-1", "agent-1").unwrap();
+    let fence = lease();
+    let mut machine = AttemptMachine::new(
+        identity,
+        "session-1",
+        fence.clone(),
+        "heartbeat-1",
+        "fingerprint-1",
+    )
+    .unwrap();
+    machine.start(&fence, 10).unwrap();
+
+    let checkpoint = machine.checkpoint();
+    assert_eq!(checkpoint.protocol_version, ATTEMPT_PROTOCOL_VERSION);
+    assert_eq!(checkpoint.attempt.attempt, 1);
+    assert_eq!(checkpoint.phase, Phase::Executing);
+    assert_eq!(checkpoint.session.session_id, "session-1");
+    assert!(checkpoint.session.pristine);
+
+    let restored = AttemptMachine::from_checkpoint(checkpoint.clone()).unwrap();
+    assert_eq!(restored.checkpoint(), checkpoint);
+}
+
+#[test]
+fn backoff_is_frozen_and_deterministic_jitter_stays_bounded() {
+    assert_eq!(NETWORK_BACKOFF_SECONDS, [2, 5, 10, 20, 30, 60]);
+    for (retry_number, expected_seconds) in NETWORK_BACKOFF_SECONDS.into_iter().enumerate() {
+        let retry_number = retry_number as u8 + 1;
+        assert_eq!(
+            BackoffDelay::for_retry(retry_number, None)
+                .unwrap()
+                .delay_millis,
+            expected_seconds * 1_000
+        );
+    }
+
+    let first = BackoffDelay::for_retry(1, Some(42)).unwrap();
+    let replay = BackoffDelay::for_retry(1, Some(42)).unwrap();
+    assert_eq!(first, replay);
+    assert!(first.jitter_millis <= 500);
+    assert!(first.delay_millis <= 2_500);
+    assert!(BackoffDelay::for_retry(0, None).is_err());
+    assert!(BackoffDelay::for_retry(7, None).is_err());
+}
+
+#[test]
+fn pristine_transport_failure_chooses_fresh_session_and_persists_retry_plan() {
+    let identity = HeartbeatIdentity::new("org-1", "run-1", "agent-1").unwrap();
+    let fence = lease();
+    let mut machine = AttemptMachine::new(
+        identity,
+        "session-1",
+        fence.clone(),
+        "heartbeat-1",
+        "fingerprint-1",
+    )
+    .unwrap();
+    machine.start(&fence, 10).unwrap();
+    machine.mark_waiting_for_network(&fence, 100).unwrap();
+
+    let failure = Failure::transport(TransportFailure::Timeout, "provider timed out").unwrap();
+    let result = machine
+        .record_failure(failure.clone(), &fence, 100, Some(9))
+        .unwrap();
+    let plan = match result {
+        RecoveryResult::RetryScheduled(plan) => plan,
+        RecoveryResult::Terminal(outcome) => panic!("unexpected terminal outcome: {outcome:?}"),
+    };
+    assert_eq!(plan.failed_attempt.attempt, 1);
+    assert_eq!(plan.classification, FailureClassification::Transport);
+    assert_eq!(plan.decision, RecoveryDecision::FreshIfPristine);
+    assert_eq!(plan.backoff.base_seconds, 2);
+    assert!(plan.backoff.jitter_millis <= 500);
+    assert_eq!(machine.phase(), Phase::WaitingForRetry);
+    assert_eq!(
+        machine
+            .record_failure(failure, &fence, 100, Some(9))
+            .unwrap(),
+        RecoveryResult::RetryScheduled(plan.clone())
+    );
+
+    let checkpoint = machine.checkpoint();
+    assert_eq!(checkpoint.recovery.as_ref(), Some(&plan));
+    let mut restored = AttemptMachine::from_checkpoint(checkpoint).unwrap();
+    let next = restored
+        .fresh_if_pristine(&fence, plan.next_attempt_at_millis, "session-2")
+        .unwrap();
+    assert_eq!(next.attempt, 2);
+    assert_eq!(restored.session_id(), "session-2");
+    assert_eq!(restored.phase(), Phase::Executing);
+}
+
+#[test]
+fn checkpointed_progress_resumes_same_session_and_enforces_due_time_and_choice() {
+    let identity = HeartbeatIdentity::new("org-1", "run-1", "agent-1").unwrap();
+    let fence = lease();
+    let mut machine = AttemptMachine::new(
+        identity,
+        "session-1",
+        fence.clone(),
+        "heartbeat-1",
+        "fingerprint-1",
+    )
+    .unwrap();
+    machine.start(&fence, 10).unwrap();
+    machine.checkpoint_progress(&fence, 20).unwrap();
+    machine.mark_waiting_for_network(&fence, 30).unwrap();
+
+    let failure = Failure::server_5xx(503, "upstream unavailable").unwrap();
+    let plan = match machine.record_failure(failure, &fence, 30, None).unwrap() {
+        RecoveryResult::RetryScheduled(plan) => plan,
+        RecoveryResult::Terminal(outcome) => panic!("unexpected terminal outcome: {outcome:?}"),
+    };
+    assert_eq!(plan.classification, FailureClassification::Server5xx);
+    assert_eq!(plan.decision, RecoveryDecision::ResumeSameSession);
+    assert_eq!(
+        machine
+            .resume_same_session(&fence, plan.next_attempt_at_millis - 1)
+            .unwrap_err()
+            .code(),
+        "retry_not_due"
+    );
+    assert_eq!(
+        machine
+            .fresh_if_pristine(&fence, plan.next_attempt_at_millis, "session-2")
+            .unwrap_err()
+            .code(),
+        "recovery_choice_mismatch"
+    );
+
+    let next = machine
+        .resume_same_session(&fence, plan.next_attempt_at_millis)
+        .unwrap();
+    assert_eq!(next.attempt, 2);
+    assert_eq!(machine.session_id(), "session-1");
+    assert_eq!(
+        machine
+            .resume_same_session(&fence, plan.next_attempt_at_millis)
+            .unwrap(),
+        next
+    );
+}
+
+#[test]
+fn retryable_network_failures_stop_at_the_sixth_attempt() {
+    let identity = HeartbeatIdentity::new("org-1", "run-1", "agent-1").unwrap();
+    let fence = lease();
+    let mut machine = AttemptMachine::new(
+        identity,
+        "session-1",
+        fence.clone(),
+        "heartbeat-1",
+        "fingerprint-1",
+    )
+    .unwrap();
+
+    let mut final_failure = None;
+    for attempt in 1..=MAX_ATTEMPTS {
+        machine.start(&fence, 0).unwrap();
+        let failure =
+            Failure::transport(TransportFailure::ConnectionReset, "connection reset").unwrap();
+        let result = machine
+            .record_failure(failure.clone(), &fence, 0, None)
+            .unwrap();
+        match result {
+            RecoveryResult::RetryScheduled(plan) => {
+                assert_eq!(attempt, plan.failed_attempt.attempt);
+                assert!(attempt < MAX_ATTEMPTS);
+                machine
+                    .fresh_if_pristine(
+                        &fence,
+                        plan.next_attempt_at_millis,
+                        format!("session-{attempt}"),
+                    )
+                    .unwrap();
+            }
+            RecoveryResult::Terminal(outcome) => {
+                assert_eq!(attempt, MAX_ATTEMPTS);
+                assert_eq!(outcome.code(), "network_retry_exhausted");
+                final_failure = Some(failure);
+            }
+        }
+    }
+    assert_eq!(machine.phase(), Phase::Terminal);
+    let replay = machine
+        .record_failure(final_failure.unwrap(), &fence, 0, None)
+        .unwrap();
+    assert!(
+        matches!(replay, RecoveryResult::Terminal(outcome) if outcome.code() == "network_retry_exhausted")
+    );
+}
+
+#[test]
+fn credential_quota_and_ambiguous_failures_fail_closed_without_retry() {
+    for (failure, expected_code) in [
+        (
+            Failure::credential("invalid_credential", "token rejected").unwrap(),
+            "failed",
+        ),
+        (
+            Failure::quota("quota_exhausted", "quota exhausted").unwrap(),
+            "failed",
+        ),
+        (
+            Failure::ambiguous("response_unknown", "request outcome is unknown").unwrap(),
+            "network_resume_unsafe",
+        ),
+    ] {
+        let identity = HeartbeatIdentity::new("org-1", "run-1", "agent-1").unwrap();
+        let fence = lease();
+        let mut machine = AttemptMachine::new(
+            identity,
+            "session-1",
+            fence.clone(),
+            "heartbeat-1",
+            "fingerprint-1",
+        )
+        .unwrap();
+        machine.start(&fence, 10).unwrap();
+        let result = machine
+            .record_failure(failure, &fence, 10, Some(3))
+            .unwrap();
+        match result {
+            RecoveryResult::Terminal(outcome) => assert_eq!(outcome.code(), expected_code),
+            RecoveryResult::RetryScheduled(plan) => panic!("unexpected retry: {plan:?}"),
+        }
+        assert_eq!(machine.phase(), Phase::Terminal);
+    }
+}
+
+#[test]
+fn cancellation_and_lease_fences_block_late_recovery() {
+    let identity = HeartbeatIdentity::new("org-1", "run-1", "agent-1").unwrap();
+    let fence = lease();
+    let stale = LeaseFence::new("worker-1", 2, 0, 100_000).unwrap();
+    let mut machine = AttemptMachine::new(
+        identity,
+        "session-1",
+        fence.clone(),
+        "heartbeat-1",
+        "fingerprint-1",
+    )
+    .unwrap();
+    machine.start(&fence, 10).unwrap();
+
+    assert_eq!(
+        machine
+            .mark_waiting_for_network(&stale, 10)
+            .unwrap_err()
+            .code(),
+        "stale_lease_fence"
+    );
+    let expired_fence = LeaseFence::new("worker-1", 1, 0, 100).unwrap();
+    let mut expired_machine = AttemptMachine::new(
+        HeartbeatIdentity::new("org-1", "run-2", "agent-1").unwrap(),
+        "session-1",
+        expired_fence.clone(),
+        "heartbeat-2",
+        "fingerprint-2",
+    )
+    .unwrap();
+    expired_machine.start(&expired_fence, 10).unwrap();
+    assert_eq!(
+        expired_machine
+            .mark_waiting_for_network(&expired_fence, 100)
+            .unwrap_err()
+            .code(),
+        "lease_expired"
+    );
+    assert_eq!(machine.phase(), Phase::Executing);
+
+    let cancelled = machine
+        .cancel(&fence, CancellationReason::Operator, 20)
+        .unwrap();
+    assert_eq!(cancelled.code(), "cancelled");
+    assert_eq!(
+        machine.cancellation(),
+        CancellationState::Requested(CancellationReason::Operator)
+    );
+    assert_eq!(machine.phase(), Phase::Terminal);
+    let failure = Failure::transport(TransportFailure::Timeout, "late timeout").unwrap();
+    assert_eq!(
+        machine
+            .record_failure(failure, &fence, 20, None)
+            .unwrap_err()
+            .code(),
+        "cancellation_requested"
+    );
+    assert_eq!(
+        machine
+            .cancel(&fence, CancellationReason::Operator, 20)
+            .unwrap(),
+        cancelled
+    );
+}
+
+#[test]
+fn fail_closed_is_an_explicit_terminal_recovery_choice() {
+    assert_eq!(RecoveryDecision::FailClosed.code(), "fail_closed");
+    let identity = HeartbeatIdentity::new("org-1", "run-1", "agent-1").unwrap();
+    let fence = lease();
+    let mut machine = AttemptMachine::new(
+        identity,
+        "session-1",
+        fence.clone(),
+        "heartbeat-1",
+        "fingerprint-1",
+    )
+    .unwrap();
+    machine.start(&fence, 10).unwrap();
+    machine.mark_waiting_for_network(&fence, 10).unwrap();
+    let failure = Failure::transport(TransportFailure::Timeout, "timeout").unwrap();
+    let plan = match machine
+        .record_failure(failure.clone(), &fence, 10, None)
+        .unwrap()
+    {
+        RecoveryResult::RetryScheduled(plan) => plan,
+        RecoveryResult::Terminal(outcome) => panic!("unexpected terminal outcome: {outcome:?}"),
+    };
+
+    let outcome = machine.fail_closed(&fence, 10).unwrap();
+    assert_eq!(outcome.code(), "network_resume_unsafe");
+    assert_eq!(machine.phase(), Phase::Terminal);
+    assert_eq!(
+        machine
+            .fail_closed(&fence, plan.next_attempt_at_millis)
+            .unwrap(),
+        outcome
+    );
+}
+
+#[test]
+fn idempotency_ledger_replays_same_fingerprint_and_rejects_conflicts() {
+    let mut ledger = IdempotencyLedger::default();
+    let key = IdempotencyKey::new("heartbeat-key").unwrap();
+    assert_eq!(
+        ledger
+            .reserve("org-1", key.clone(), "fingerprint-a", "run-1")
+            .unwrap(),
+        IdempotencyDecision::New
+    );
+    assert_eq!(
+        ledger
+            .reserve("org-1", key.clone(), "fingerprint-a", "run-2")
+            .unwrap(),
+        IdempotencyDecision::Replay {
+            run_id: "run-1".to_owned()
+        }
+    );
+    assert_eq!(
+        ledger
+            .reserve("org-1", key.clone(), "fingerprint-b", "run-3")
+            .unwrap_err()
+            .code(),
+        "idempotency_conflict"
+    );
+
+    let outcome = rudder_runtime_attempt_core::TerminalOutcome::NetworkResumeUnsafe {
+        attempt: HeartbeatIdentity::new("org-1", "run-1", "agent-1")
+            .unwrap()
+            .attempt(1)
+            .unwrap(),
+        failure: Failure::ambiguous("response_unknown", "response not observed").unwrap(),
+    };
+    ledger
+        .record_outcome("org-1", key.clone(), outcome.clone())
+        .unwrap();
+    assert_eq!(ledger.outcome("org-1", &key), Some(&outcome));
+    ledger
+        .record_outcome("org-1", key, outcome)
+        .expect("recording the same terminal receipt is idempotent");
+}
+
+#[test]
+fn success_is_terminal_and_duplicate_completion_replays_the_same_receipt() {
+    let identity = HeartbeatIdentity::new("org-1", "run-1", "agent-1").unwrap();
+    let fence = lease();
+    let mut machine = AttemptMachine::new(
+        identity,
+        "session-1",
+        fence.clone(),
+        "heartbeat-1",
+        "fingerprint-1",
+    )
+    .unwrap();
+    machine.start(&fence, 10).unwrap();
+
+    let outcome = machine.succeed(&fence, 20).unwrap();
+    assert_eq!(outcome.code(), "succeeded");
+    assert_eq!(machine.phase(), Phase::Succeeded);
+    assert_eq!(machine.succeed(&fence, 20).unwrap(), outcome);
+    assert_eq!(
+        machine
+            .cancel(&fence, CancellationReason::Operator, 20)
+            .unwrap_err()
+            .code(),
+        "already_terminal"
+    );
+}

--- a/native/crates/runtime-attempt-core/tests/recovery_core.rs
+++ b/native/crates/runtime-attempt-core/tests/recovery_core.rs
@@ -1,8 +1,8 @@
 use rudder_runtime_attempt_core::{
     ATTEMPT_PROTOCOL_VERSION, AttemptMachine, BackoffDelay, CancellationReason, CancellationState,
     Failure, FailureClassification, HeartbeatIdentity, IdempotencyDecision, IdempotencyKey,
-    IdempotencyLedger, LeaseFence, MAX_ATTEMPTS, NETWORK_BACKOFF_SECONDS, Phase, RecoveryDecision,
-    RecoveryResult, TransportFailure,
+    IdempotencyLedger, LeaseFence, MAX_ATTEMPTS, MAX_NETWORK_WAITS, NETWORK_BACKOFF_SECONDS, Phase,
+    RecoveryDecision, RecoveryResult, TransportFailure,
 };
 
 fn lease() -> LeaseFence {
@@ -679,7 +679,7 @@ fn indeterminate_or_terminal_event_evidence_fails_closed() {
 }
 
 #[test]
-fn six_network_waits_reach_the_frozen_schedule_before_exhaustion() {
+fn six_network_waits_exhaust_without_starting_a_seventh_attempt() {
     let identity = HeartbeatIdentity::new("org-1", "run-1", "agent-1").unwrap();
     let fence = lease();
     let mut machine = AttemptMachine::new(
@@ -693,7 +693,11 @@ fn six_network_waits_reach_the_frozen_schedule_before_exhaustion() {
     machine.start(&fence, 0).unwrap();
     machine.checkpoint_progress(&fence, 0).unwrap();
 
-    for (index, expected_seconds) in NETWORK_BACKOFF_SECONDS.into_iter().enumerate() {
+    for (index, expected_seconds) in NETWORK_BACKOFF_SECONDS
+        .into_iter()
+        .enumerate()
+        .take((MAX_ATTEMPTS - 1) as usize)
+    {
         let wait_number = index as u8 + 1;
         machine.start(&fence, 0).unwrap();
         machine.mark_waiting_for_network(&fence, 0).unwrap();
@@ -723,6 +727,9 @@ fn six_network_waits_reach_the_frozen_schedule_before_exhaustion() {
     assert!(
         matches!(exhausted, RecoveryResult::Terminal(outcome) if outcome.code() == "network_retry_exhausted")
     );
+    assert_eq!(machine.network_wait_count(), MAX_NETWORK_WAITS);
+    assert_eq!(machine.attempt_identity().attempt, MAX_ATTEMPTS);
+    assert!(AttemptMachine::from_checkpoint(machine.checkpoint()).is_ok());
 }
 
 #[test]
@@ -796,4 +803,551 @@ fn lease_rebind_requires_the_current_fence_and_accepts_a_new_valid_epoch_after_e
         machine.start(&expired, 150).unwrap_err().code(),
         "stale_lease_fence"
     );
+}
+
+#[test]
+fn retry_budget_has_six_failure_boundaries_but_never_starts_attempt_seven() {
+    assert_eq!(MAX_NETWORK_WAITS, 6);
+    assert_eq!(MAX_ATTEMPTS, MAX_NETWORK_WAITS);
+
+    let identity = HeartbeatIdentity::new("org-1", "run-1", "agent-1").unwrap();
+    let fence = lease();
+    let mut machine = AttemptMachine::new(
+        identity.clone(),
+        "session-1",
+        fence.clone(),
+        "heartbeat-1",
+        "fingerprint-1",
+    )
+    .unwrap();
+    machine.start(&fence, 0).unwrap();
+    machine.checkpoint_progress(&fence, 0).unwrap();
+
+    for expected_attempt in 1..=MAX_NETWORK_WAITS {
+        assert_eq!(machine.attempt_identity().attempt, expected_attempt);
+        machine.start(&fence, 0).unwrap();
+        machine.mark_waiting_for_network(&fence, 0).unwrap();
+        let failure =
+            Failure::transport(TransportFailure::ConnectionReset, "connection reset").unwrap();
+        match machine.record_failure(failure, &fence, 0, None).unwrap() {
+            RecoveryResult::RetryScheduled(plan) if expected_attempt < MAX_NETWORK_WAITS => {
+                assert_eq!(plan.failed_attempt.attempt, expected_attempt);
+                assert!(plan.next_attempt.attempt <= MAX_ATTEMPTS);
+                machine
+                    .resume_same_session(&fence, plan.next_attempt_at_millis)
+                    .unwrap();
+            }
+            RecoveryResult::Terminal(outcome) => {
+                assert_eq!(expected_attempt, MAX_NETWORK_WAITS);
+                assert_eq!(outcome.code(), "network_retry_exhausted");
+            }
+            RecoveryResult::RetryScheduled(plan) => {
+                panic!("sixth wait created an additional provider attempt: {plan:?}");
+            }
+        }
+    }
+
+    assert_eq!(machine.attempt_identity().attempt, MAX_NETWORK_WAITS);
+    assert_eq!(machine.network_wait_count(), MAX_NETWORK_WAITS);
+    assert!(
+        rudder_runtime_attempt_core::AttemptIdentity::new(
+            identity.organization_id,
+            identity.run_id,
+            identity.agent_id,
+            MAX_NETWORK_WAITS + 1,
+        )
+        .is_err()
+    );
+}
+
+#[test]
+fn unsafe_evidence_wins_at_the_retry_boundary() {
+    let identity = HeartbeatIdentity::new("org-1", "run-1", "agent-1").unwrap();
+    let fence = lease();
+    let mut machine = AttemptMachine::new(
+        identity,
+        "session-1",
+        fence.clone(),
+        "heartbeat-1",
+        "fingerprint-1",
+    )
+    .unwrap();
+    machine.start(&fence, 0).unwrap();
+    machine.checkpoint_progress(&fence, 0).unwrap();
+    let accepted = rudder_runtime_attempt_core::RecoveryEvidence::new(
+        rudder_runtime_attempt_core::SubmissionPhase::Accepted,
+        rudder_runtime_attempt_core::SideEffectRisk::Possible,
+        true,
+        false,
+        false,
+    )
+    .unwrap();
+
+    while machine.attempt_identity().attempt < MAX_ATTEMPTS {
+        machine.start(&fence, 0).unwrap();
+        machine.mark_waiting_for_network(&fence, 0).unwrap();
+        let plan = match machine
+            .record_failure_with_evidence(
+                Failure::transport(TransportFailure::Timeout, "timeout").unwrap(),
+                accepted,
+                &fence,
+                0,
+                None,
+            )
+            .unwrap()
+        {
+            RecoveryResult::RetryScheduled(plan) => plan,
+            RecoveryResult::Terminal(outcome) => {
+                panic!("unexpected terminal outcome before the retry boundary: {outcome:?}")
+            }
+        };
+        machine
+            .resume_same_session(&fence, plan.next_attempt_at_millis)
+            .unwrap();
+    }
+
+    machine.start(&fence, 0).unwrap();
+    machine.mark_waiting_for_network(&fence, 0).unwrap();
+    let indeterminate = rudder_runtime_attempt_core::RecoveryEvidence::new(
+        rudder_runtime_attempt_core::SubmissionPhase::Indeterminate,
+        rudder_runtime_attempt_core::SideEffectRisk::Possible,
+        false,
+        false,
+        false,
+    )
+    .unwrap();
+    let result = machine
+        .record_failure_with_evidence(
+            Failure::transport(TransportFailure::Timeout, "timeout").unwrap(),
+            indeterminate,
+            &fence,
+            0,
+            None,
+        )
+        .unwrap();
+    assert!(matches!(
+        result,
+        RecoveryResult::Terminal(outcome) if outcome.code() == "network_resume_unsafe"
+    ));
+}
+
+#[test]
+fn active_recovery_plan_evidence_is_bound_and_cannot_be_downgraded() {
+    let identity = HeartbeatIdentity::new("org-1", "run-1", "agent-1").unwrap();
+    let fence = lease();
+    let mut machine = AttemptMachine::new(
+        identity,
+        "session-1",
+        fence.clone(),
+        "heartbeat-1",
+        "fingerprint-1",
+    )
+    .unwrap();
+    machine.start(&fence, 0).unwrap();
+    machine.checkpoint_progress(&fence, 0).unwrap();
+    machine.mark_waiting_for_network(&fence, 0).unwrap();
+    let accepted = rudder_runtime_attempt_core::RecoveryEvidence::new(
+        rudder_runtime_attempt_core::SubmissionPhase::Accepted,
+        rudder_runtime_attempt_core::SideEffectRisk::Possible,
+        true,
+        false,
+        false,
+    )
+    .unwrap();
+    let plan = match machine
+        .record_failure_with_evidence(
+            Failure::transport(TransportFailure::Timeout, "timeout").unwrap(),
+            accepted,
+            &fence,
+            0,
+            None,
+        )
+        .unwrap()
+    {
+        RecoveryResult::RetryScheduled(plan) => plan,
+        RecoveryResult::Terminal(outcome) => panic!("unexpected terminal outcome: {outcome:?}"),
+    };
+    machine
+        .resume_same_session(&fence, plan.next_attempt_at_millis)
+        .unwrap();
+
+    let mut downgraded = machine.checkpoint();
+    downgraded.submission_phase = rudder_runtime_attempt_core::SubmissionPhase::PreSubmission;
+    downgraded.side_effect_risk = rudder_runtime_attempt_core::SideEffectRisk::None;
+    downgraded.model_output_observed = false;
+    downgraded.tool_activity_observed = false;
+    downgraded.terminal_event_observed = false;
+    assert!(AttemptMachine::from_checkpoint(downgraded).is_err());
+
+    let mut pristine_resume = machine.checkpoint();
+    pristine_resume.session.pristine = true;
+    pristine_resume.submission_phase = rudder_runtime_attempt_core::SubmissionPhase::PreSubmission;
+    pristine_resume.side_effect_risk = rudder_runtime_attempt_core::SideEffectRisk::None;
+    pristine_resume.model_output_observed = false;
+    pristine_resume.tool_activity_observed = false;
+    pristine_resume.terminal_event_observed = false;
+    if let Some(plan) = &mut pristine_resume.recovery {
+        plan.submission_phase = rudder_runtime_attempt_core::SubmissionPhase::PreSubmission;
+        plan.side_effect_risk = rudder_runtime_attempt_core::SideEffectRisk::None;
+        plan.model_output_observed = false;
+        plan.tool_activity_observed = false;
+        plan.terminal_event_observed = false;
+    }
+    assert!(AttemptMachine::from_checkpoint(pristine_resume).is_err());
+}
+
+#[test]
+fn terminal_event_evidence_is_only_valid_for_matching_unsafe_terminal_state() {
+    let terminal_event = rudder_runtime_attempt_core::RecoveryEvidence::new(
+        rudder_runtime_attempt_core::SubmissionPhase::Accepted,
+        rudder_runtime_attempt_core::SideEffectRisk::Possible,
+        false,
+        false,
+        true,
+    )
+    .unwrap();
+    let identity = HeartbeatIdentity::new("org-1", "run-1", "agent-1").unwrap();
+    let fence = lease();
+
+    let mut active = AttemptMachine::new(
+        identity.clone(),
+        "session-1",
+        fence.clone(),
+        "heartbeat-1",
+        "fingerprint-1",
+    )
+    .unwrap();
+    active.start(&fence, 10).unwrap();
+    let before = active.checkpoint();
+    assert_eq!(
+        active
+            .record_evidence(terminal_event, &fence, 10)
+            .unwrap_err()
+            .code(),
+        "network_resume_unsafe"
+    );
+    assert_eq!(active.checkpoint(), before);
+
+    let mut succeeded = AttemptMachine::new(
+        identity.clone(),
+        "session-2",
+        fence.clone(),
+        "heartbeat-2",
+        "fingerprint-2",
+    )
+    .unwrap();
+    succeeded.start(&fence, 10).unwrap();
+    succeeded
+        .record_evidence(
+            rudder_runtime_attempt_core::RecoveryEvidence::new(
+                rudder_runtime_attempt_core::SubmissionPhase::Accepted,
+                rudder_runtime_attempt_core::SideEffectRisk::Possible,
+                false,
+                false,
+                false,
+            )
+            .unwrap(),
+            &fence,
+            10,
+        )
+        .unwrap();
+    succeeded.succeed(&fence, 10).unwrap();
+    let mut invalid_succeeded = succeeded.checkpoint();
+    invalid_succeeded.terminal_event_observed = true;
+    assert!(AttemptMachine::from_checkpoint(invalid_succeeded).is_err());
+
+    let mut unsafe_machine = AttemptMachine::new(
+        identity,
+        "session-3",
+        fence.clone(),
+        "heartbeat-3",
+        "fingerprint-3",
+    )
+    .unwrap();
+    unsafe_machine.start(&fence, 10).unwrap();
+    unsafe_machine.mark_waiting_for_network(&fence, 10).unwrap();
+    let result = unsafe_machine
+        .record_failure_with_evidence(
+            Failure::transport(TransportFailure::Timeout, "timeout").unwrap(),
+            terminal_event,
+            &fence,
+            10,
+            None,
+        )
+        .unwrap();
+    assert!(matches!(
+        result,
+        RecoveryResult::Terminal(ref outcome)
+            if outcome.code() == "network_resume_unsafe"
+    ));
+    assert!(AttemptMachine::from_checkpoint(unsafe_machine.checkpoint()).is_ok());
+}
+
+#[test]
+fn fresh_replay_requires_the_persisted_replacement_session() {
+    let identity = HeartbeatIdentity::new("org-1", "run-1", "agent-1").unwrap();
+    let fence = lease();
+    let mut machine = AttemptMachine::new(
+        identity,
+        "session-1",
+        fence.clone(),
+        "heartbeat-1",
+        "fingerprint-1",
+    )
+    .unwrap();
+    machine.start(&fence, 0).unwrap();
+    machine.mark_waiting_for_network(&fence, 0).unwrap();
+    let plan = match machine
+        .record_failure(
+            Failure::transport(TransportFailure::Timeout, "timeout").unwrap(),
+            &fence,
+            0,
+            None,
+        )
+        .unwrap()
+    {
+        RecoveryResult::RetryScheduled(plan) => plan,
+        RecoveryResult::Terminal(outcome) => panic!("unexpected terminal outcome: {outcome:?}"),
+    };
+
+    let first = machine
+        .fresh_if_pristine(&fence, plan.next_attempt_at_millis, "session-2")
+        .unwrap();
+    assert_eq!(machine.session_id(), "session-2");
+    assert_eq!(
+        machine
+            .fresh_if_pristine(&fence, plan.next_attempt_at_millis, "session-2")
+            .unwrap(),
+        first
+    );
+    let before_rejected_replay = machine.checkpoint();
+    assert_eq!(
+        machine
+            .fresh_if_pristine(&fence, plan.next_attempt_at_millis, "session-3")
+            .unwrap_err()
+            .code(),
+        "recovery_choice_mismatch"
+    );
+    assert_eq!(machine.checkpoint(), before_rejected_replay);
+    assert_eq!(
+        machine
+            .fresh_if_pristine(&fence, plan.next_attempt_at_millis, " ")
+            .unwrap_err()
+            .code(),
+        "invalid_input"
+    );
+    assert_eq!(machine.checkpoint(), before_rejected_replay);
+}
+
+#[test]
+fn terminal_leases_are_immutable() {
+    let identity = HeartbeatIdentity::new("org-1", "run-1", "agent-1").unwrap();
+    let fence = lease();
+    let replacement = LeaseFence::new("worker-2", 2, 10, 100_000).unwrap();
+
+    let mut succeeded = AttemptMachine::new(
+        identity.clone(),
+        "session-1",
+        fence.clone(),
+        "heartbeat-1",
+        "fingerprint-1",
+    )
+    .unwrap();
+    succeeded.start(&fence, 10).unwrap();
+    succeeded.succeed(&fence, 10).unwrap();
+    let before_succeeded = succeeded.checkpoint();
+    assert_eq!(
+        succeeded
+            .renew_lease(&fence, replacement.clone(), 10)
+            .unwrap_err()
+            .code(),
+        "already_terminal"
+    );
+    assert_eq!(succeeded.checkpoint(), before_succeeded);
+
+    let mut cancelled = AttemptMachine::new(
+        identity,
+        "session-2",
+        fence.clone(),
+        "heartbeat-2",
+        "fingerprint-2",
+    )
+    .unwrap();
+    cancelled.start(&fence, 10).unwrap();
+    cancelled
+        .cancel(&fence, CancellationReason::Operator, 10)
+        .unwrap();
+    let before_cancelled = cancelled.checkpoint();
+    assert_eq!(
+        cancelled
+            .rebind_lease(&fence, replacement, 10)
+            .unwrap_err()
+            .code(),
+        "already_terminal"
+    );
+    assert_eq!(cancelled.checkpoint(), before_cancelled);
+}
+
+#[test]
+fn overflow_failures_leave_evidence_sessions_and_retry_state_unchanged() {
+    let accepted = rudder_runtime_attempt_core::RecoveryEvidence::new(
+        rudder_runtime_attempt_core::SubmissionPhase::Accepted,
+        rudder_runtime_attempt_core::SideEffectRisk::Possible,
+        true,
+        false,
+        false,
+    )
+    .unwrap();
+
+    let identity = HeartbeatIdentity::new("org-1", "run-1", "agent-1").unwrap();
+    let fence = lease();
+    let mut evidence_at_max = AttemptMachine::new(
+        identity.clone(),
+        "session-1",
+        fence.clone(),
+        "heartbeat-1",
+        "fingerprint-1",
+    )
+    .unwrap();
+    evidence_at_max.start(&fence, 10).unwrap();
+    let mut checkpoint = evidence_at_max.checkpoint();
+    checkpoint.revision = u64::MAX;
+    let mut evidence_at_max = AttemptMachine::from_checkpoint(checkpoint).unwrap();
+    let before = evidence_at_max.checkpoint();
+    assert!(
+        evidence_at_max
+            .record_evidence(accepted, &fence, 10)
+            .is_err()
+    );
+    assert_eq!(evidence_at_max.checkpoint(), before);
+
+    let mut fresh_at_max = AttemptMachine::new(
+        identity.clone(),
+        "session-1",
+        fence.clone(),
+        "heartbeat-2",
+        "fingerprint-2",
+    )
+    .unwrap();
+    fresh_at_max.start(&fence, 0).unwrap();
+    fresh_at_max.mark_waiting_for_network(&fence, 0).unwrap();
+    let plan = match fresh_at_max
+        .record_failure(
+            Failure::transport(TransportFailure::Timeout, "timeout").unwrap(),
+            &fence,
+            0,
+            None,
+        )
+        .unwrap()
+    {
+        RecoveryResult::RetryScheduled(plan) => plan,
+        RecoveryResult::Terminal(outcome) => panic!("unexpected terminal outcome: {outcome:?}"),
+    };
+    let mut checkpoint = fresh_at_max.checkpoint();
+    checkpoint.revision = u64::MAX;
+    let mut fresh_at_max = AttemptMachine::from_checkpoint(checkpoint).unwrap();
+    let before = fresh_at_max.checkpoint();
+    assert!(
+        fresh_at_max
+            .fresh_if_pristine(&fence, plan.next_attempt_at_millis, "session-2")
+            .is_err()
+    );
+    assert_eq!(fresh_at_max.checkpoint(), before);
+
+    let mut retry_at_max_minus_one = AttemptMachine::new(
+        identity.clone(),
+        "session-1",
+        fence.clone(),
+        "heartbeat-3",
+        "fingerprint-3",
+    )
+    .unwrap();
+    retry_at_max_minus_one.start(&fence, 0).unwrap();
+    let mut checkpoint = retry_at_max_minus_one.checkpoint();
+    checkpoint.revision = u64::MAX - 1;
+    let mut retry_at_max_minus_one = AttemptMachine::from_checkpoint(checkpoint).unwrap();
+    let before = retry_at_max_minus_one.checkpoint();
+    assert!(
+        retry_at_max_minus_one
+            .record_failure_with_evidence(
+                Failure::transport(TransportFailure::Timeout, "timeout").unwrap(),
+                accepted,
+                &fence,
+                0,
+                None,
+            )
+            .is_err()
+    );
+    assert_eq!(retry_at_max_minus_one.checkpoint(), before);
+
+    let near_max_fence = LeaseFence::new("worker-1", 1, 0, u64::MAX).unwrap();
+    let mut timestamp_overflow = AttemptMachine::new(
+        identity,
+        "session-1",
+        near_max_fence.clone(),
+        "heartbeat-4",
+        "fingerprint-4",
+    )
+    .unwrap();
+    timestamp_overflow
+        .start(&near_max_fence, u64::MAX - 1)
+        .unwrap();
+    let before = timestamp_overflow.checkpoint();
+    assert!(
+        timestamp_overflow
+            .record_failure_with_evidence(
+                Failure::transport(TransportFailure::Timeout, "timeout").unwrap(),
+                accepted,
+                &near_max_fence,
+                u64::MAX - 1,
+                None,
+            )
+            .is_err()
+    );
+    assert_eq!(timestamp_overflow.checkpoint(), before);
+}
+
+#[test]
+fn indeterminate_evidence_is_monotonic_against_later_accepted_observations() {
+    let identity = HeartbeatIdentity::new("org-1", "run-1", "agent-1").unwrap();
+    let fence = lease();
+    let mut machine = AttemptMachine::new(
+        identity,
+        "session-1",
+        fence.clone(),
+        "heartbeat-1",
+        "fingerprint-1",
+    )
+    .unwrap();
+    machine.start(&fence, 10).unwrap();
+
+    let indeterminate = rudder_runtime_attempt_core::RecoveryEvidence::new(
+        rudder_runtime_attempt_core::SubmissionPhase::Indeterminate,
+        rudder_runtime_attempt_core::SideEffectRisk::Possible,
+        false,
+        false,
+        false,
+    )
+    .unwrap();
+    machine.record_evidence(indeterminate, &fence, 10).unwrap();
+
+    let accepted = rudder_runtime_attempt_core::RecoveryEvidence::new(
+        rudder_runtime_attempt_core::SubmissionPhase::Accepted,
+        rudder_runtime_attempt_core::SideEffectRisk::Possible,
+        false,
+        false,
+        false,
+    )
+    .unwrap();
+    machine.record_evidence(accepted, &fence, 10).unwrap();
+
+    assert_eq!(
+        machine.submission_phase(),
+        rudder_runtime_attempt_core::SubmissionPhase::Indeterminate
+    );
+    assert_eq!(
+        machine.side_effect_risk(),
+        rudder_runtime_attempt_core::SideEffectRisk::Possible
+    );
+    assert!(!machine.model_output_observed());
 }

--- a/native/crates/runtime-attempt-core/tests/recovery_core.rs
+++ b/native/crates/runtime-attempt-core/tests/recovery_core.rs
@@ -52,6 +52,9 @@ fn checkpoint_round_trip_preserves_identity_phase_and_session_metadata() {
 
     let restored = AttemptMachine::from_checkpoint(checkpoint.clone()).unwrap();
     assert_eq!(restored.checkpoint(), checkpoint);
+    let encoded = serde_json::to_string(&checkpoint).unwrap();
+    let decoded: rudder_runtime_attempt_core::Checkpoint = serde_json::from_str(&encoded).unwrap();
+    assert_eq!(decoded, checkpoint);
 }
 
 #[test]
@@ -121,6 +124,18 @@ fn pristine_transport_failure_chooses_fresh_session_and_persists_retry_plan() {
     assert_eq!(next.attempt, 2);
     assert_eq!(restored.session_id(), "session-2");
     assert_eq!(restored.phase(), Phase::Executing);
+    let evidence = rudder_runtime_attempt_core::RecoveryEvidence::new(
+        rudder_runtime_attempt_core::SubmissionPhase::Accepted,
+        rudder_runtime_attempt_core::SideEffectRisk::Possible,
+        true,
+        false,
+        false,
+    )
+    .unwrap();
+    let checkpoint = restored
+        .record_evidence(evidence, &fence, plan.next_attempt_at_millis)
+        .unwrap();
+    assert!(AttemptMachine::from_checkpoint(checkpoint).is_ok());
 }
 
 #[test]
@@ -139,12 +154,12 @@ fn checkpointed_progress_resumes_same_session_and_enforces_due_time_and_choice()
     machine.checkpoint_progress(&fence, 20).unwrap();
     machine.mark_waiting_for_network(&fence, 30).unwrap();
 
-    let failure = Failure::server_5xx(503, "upstream unavailable").unwrap();
+    let failure = Failure::transport(TransportFailure::Timeout, "upstream unavailable").unwrap();
     let plan = match machine.record_failure(failure, &fence, 30, None).unwrap() {
         RecoveryResult::RetryScheduled(plan) => plan,
         RecoveryResult::Terminal(outcome) => panic!("unexpected terminal outcome: {outcome:?}"),
     };
-    assert_eq!(plan.classification, FailureClassification::Server5xx);
+    assert_eq!(plan.classification, FailureClassification::Transport);
     assert_eq!(plan.decision, RecoveryDecision::ResumeSameSession);
     assert_eq!(
         machine
@@ -175,7 +190,7 @@ fn checkpointed_progress_resumes_same_session_and_enforces_due_time_and_choice()
 }
 
 #[test]
-fn retryable_network_failures_stop_at_the_sixth_attempt() {
+fn retryable_network_failures_stop_after_six_waits() {
     let identity = HeartbeatIdentity::new("org-1", "run-1", "agent-1").unwrap();
     let fence = lease();
     let mut machine = AttemptMachine::new(
@@ -203,7 +218,7 @@ fn retryable_network_failures_stop_at_the_sixth_attempt() {
                     .fresh_if_pristine(
                         &fence,
                         plan.next_attempt_at_millis,
-                        format!("session-{attempt}"),
+                        format!("retry-session-{attempt}"),
                     )
                     .unwrap();
             }
@@ -365,16 +380,17 @@ fn fail_closed_is_an_explicit_terminal_recovery_choice() {
 #[test]
 fn idempotency_ledger_replays_same_fingerprint_and_rejects_conflicts() {
     let mut ledger = IdempotencyLedger::default();
+    let identity = HeartbeatIdentity::new("org-1", "run-1", "agent-1").unwrap();
     let key = IdempotencyKey::new("heartbeat-key").unwrap();
     assert_eq!(
         ledger
-            .reserve("org-1", key.clone(), "fingerprint-a", "run-1")
+            .reserve_for_identity(identity.clone(), key.clone(), "fingerprint-a")
             .unwrap(),
         IdempotencyDecision::New
     );
     assert_eq!(
         ledger
-            .reserve("org-1", key.clone(), "fingerprint-a", "run-2")
+            .reserve_for_identity(identity.clone(), key.clone(), "fingerprint-a")
             .unwrap(),
         IdempotencyDecision::Replay {
             run_id: "run-1".to_owned()
@@ -382,25 +398,25 @@ fn idempotency_ledger_replays_same_fingerprint_and_rejects_conflicts() {
     );
     assert_eq!(
         ledger
-            .reserve("org-1", key.clone(), "fingerprint-b", "run-3")
+            .reserve_for_identity(identity.clone(), key.clone(), "fingerprint-b")
             .unwrap_err()
             .code(),
         "idempotency_conflict"
     );
 
     let outcome = rudder_runtime_attempt_core::TerminalOutcome::NetworkResumeUnsafe {
-        attempt: HeartbeatIdentity::new("org-1", "run-1", "agent-1")
-            .unwrap()
-            .attempt(1)
-            .unwrap(),
+        attempt: identity.attempt(1).unwrap(),
         failure: Failure::ambiguous("response_unknown", "response not observed").unwrap(),
     };
     ledger
-        .record_outcome("org-1", key.clone(), outcome.clone())
+        .record_outcome_for_identity(&identity, &key, "fingerprint-a", outcome.clone())
         .unwrap();
-    assert_eq!(ledger.outcome("org-1", &key), Some(&outcome));
+    assert_eq!(
+        ledger.outcome_for_identity(&identity, &key, "fingerprint-a"),
+        Some(&outcome)
+    );
     ledger
-        .record_outcome("org-1", key, outcome)
+        .record_outcome_for_identity(&identity, &key, "fingerprint-a", outcome)
         .expect("recording the same terminal receipt is idempotent");
 }
 
@@ -428,5 +444,356 @@ fn success_is_terminal_and_duplicate_completion_replays_the_same_receipt() {
             .unwrap_err()
             .code(),
         "already_terminal"
+    );
+}
+
+#[test]
+fn checkpoint_loading_rejects_nested_identity_and_attempt_tampering() {
+    let identity = HeartbeatIdentity::new("org-1", "run-1", "agent-1").unwrap();
+    let fence = lease();
+    let mut machine = AttemptMachine::new(
+        identity.clone(),
+        "session-1",
+        fence.clone(),
+        "heartbeat-1",
+        "fingerprint-1",
+    )
+    .unwrap();
+    machine.start(&fence, 10).unwrap();
+    machine.mark_waiting_for_network(&fence, 10).unwrap();
+    let failure = Failure::transport(TransportFailure::Timeout, "timeout").unwrap();
+    machine.record_failure(failure, &fence, 10, None).unwrap();
+
+    let mut nested_identity = machine.checkpoint();
+    nested_identity
+        .recovery
+        .as_mut()
+        .unwrap()
+        .failed_attempt
+        .organization_id = "other-org".to_owned();
+    let error = AttemptMachine::from_checkpoint(nested_identity).unwrap_err();
+    assert_eq!(
+        error.kind(),
+        rudder_runtime_attempt_core::ErrorKind::CheckpointInvalid
+    );
+
+    let mut out_of_range = machine.checkpoint();
+    out_of_range.recovery.as_mut().unwrap().next_attempt.attempt = u8::MAX;
+    assert!(AttemptMachine::from_checkpoint(out_of_range).is_err());
+
+    let mut nested_next_identity = machine.checkpoint();
+    nested_next_identity
+        .recovery
+        .as_mut()
+        .unwrap()
+        .next_attempt
+        .agent_id = "other-agent".to_owned();
+    assert!(AttemptMachine::from_checkpoint(nested_next_identity).is_err());
+
+    let mut malformed_backoff = machine.checkpoint();
+    malformed_backoff
+        .recovery
+        .as_mut()
+        .unwrap()
+        .backoff
+        .delay_millis += 1;
+    assert!(AttemptMachine::from_checkpoint(malformed_backoff).is_err());
+
+    let mut oversized_fingerprint = machine.checkpoint();
+    oversized_fingerprint.request_fingerprint =
+        "x".repeat(rudder_runtime_attempt_core::MAX_REQUEST_FINGERPRINT_BYTES + 1);
+    assert!(AttemptMachine::from_checkpoint(oversized_fingerprint).is_err());
+
+    let mut completed = AttemptMachine::new(
+        identity.clone(),
+        "session-2",
+        fence.clone(),
+        "heartbeat-2",
+        "fingerprint-2",
+    )
+    .unwrap();
+    completed.start(&fence, 10).unwrap();
+    completed.succeed(&fence, 20).unwrap();
+    let mut terminal_identity = completed.checkpoint();
+    if let Some(rudder_runtime_attempt_core::TerminalOutcome::Succeeded { attempt }) =
+        terminal_identity.terminal_outcome.as_mut()
+    {
+        attempt.organization_id = "other-org".to_owned();
+    }
+    assert!(AttemptMachine::from_checkpoint(terminal_identity).is_err());
+}
+
+#[test]
+fn public_deserialization_cannot_bypass_lease_or_machine_invariants() {
+    let invalid_lease = serde_json::json!({
+        "ownerId": "worker-1",
+        "epoch": 0,
+        "issuedAtMillis": 0,
+        "expiresAtMillis": 100
+    });
+    assert!(serde_json::from_value::<LeaseFence>(invalid_lease).is_err());
+    assert!(
+        serde_json::from_value::<Failure>(serde_json::json!({
+            "kind": "transport",
+            "reason": "tls",
+            "code": "transport_timeout",
+            "summary": "certificate rejected"
+        }))
+        .is_err()
+    );
+    assert!(
+        serde_json::from_value::<BackoffDelay>(serde_json::json!({
+            "retryNumber": 6,
+            "baseSeconds": 60,
+            "jitterMillis": 0,
+            "delayMillis": 1
+        }))
+        .is_err()
+    );
+
+    let identity = HeartbeatIdentity::new("org-1", "run-1", "agent-1").unwrap();
+    let fence = lease();
+    let machine =
+        AttemptMachine::new(identity, "session-1", fence, "heartbeat-1", "fingerprint-1").unwrap();
+    let mut raw = serde_json::to_value(&machine).unwrap();
+    raw["phase"] = serde_json::json!("terminal");
+    raw["terminalOutcome"] = serde_json::Value::Null;
+    assert!(serde_json::from_value::<AttemptMachine>(raw).is_err());
+}
+
+#[test]
+fn provider_server_and_tls_failures_are_terminal_not_retryable() {
+    for failure in [
+        Failure::server_5xx(503, "provider unavailable").unwrap(),
+        Failure::transport(TransportFailure::Tls, "certificate rejected").unwrap(),
+    ] {
+        let identity = HeartbeatIdentity::new("org-1", "run-1", "agent-1").unwrap();
+        let fence = lease();
+        let mut machine = AttemptMachine::new(
+            identity,
+            "session-1",
+            fence.clone(),
+            "heartbeat-1",
+            "fingerprint-1",
+        )
+        .unwrap();
+        machine.start(&fence, 10).unwrap();
+        let result = machine.record_failure(failure, &fence, 10, None).unwrap();
+        assert!(matches!(result, RecoveryResult::Terminal(outcome) if outcome.code() == "failed"));
+    }
+}
+
+#[test]
+fn submitted_evidence_requires_same_session_recovery_and_is_exposed() {
+    let identity = HeartbeatIdentity::new("org-1", "run-1", "agent-1").unwrap();
+    let fence = lease();
+    let mut machine = AttemptMachine::new(
+        identity,
+        "session-1",
+        fence.clone(),
+        "heartbeat-1",
+        "fingerprint-1",
+    )
+    .unwrap();
+    machine.start(&fence, 10).unwrap();
+    machine.mark_waiting_for_network(&fence, 10).unwrap();
+
+    let evidence = rudder_runtime_attempt_core::RecoveryEvidence::new(
+        rudder_runtime_attempt_core::SubmissionPhase::Accepted,
+        rudder_runtime_attempt_core::SideEffectRisk::Possible,
+        true,
+        false,
+        false,
+    )
+    .unwrap();
+    let failure = Failure::transport(TransportFailure::Timeout, "timeout").unwrap();
+    let plan = match machine
+        .record_failure_with_evidence(failure, evidence, &fence, 10, None)
+        .unwrap()
+    {
+        RecoveryResult::RetryScheduled(plan) => plan,
+        RecoveryResult::Terminal(outcome) => panic!("unexpected terminal outcome: {outcome:?}"),
+    };
+    assert_eq!(plan.decision, RecoveryDecision::ResumeSameSession);
+    assert_eq!(
+        plan.submission_phase,
+        rudder_runtime_attempt_core::SubmissionPhase::Accepted
+    );
+    assert_eq!(
+        plan.side_effect_risk,
+        rudder_runtime_attempt_core::SideEffectRisk::Possible
+    );
+    assert!(plan.model_output_observed);
+    assert!(!plan.tool_activity_observed);
+    assert_eq!(machine.submission_phase(), plan.submission_phase);
+    assert_eq!(machine.side_effect_risk(), plan.side_effect_risk);
+    assert!(machine.model_output_observed());
+}
+
+#[test]
+fn indeterminate_or_terminal_event_evidence_fails_closed() {
+    for evidence in [
+        rudder_runtime_attempt_core::RecoveryEvidence::new(
+            rudder_runtime_attempt_core::SubmissionPhase::Indeterminate,
+            rudder_runtime_attempt_core::SideEffectRisk::Possible,
+            false,
+            false,
+            false,
+        )
+        .unwrap(),
+        rudder_runtime_attempt_core::RecoveryEvidence::new(
+            rudder_runtime_attempt_core::SubmissionPhase::Accepted,
+            rudder_runtime_attempt_core::SideEffectRisk::Possible,
+            false,
+            false,
+            true,
+        )
+        .unwrap(),
+    ] {
+        let identity = HeartbeatIdentity::new("org-1", "run-1", "agent-1").unwrap();
+        let fence = lease();
+        let mut machine = AttemptMachine::new(
+            identity,
+            "session-1",
+            fence.clone(),
+            "heartbeat-1",
+            "fingerprint-1",
+        )
+        .unwrap();
+        machine.start(&fence, 10).unwrap();
+        machine.mark_waiting_for_network(&fence, 10).unwrap();
+        let result = machine
+            .record_failure_with_evidence(
+                Failure::transport(TransportFailure::Timeout, "timeout").unwrap(),
+                evidence,
+                &fence,
+                10,
+                None,
+            )
+            .unwrap();
+        assert!(matches!(
+            result,
+            RecoveryResult::Terminal(outcome) if outcome.code() == "network_resume_unsafe"
+        ));
+    }
+}
+
+#[test]
+fn six_network_waits_reach_the_frozen_schedule_before_exhaustion() {
+    let identity = HeartbeatIdentity::new("org-1", "run-1", "agent-1").unwrap();
+    let fence = lease();
+    let mut machine = AttemptMachine::new(
+        identity,
+        "session-1",
+        fence.clone(),
+        "heartbeat-1",
+        "fingerprint-1",
+    )
+    .unwrap();
+    machine.start(&fence, 0).unwrap();
+    machine.checkpoint_progress(&fence, 0).unwrap();
+
+    for (index, expected_seconds) in NETWORK_BACKOFF_SECONDS.into_iter().enumerate() {
+        let wait_number = index as u8 + 1;
+        machine.start(&fence, 0).unwrap();
+        machine.mark_waiting_for_network(&fence, 0).unwrap();
+        let failure = Failure::transport(TransportFailure::Timeout, "timeout").unwrap();
+        let plan = match machine.record_failure(failure, &fence, 0, None).unwrap() {
+            RecoveryResult::RetryScheduled(plan) => plan,
+            RecoveryResult::Terminal(outcome) => panic!("unexpected exhaustion: {outcome:?}"),
+        };
+        assert_eq!(plan.network_wait_number, wait_number);
+        assert_eq!(plan.backoff.base_seconds, expected_seconds);
+        machine
+            .resume_same_session(&fence, plan.next_attempt_at_millis)
+            .unwrap();
+    }
+
+    assert_eq!(machine.attempt_identity().attempt, MAX_ATTEMPTS);
+    machine.start(&fence, 0).unwrap();
+    machine.mark_waiting_for_network(&fence, 0).unwrap();
+    let exhausted = machine
+        .record_failure(
+            Failure::transport(TransportFailure::Timeout, "timeout").unwrap(),
+            &fence,
+            0,
+            None,
+        )
+        .unwrap();
+    assert!(
+        matches!(exhausted, RecoveryResult::Terminal(outcome) if outcome.code() == "network_retry_exhausted")
+    );
+}
+
+#[test]
+fn idempotency_rejects_cross_identity_and_fingerprint_outcomes_and_round_trips_json() {
+    let identity = HeartbeatIdentity::new("org-1", "run-1", "agent-1").unwrap();
+    let other_identity = HeartbeatIdentity::new("org-1", "run-1", "agent-2").unwrap();
+    let key = IdempotencyKey::new("heartbeat-key").unwrap();
+    let mut ledger = IdempotencyLedger::default();
+    ledger
+        .reserve_for_identity(identity.clone(), key.clone(), "fingerprint-a")
+        .unwrap();
+    let outcome = rudder_runtime_attempt_core::TerminalOutcome::Failed {
+        attempt: identity.attempt(1).unwrap(),
+        failure: Failure::non_retryable("tool_failure", "tool failed").unwrap(),
+    };
+    assert_eq!(
+        ledger
+            .record_outcome_for_identity(&other_identity, &key, "fingerprint-a", outcome.clone(),)
+            .unwrap_err()
+            .code(),
+        "idempotency_conflict"
+    );
+    assert_eq!(
+        ledger
+            .record_outcome_for_identity(&identity, &key, "fingerprint-b", outcome.clone())
+            .unwrap_err()
+            .code(),
+        "idempotency_conflict"
+    );
+    ledger
+        .record_outcome_for_identity(&identity, &key, "fingerprint-a", outcome.clone())
+        .unwrap();
+
+    let encoded = serde_json::to_string(&ledger).unwrap();
+    assert!(encoded.starts_with("{\"records\":["));
+    let restored: IdempotencyLedger = serde_json::from_str(&encoded).unwrap();
+    assert_eq!(
+        restored.outcome_for_identity(&identity, &key, "fingerprint-a"),
+        Some(&outcome)
+    );
+}
+
+#[test]
+fn lease_rebind_requires_the_current_fence_and_accepts_a_new_valid_epoch_after_expiry() {
+    let identity = HeartbeatIdentity::new("org-1", "run-1", "agent-1").unwrap();
+    let expired = LeaseFence::new("worker-1", 1, 0, 100).unwrap();
+    let replacement = LeaseFence::new("worker-2", 2, 100, 300).unwrap();
+    let stale = LeaseFence::new("worker-1", 3, 100, 300).unwrap();
+    let mut machine = AttemptMachine::new(
+        identity,
+        "session-1",
+        expired.clone(),
+        "heartbeat-1",
+        "fingerprint-1",
+    )
+    .unwrap();
+    machine.start(&expired, 10).unwrap();
+
+    assert_eq!(
+        machine
+            .rebind_lease(&stale, replacement.clone(), 150)
+            .unwrap_err()
+            .code(),
+        "stale_lease_fence"
+    );
+    machine
+        .rebind_lease(&expired, replacement.clone(), 150)
+        .unwrap();
+    assert_eq!(machine.start(&replacement, 150).unwrap().attempt, 1);
+    assert_eq!(
+        machine.start(&expired, 150).unwrap_err().code(),
+        "stale_lease_fence"
     );
 }

--- a/native/crates/runtime-attempt-core/tests/recovery_core.rs
+++ b/native/crates/runtime-attempt-core/tests/recovery_core.rs
@@ -58,6 +58,86 @@ fn checkpoint_round_trip_preserves_identity_phase_and_session_metadata() {
 }
 
 #[test]
+fn v1_recovery_checkpoint_migration_is_safe_for_same_session_only() {
+    let identity = HeartbeatIdentity::new("org-1", "run-1", "agent-1").unwrap();
+    let fence = lease();
+    let mut resume_machine = AttemptMachine::new(
+        identity.clone(),
+        "session-1",
+        fence.clone(),
+        "heartbeat-1",
+        "fingerprint-1",
+    )
+    .unwrap();
+    resume_machine.start(&fence, 0).unwrap();
+    resume_machine.checkpoint_progress(&fence, 0).unwrap();
+    resume_machine.mark_waiting_for_network(&fence, 0).unwrap();
+    resume_machine
+        .record_failure(
+            Failure::transport(TransportFailure::Timeout, "timeout").unwrap(),
+            &fence,
+            0,
+            None,
+        )
+        .unwrap();
+
+    let mut legacy_resume = serde_json::to_value(resume_machine.checkpoint()).unwrap();
+    let recovery = legacy_resume["recovery"].as_object_mut().unwrap();
+    assert!(recovery.remove("sourceSessionId").is_some());
+    assert!(recovery.remove("replacementSessionId").is_some());
+    let migrated: rudder_runtime_attempt_core::Checkpoint =
+        serde_json::from_value(legacy_resume).unwrap();
+    assert_eq!(
+        migrated.recovery.as_ref().unwrap().source_session_id,
+        "session-1"
+    );
+    assert_eq!(
+        migrated.recovery.as_ref().unwrap().replacement_session_id,
+        None
+    );
+    let encoded = serde_json::to_string(&migrated).unwrap();
+    assert_eq!(
+        serde_json::from_str::<rudder_runtime_attempt_core::Checkpoint>(&encoded).unwrap(),
+        migrated
+    );
+    let next_attempt_at_millis = migrated.recovery.as_ref().unwrap().next_attempt_at_millis;
+    let mut restored = AttemptMachine::from_checkpoint(migrated).unwrap();
+    assert_eq!(
+        restored
+            .resume_same_session(&fence, next_attempt_at_millis)
+            .unwrap()
+            .attempt,
+        2
+    );
+
+    let mut fresh_machine = AttemptMachine::new(
+        identity,
+        "session-1",
+        fence.clone(),
+        "heartbeat-2",
+        "fingerprint-2",
+    )
+    .unwrap();
+    fresh_machine.start(&fence, 0).unwrap();
+    fresh_machine.mark_waiting_for_network(&fence, 0).unwrap();
+    fresh_machine
+        .record_failure(
+            Failure::transport(TransportFailure::Timeout, "timeout").unwrap(),
+            &fence,
+            0,
+            None,
+        )
+        .unwrap();
+    let mut legacy_fresh = serde_json::to_value(fresh_machine.checkpoint()).unwrap();
+    let recovery = legacy_fresh["recovery"].as_object_mut().unwrap();
+    assert!(recovery.remove("sourceSessionId").is_some());
+    assert!(recovery.remove("replacementSessionId").is_some());
+    assert!(
+        serde_json::from_value::<rudder_runtime_attempt_core::Checkpoint>(legacy_fresh).is_err()
+    );
+}
+
+#[test]
 fn backoff_is_frozen_and_deterministic_jitter_stays_bounded() {
     assert_eq!(NETWORK_BACKOFF_SECONDS, [2, 5, 10, 20, 30, 60]);
     for (retry_number, expected_seconds) in NETWORK_BACKOFF_SECONDS.into_iter().enumerate() {


### PR DESCRIPTION
## Summary
- Add the pure, bounded `rudder-runtime-attempt-core` state machine for heartbeat attempt recovery.
- Model lease/fence and org/run/agent/session identity binding, checkpoint round trips and migration, deterministic bounded backoff, retry exhaustion, same-session/fresh-session recovery choices, idempotency, and fail-closed unsafe/indeterminate evidence.
- Keep process execution, persistence, and production authority in existing adapters; this slice has no process/network/filesystem/database/async dependencies.

## Validation
- `cargo fmt --all -- --check`
- `cargo metadata --locked --format-version 1 --no-deps`
- `cargo test -p rudder-runtime-attempt-core --all-targets --locked` (33 passed)
- `cargo test --workspace --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- Independent stage review: accept, exact candidate `30d01f60198fa18c16e37b29c58d0fb3bfd5645e`.

## Scope
Part of R6Z-120. This is a draft pure foundation; adapter wiring, database persistence, and production authority transfer remain out of scope.